### PR TITLE
[MSE][GStreamer] Assign track indices per-MediaSource

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -36,6 +36,9 @@
 
 namespace WebCore {
 
+typedef MediaSourcePrivateGStreamer::StreamType StreamType;
+typedef MediaSourcePrivateGStreamer::RegisteredTrack RegisteredTrack;
+
 #if !LOG_DISABLED || ENABLE(ENCRYPTED_MEDIA)
 struct PadProbeInformation {
     AppendPipeline* appendPipeline;
@@ -57,9 +60,6 @@ public:
     MediaPlayerPrivateGStreamerMSE* playerPrivate() { return m_playerPrivate; }
 
 private:
-    // Similar to TrackPrivateBaseGStreamer::TrackType, but with a new value (Invalid) for when the codec is
-    // not supported on this system, which should result in ParsingFailed error being thrown in SourceBuffer.
-    enum StreamType { Audio, Video, Text, Unknown, Invalid };
 #ifndef GST_DISABLE_GST_DEBUG
     static const char * streamTypeToString(StreamType);
     static const char * streamTypeToStringLower(StreamType);
@@ -118,7 +118,7 @@ private:
     void handleErrorConditionFromStreamingThread();
 
     void hookTrackEvents(Track&);
-    static std::tuple<GRefPtr<GstCaps>, AppendPipeline::StreamType, FloatSize> parseDemuxerSrcPadCaps(GstCaps*);
+    static std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> parseDemuxerSrcPadCaps(GstCaps*);
     Ref<WebCore::TrackPrivateBase> makeWebKitTrack(Track& appendPipelineTrack, int trackIndex, TrackID);
     void appsinkCapsChanged(Track&);
     void appsinkNewSample(const Track&, GRefPtr<GstSample>&&);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -216,44 +216,43 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
     player->startSource(tracks);
 }
 
-TrackID MediaSourcePrivateGStreamer::registerTrackId(TrackID preferredId)
+MediaSourcePrivateGStreamer::RegisteredTrack MediaSourcePrivateGStreamer::registerTrack(TrackID preferredId, StreamType streamType)
 {
     ASSERT(isMainThread());
     RefPtr player = platformPlayer();
 
-    if (m_trackIdRegistry.add(preferredId).isNewEntry) {
-        if (player)
-            GST_DEBUG_OBJECT(player->pipeline(), "Registered new Track ID: %" PRIu64 "", preferredId);
-        return preferredId;
-    }
+    TrackID assignedId = preferredId;
 
     // If the ID is already known, assign one starting at 100 - this helps avoid a snowball effect
     // where each following ID would now need to be offset by 1.
-    auto maxRegisteredId = std::max_element(m_trackIdRegistry.begin(), m_trackIdRegistry.end());
-    auto assignedId = std::max((TrackID) 100, *maxRegisteredId + 1);
-
-    [[maybe_unused]] auto result = m_trackIdRegistry.add(assignedId);
-    ASSERT(result.isNewEntry);
-    if (player)
-        GST_DEBUG_OBJECT(player->pipeline(), "Registered new Track ID: %" PRIu64 " (preferred ID would have been %" PRIu64 ")", assignedId, preferredId);
-
-    return assignedId;
-}
-
-bool MediaSourcePrivateGStreamer::unregisterTrackId(TrackID trackId)
-{
-    ASSERT(isMainThread());
-
-    bool res = m_trackIdRegistry.remove(trackId);
-
-    if (RefPtr player = this->platformPlayer()) {
-        if (res)
-            GST_DEBUG_OBJECT(player->pipeline(), "Unregistered Track ID: %" PRIu64 "", trackId);
-        else
-            GST_WARNING_OBJECT(player->pipeline(), "Failed to unregister unknown Track ID: %" PRIu64 "", trackId);
+    if (m_trackRegistry.contains(assignedId)) {
+        auto maxRegisteredId = std::max_element(m_trackRegistry.keys().begin(), m_trackRegistry.keys().end());
+        assignedId = std::max((TrackID) 100, *maxRegisteredId + 1);
     }
 
-    return res;
+    // Ensure that indices are sequential by track type.
+    size_t assignedIndex = std::count_if(m_trackRegistry.values().begin(), m_trackRegistry.values().end(), [streamType](RegisteredTrack& other) -> bool {
+        return other.streamType == streamType;
+    });
+
+    RegisteredTrack info = RegisteredTrack(assignedId, assignedIndex, streamType);
+    [[maybe_unused]] auto result = m_trackRegistry.add(assignedId, info);
+    ASSERT(result.isNewEntry);
+
+    if (player)
+        GST_DEBUG_OBJECT(player->pipeline(), "Registered new Track with index %" PRIu64 " and ID %" PRIu64 " (preferred ID was %" PRIu64 ")", assignedIndex, assignedId, preferredId);
+
+    return info;
+}
+
+void MediaSourcePrivateGStreamer::unregisterTrack(TrackID trackId)
+{
+    ASSERT(isMainThread());
+    ASSERT(m_trackRegistry.contains(trackId));
+    m_trackRegistry.remove(trackId);
+
+    if (RefPtr player = platformPlayer())
+        GST_DEBUG_OBJECT(player->pipeline(), "Unregistered Track ID: %" PRIu64 "", trackId);
 }
 
 void MediaSourcePrivateGStreamer::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -77,8 +77,33 @@ public:
 
     void detach();
 
-    TrackID registerTrackId(TrackID);
-    bool unregisterTrackId(TrackID);
+    // Similar to TrackPrivateBaseGStreamer::TrackType, but with a new value (Invalid) for when the codec is
+    // not supported on this system, which should result in ParsingFailed error being thrown in SourceBuffer.
+    enum StreamType { Audio, Video, Text, Unknown, Invalid };
+
+    struct RegisteredTrack {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED(RegisteredTrack);
+    public:
+
+        RegisteredTrack()
+            : id(0)
+            , index(0)
+            , streamType(Invalid)
+        { }
+
+        RegisteredTrack(TrackID id, size_t index, StreamType streamType)
+            : id(id)
+            , index(index)
+            , streamType(streamType)
+        { }
+
+        TrackID id;
+        size_t index;
+        StreamType streamType;
+    };
+
+    RegisteredTrack registerTrack(TrackID, StreamType);
+    void unregisterTrack(TrackID);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
@@ -102,10 +127,18 @@ private:
 
     uint64_t m_nextSourceBufferID { 0 };
 
-    // Stores known track IDs, so we can work around ID collisions between multiple source buffers.
-    // The registry is placed here to enforce ID uniqueness specifically by player, not by process,
-    // since its not an issue if multiple players use the same ID, and we want to preserve IDs as much as possible.
-    UncheckedKeyHashSet<TrackID, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackIdRegistry;
+    // Stores info on known tracks, so we can:
+    // 1) Work around collision in track ID between multiple source buffers.
+    //    The registry is placed here to enforce ID uniqueness specifically by player, not by process,
+    //    since it's not an issue if multiple players use the same ID, and we want to preserve IDs as much as possible.
+    // 2) Assign indices sequentially by track type.
+    //    This means the first track of a type will always have index 0,
+    //    the next of the same type will be assigned 1, and so on, which:
+    //    - matches how MediaPlayerPrivateGStreamer assigns indices
+    //    - how {Audio,Video,Text}TrackList stores its tracks
+    //    - prevents a potential out-of-bounds crash in TextTrackList
+    //    Just like for IDs, we store known indices here to enforce uniqueness by player.
+    UncheckedKeyHashMap<TrackID, RegisteredTrack, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackRegistry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -283,26 +283,24 @@ WTFLogChannel& SourceBufferPrivateGStreamer::logChannel() const
 }
 #endif
 
-std::optional<TrackID> SourceBufferPrivateGStreamer::tryRegisterTrackId(TrackID preferredId)
+RegisteredTrack SourceBufferPrivateGStreamer::registerTrack(TrackID preferredId, StreamType streamType)
 {
     ASSERT(isMainThread());
 
     RefPtr mediaSource = m_mediaSource.get();
-    if (!mediaSource)
-        return std::nullopt;
+    ASSERT(mediaSource);
 
-    return downcast<MediaSourcePrivateGStreamer>(mediaSource)->registerTrackId(preferredId);
+    return downcast<MediaSourcePrivateGStreamer>(mediaSource)->registerTrack(preferredId, streamType);
 }
 
-bool SourceBufferPrivateGStreamer::tryUnregisterTrackId(TrackID trackId)
+void SourceBufferPrivateGStreamer::unregisterTrack(TrackID trackId)
 {
     ASSERT(isMainThread());
 
     RefPtr mediaSource = m_mediaSource.get();
-    if (!mediaSource)
-        return false;
+    ASSERT(mediaSource);
 
-    return downcast<MediaSourcePrivateGStreamer>(mediaSource)->unregisterTrackId(trackId);
+    downcast<MediaSourcePrivateGStreamer>(mediaSource)->unregisterTrack(trackId);
 }
 
 size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -50,6 +50,8 @@
 namespace WebCore {
 
 using TrackID = uint64_t;
+typedef MediaSourcePrivateGStreamer::StreamType StreamType;
+typedef MediaSourcePrivateGStreamer::RegisteredTrack RegisteredTrack;
 
 class AppendPipeline;
 class MediaSourcePrivateGStreamer;
@@ -81,8 +83,8 @@ public:
 
     ContentType type() const { return m_type; }
 
-    std::optional<TrackID> tryRegisterTrackId(TrackID);
-    bool tryUnregisterTrackId(TrackID);
+    RegisteredTrack registerTrack(TrackID, StreamType);
+    void unregisterTrack(TrackID);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }


### PR DESCRIPTION
#### 35206c679b712981303a4d5f826d5543a1fa0df2
<pre>
[MSE][GStreamer] Assign track indices per-MediaSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=289476">https://bugs.webkit.org/show_bug.cgi?id=289476</a>

Reviewed by Philippe Normand.

Similar to track IDs, track indices (for a given type of track) should be unique
per MediaPlayer/MediaSource.

For that reason, this changes the track ID registry on MediaSourcePrivateGStreamer
to additionally hold each track&apos;s index and streamType, so the logic for assigning
indices to can be moved out of AppendPipeline. Instead, registering the track now
returns a RegisteredTrack structure informing it of the track&apos;s final ID and index.

All the (un)registerTrackId methods, along with m_trackIdRegistry, were renamed,
to more accurately express that they are not dealing with just the IDs anymore.

Finally, the StreamType enum was moved to MediaSourcePrivateGStreamer as well,
since the registry needs to keep track of each track&apos;s type to assign indices.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::~AppendPipeline):
(WebCore::AppendPipeline::appsinkNewSample):
(WebCore::AppendPipeline::parseDemuxerSrcPadCaps):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::AppendPipeline::tryCreateTrackFromPad): Index is now assigned by track registry.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::registerTrack): Aside from IDs, also determines index now.
(WebCore::MediaSourcePrivateGStreamer::unregisterTrack):
  ASSERT() that the given ID is known, instead of just returning false.
  If the ID was never registered or unregistered twice, that would be a bug.
(WebCore::MediaSourcePrivateGStreamer::registerTrackId): Deleted.
(WebCore::MediaSourcePrivateGStreamer::unregisterTrackId): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
  Move StreamType here, and create a new RegisteredTrack struct to store ID, index, and type.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::registerTrack):
  Just ASSERT() that mediaSource exists, there should be no reasonable scenario where it would be missing at this point.
(WebCore::SourceBufferPrivateGStreamer::unregisterTrack): Ditto.
(WebCore::SourceBufferPrivateGStreamer::tryRegisterTrackId): Deleted.
(WebCore::SourceBufferPrivateGStreamer::tryUnregisterTrackId): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/292009@main">https://commits.webkit.org/292009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2ee237f80cded60986835ab1c0fdd648edd373d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72017 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29350 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10603 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85216 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101424 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80391 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2318 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14643 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21087 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->