### PR TITLE
[Adwaita] Fix arrow placement in menulist with VerticalWritingMode

### DIFF
--- a/Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp
@@ -49,12 +49,21 @@ void MenuListAdwaita::draw(GraphicsContext& graphicsContext, const FloatRoundedR
 
     auto zoomedArrowSize = menuListButtonArrowSize * style.zoomFactor;
     FloatRect fieldRect = borderRect.rect();
-    fieldRect.inflate(menuListButtonBorderSize);
-    if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
-        fieldRect.move(menuListButtonPadding, 0);
-    else
-        fieldRect.move(fieldRect.width() - (zoomedArrowSize + menuListButtonPadding), 0);
-    fieldRect.setWidth(zoomedArrowSize);
+    auto borderWidth = fieldRect.width();
+    auto borderHeight = fieldRect.height();
+    fieldRect.setSize({ zoomedArrowSize, zoomedArrowSize });
+
+    if (!style.states.contains(ControlStyle::State::VerticalWritingMode)) {
+        auto centerY = (borderHeight / 2) - (zoomedArrowSize / 2);
+
+        if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
+            fieldRect.move(menuListButtonPadding, centerY);
+        else
+            fieldRect.move(borderWidth - (zoomedArrowSize + menuListButtonPadding), centerY);
+    } else {
+        auto centerX = (borderWidth / 2) - (zoomedArrowSize / 2);
+        fieldRect.move(centerX, borderHeight - (zoomedArrowSize + menuListButtonPadding));
+    }
     Adwaita::paintArrow(graphicsContext, fieldRect, Adwaita::ArrowDirection::Down, style.states.contains(ControlStyle::State::DarkAppearance));
 
     if (style.states.contains(ControlStyle::State::Focused))


### PR DESCRIPTION
#### 8526139c8f35e81f4a0a5fd286ff21d6d1f33170
<pre>
[Adwaita] Fix arrow placement in menulist with VerticalWritingMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289482">https://bugs.webkit.org/show_bug.cgi?id=289482</a>

Reviewed by Michael Catanzaro.

This matches the placement of the arrow in TextFieldAdwaita.

* Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp:
(WebCore::MenuListAdwaita::draw):

Canonical link: <a href="https://commits.webkit.org/291951@main">https://commits.webkit.org/291951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e6bdb2e85dabe3d09aea5c91e82187853913144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22383 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72019 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29349 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97365 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10605 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81021 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14645 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15166 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26582 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->