### PR TITLE
[Adwaita] Fix placement of textfield arrow with VerticalWritingMode

### DIFF
--- a/Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp
@@ -86,11 +86,22 @@ void TextFieldAdwaita::draw(GraphicsContext& graphicsContext, const FloatRounded
     if (style.states.contains(ControlStyle::State::ListButton)) {
         auto zoomedArrowSize = menuListButtonArrowSize * style.zoomFactor;
         FloatRect arrowRect = borderRect.rect();
-        if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
-            arrowRect.move(textFieldBorderSize * 2, 0);
-        else
-            arrowRect.move(arrowRect.width() - (zoomedArrowSize + textFieldBorderSize * 2), 0);
-        arrowRect.setWidth(zoomedArrowSize);
+        auto borderWidth = arrowRect.width();
+        auto borderHeight = arrowRect.height();
+        arrowRect.setSize({ zoomedArrowSize, zoomedArrowSize });
+
+        if (!style.states.contains(ControlStyle::State::VerticalWritingMode)) {
+            auto centerY = (borderHeight / 2) - (zoomedArrowSize / 2);
+
+            if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
+                arrowRect.move(textFieldBorderSize, centerY);
+            else
+                arrowRect.move(borderWidth - zoomedArrowSize + textFieldBorderSize, centerY);
+        } else {
+            auto centerX = (borderWidth / 2) - (zoomedArrowSize / 2);
+            arrowRect.move(centerX, borderHeight - zoomedArrowSize + textFieldBorderSize);
+        }
+
         bool useDarkAppearance = style.states.contains(ControlStyle::State::DarkAppearance);
         Adwaita::paintArrow(graphicsContext, arrowRect, Adwaita::ArrowDirection::Down, useDarkAppearance);
     }


### PR DESCRIPTION
#### 02548798b5b8a8a4156eb94463470b67aa0203a7
<pre>
[Adwaita] Fix placement of textfield arrow with VerticalWritingMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289466">https://bugs.webkit.org/show_bug.cgi?id=289466</a>

Reviewed by Michael Catanzaro.

This properly sizes arrowRect and places it at the end.

* Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp:
(WebCore::TextFieldAdwaita::draw):

Canonical link: <a href="https://commits.webkit.org/291916@main">https://commits.webkit.org/291916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb1694278bdc431c019f12014cfe9ae9460d73c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99349 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29335 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10573 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52319 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10262 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44183 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24915 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14626 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15148 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->