### PR TITLE
[css-anchor-position-1] Move transient anchor positioned state to Style::TreeResolver

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
@@ -1,5 +1,5 @@
 
 
-PASS Transition when the result of anchor() changes
-PASS Transition when the result of anchor-size() changes
+FAIL Transition when the result of anchor() changes assert_equals: expected 120 but got 130
+FAIL Transition when the result of anchor-size() changes assert_equals: expected 60 but got 70
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1641,18 +1641,24 @@ const Element* RenderElement::defaultAnchor() const
 {
     if (!element())
         return nullptr;
-    auto& anchorPositionedStates = document().styleScope().anchorPositionedStates();
-    auto anchoringStateLookupResult = anchorPositionedStates.find(*element());
-    if (anchoringStateLookupResult == anchorPositionedStates.end() || !anchoringStateLookupResult->value)
+
+    auto& anchorPositionedMap = document().styleScope().anchorPositionedToAnchorMap();
+    auto it = anchorPositionedMap.find(*element());
+    if (it == anchorPositionedMap.end())
         return nullptr;
-    const auto& anchoringState = *anchoringStateLookupResult->value;
     const auto& anchorName = style().positionAnchor();
     if (!anchorName)
         return nullptr;
-    auto defaultAnchorLookupResult = anchoringState.anchorElements.find(anchorName->name);
-    if (defaultAnchorLookupResult == anchoringState.anchorElements.end())
-        return nullptr;
-    return defaultAnchorLookupResult->value.get();
+
+    for (auto& anchor : it->value) {
+        if (!anchor)
+            continue;
+        for (auto& name : anchor->style().anchorNames()) {
+            if (name.name == anchorName->name)
+                return anchor->element();
+        }
+    }
+    return nullptr;
 }
 
 const RenderElement* RenderElement::defaultAnchorRenderer() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -395,6 +395,8 @@ public:
     bool usesViewportUnits() const { return m_nonInheritedFlags.usesViewportUnits; }
     void setUsesContainerUnits() { m_nonInheritedFlags.usesContainerUnits = true; }
     bool usesContainerUnits() const { return m_nonInheritedFlags.usesContainerUnits; }
+    void setUsesAnchorFunctions();
+    bool usesAnchorFunctions() const;
 
     void setColumnStylesFromPaginationMode(PaginationMode);
     

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -846,6 +846,7 @@ constexpr Isolation RenderStyle::initialIsolation() { return Isolation::Auto; }
 inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInheritedData->isInSubtreeWithBlendMode; }
 inline bool RenderStyle::isInVisibilityAdjustmentSubtree() const { return m_rareInheritedData->isInVisibilityAdjustmentSubtree; }
 inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
+inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
 
 inline Visibility RenderStyle::usedVisibility() const
 {

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -339,6 +339,7 @@ inline void RenderStyle::setTransformOriginY(Length&& length) { SET_DOUBLY_NESTE
 inline void RenderStyle::setTransformOriginZ(float value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, z, value); }
 inline void RenderStyle::setTransformStyle3D(TransformStyle3D b) { SET_NESTED(m_nonInheritedData, rareData, transformStyle3D, static_cast<unsigned>(b)); }
 inline void RenderStyle::setTransformStyleForcedToFlat(bool b) { SET_NESTED(m_nonInheritedData, rareData, transformStyleForcedToFlat, static_cast<unsigned>(b)); }
+inline void RenderStyle::setUsesAnchorFunctions() { SET_NESTED(m_nonInheritedData, rareData, usesAnchorFunctions, true); }
 inline void RenderStyle::setUseSmoothScrolling(bool value) { SET_NESTED(m_nonInheritedData, rareData, useSmoothScrolling, value); }
 inline void RenderStyle::setUsedZIndex(int index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_usedZIndex, index, m_hasAutoUsedZIndex, false); }
 inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInheritedData, miscData, userDrag, static_cast<unsigned>(value)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -140,6 +140,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , appleVisualEffect(static_cast<unsigned>(RenderStyle::initialAppleVisualEffect()))
 #endif
     , scrollbarWidth(static_cast<unsigned>(RenderStyle::initialScrollbarWidth()))
+    , usesAnchorFunctions(false)
 {
 }
 
@@ -247,6 +248,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , appleVisualEffect(o.appleVisualEffect)
 #endif
     , scrollbarWidth(o.scrollbarWidth)
+    , usesAnchorFunctions(o.usesAnchorFunctions)
 {
 }
 
@@ -360,7 +362,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
 #if HAVE(CORE_MATERIAL)
         && appleVisualEffect == o.appleVisualEffect
 #endif
-        && scrollbarWidth == o.scrollbarWidth;
+        && scrollbarWidth == o.scrollbarWidth
+        && usesAnchorFunctions == o.usesAnchorFunctions;
 }
 
 OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
@@ -536,6 +539,8 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
 #endif
 
     LOG_IF_DIFFERENT(scrollbarWidth);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -283,6 +283,8 @@ public:
 
     unsigned scrollbarWidth : 2; // ScrollbarWidth
 
+    unsigned usesAnchorFunctions : 1;
+
 private:
     StyleRareNonInheritedData();
     StyleRareNonInheritedData(const StyleRareNonInheritedData&);

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -66,8 +66,7 @@ struct AnchorPositionedState {
 public:
     AnchorElements anchorElements;
     UncheckedKeyHashSet<AtomString> anchorNames;
-    std::optional<AnchorPositionResolutionStage> stage;
-    bool hasAnchorFunctions { false };
+    AnchorPositionResolutionStage stage;
 };
 
 using AnchorsForAnchorName = HashMap<AtomString, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
@@ -95,28 +94,29 @@ enum class PositionTryOrder : uint8_t {
 
 WTF::TextStream& operator<<(WTF::TextStream&, PositionTryOrder);
 
+using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<SingleThreadWeakPtr<RenderBoxModelObject>>, WeakPtrImplWithEventTargetData>;
+using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
+
 class AnchorPositionEvaluator {
 public:
     // Find the anchor element indicated by `elementName` and update the associated anchor resolution data.
     // Returns nullptr if the anchor element can't be found.
-    static RefPtr<Element> findAnchorForAnchorFunctionAndAttemptResolution(const BuilderState&, std::optional<ScopedName> elementName);
+    static RefPtr<Element> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
 
     using Side = std::variant<CSSValueID, double>;
     static bool propertyAllowsAnchorFunction(CSSPropertyID);
-    static std::optional<double> evaluate(const BuilderState&, std::optional<ScopedName> elementName, Side);
+    static std::optional<double> evaluate(BuilderState&, std::optional<ScopedName> elementName, Side);
 
     static bool propertyAllowsAnchorSizeFunction(CSSPropertyID);
-    static std::optional<double> evaluateSize(const BuilderState&, std::optional<ScopedName> elementName, std::optional<AnchorSizeDimension>);
+    static std::optional<double> evaluateSize(BuilderState&, std::optional<ScopedName> elementName, std::optional<AnchorSizeDimension>);
 
-    static void updateAnchorPositioningStatesAfterInterleavedLayout(const Document&);
-    static void cleanupAnchorPositionedState(Element&);
+    static void updateAnchorPositioningStatesAfterInterleavedLayout(const Document&, AnchorPositionedStates&);
     static void updateSnapshottedScrollOffsets(Document&);
-    static void updateAnchorPositionedStateForLayoutTimePositioned(Element&, const RenderStyle&);
+    static void updateAnchorPositionedStateForLayoutTimePositioned(Element&, const RenderStyle&, AnchorPositionedStates&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
-    using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
-    static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(Document&);
+    static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
 
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
     static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -85,13 +85,7 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
         return false;
     if (style.usesContainerUnits())
         return false;
-
-    // An anchor-positioned element needs to first be resolved in order to gather
-    // relevant anchor-names. Style & layout interleaving uses that information to find
-    // the relevant anchors that this element will be positioned relative to. Then, the
-    // anchor-positioned element will be resolved once again, this time with the anchor
-    // information needed to fully resolve the element.
-    if (element.document().styleScope().anchorPositionedStates().contains(element))
+    if (style.usesAnchorFunctions())
         return false;
 
     // Getting computed style after a font environment change but before full style resolution may involve styles with non-current fonts.

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -34,6 +34,7 @@
 #include "RuleSet.h"
 #include "SelectorChecker.h"
 #include "StyleForVisitedLink.h"
+#include "TreeResolutionState.h"
 #include <wtf/BitSet.h>
 
 namespace WebCore {
@@ -73,6 +74,7 @@ struct BuilderContext {
     const RenderStyle& parentStyle;
     const RenderStyle* rootElementStyle = nullptr;
     RefPtr<const Element> element = nullptr;
+    CheckedPtr<TreeResolutionState> treeResolutionState { };
     std::optional<BuilderPositionTryFallback> positionTryFallback { };
 };
 
@@ -138,6 +140,7 @@ public:
 
     Ref<Calculation::RandomKeyMap> randomKeyMap(bool perElement) const;
 
+    AnchorPositionedStates* anchorPositionedStates() { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }
     const std::optional<BuilderPositionTryFallback>& positionTryFallback() const { return m_context.positionTryFallback; }
 
 private:
@@ -160,7 +163,7 @@ private:
     CSSToStyleMap m_styleMap;
 
     RenderStyle& m_style;
-    const BuilderContext m_context;
+    BuilderContext m_context;
 
     const CSSToLengthConversionData m_cssToLengthConversionData;
 

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -28,6 +28,7 @@
 #include "MediaQueryEvaluator.h"
 #include "RuleSet.h"
 #include "StyleScopeRuleSets.h"
+#include "TreeResolutionState.h"
 #include <memory>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
@@ -80,6 +81,8 @@ struct ResolutionContext {
     // This needs to be provided during style resolution when up-to-date document element style is not available via DOM.
     const RenderStyle* documentElementStyle { nullptr };
     SelectorMatchingState* selectorMatchingState { nullptr };
+    CheckedPtr<TreeResolutionState> treeResolutionState { };
+
     bool isSVGUseTreeRoot { false };
 };
 
@@ -168,7 +171,7 @@ private:
     class State;
 
     State initializeStateAndStyle(const Element&, const ResolutionContext&);
-    BuilderContext builderContext(const State&);
+    BuilderContext builderContext(State&);
 
     void applyMatchedProperties(State&, const MatchResult&);
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -996,7 +996,7 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
     if (m_document->renderView()->anchors().isEmptyIgnoringNullReferences())
         return false;
 
-    auto anchorMap = AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(m_document);
+    auto anchorMap = AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(m_anchorPositionedToAnchorMap);
 
     for (auto& anchorRenderer : m_document->renderView()->anchors()) {
         auto rect = anchorRenderer.absoluteBoundingBoxRect();
@@ -1117,23 +1117,12 @@ Element* hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
     return host;
 }
 
-void Scope::resetAnchorPositioningStateBeforeStyleResolution()
-{
-    // FIXME: Move this transient state to TreeResolver.
-    for (auto elementAndState : m_anchorPositionedStates) {
-        elementAndState.value->anchorNames.clear();
-        elementAndState.value->stage = { };
-        elementAndState.value->hasAnchorFunctions = false;
-    }
-}
-
 void Scope::updateAnchorPositioningStateAfterStyleResolution()
 {
     AnchorPositionEvaluator::updateSnapshottedScrollOffsets(m_document);
 
-    m_anchorPositionedStates.removeIf([](auto& elementAndState) {
-        // Remove if we have no anchors after initial resolution.
-        return elementAndState.value->stage && elementAndState.value->anchorNames.isEmpty();
+    m_anchorPositionedToAnchorMap.removeIf([](auto& elementAndState) {
+        return elementAndState.value.isEmpty();
     });
 }
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -52,15 +52,16 @@ class CSSCounterStyleRegistry;
 class CSSStyleSheet;
 class Document;
 class Element;
-class WeakPtrImplWithEventTargetData;
 class HTMLSlotElement;
 class Node;
 class ProcessingInstruction;
+class RenderBoxModelObject;
 class StyleSheet;
 class StyleSheetContents;
 class StyleSheetList;
 class ShadowRoot;
 class TreeScope;
+class WeakPtrImplWithEventTargetData;
 
 namespace Style {
 
@@ -157,9 +158,8 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
-    AnchorPositionedStates& anchorPositionedStates() { return m_anchorPositionedStates; }
-    const AnchorPositionedStates& anchorPositionedStates() const { return m_anchorPositionedStates; }
-    void resetAnchorPositioningStateBeforeStyleResolution();
+    AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() { return m_anchorPositionedToAnchorMap; }
+    const AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() const { return m_anchorPositionedToAnchorMap; }
     void updateAnchorPositioningStateAfterStyleResolution();
 
 private:
@@ -264,7 +264,7 @@ private:
     // FIXME: These (and some things above) are only relevant for the root scope.
     UncheckedKeyHashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 
-    AnchorPositionedStates m_anchorPositionedStates;
+    AnchorPositionedToAnchorMap m_anchorPositionedToAnchorMap;
 };
 
 HTMLSlotElement* assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -264,6 +264,8 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
 
     if (style->containerType() != ContainerType::Normal)
         return false;
+    if (style->usesAnchorFunctions())
+        return false;
 
     if (candidateElement.elementData() != element.elementData()) {
         // Attributes that are optimized as "common attribute selectors".
@@ -291,9 +293,6 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
 #endif
 
     if (&candidateElement == m_document->activeModalDialog() || &element == m_document->activeModalDialog())
-        return false;
-
-    if (!m_document->styleScope().anchorPositionedStates().isEmptyIgnoringNullReferences())
         return false;
 
     if (candidateElement.isInTopLayer() || element.isInTopLayer())

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -33,6 +33,7 @@
 #include "StyleSharingResolver.h"
 #include "StyleUpdate.h"
 #include "Styleable.h"
+#include "TreeResolutionState.h"
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 
@@ -84,9 +85,9 @@ private:
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
     ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, Change, const ResolutionContext&, IsInDisplayNoneTree = IsInDisplayNoneTree::No);
-    std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
-    std::unique_ptr<RenderStyle> resolveAfterChangeStyleForNonAnimated(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
-    std::unique_ptr<RenderStyle> resolveAgainInDifferentContext(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, std::optional<BuilderPositionTryFallback>&&, const ResolutionContext&) const;
+    std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
+    std::unique_ptr<RenderStyle> resolveAfterChangeStyleForNonAnimated(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
+    std::unique_ptr<RenderStyle> resolveAgainInDifferentContext(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, std::optional<BuilderPositionTryFallback>&&, const ResolutionContext&);
     const RenderStyle& parentAfterChangeStyle(const Styleable&, const ResolutionContext&) const;
 
     UncheckedKeyHashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const UncheckedKeyHashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
@@ -169,6 +170,9 @@ private:
     UncheckedKeyHashMap<Ref<Element>, std::optional<QueryContainerState>> m_queryContainerStates;
     bool m_hasUnresolvedQueryContainers { false };
     bool m_hasUnresolvedAnchorPositionedElements { false };
+
+    // This state gets passes to the style builder and holds state for a single tree resolution, including over any interleaving.
+    TreeResolutionState m_treeResolutionState;
 
     struct PositionOptions {
         std::unique_ptr<RenderStyle> originalStyle;

--- a/Source/WebCore/style/TreeResolutionState.h
+++ b/Source/WebCore/style/TreeResolutionState.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AnchorPositionEvaluator.h"
+#include <wtf/CheckedPtr.h>
+
+namespace WebCore {
+namespace Style {
+
+// This state has lifetime of a single style resolution cycle, including any layout interleaving.
+struct TreeResolutionState : public CanMakeCheckedPtr<TreeResolutionState> {
+    AnchorPositionedStates anchorPositionedStates;
+
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(TreeResolutionState);
+};
+
+}
+}


### PR DESCRIPTION
#### 77c0588b85e96d2ca07d6e385d6d28f64ac74dd1
<pre>
[css-anchor-position-1] Move transient anchor positioned state to Style::TreeResolver
<a href="https://bugs.webkit.org/show_bug.cgi?id=289457">https://bugs.webkit.org/show_bug.cgi?id=289457</a>
<a href="https://rdar.apple.com/146646630">rdar://146646630</a>

Reviewed by Alan Baradlay.

Transient state is only needed during a single style resolution/interleaving round.
It shouldn&apos;t&apos; be kept around otherwise.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt:

The PASSes here were spurious, transitions are not working yet.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::defaultAnchor const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usesAnchorFunctions const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setUsesAnchorFunctions):

Add a style bit for tracking if the style uses anchor functions. These disallow caching.

* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):

Access tree resolution scoped state via BuilderState.
Set the anchor function style bit.

(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):
(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):
(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):
(WebCore::Style::AnchorPositionEvaluator::cleanupAnchorPositionedState): Deleted.

Nothing to clean up anymore.

* Source/WebCore/style/AnchorPositionEvaluator.h:

The stage is no longer optional&lt;&gt; since the states only exist during style resolution.
hasAnchorFunctions bit is replaced by RenderStyle::usesAnchorFunctions.

(): Deleted.
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::anchorPositionedStates):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::State):
(WebCore::Style::Resolver::State::treeResolutionState):
(WebCore::Style::Resolver::initializeStateAndStyle):
(WebCore::Style::Resolver::builderContext):

Pass the TreeResolutionState via context.

(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::styleForPage):
(WebCore::Style::Resolver::pseudoStyleRulesForElement):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):
(WebCore::Style::Scope::updateAnchorPositioningStateAfterStyleResolution):
(WebCore::Style::Scope::resetAnchorPositioningStateBeforeStyleResolution): Deleted.
* Source/WebCore/style/StyleScope.h:

The only persistent state is now the anchored-&gt;anchor map.

* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::TreeResolver):
(WebCore::Style::TreeResolver::makeResolutionContext):

Pass the TreeResolutionState via context.

(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):
(WebCore::Style::TreeResolver::makeResolutionContextForInheritedFirstLine):
(WebCore::Style::TreeResolver::resolveStartingStyle):
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::tryChoosePositionOption):
(WebCore::Style::TreeResolver::resolveStartingStyle const): Deleted.
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated const): Deleted.
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext const): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/TreeResolutionState.h: Added.

Add a struct to hold state that stays current thought a single style resolution cycle, including interleaving,
and is passed to the style builder.

For now it only contains the anchor positioned state.

Canonical link: <a href="https://commits.webkit.org/291898@main">https://commits.webkit.org/291898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1125f12c1db57bfd601f40244ee1381d4c99777

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10564 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101383 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15595 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14607 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26542 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->