### PR TITLE
Add CF_BRIDGED_TYPE to CVPixelBufferRef forward declarations

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -32,7 +32,9 @@
 #include "WebGPUExternalTextureDescriptor.h"
 #include <wtf/RefPtr.h>
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+#if PLATFORM(COCOA)
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.cpp
@@ -62,10 +62,12 @@ void ExternalTextureImpl::undestroy()
     wgpuExternalTextureUndestroy(m_backing.get());
 }
 
+#if PLATFORM(COCOA)
 void ExternalTextureImpl::updateExternalTexture(CVPixelBufferRef pixelBuffer)
 {
     wgpuExternalTextureUpdate(m_backing.get(), pixelBuffer);
 }
+#endif
 
 } // namespace WebCore::WebGPU
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.h
@@ -65,7 +65,9 @@ private:
     void setLabelInternal(const String&) final;
     void destroy() final;
     void undestroy() final;
+#if PLATFORM(COCOA)
     void updateExternalTexture(CVPixelBufferRef) final;
+#endif
 
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
@@ -30,7 +30,9 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
-using CVPixelBufferRef = struct __CVBuffer*;
+#if PLATFORM(COCOA)
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
+#endif
 
 namespace WebCore::WebGPU {
 
@@ -47,7 +49,9 @@ public:
     }
     virtual void destroy() = 0;
     virtual void undestroy() = 0;
+#if PLATFORM(COCOA)
     virtual void updateExternalTexture(CVPixelBufferRef) = 0;
+#endif
 
 protected:
     ExternalTexture() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
@@ -32,7 +32,7 @@
 #include <wtf/Vector.h>
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 #endif
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -37,7 +37,9 @@
 #include <wtf/text/AtomString.h>
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+#if PLATFORM(COCOA)
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
+#endif
 typedef struct _GstSample GstSample;
 typedef const struct opaqueCMFormatDescription *CMFormatDescriptionRef;
 

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -36,7 +36,9 @@
 #include <wtf/MediaTime.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
-typedef struct __CVBuffer *CVPixelBufferRef;
+#if PLATFORM(COCOA)
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/cocoa/MediaUtilities.h
+++ b/Source/WebCore/platform/cocoa/MediaUtilities.h
@@ -30,7 +30,7 @@
 
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
 typedef struct opaqueCMSampleBuffer* CMSampleBufferRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -30,7 +30,7 @@
 #include <span>
 #include <wtf/RetainPtr.h>
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 typedef struct __CVPixelBufferPool* CVPixelBufferPoolRef;
 
 namespace webrtc {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -72,7 +72,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaPlayerF
 }
 
 #if USE(AVFOUNDATION)
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 #endif
 
 namespace WTF {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -40,7 +40,7 @@
 OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_CLASS WebAVSampleBufferStatusChangeListener;
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -56,7 +56,7 @@ OBJC_CLASS WebCoreAVFMovieObserver;
 OBJC_CLASS WebCoreAVFPullDelegate;
 
 typedef struct CGImage *CGImageRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef struct OpaqueFigVideoTarget *FigVideoTargetRef;
 typedef NSString *AVMediaCharacteristic;
 typedef double NSTimeInterval;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -48,7 +48,7 @@ OBJC_CLASS AVSampleBufferVideoRenderer;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 
 typedef struct OpaqueCMTimebase* CMTimebaseRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef struct __CVBuffer *CVOpenGLTextureRef;
 typedef struct OpaqueFigVideoTarget *FigVideoTargetRef;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -31,7 +31,7 @@
 #include <wtf/Forward.h>
 #include <wtf/TypeCasts.h>
 
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.h
@@ -42,7 +42,7 @@ OBJC_CLASS AVPlayerItem;
 OBJC_CLASS AVPlayerItemVideoOutput;
 OBJC_CLASS WebQueuedVideoOutputDelegate;
 
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -38,7 +38,7 @@
 typedef struct AudioFormatVorbisModeInfo AudioFormatVorbisModeInfo;
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
 typedef struct opaqueCMSampleBuffer* CMSampleBufferRef;
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 typedef struct OpaqueCMBlockBuffer* CMBlockBufferRef;
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -48,7 +48,7 @@ OBJC_CLASS AVSampleBufferRenderSynchronizer;
 OBJC_CLASS AVSampleBufferVideoRenderer;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WTF {
 class WorkQueue;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -41,7 +41,7 @@ OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 typedef struct opaqueCMBufferQueue *CMBufferQueueRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 typedef struct OpaqueCMTimebase* CMTimebaseRef;
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 namespace WTF {
 class WorkQueue;

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -40,7 +40,7 @@
 #include <wtf/WorkQueue.h>
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef struct __CVBuffer *CVImageBufferRef;
 typedef UInt32 VTDecodeInfoFlags;
 typedef struct OpaqueVTDecompressionSession*  VTDecompressionSessionRef;

--- a/Source/WebCore/platform/graphics/cv/CVUtilities.h
+++ b/Source/WebCore/platform/graphics/cv/CVUtilities.h
@@ -32,7 +32,7 @@
 
 using CGColorSpaceRef = struct CGColorSpace*;
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WebCore {
 class ProcessIdentity;

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -32,7 +32,7 @@
 #include <memory>
 #include <wtf/TZoneMalloc.h>
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 namespace WebCore {
 class GraphicsContextGLCocoa;

--- a/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
@@ -30,7 +30,7 @@
 #include <wtf/TZoneMalloc.h>
 
 typedef struct OpaqueVTImageRotationSession* VTImageRotationSessionRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef struct __CVPixelBufferPool* CVPixelBufferPoolRef;
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
@@ -31,7 +31,7 @@
 
 typedef struct CGImage *CGImageRef;
 typedef struct OpaqueVTPixelTransferSession* VTPixelTransferSessionRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef struct __CVPixelBufferPool *CVPixelBufferPoolRef;
 typedef struct __IOSurface *IOSurfaceRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h
@@ -31,7 +31,7 @@
 typedef struct CGColorSpace *CGColorSpaceRef;
 typedef struct CGImage* CGImageRef;
 typedef struct OpaqueVTPixelBufferConformer* VTPixelBufferConformerRef;
-typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -32,7 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -40,7 +40,7 @@
 #include <wtf/text/WTFString.h>
 
 using CGImageRef = CGImage*;
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 using IOSurfaceRef = struct __IOSurface*;
 using CMSampleBufferRef = struct opaqueCMSampleBuffer*;
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -36,7 +36,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
@@ -32,7 +32,7 @@
 #include "RealtimeIncomingVideoSource.h"
 
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace webrtc {
 enum class BufferType;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h
@@ -31,7 +31,7 @@
 #include <webrtc/api/video/video_rotation.h>
 
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.h
@@ -25,7 +25,7 @@
 
 #if USE(LIBWEBRTC)
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 using RTCVideoDecoderVTBAV1Callback = void (^)(CVPixelBufferRef, int64_t timeStamp, int64_t timeStampNs, bool);
 

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
@@ -30,7 +30,7 @@
 #include "VideoCodecType.h"
 #include <wtf/UniqueRef.h>
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 using WebRTCVideoDecoderCallback = void (^)(CVPixelBufferRef, int64_t timeStamp, int64_t timeStampNs, bool isReordered);
 
 namespace webrtc {

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -32,7 +32,7 @@
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
-using CVPixelBufferRef = struct __CVBuffer*;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 struct WGPUExternalTextureImpl {
 };

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -47,7 +47,7 @@
 #include <wtf/Vector.h>
 
 #ifdef __swift__
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 #endif
 
 typedef struct WGPUExternalTextureImpl* WGPUExternalTexture;

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
@@ -46,7 +46,7 @@
 #include <wtf/RefCounted.h>
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 #endif
 
 namespace WebCore::WebGPU {

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -54,29 +54,29 @@
 
 #if HAVE(SEC_ACCESS_CONTROL)
 
-additional_forward_declaration: typedef struct __SecAccessControl *SecAccessControlRef
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) __SecAccessControl *SecAccessControlRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecAccessControl()] SecAccessControlRef wrapped by WebKit::CoreIPCSecAccessControl {
 }
 
 #endif
 
-additional_forward_declaration: typedef struct __SecCertificate *SecCertificateRef
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) __SecCertificate *SecCertificateRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecCertificate()] SecCertificateRef wrapped by WebKit::CoreIPCSecCertificate {
 }
 
 #if HAVE(SEC_KEYCHAIN)
 
-additional_forward_declaration: typedef struct __SecKeychainItem *SecKeychainItemRef
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) __SecKeychainItem *SecKeychainItemRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecKeychainItem()] SecKeychainItemRef wrapped by WebKit::CoreIPCSecKeychainItem {
 }
 
 #endif
 
-additional_forward_declaration: typedef struct __CVBuffer *CVPixelBufferRef
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef
 [WebKitPlatform, CustomHeader,  AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->toCF()] CVPixelBufferRef wrapped by WebKit::CoreIPCCVPixelBufferRef {
 }
 
-additional_forward_declaration: typedef struct __SecTrust *SecTrustRef
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) __SecTrust *SecTrustRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecTrust()] SecTrustRef wrapped by WebKit::CoreIPCSecTrust {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
@@ -67,10 +67,12 @@ void RemoteExternalTextureProxy::undestroy()
     UNUSED_VARIABLE(sendResult);
 }
 
+#if PLATFORM(COCOA)
 void RemoteExternalTextureProxy::updateExternalTexture(CVPixelBufferRef)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
+#endif
 
 } // namespace WebKit::WebGPU
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -70,7 +70,9 @@ private:
     void setLabelInternal(const String&) final;
     void destroy() final;
     void undestroy() final;
+#if PLATFORM(COCOA)
     void updateExternalTexture(CVPixelBufferRef) final;
+#endif
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -38,7 +38,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
-typedef struct __CVBuffer* CVPixelBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 typedef struct __CVPixelBufferPool* CVPixelBufferPoolRef;
 
 namespace WebCore {


### PR DESCRIPTION
#### fbabe9b3dfc46ebf86baf6418916491a7552d32a
<pre>
Add CF_BRIDGED_TYPE to CVPixelBufferRef forward declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=289455">https://bugs.webkit.org/show_bug.cgi?id=289455</a>

Reviewed by Geoffrey Garen.

Added CF_BRIDGED_TYPE to the forward declarations of CVPixelBufferRef.
This helps with upcoming WebKit static analyzers.

* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h:
* Source/WebCore/platform/MediaSample.h:
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/cocoa/MediaUtilities.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cv/CVUtilities.h:
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h:
* Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h:
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h:
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.h:
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h:
* Source/WebGPU/WebGPU/ExternalTexture.h:
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/291917@main">https://commits.webkit.org/291917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d448d369e2f614c81049422bd077f9448fb9f86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72014 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2895 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44206 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101421 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15629 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80395 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14640 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->