### PR TITLE
[Gtk][WPE][Skia] Use SkPicture(Recorder) instead of DisplayList(Recorder) for paint command recording in multi-threaded rendering mode

### DIFF
--- a/LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html
+++ b/LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-520" />
+<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-22257" />
 <head>
     <style>
         .box {

--- a/LayoutTests/fast/multicol/transform-inside-opacity.html
+++ b/LayoutTests/fast/multicol/transform-inside-opacity.html
@@ -1,4 +1,5 @@
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-20000" />
 <style>
 .transformed { background-color:green }
 .transformed:hover { background-color:maroon }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html
@@ -7,7 +7,7 @@
     <meta name="assert" content="The background image should have opacity applied to
     it as part of the Root Element Group">
     <link rel="match" href="root-element-background-image-transparency-001-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-244800" />
     <style>
       html {
         background: url(support/transform-triangle-left.svg);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html
@@ -7,7 +7,7 @@
     <meta name="assert" content="The background image should have opacity applied to
     it as part of the Root Element Group">
     <link rel="match" href="root-element-background-image-transparency-001-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-244800" />
     <style>
       html {
         background: url(support/transform-triangle-left.svg) fixed;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-002.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1531609">
 <link rel="help" href="https://drafts.csswg.org/css-overflow/#valdef-overflow-clip">
 <link rel="match" href="clip-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000" />
 <style>
   .outer {
     width: 50px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-004.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1531609">
 <link rel="help" href="https://drafts.csswg.org/css-overflow/#valdef-overflow-clip">
 <link rel="match" href="clip-004-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000" />
 <style>
   .outer {
     width: 30px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-005.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1531609">
 <link rel="help" href="https://drafts.csswg.org/css-overflow/#valdef-overflow-clip">
 <link rel="match" href="clip-005-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000" />
 <style>
   .outer {
     width: 30px;

--- a/LayoutTests/svg/as-background-image/svg-transformed-background.html
+++ b/LayoutTests/svg/as-background-image/svg-transformed-background.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-34; totalPixels=0-744" />
 <style>
 #circle {
   position: absolute;

--- a/LayoutTests/svg/repaint/buffered-rendering-static-image.html
+++ b/LayoutTests/svg/repaint/buffered-rendering-static-image.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=1-46; totalPixels=7-512" />
+    <meta name="fuzzy" content="maxDifference=1-46; totalPixels=1-512" />
     <script src="../../fast/repaint/resources/repaint.js"></script>
     <script>
         function repaintTest() {

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
     platform/graphics/skia/SkiaPaintingEngine.h
+    platform/graphics/skia/SkiaReplayCanvas.h
     platform/graphics/skia/SkiaSpanExtras.h
 )
 

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -62,5 +62,6 @@ platform/graphics/skia/ShareableBitmapSkia.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
+platform/graphics/skia/SkiaReplayCanvas.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -431,6 +431,13 @@ IOSurface* ImageBuffer::surface()
 }
 #endif
 
+#if USE(SKIA)
+SkSurface* ImageBuffer::surface() const
+{
+    return m_backend ? m_backend->surface() : nullptr;
+}
+#endif
+
 #if USE(CAIRO)
 RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 {

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -51,6 +51,7 @@
 
 #if USE(SKIA)
 class GrDirectContext;
+class SkSurface;
 #endif
 
 namespace WTF {
@@ -64,7 +65,6 @@ class DynamicContentScalingDisplayList;
 class Filter;
 class GraphicsClient;
 class ScriptExecutionContext;
-
 class SerializedImageBuffer;
 
 struct ImageBufferCreationContext {
@@ -194,18 +194,12 @@ public:
 #endif
 
 #if USE(SKIA)
-    // During DisplayList recording a fence is created, so that we can wait until the SkSurface finished rendering
-    // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
+    SkSurface* surface() const;
+
+    // FIXME: Remove the obsolete Skia specific methods below.
     bool finishAcceleratedRenderingAndCreateFence();
     void waitForAcceleratedRenderingFenceCompletion();
-
     const GrDirectContext* skiaGrContext() const;
-
-    // Use to copy an accelerated ImageBuffer, cloning the ImageBufferSkiaAcceleratedBackend, creating
-    // a new SkSurface tied to the current thread (and thus the thread-local GrDirectContext), but re-using
-    // the existing backend render target, of this ImageBuffer. This avoids any GPU->GPU copies and has the
-    // sole purpose to abe able to access an accelerated ImageBuffer from another thread, that is not
-    // the creation thread.
     RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -52,6 +52,7 @@
 
 #if USE(SKIA)
 class GrDirectContext;
+class SkSurface;
 #endif
 
 namespace WTF {
@@ -142,9 +143,11 @@ public:
 #endif
 
 #if USE(SKIA)
+    virtual SkSurface* surface() const { return nullptr; }
+
+    // FIXME: Remove the obsolete Skia specific methods below.
     virtual bool finishAcceleratedRenderingAndCreateFence() { return false; }
     virtual void waitForAcceleratedRenderingFenceCompletion() { }
-
     virtual const GrDirectContext* skiaGrContext() const { return nullptr; }
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const;
 #endif

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -119,11 +119,10 @@ public:
     WEBCORE_EXPORT Headroom headroom() const final;
 
 #if USE(SKIA)
+    // FIXME: Remove the obsolete Skia specific methods and members below.
     bool finishAcceleratedRenderingAndCreateFence() final;
     void waitForAcceleratedRenderingFenceCompletion() final;
-
     const GrDirectContext* skiaGrContext() const final;
-
     RefPtr<NativeImage> copyAcceleratedNativeImageBorrowingBackendTexture() const final;
 #endif
 private:

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -41,12 +41,12 @@ class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBac
     WTF_MAKE_NONCOPYABLE(ImageBufferSkiaAcceleratedBackend);
 public:
     static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&, sk_sp<SkSurface>&&);
     ~ImageBufferSkiaAcceleratedBackend();
 
     static constexpr RenderingMode renderingMode = RenderingMode::Accelerated;
 
 private:
-    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&, sk_sp<SkSurface>&&);
     ImageBufferSkiaAcceleratedBackend(const Parameters&, sk_sp<SkSurface>&&);
 
     void prepareForDisplay() final;
@@ -57,9 +57,9 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
+    // FIXME: Remove the obsolete Skia specific methods and members below.
     bool finishAcceleratedRenderingAndCreateFence() final;
     void waitForAcceleratedRenderingFenceCompletion() final;
-
     const GrDirectContext* skiaGrContext() const final { return m_skiaGrContext; }
     RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const final;
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -45,6 +45,8 @@ public:
     static unsigned calculateBytesPerRow(const IntSize&);
     static size_t calculateMemoryCost(const Parameters&);
 
+    SkSurface* surface() const final { return m_surface.get(); }
+
 protected:
     ImageBufferSkiaSurfaceBackend(const Parameters&, sk_sp<SkSurface>&&, RenderingMode);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -28,10 +28,12 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Vector.h>
 #include <wtf/WorkerPool.h>
 
+class SkImage;
+
 namespace WebCore {
+
 class BitmapTexturePool;
 class CoordinatedTileBuffer;
 class GraphicsContext;
@@ -39,10 +41,6 @@ class GraphicsLayer;
 class IntRect;
 class IntSize;
 enum class RenderingMode : uint8_t;
-
-namespace DisplayList {
-class DisplayList;
-}
 
 class SkiaPaintingEngine {
     WTF_MAKE_TZONE_ALLOCATED(SkiaPaintingEngine);
@@ -72,10 +70,7 @@ public:
 
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
-    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(RenderingMode&, const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
-
-    static bool paintDisplayListIntoBuffer(Ref<CoordinatedTileBuffer>&, DisplayList::DisplayList&);
     bool paintGraphicsLayerIntoBuffer(Ref<CoordinatedTileBuffer>&, const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const;
 
     // Threaded rendering

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaReplayCanvas.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "GLFence.h"
+#include "PlatformDisplay.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaReplayCanvas);
+
+SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, SkiaImageToFenceMap&& imageToFenceMap)
+    : SkNWayCanvas(size.width(), size.height())
+    , m_imageToFenceMap(WTFMove(imageToFenceMap))
+{
+}
+
+SkiaReplayCanvas::~SkiaReplayCanvas() = default;
+
+Ref<SkiaReplayCanvas> SkiaReplayCanvas::create(const IntSize& size, SkiaImageToFenceMap&& imageToFenceMap)
+{
+    return adoptRef(*new SkiaReplayCanvas(size, WTFMove(imageToFenceMap)));
+}
+
+sk_sp<SkImage> SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage* image)
+{
+    if (!image || !image->isTextureBacked())
+        return nullptr;
+
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+    if (!glContext || !glContext->makeContextCurrent())
+        return nullptr;
+
+    if (auto fence = m_imageToFenceMap.take(image))
+        fence->serverWait();
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    if (image->isValid(grContext))
+        return nullptr;
+
+    // FIXME: Add error reporting mechanism, a failure from GetBackendTextureFromImage() should be visible / reported.
+    GrBackendTexture backendTexture;
+    if (!SkImages::GetBackendTextureFromImage(image, &backendTexture, false))
+        return nullptr;
+
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace());
+}
+
+void SkiaReplayCanvas::invokeDrawFunctionWithImage(const SkImage* image, Function<void(const SkImage*)>&& drawFunction)
+{
+    if (auto wrappedImage = waitForRenderingCompletionAndRewrapImageIfNeeded(image)) {
+        drawFunction(wrappedImage.get());
+        return;
+    }
+
+    drawFunction(image);
+}
+
+void SkiaReplayCanvas::invokeDrawFunctionWithPaint(const SkPaint& paint, Function<void(const SkPaint&)>&& drawFunction)
+{
+    auto* shader = paint.getShader();
+
+    SkMatrix localMatrix;
+    SkTileMode mode[2];
+    auto* image = shader ? shader->isAImage(&localMatrix, mode) : nullptr;
+    if (auto wrappedImage = waitForRenderingCompletionAndRewrapImageIfNeeded(image)) {
+        // FIXME: There is no way to get the SkSamplingOptions that were used to create the original shader.
+        // Add Skia API? (SkImageShader stores SkSamplingOptions but is private and not installed).
+        auto paintCopy = paint;
+        paintCopy.setShader(wrappedImage->makeShader(mode[0], mode[1], SkSamplingOptions(), &localMatrix));
+        drawFunction(paintCopy);
+        return;
+    }
+
+    drawFunction(paint);
+}
+
+void SkiaReplayCanvas::invokeDrawFunctionWithShader(const SkShader* shader, Function<void(const SkShader*)>&& drawFunction)
+{
+    SkMatrix localMatrix;
+    SkTileMode mode[2];
+    auto* image = shader ? shader->isAImage(&localMatrix, mode) : nullptr;
+    if (auto wrappedImage = waitForRenderingCompletionAndRewrapImageIfNeeded(image)) {
+        // FIXME: There is no way to get the SkSamplingOptions that were used to create the original shader.
+        // Add Skia API? (SkImageShader stores SkSamplingOptions but is private and not installed).
+        auto shaderCopy = wrappedImage->makeShader(mode[0], mode[1], SkSamplingOptions(), &localMatrix);
+        drawFunction(shaderCopy.get());
+        return;
+    }
+
+    drawFunction(shader);
+}
+
+void SkiaReplayCanvas::onClipShader(sk_sp<SkShader> shader, SkClipOp clipOp)
+{
+    invokeDrawFunctionWithShader(shader.get(), [&](const SkShader* shader) {
+        SkNWayCanvas::onClipShader(sk_ref_sp(shader), clipOp);
+    });
+}
+
+void SkiaReplayCanvas::onDrawArc(const SkRect& rect, SkScalar startAngle, SkScalar sweepAngle, bool useCenter, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawArc(rect, startAngle, sweepAngle, useCenter, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawAtlas2(const SkImage* atlas, const SkRSXform xform[], const SkRect tex[], const SkColor colors[], int count, SkBlendMode mode, const SkSamplingOptions& sampling, const SkRect* cull, const SkPaint* paint)
+{
+    invokeDrawFunctionWithImage(atlas, [&](const SkImage* atlas) {
+        SkNWayCanvas::onDrawAtlas2(atlas, xform, tex, colors, count, mode, sampling, cull, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawBehind(const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawBehind(paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawDRRect(const SkRRect& outer, const SkRRect& inner, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawDRRect(outer, inner, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawEdgeAAImageSet2(const ImageSetEntry set[], int count, const SkPoint dstClips[], const SkMatrix preViewMatrices[], const SkSamplingOptions& sampling, const SkPaint* paint, SrcRectConstraint constraint)
+{
+    if (!paint) {
+        SkNWayCanvas::onDrawEdgeAAImageSet2(set, count, dstClips, preViewMatrices, sampling, nullptr, constraint);
+        return;
+    }
+
+    invokeDrawFunctionWithPaint(*paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawEdgeAAImageSet2(set, count, dstClips, preViewMatrices, sampling, &paint, constraint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawGlyphRunList(const sktext::GlyphRunList& glyphRunList, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawGlyphRunList(glyphRunList, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawImage2(const SkImage* image, SkScalar x, SkScalar y, const SkSamplingOptions& sampling, const SkPaint* paint)
+{
+    invokeDrawFunctionWithImage(image, [&](const SkImage* image) {
+        SkNWayCanvas::onDrawImage2(image, x, y, sampling, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawImageLattice2(const SkImage* image, const Lattice& lattice, const SkRect& dst, SkFilterMode filter, const SkPaint* paint)
+{
+    invokeDrawFunctionWithImage(image, [&](const SkImage* image) {
+        SkNWayCanvas::onDrawImageLattice2(image, lattice, dst, filter, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawImageRect2(const SkImage* image, const SkRect& src, const SkRect& dst, const SkSamplingOptions& sampling, const SkPaint* paint, SrcRectConstraint constraint)
+{
+    invokeDrawFunctionWithImage(image, [&](const SkImage* image) {
+        SkNWayCanvas::onDrawImageRect2(image, src, dst, sampling, paint, constraint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawOval(const SkRect& oval, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawOval(oval, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawPaint(const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawPaint(paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawPoints(PointMode mode, size_t count, const SkPoint points[], const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawPoints(mode, count, points, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawPatch(const SkPoint cubics[12], const SkColor colors[4], const SkPoint texCoords[4], SkBlendMode blendMode, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawPatch(cubics, colors, texCoords, blendMode, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawPath(const SkPath& path, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawPath(path, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawRRect(const SkRRect& rrect, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawRRect(rrect, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawRect(const SkRect& rect, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawRect(rect, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawRegion(const SkRegion& region, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawRegion(region, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawSlug(const sktext::gpu::Slug* slug, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawSlug(slug, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawTextBlob(const SkTextBlob* blob, SkScalar x, SkScalar y, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawTextBlob(blob, x, y, paint);
+    });
+}
+
+void SkiaReplayCanvas::onDrawVerticesObject(const SkVertices* vertices, SkBlendMode mode, const SkPaint& paint)
+{
+    invokeDrawFunctionWithPaint(paint, [&](const SkPaint& paint) {
+        SkNWayCanvas::onDrawVerticesObject(vertices, mode, paint);
+    });
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "GraphicsContextSkia.h"
+#include "IntSize.h"
+#include <skia/utils/SkNWayCanvas.h>
+#include <wtf/Assertions.h>
+#include <wtf/Function.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+
+class SkImage;
+
+namespace WebCore {
+
+class GLFence;
+
+class SkiaReplayCanvas final : public SkNWayCanvas, public RefCounted<SkiaReplayCanvas> {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaReplayCanvas);
+    WTF_MAKE_NONCOPYABLE(SkiaReplayCanvas);
+public:
+    ~SkiaReplayCanvas() override;
+    static Ref<SkiaReplayCanvas> create(const IntSize&, SkiaImageToFenceMap&&);
+
+private:
+    SkiaReplayCanvas(const IntSize&, SkiaImageToFenceMap&&);
+
+    sk_sp<SkImage> waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage*);
+
+    void invokeDrawFunctionWithImage(const SkImage*, Function<void(const SkImage*)>&&);
+    void invokeDrawFunctionWithPaint(const SkPaint&, Function<void(const SkPaint&)>&&);
+    void invokeDrawFunctionWithShader(const SkShader*, Function<void(const SkShader*)>&&);
+
+    // SkNWayCanvas overrides
+    void onClipShader(sk_sp<SkShader>, SkClipOp) override;
+    void onDrawArc(const SkRect&, SkScalar, SkScalar, bool, const SkPaint&) override;
+    void onDrawAtlas2(const SkImage*, const SkRSXform[], const SkRect[], const SkColor[], int, SkBlendMode, const SkSamplingOptions&, const SkRect*, const SkPaint*) override;
+    void onDrawBehind(const SkPaint&) override;
+    void onDrawDRRect(const SkRRect&, const SkRRect&, const SkPaint&) override;
+    void onDrawEdgeAAImageSet2(const ImageSetEntry[], int, const SkPoint[], const SkMatrix[], const SkSamplingOptions&, const SkPaint*, SrcRectConstraint) override;
+    void onDrawGlyphRunList(const sktext::GlyphRunList&, const SkPaint&) override;
+    void onDrawImage2(const SkImage*, SkScalar, SkScalar, const SkSamplingOptions&, const SkPaint*) override;
+    void onDrawImageLattice2(const SkImage*, const Lattice&, const SkRect&, SkFilterMode, const SkPaint*) override;
+    void onDrawImageRect2(const SkImage*, const SkRect&, const SkRect&, const SkSamplingOptions&, const SkPaint*, SrcRectConstraint) override;
+    void onDrawOval(const SkRect&, const SkPaint&) override;
+    void onDrawPaint(const SkPaint&) override;
+    void onDrawPatch(const SkPoint[12], const SkColor[4], const SkPoint[4], SkBlendMode, const SkPaint&) override;
+    void onDrawPath(const SkPath&, const SkPaint&) override;
+    void onDrawPoints(PointMode, size_t, const SkPoint[], const SkPaint&) override;
+    void onDrawRRect(const SkRRect&, const SkPaint&) override;
+    void onDrawRect(const SkRect&, const SkPaint&) override;
+    void onDrawRegion(const SkRegion&, const SkPaint&) override;
+    void onDrawSlug(const sktext::gpu::Slug*, const SkPaint&) override;
+    void onDrawTextBlob(const SkTextBlob*, SkScalar x, SkScalar y, const SkPaint&) override;
+    void onDrawVerticesObject(const SkVertices*, SkBlendMode, const SkPaint&) override;
+
+    SkiaImageToFenceMap m_imageToFenceMap;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)


### PR DESCRIPTION
#### fca89822979c51c7dbfe019c6808fb3e8cccbefc
<pre>
[Gtk][WPE][Skia] Use SkPicture(Recorder) instead of DisplayList(Recorder) for paint command recording in multi-threaded rendering mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289456">https://bugs.webkit.org/show_bug.cgi?id=289456</a>

Reviewed by Carlos Garcia Campos.

For multi-threaded rendering Gtk/WPE ports serialized the painting
commands for a given layer and tile into a DisplayList, and dispatched
a task to a WorkerPool to replay the DisplayList in a secondary thread.

The cross-thread usage of DisplayLists is fragile, and the way we use
DisplayList wouldn&apos;t work on Apple ports, due to timing differences when
a new frame rendering starts. While DisplayList (and its ResourceHeap) protects
the referenced WebCore objects (such as Gradient / Pattern etc.) from
destruction, we&apos;re not protected from mutations between the recording of
a DisplayList and the replay, later on in time.

Furthermore, the Gtk/WPE ports currently depend on specific
synchronization primitives (creating fences in the accelerated rendering
case during recording, and waiting for the fences in the replay, before
attempting to use the fence-protected GPU resource) that were built only
into DisplayList. That was a bad idea, the Skia ports should be able to
properly paint in both CPU and GPU mode, independent of whether
DisplayList is used or not.

This PR moves the Gtk/WPE ports away from DisplayList recording to use a
Skia built-in functionality instead: SkPicture and SkPictureRecorder.
While this doesn&apos;t yet solve the mutation problem in a general way, it
removes a lot of potential problems, when we start to paint the next
frame earlier, then we do right now. Furthermore it resolves some
general design issues Kimmo detected with the current code -- namely
the sprinkling of USE(SKIA) throughout ImageBuffer/ImageBufferBackend
and NativeImage &amp; co.

Follow-up patches will remove the Skia-specific functionality that was
added to ImageBuffer &amp; co to make threaded DisplayList rendering
possible for our ports (albeit only under limited constraints, that we
want to get rid of in the long-term).

Covered by existing tests.

* LayoutTests/fast/backgrounds/background-clip-border-area-alpha.html:
Adjust for slight pixel test differences -- no visible change.
* LayoutTests/fast/multicol/transform-inside-opacity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/clip-005.html:
* LayoutTests/svg/as-background-image/svg-transformed-background.html:
* LayoutTests/svg/repaint/buffered-rendering-static-image.html:
* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::surface const):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::surface const):
(WebCore::ImageBufferBackend::waitForAcceleratedRenderingFenceCompletion):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImageInternal):
(WebCore::GraphicsContextSkia::setupFillSource):
(WebCore::GraphicsContextSkia::setupStrokeSource):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
(WebCore::createAcceleratedSurface):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
(WebCore::GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded):
(WebCore::GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded):
(WebCore::GraphicsContextSkia::drawSkiaImage): Deleted.
(WebCore::GraphicsContextSkia::drawFilteredImageBuffer): Deleted.
(WebCore::GraphicsContextSkia::setupFillSource const): Deleted.
(WebCore::GraphicsContextSkia::setupStrokeSource const): Deleted.
(WebCore::GraphicsContextSkia::drawSkiaPattern): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::postPaintingTask):
(WebCore::SkiaPaintingEngine::recordDisplayList const): Deleted.
(WebCore::SkiaPaintingEngine::paintDisplayListIntoBuffer): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp: Added.
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
(WebCore::SkiaReplayCanvas::create):
(WebCore::SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded):
(WebCore::SkiaReplayCanvas::invokeDrawFunctionWithImage):
(WebCore::SkiaReplayCanvas::invokeDrawFunctionWithPaint):
(WebCore::SkiaReplayCanvas::invokeDrawFunctionWithShader):
(WebCore::SkiaReplayCanvas::onClipShader):
(WebCore::SkiaReplayCanvas::onDrawArc):
(WebCore::SkiaReplayCanvas::onDrawAtlas2):
(WebCore::SkiaReplayCanvas::onDrawBehind):
(WebCore::SkiaReplayCanvas::onDrawDRRect):
(WebCore::SkiaReplayCanvas::onDrawEdgeAAImageSet2):
(WebCore::SkiaReplayCanvas::onDrawGlyphRunList):
(WebCore::SkiaReplayCanvas::onDrawImage2):
(WebCore::SkiaReplayCanvas::onDrawImageLattice2):
(WebCore::SkiaReplayCanvas::onDrawImageRect2):
(WebCore::SkiaReplayCanvas::onDrawOval):
(WebCore::SkiaReplayCanvas::onDrawPaint):
(WebCore::SkiaReplayCanvas::onDrawPoints):
(WebCore::SkiaReplayCanvas::onDrawPatch):
(WebCore::SkiaReplayCanvas::onDrawPath):
(WebCore::SkiaReplayCanvas::onDrawRRect):
(WebCore::SkiaReplayCanvas::onDrawRect):
(WebCore::SkiaReplayCanvas::onDrawRegion):
(WebCore::SkiaReplayCanvas::onDrawSlug):
(WebCore::SkiaReplayCanvas::onDrawTextBlob):
(WebCore::SkiaReplayCanvas::onDrawVerticesObject):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h: Added.

Canonical link: <a href="https://commits.webkit.org/292639@main">https://commits.webkit.org/292639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab77ffc5f9861606d8945ebff4ec8c0a99ebc7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24675 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73666 "Found 1 new test failure: fast/multicol/layers-split-across-columns.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83421 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82097 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28812 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->