### PR TITLE
[GPUP][macOS] Platform check is not working for IOAccelerator filter

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -161,19 +161,6 @@
     (allow IOKIT_OPEN_SERVICE
         (iokit-connection "IOAccelerator"))
 
-    (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (not (equal? (param "CPU") "arm64")))
-        (allow IOKIT_OPEN_USER_CLIENT
-            (iokit-connection "IOAccelerator")
-            (apply-message-filter
-                (allow (with report) (with telemetry)
-                    iokit-async-external-method
-                    iokit-external-method
-                    iokit-external-trap)
-                (allow iokit-external-method
-                    (iokit-method-number 1 4 9 11 12 20 257))
-                (allow iokit-async-external-method
-                    (iokit-method-number 0)))))
-
     (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
         (allow IOKIT_OPEN_USER_CLIENT
             (iokit-connection "IOAccelerator")
@@ -182,6 +169,11 @@
                     iokit-async-external-method
                     iokit-external-method
                     iokit-external-trap)
+                (when (not (equal? (param "CPU") "arm64"))
+                    (allow iokit-external-method
+                        (iokit-method-number 1 4 9 11 12 20 257))
+                    (allow iokit-async-external-method
+                        (iokit-method-number 0)))
                 (allow iokit-external-method
                     (iokit-method-number 0 2 5 6 7 8 9 10 14 15 16 17 28 29 30 31 39 40 256 258 261 263 264))
                 (allow iokit-external-trap


### PR DESCRIPTION
#### 05ca05fe68cae2265e666480e99186633ae2a5c3
<pre>
[GPUP][macOS] Platform check is not working for IOAccelerator filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=289450">https://bugs.webkit.org/show_bug.cgi?id=289450</a>
<a href="https://rdar.apple.com/146580155">rdar://146580155</a>

Reviewed by Sihui Liu.

The platform check needs to be inside the message filter, otherwise it will not be applied.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/291900@main">https://commits.webkit.org/291900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/625e423d54f6fd63e82137dd9238e49873988d49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44857 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10252 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44175 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21381 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80353 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14610 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15134 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->