### PR TITLE
Use smart pointer for MemoryCursor

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -259,5 +259,15 @@ void MemoryBackingStoreTransaction::finish()
         objectStore->writeTransactionFinished(*this);
 }
 
+MemoryCursor* MemoryBackingStoreTransaction::cursor(const IDBResourceIdentifier& identifier) const
+{
+    return m_cursors.get(identifier).get();
+}
+
+void MemoryBackingStoreTransaction::addCursor(MemoryCursor& cursor)
+{
+    m_cursors.add(cursor.info().identifier(), &cursor);
+}
+
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 namespace IDBServer {
 
+class MemoryCursor;
 class MemoryIDBBackingStore;
 class MemoryIndex;
 class MemoryObjectStore;
@@ -77,6 +78,9 @@ public:
 
     IDBTransactionInfo info() const { return m_info; }
 
+    MemoryCursor* cursor(const IDBResourceIdentifier&) const;
+    void addCursor(MemoryCursor&);
+
 private:
     void finish();
 
@@ -97,6 +101,8 @@ private:
     HashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
     HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
     HashMap<MemoryIndex*, String> m_originalIndexNames;
+
+    HashMap<IDBResourceIdentifier, WeakPtr<MemoryCursor>> m_cursors;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
@@ -33,38 +33,17 @@
 namespace WebCore {
 namespace IDBServer {
 
-static Lock cursorMapLock;
-static HashMap<IDBResourceIdentifier, MemoryCursor*>& cursorMap() WTF_REQUIRES_LOCK(cursorMapLock)
-{
-    static NeverDestroyed<HashMap<IDBResourceIdentifier, MemoryCursor*>> map;
-    return map;
-}
-
-MemoryCursor::MemoryCursor(const IDBCursorInfo& info)
+MemoryCursor::MemoryCursor(const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
     : m_info(info)
 {
     ASSERT(!isMainThread());
 
-    Locker locker { cursorMapLock };
-    ASSERT(!cursorMap().contains(m_info.identifier()));
-    cursorMap().set(m_info.identifier(), this);
+    transaction.addCursor(*this);
 }
 
 MemoryCursor::~MemoryCursor()
 {
     ASSERT(!isMainThread());
-
-    Locker locker { cursorMapLock };
-    ASSERT(cursorMap().contains(m_info.identifier()));
-    cursorMap().remove(m_info.identifier());
-}
-
-MemoryCursor* MemoryCursor::cursorForIdentifier(const IDBResourceIdentifier& identifier)
-{
-    ASSERT(!isMainThread());
-
-    Locker locker { cursorMapLock };
-    return cursorMap().get(identifier);
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IDBCursorInfo.h"
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,7 +36,9 @@ class IDBResourceIdentifier;
 
 namespace IDBServer {
 
-class MemoryCursor {
+class MemoryBackingStoreTransaction;
+
+class MemoryCursor : public RefCountedAndCanMakeWeakPtr<MemoryCursor> {
     WTF_MAKE_TZONE_ALLOCATED(MemoryCursor);
 public:
     virtual ~MemoryCursor();
@@ -43,11 +46,12 @@ public:
     virtual void currentData(IDBGetResult&) = 0;
     virtual void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) = 0;
 
-    static MemoryCursor* cursorForIdentifier(const IDBResourceIdentifier&);
+    IDBCursorInfo info() const { return m_info; }
 
 protected:
-    MemoryCursor(const IDBCursorInfo&);
+    MemoryCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);
 
+private:
     IDBCursorInfo m_info;
 };
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -65,12 +65,12 @@ RefPtr<MemoryObjectStore> MemoryIndex::protectedObjectStore()
 
 void MemoryIndex::cursorDidBecomeClean(MemoryIndexCursor& cursor)
 {
-    m_cleanCursors.add(&cursor);
+    m_cleanCursors.add(cursor);
 }
 
 void MemoryIndex::cursorDidBecomeDirty(MemoryIndexCursor& cursor)
 {
-    m_cleanCursors.remove(&cursor);
+    m_cleanCursors.remove(cursor);
 }
 
 void MemoryIndex::objectStoreCleared()
@@ -91,16 +91,20 @@ void MemoryIndex::objectStoreCleared()
 
 void MemoryIndex::notifyCursorsOfValueChange(const IDBKeyData& indexKey, const IDBKeyData& primaryKey)
 {
-    for (auto* cursor : copyToVector(m_cleanCursors))
-        cursor->indexValueChanged(indexKey, primaryKey);
+    for (WeakPtr cursor : copyToVector(m_cleanCursors)) {
+        if (RefPtr protectedCusor = cursor.get())
+            protectedCusor->indexValueChanged(indexKey, primaryKey);
+    }
 }
 
 void MemoryIndex::notifyCursorsOfAllRecordsChanged()
 {
-    for (auto* cursor : copyToVector(m_cleanCursors))
-        cursor->indexRecordsAllChanged();
+    for (WeakPtr cursor : copyToVector(m_cleanCursors)) {
+        if (RefPtr protectedCusor = cursor.get())
+            protectedCusor->indexRecordsAllChanged();
+    }
 
-    ASSERT(m_cleanCursors.isEmpty());
+    ASSERT(!m_cleanCursors.computeSize());
 }
 
 IDBGetResult MemoryIndex::getResultForKeyRange(IndexedDB::IndexRecordType type, const IDBKeyRangeData& range) const
@@ -262,13 +266,13 @@ void MemoryIndex::removeEntriesWithValueKey(const IDBKeyData& valueKey)
     m_records->removeEntriesWithValueKey(*this, valueKey);
 }
 
-MemoryIndexCursor* MemoryIndex::maybeOpenCursor(const IDBCursorInfo& info)
+MemoryIndexCursor* MemoryIndex::maybeOpenCursor(const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
 {
     auto result = m_cursors.add(info.identifier(), nullptr);
     if (!result.isNewEntry)
         return nullptr;
 
-    result.iterator->value = makeUnique<MemoryIndexCursor>(*this, info);
+    result.iterator->value = MemoryIndexCursor::create(*this, info, transaction);
     return result.iterator->value.get();
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -79,8 +80,7 @@ public:
 
     void objectStoreCleared();
 
-    MemoryIndexCursor* maybeOpenCursor(const IDBCursorInfo&);
-
+    MemoryIndexCursor* maybeOpenCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);
     IndexValueStore* valueStore() { return m_records.get(); }
 
     MemoryObjectStore* objectStore();
@@ -112,8 +112,8 @@ private:
     HashMap<IDBKeyData, Vector<IDBKeyData>, IDBKeyDataHash, IDBKeyDataHashTraits> m_transactionModifiedRecords;
     std::unique_ptr<IndexValueStore> m_records;
 
-    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryIndexCursor>> m_cursors;
-    HashSet<MemoryIndexCursor*> m_cleanCursors;
+    HashMap<IDBResourceIdentifier, RefPtr<MemoryIndexCursor>> m_cursors;
+    WeakHashSet<MemoryIndexCursor> m_cleanCursors;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -40,22 +40,27 @@ namespace IDBServer {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MemoryIndexCursor);
 
-MemoryIndexCursor::MemoryIndexCursor(MemoryIndex& index, const IDBCursorInfo& info)
-    : MemoryCursor(info)
+Ref<MemoryIndexCursor> MemoryIndexCursor::create(MemoryIndex& index, const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
+{
+    return adoptRef(*new MemoryIndexCursor(index, info, transaction));
+}
+
+MemoryIndexCursor::MemoryIndexCursor(MemoryIndex& index, const IDBCursorInfo& cursorInfo, MemoryBackingStoreTransaction& transaction)
+    : MemoryCursor(cursorInfo, transaction)
     , m_index(index)
 {
-    LOG(IndexedDB, "MemoryIndexCursor::MemoryIndexCursor %s", info.range().loggingString().utf8().data());
+    LOG(IndexedDB, "MemoryIndexCursor::MemoryIndexCursor %s", cursorInfo.range().loggingString().utf8().data());
 
     auto* valueStore = index.valueStore();
     if (!valueStore)
         return;
 
-    if (m_info.isDirectionForward())
-        m_currentIterator = valueStore->find(m_info.range().lowerKey, m_info.range().lowerOpen);
+    if (info().isDirectionForward())
+        m_currentIterator = valueStore->find(info().range().lowerKey, info().range().lowerOpen);
     else
-        m_currentIterator = valueStore->reverseFind(m_info.range().upperKey, m_info.duplicity(), m_info.range().upperOpen);
+        m_currentIterator = valueStore->reverseFind(info().range().upperKey, info().duplicity(), info().range().upperOpen);
 
-    if (m_currentIterator.isValid() && m_info.range().containsKey(m_currentIterator.key())) {
+    if (m_currentIterator.isValid() && info().range().containsKey(m_currentIterator.key())) {
         m_currentKey = m_currentIterator.key();
         m_currentPrimaryKey = m_currentIterator.primaryKey();
         index.cursorDidBecomeClean(*this);
@@ -72,7 +77,7 @@ void MemoryIndexCursor::currentData(IDBGetResult& getResult)
         return;
     }
 
-    if (m_info.cursorType() == IndexedDB::CursorType::KeyOnly)
+    if (info().cursorType() == IndexedDB::CursorType::KeyOnly)
         getResult = { m_currentKey, m_currentPrimaryKey };
     else {
         IDBValue value = { m_index->protectedObjectStore()->valueForKey(m_currentPrimaryKey), { }, { } };
@@ -103,18 +108,18 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
         }
 
         if (primaryKey.isValid()) {
-            if (m_info.isDirectionForward())
+            if (info().isDirectionForward())
                 m_currentIterator = valueStore->find(key, primaryKey);
             else
-                m_currentIterator = valueStore->reverseFind(key, primaryKey, m_info.duplicity());
+                m_currentIterator = valueStore->reverseFind(key, primaryKey, info().duplicity());
         } else {
-            if (m_info.isDirectionForward())
+            if (info().isDirectionForward())
                 m_currentIterator = valueStore->find(key);
             else
-                m_currentIterator = valueStore->reverseFind(key, m_info.duplicity());
+                m_currentIterator = valueStore->reverseFind(key, info().duplicity());
         }
 
-        if (m_currentIterator.isValid() && !m_info.range().containsKey(m_currentIterator.key()))
+        if (m_currentIterator.isValid() && !info().range().containsKey(m_currentIterator.key()))
             m_currentIterator.invalidate();
 
         if (!m_currentIterator.isValid()) {
@@ -147,7 +152,7 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
             return;
         }
 
-        switch (m_info.cursorDirection()) {
+        switch (info().cursorDirection()) {
         case IndexedDB::CursorDirection::Next:
             m_currentIterator = valueStore->find(m_currentKey, m_currentPrimaryKey);
             break;
@@ -155,10 +160,10 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
             m_currentIterator = valueStore->find(m_currentKey, true);
             break;
         case IndexedDB::CursorDirection::Prev:
-            m_currentIterator = valueStore->reverseFind(m_currentKey, m_currentPrimaryKey, m_info.duplicity());
+            m_currentIterator = valueStore->reverseFind(m_currentKey, m_currentPrimaryKey, info().duplicity());
             break;
         case IndexedDB::CursorDirection::Prevunique:
-            m_currentIterator = valueStore->reverseFind(m_currentKey, m_info.duplicity(), true);
+            m_currentIterator = valueStore->reverseFind(m_currentKey, info().duplicity(), true);
             break;
         }
 
@@ -180,7 +185,7 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
     ASSERT(m_currentIterator.isValid());
 
     while (count) {
-        if (m_info.duplicity() == CursorDuplicity::NoDuplicates)
+        if (info().duplicity() == CursorDuplicity::NoDuplicates)
             m_currentIterator.nextIndexEntry();
         else
             ++m_currentIterator;
@@ -191,7 +196,7 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
         --count;
     }
 
-    if (m_currentIterator.isValid() && !m_info.range().containsKey(m_currentIterator.key()))
+    if (m_currentIterator.isValid() && !info().range().containsKey(m_currentIterator.key()))
         m_currentIterator.invalidate();
 
     // Not having a valid iterator after finishing any iteration means we've reached the end of the cursor.

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h
@@ -39,13 +39,15 @@ class MemoryIndex;
 class MemoryIndexCursor : public MemoryCursor {
     WTF_MAKE_TZONE_ALLOCATED(MemoryIndexCursor);
 public:
-    MemoryIndexCursor(MemoryIndex&, const IDBCursorInfo&);
+    static Ref<MemoryIndexCursor> create(MemoryIndex&, const IDBCursorInfo&, MemoryBackingStoreTransaction&);
+
     virtual ~MemoryIndexCursor();
 
     void indexRecordsAllChanged();
     void indexValueChanged(const IDBKeyData& indexKey, const IDBKeyData& primaryKey);
 
 private:
+    MemoryIndexCursor(MemoryIndex&, const IDBCursorInfo&, MemoryBackingStoreTransaction&);
     void currentData(IDBGetResult&) final;
     void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) final;
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -523,13 +523,13 @@ void MemoryObjectStore::registerIndex(Ref<MemoryIndex>&& index)
     m_indexesByIdentifier.set(identifier, WTFMove(index));
 }
 
-MemoryObjectStoreCursor* MemoryObjectStore::maybeOpenCursor(const IDBCursorInfo& info)
+MemoryObjectStoreCursor* MemoryObjectStore::maybeOpenCursor(const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
 {
     auto result = m_cursors.add(info.identifier(), nullptr);
     if (!result.isNewEntry)
         return nullptr;
 
-    result.iterator->value = makeUnique<MemoryObjectStoreCursor>(*this, info);
+    result.iterator->value = MemoryObjectStoreCursor::create(*this, info, transaction);
     return result.iterator->value.get();
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -96,7 +96,7 @@ public:
     const IDBObjectStoreInfo& info() const { return m_info; }
     IDBObjectStoreInfo& info() { return m_info; }
 
-    MemoryObjectStoreCursor* maybeOpenCursor(const IDBCursorInfo&);
+    MemoryObjectStoreCursor* maybeOpenCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);
 
     IDBKeyDataSet* orderedKeys() { return m_orderedKeys.get(); }
 
@@ -132,7 +132,7 @@ private:
 
     HashMap<IDBIndexIdentifier, RefPtr<MemoryIndex>> m_indexesByIdentifier;
     HashMap<String, RefPtr<MemoryIndex>> m_indexesByName;
-    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryObjectStoreCursor>> m_cursors;
+    HashMap<IDBResourceIdentifier, RefPtr<MemoryObjectStoreCursor>> m_cursors;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
@@ -36,8 +36,13 @@ namespace IDBServer {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MemoryObjectStoreCursor);
 
-MemoryObjectStoreCursor::MemoryObjectStoreCursor(MemoryObjectStore& objectStore, const IDBCursorInfo& info)
-    : MemoryCursor(info)
+Ref<MemoryObjectStoreCursor> MemoryObjectStoreCursor::create(MemoryObjectStore& objectStore, const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
+{
+    return adoptRef(*new MemoryObjectStoreCursor(objectStore, info, transaction));
+}
+
+MemoryObjectStoreCursor::MemoryObjectStoreCursor(MemoryObjectStore& objectStore, const IDBCursorInfo& info, MemoryBackingStoreTransaction& transaction)
+    : MemoryCursor(info, transaction)
     , m_objectStore(objectStore)
     , m_remainingRange(info.range())
 {
@@ -76,7 +81,7 @@ void MemoryObjectStoreCursor::setFirstInRemainingRange(IDBKeyDataSet& set)
 {
     m_iterator = std::nullopt;
 
-    if (m_info.isDirectionForward()) {
+    if (info().isDirectionForward()) {
         setForwardIteratorFromRemainingRange(set);
         if (m_iterator) {
             m_remainingRange.lowerKey = **m_iterator;
@@ -191,7 +196,7 @@ void MemoryObjectStoreCursor::currentData(IDBGetResult& data)
     }
 
     m_currentPositionKey = **m_iterator;
-    if (m_info.cursorType() == IndexedDB::CursorType::KeyOnly)
+    if (info().cursorType() == IndexedDB::CursorType::KeyOnly)
         data = { m_currentPositionKey, m_currentPositionKey };
     else {
         Ref objectStore = m_objectStore.get();
@@ -225,7 +230,7 @@ void MemoryObjectStoreCursor::incrementForwardIterator(IDBKeyDataSet& set, const
         // If iterating to a key, the count passed in must be zero, as there is no way to iterate by both a count and to a key.
         ASSERT(!count);
 
-        if (!m_info.range().containsKey(key))
+        if (!info().range().containsKey(key))
             return;
 
         if ((*m_iterator)->compare(key) < 0) {
@@ -249,7 +254,7 @@ void MemoryObjectStoreCursor::incrementForwardIterator(IDBKeyDataSet& set, const
         --count;
         ++*m_iterator;
 
-        if (*m_iterator == set.end() || !m_info.range().containsKey(**m_iterator)) {
+        if (*m_iterator == set.end() || !info().range().containsKey(**m_iterator)) {
             m_iterator = std::nullopt;
             return;
         }
@@ -279,7 +284,7 @@ void MemoryObjectStoreCursor::incrementReverseIterator(IDBKeyDataSet& set, const
         // If iterating to a key, the count passed in must be zero, as there is no way to iterate by both a count and to a key.
         ASSERT(!count);
 
-        if (!m_info.range().containsKey(key))
+        if (!info().range().containsKey(key))
             return;
 
         if ((*m_iterator)->compare(key) > 0) {
@@ -309,7 +314,7 @@ void MemoryObjectStoreCursor::incrementReverseIterator(IDBKeyDataSet& set, const
         --count;
         --*m_iterator;
 
-        if (!m_info.range().containsKey(**m_iterator)) {
+        if (!info().range().containsKey(**m_iterator)) {
             m_iterator = std::nullopt;
             return;
         }
@@ -329,7 +334,7 @@ void MemoryObjectStoreCursor::iterate(const IDBKeyData& key, const IDBKeyData& p
         return;
     }
 
-    if (key.isValid() && !m_info.range().containsKey(key)) {
+    if (key.isValid() && !info().range().containsKey(key)) {
         m_currentPositionKey = { };
         outData = { };
         return;
@@ -337,7 +342,7 @@ void MemoryObjectStoreCursor::iterate(const IDBKeyData& key, const IDBKeyData& p
 
     auto* set = objectStore->orderedKeys();
     if (set) {
-        if (m_info.isDirectionForward())
+        if (info().isDirectionForward())
             incrementForwardIterator(*set, key, count);
         else
             incrementReverseIterator(*set, key, count);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h
@@ -33,18 +33,20 @@
 namespace WebCore {
 namespace IDBServer {
 
+class MemoryBackingStoreTransaction;
 class MemoryObjectStore;
 
 class MemoryObjectStoreCursor : public MemoryCursor {
     WTF_MAKE_TZONE_ALLOCATED(MemoryObjectStoreCursor);
 public:
-    MemoryObjectStoreCursor(MemoryObjectStore&, const IDBCursorInfo&);
+    static Ref<MemoryObjectStoreCursor> create(MemoryObjectStore&, const IDBCursorInfo&, MemoryBackingStoreTransaction&);
 
     void objectStoreCleared();
     void keyDeleted(const IDBKeyData&);
     void keyAdded(IDBKeyDataSet::iterator);
 
 private:
+    MemoryObjectStoreCursor(MemoryObjectStore&, const IDBCursorInfo&, MemoryBackingStoreTransaction&);
     void currentData(IDBGetResult&) final;
     void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) final;
 


### PR DESCRIPTION
#### d16c38c482d57d25a73a30aeaef9d16a16767e76
<pre>
Use smart pointer for MemoryCursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=289264">https://bugs.webkit.org/show_bug.cgi?id=289264</a>
<a href="https://rdar.apple.com/143027385">rdar://143027385</a>

Reviewed by Per Arne Vollan.

This change was originally landed in 291810@main and reverted in 291839@main since it caused crashes in IndexedDB tests.
The cause is 291810@main didn&apos;t preserve `copyToVector(m_cleanCursors)` in `MemoryIndex::notifyCursorsOfValueChange()`
and `MemoryIndex::notifyCursorsOfAllRecordsChanged()`. The copy is important because `MemoryIndex::indexValueChanged`
and `MemoryIndex::notifyCursorsOfValueChange` can lead to m_cleanCursors being modified (via
`MemoryIndex::cursorDidBecomeDirty()`). The new patch adds `copyToVector` back, and tests will no longer crash.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::cursor const):
(WebCore::IDBServer::MemoryBackingStoreTransaction::addCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp:
(WebCore::IDBServer::MemoryCursor::MemoryCursor):
(WebCore::IDBServer::MemoryCursor::~MemoryCursor):
(): Deleted.
(WebCore::IDBServer::MemoryCursor::cursorForIdentifier): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.h:
(WebCore::IDBServer::MemoryCursor::info const):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::openCursor):
(WebCore::IDBServer::MemoryIDBBackingStore::iterateCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::cursorDidBecomeClean):
(WebCore::IDBServer::MemoryIndex::cursorDidBecomeDirty):
(WebCore::IDBServer::MemoryIndex::notifyCursorsOfValueChange):
(WebCore::IDBServer::MemoryIndex::notifyCursorsOfAllRecordsChanged):
(WebCore::IDBServer::MemoryIndex::maybeOpenCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::create):
(WebCore::IDBServer::MemoryIndexCursor::MemoryIndexCursor):
(WebCore::IDBServer::MemoryIndexCursor::currentData):
(WebCore::IDBServer::MemoryIndexCursor::iterate):
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::maybeOpenCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp:
(WebCore::IDBServer::MemoryObjectStoreCursor::create):
(WebCore::IDBServer::MemoryObjectStoreCursor::MemoryObjectStoreCursor):
(WebCore::IDBServer::MemoryObjectStoreCursor::setFirstInRemainingRange):
(WebCore::IDBServer::MemoryObjectStoreCursor::currentData):
(WebCore::IDBServer::MemoryObjectStoreCursor::incrementForwardIterator):
(WebCore::IDBServer::MemoryObjectStoreCursor::incrementReverseIterator):
(WebCore::IDBServer::MemoryObjectStoreCursor::iterate):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.h:

Canonical link: <a href="https://commits.webkit.org/291909@main">https://commits.webkit.org/291909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ff0ddff2df65dfae9c3b3855740d3ce82c5978e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29278 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2830 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15562 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80943 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->