### PR TITLE
[css-anchor-position-1] Support transitions with anchor functions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition of anchor() when changing target anchor element name assert_equals: expected 300 but got 400
-FAIL Transition of anchor-size() when changing target anchor element name assert_equals: expected 150 but got 100
+PASS Transition of anchor() when changing target anchor element name
+PASS Transition of anchor-size() when changing target anchor element name
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt
@@ -1,5 +1,5 @@
 Anchor1
 Anchor2
 
-FAIL Transition when position-anchor changes assert_equals: expected 25 but got 50
+PASS Transition when position-anchor changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Transition when the result of anchor() changes assert_equals: expected 120 but got 130
-FAIL Transition when the result of anchor-size() changes assert_equals: expected 60 but got 70
+PASS Transition when the result of anchor() changes
+PASS Transition when the result of anchor-size() changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Anchored popover ::backdrop transitioning opacity with @starting-style
+FAIL Anchored popover ::backdrop transitioning opacity with @starting-style assert_equals: expected "0" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL No transition for initial style with @position-try assert_equals: expected "50px" but got "30px"
+PASS No transition for initial style with @position-try
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Transition to a flipped state
-FAIL Transition to an unflipped state assert_equals: expected 275 but got 300
+PASS Transition to an unflipped state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/after-change-style-inherited-try-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/after-change-style-inherited-try-fallback-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Position fallback correctly applied to after-change style assert_equals: Transitioning from !important width to fallback width expected 250 but got 200
+FAIL Position fallback correctly applied to after-change style assert_equals: #inner halfway between black and lime expected "rgb(0, 128, 0)" but got "rgb(64, 64, 0)"
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4474,9 +4474,6 @@ const RenderStyle* Element::renderOrDisplayContentsStyle() const
 const RenderStyle* Element::renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (pseudoElementIdentifier) {
-        if (RefPtr pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementIdentifier->pseudoId))
-            return pseudoElement->renderOrDisplayContentsStyle();
-
         if (auto* style = renderOrDisplayContentsStyle()) {
             if (auto* cachedPseudoStyle = style->getCachedPseudoStyle(*pseudoElementIdentifier))
                 return cachedPseudoStyle;

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -155,6 +155,13 @@ private:
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::optional<ResolvedStyle> tryChoosePositionOption(const Styleable&, const RenderStyle* existingStyle);
 
+    // This returns the style that was in effect (applied to the render tree) before we started the style resolution.
+    // Layout interleaving may cause different styles to be applied during the style resolution.
+    const RenderStyle* beforeResolutionStyle(const Element&, std::optional<PseudoElementIdentifier>);
+    void saveBeforeResolutionStyleForInterleaving(const Element&);
+
+    bool hasUnresolvedAnchorPosition(const Element&) const;
+
     struct QueryContainerState {
         Change change { Change::None };
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
@@ -173,6 +180,7 @@ private:
 
     // This state gets passes to the style builder and holds state for a single tree resolution, including over any interleaving.
     TreeResolutionState m_treeResolutionState;
+    HashMap<Ref<const Element>, std::unique_ptr<RenderStyle>> m_savedBeforeResolutionStylesForInterleaving;
 
     struct PositionOptions {
         std::unique_ptr<RenderStyle> originalStyle;


### PR DESCRIPTION
#### 2e762d0b3dbe3b07783143537646a3cee73c58ec
<pre>
[css-anchor-position-1] Support transitions with anchor functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=289464">https://bugs.webkit.org/show_bug.cgi?id=289464</a>
<a href="https://rdar.apple.com/146663067">rdar://146663067</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-default-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::renderOrDisplayContentsStyle const):

Remove an unncesary branch, ::before and ::after can be found from the parent style like the rest of the pseudo elements.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Use the style as it was before the first layout interleaving round as the transition starting style.
Don&apos;t resolve transitions and animations until anchors are fully resolved.

(WebCore::Style::TreeResolver::resolve):

Save the original render tree style before entering interleaving so we can look it up later.
Interleaving commits a temporary style to the render tree so we lose it otherwise.

(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::beforeResolutionStyle):
(WebCore::Style::TreeResolver::saveBeforeResolutionStyleForInterleaving):
(WebCore::Style::TreeResolver::hasUnresolvedAnchorPosition const):

Add a helper.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/291910@main">https://commits.webkit.org/291910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6515e33e9ac7a24380eeeed99ede1ba86d07fb9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99375 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22376 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97358 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/52343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10287 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44204 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101419 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21411 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24935 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21394 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->