### PR TITLE
REGRESSION(288484@main): ApplePaySetup.getSetupFeatures() fails because PKPaymentSetupFeature is dropped on the floor during IPC serialization

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -59,6 +59,7 @@ OBJC_CLASS PKContact;
 OBJC_CLASS PKDateComponentsRange;
 OBJC_CLASS PKPayment;
 OBJC_CLASS PKPaymentMerchantSession;
+OBJC_CLASS PKPaymentSetupFeature;
 OBJC_CLASS PKPaymentMethod;
 OBJC_CLASS PKPaymentToken;
 OBJC_CLASS PKShippingMethod;
@@ -77,6 +78,7 @@ enum class NSType : uint8_t {
 #if USE(PASSKIT)
     PKPaymentMethod,
     PKPaymentMerchantSession,
+    PKPaymentSetupFeature,
     PKContact,
     PKSecureElementPass,
     PKPayment,
@@ -152,6 +154,7 @@ template<> Class getClass<CNPhoneNumber>();
 template<> Class getClass<CNPostalAddress>();
 template<> Class getClass<PKContact>();
 template<> Class getClass<PKPaymentMerchantSession>();
+template<> Class getClass<PKPaymentSetupFeature>();
 template<> Class getClass<PKPayment>();
 template<> Class getClass<PKPaymentToken>();
 template<> Class getClass<PKShippingMethod>();

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -310,6 +310,10 @@ template<> Class getClass<PKPaymentMerchantSession>()
 {
     return PAL::getPKPaymentMerchantSessionClass();
 }
+template<> Class getClass<PKPaymentSetupFeature>()
+{
+    return PAL::getPKPaymentSetupFeatureClass();
+}
 template<> Class getClass<PKPayment>()
 {
     return PAL::getPKPaymentClass();
@@ -380,6 +384,8 @@ NSType typeFromObject(id object)
         return NSType::PKPaymentMethod;
     if ([object isKindOfClass:getClass<PKPaymentMerchantSession>()])
         return NSType::PKPaymentMerchantSession;
+    if ([object isKindOfClass:getClass<PKPaymentSetupFeature>()])
+        return NSType::PKPaymentSetupFeature;
     if ([object isKindOfClass:getClass<PKContact>()])
         return NSType::PKContact;
     if ([object isKindOfClass:getClass<PKSecureElementPass>()])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -39,6 +39,7 @@ class CoreIPCColor;
 #if USE(PASSKIT)
 class CoreIPCPKPaymentMethod;
 class CoreIPCPKPaymentMerchantSession;
+class CoreIPCPKPaymentSetupFeature;
 class CoreIPCPKContact;
 class CoreIPCPKSecureElementPass;
 class CoreIPCPKPayment;
@@ -90,6 +91,7 @@ using ObjectValue = std::variant<
 #if USE(PASSKIT)
     CoreIPCPKPaymentMethod,
     CoreIPCPKPaymentMerchantSession,
+    CoreIPCPKPaymentSetupFeature,
     CoreIPCPKContact,
     CoreIPCPKSecureElementPass,
     CoreIPCPKPayment,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -50,6 +50,8 @@ static ObjectValue valueFromID(id object)
         return CoreIPCPKPaymentMethod((PKPaymentMethod *)object);
     case IPC::NSType::PKPaymentMerchantSession:
         return CoreIPCPKPaymentMerchantSession((PKPaymentMerchantSession *)object);
+    case IPC::NSType::PKPaymentSetupFeature:
+        return CoreIPCPKPaymentSetupFeature((PKPaymentSetupFeature *)object);
     case IPC::NSType::PKContact:
         return CoreIPCPKContact((PKContact *)object);
     case IPC::NSType::PKSecureElementPass:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -46,6 +46,7 @@ using WebKit::ObjectValue = std::variant<
 #if USE(PASSKIT)
     WebKit::CoreIPCPKPaymentMethod,
     WebKit::CoreIPCPKPaymentMerchantSession,
+    WebKit::CoreIPCPKPaymentSetupFeature,
     WebKit::CoreIPCPKContact,
     WebKit::CoreIPCPKSecureElementPass,
     WebKit::CoreIPCPKPayment,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +25,28 @@
 
 #pragma once
 
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCContacts.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDateComponents.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSShadow.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNull.h"
-#import "CoreIPCNumber.h"
-#import "CoreIPCPKPaymentSetupFeature.h"
-#import "CoreIPCPKSecureElementPass.h"
-#import "CoreIPCPassKit.h"
-#import "CoreIPCPersonNameComponents.h"
-#import "CoreIPCPresentationIntent.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
-#import "GeneratedWebKitSecureCoding.h"
+#if USE(PASSKIT)
+
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+
+OBJC_CLASS PKPaymentSetupFeature;
+
+namespace WebKit {
+
+class CoreIPCPKPaymentSetupFeature {
+public:
+    CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature *);
+    CoreIPCPKPaymentSetupFeature(Vector<uint8_t>&& data)
+        : m_data(WTFMove(data)) { }
+
+    RetainPtr<id> toID() const;
+    const Vector<uint8_t>& ipcData() const { return m_data; }
+
+private:
+    Vector<uint8_t> m_data;
+};
+
+} // namespace WebKit
+
+#endif // USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,29 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCContacts.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDateComponents.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSShadow.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNull.h"
-#import "CoreIPCNumber.h"
+#import "config.h"
 #import "CoreIPCPKPaymentSetupFeature.h"
-#import "CoreIPCPKSecureElementPass.h"
-#import "CoreIPCPassKit.h"
-#import "CoreIPCPersonNameComponents.h"
-#import "CoreIPCPresentationIntent.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
-#import "GeneratedWebKitSecureCoding.h"
+
+#if USE(PASSKIT)
+
+#import <wtf/RuntimeApplicationChecks.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+#import <pal/cocoa/PassKitSoftLink.h>
+
+namespace WebKit {
+
+CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature *feature)
+    : m_data(makeVector([NSKeyedArchiver archivedDataWithRootObject:feature requiringSecureCoding:YES error:nil])) { }
+
+RetainPtr<id> CoreIPCPKPaymentSetupFeature::toID() const
+{
+    RetainPtr data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(m_data.data()) length:m_data.size() freeWhenDone:NO]);
+    RELEASE_ASSERT(isInWebProcess());
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKPaymentSetupFeatureClass() fromData:data.get() error:nil];
+}
+
+} // namespace WebKit
+
+#endif // USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
@@ -47,4 +47,4 @@ RetainPtr<id> CoreIPCPKSecureElementPass::toID() const
 
 } // namespace WebKit
 
-#endif // PLATFORM(COCOA)
+#endif // USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -55,6 +55,11 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     signedFields: Array<String>?
 }
 
+webkit_platform_headers: "CoreIPCPKPaymentSetupFeature.h"
+[WebKitPlatform] class WebKit::CoreIPCPKPaymentSetupFeature {
+    Vector<uint8_t> ipcData()
+}
+
 [WebKitSecureCodingClass=PAL::getPKPaymentClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPayment {
     token: PKPaymentToken
     shippingContact: PKContact

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -475,6 +475,7 @@ AVOutputContext wrapped by CoreIPCAVOutputContext
 #if USE(PASSKIT)
 PKPaymentMethod wrapped by CoreIPCPKPaymentMethod
 PKPaymentMerchantSession wrapped by CoreIPCPKPaymentMerchantSession
+PKPaymentSetupFeature wrapped by CoreIPCPKPaymentSetupFeature
 PKContact wrapped by CoreIPCPKContact
 PKSecureElementPass wrapped by CoreIPCPKSecureElementPass
 PKPayment wrapped by CoreIPCPKPayment

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1560,7 +1560,7 @@ void WebPageProxy::didAttachToRunningProcess()
         videoPresentationManager->setMockVideoPresentationModeEnabled(m_mockVideoPresentationModeEnabled);
 #endif
 
-#if ENABLE(APPLE_PAY) && !ENABLE(APPLE_PAY_REMOTE_UI)
+#if ENABLE(APPLE_PAY)
     ASSERT(!internals().paymentCoordinator);
     internals().paymentCoordinator = WebPaymentCoordinatorProxy::create(internals());
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -960,6 +960,7 @@
 		31B362952141EBCD007BFA53 /* _WKInternalDebugFeature.h in Headers */ = {isa = PBXBuildFile; fileRef = 31B362942141EBAD007BFA53 /* _WKInternalDebugFeature.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31BA924E148831260062EDB5 /* WebNotificationManagerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 31BA9249148830810062EDB5 /* WebNotificationManagerMessages.h */; };
 		31D755C11D91B81500843BD1 /* WKTextChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 314888FF1D91B11D00377042 /* WKTextChecker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		33058F192D7F820300F375A9 /* CoreIPCPKPaymentSetupFeature.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33058F182D7F81ED00F375A9 /* CoreIPCPKPaymentSetupFeature.mm */; };
 		330934481315B9220097A7BC /* WebCookieManagerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 330934441315B9220097A7BC /* WebCookieManagerMessages.h */; };
 		330934501315B94D0097A7BC /* WebCookieManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3309344D1315B94D0097A7BC /* WebCookieManager.h */; };
 		3309345B1315B9980097A7BC /* WKCookieManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 330934591315B9980097A7BC /* WKCookieManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5013,6 +5014,8 @@
 		31F060DD1654317500F3281C /* NetworkSocketChannelMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkSocketChannelMessageReceiver.cpp; sourceTree = "<group>"; };
 		32DBCF5E0370ADEE00C91783 /* WebKit2Prefix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKit2Prefix.h; sourceTree = "<group>"; };
 		3302293F2938263E001F00FA /* WebExtensionAPIWebNavigationEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebNavigationEvent.idl; sourceTree = "<group>"; };
+		33058F172D7F81ED00F375A9 /* CoreIPCPKPaymentSetupFeature.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKPaymentSetupFeature.h; sourceTree = "<group>"; };
+		33058F182D7F81ED00F375A9 /* CoreIPCPKPaymentSetupFeature.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKPaymentSetupFeature.mm; sourceTree = "<group>"; };
 		33066F09293A90DC008C5749 /* WebExtensionAPIWebNavigation.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebNavigation.idl; sourceTree = "<group>"; };
 		330934431315B9220097A7BC /* WebCookieManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebCookieManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		330934441315B9220097A7BC /* WebCookieManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCookieManagerMessages.h; sourceTree = "<group>"; };
@@ -12228,6 +12231,8 @@
 				51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */,
 				51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */,
 				51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */,
+				33058F172D7F81ED00F375A9 /* CoreIPCPKPaymentSetupFeature.h */,
+				33058F182D7F81ED00F375A9 /* CoreIPCPKPaymentSetupFeature.mm */,
 				FAF27D2E2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.h */,
 				FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */,
 				F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */,
@@ -20064,6 +20069,7 @@
 				FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */,
 				5157AE0B2B23E97400C0E095 /* CoreIPCPassKit.mm in Sources */,
 				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
+				33058F192D7F820300F375A9 /* CoreIPCPKPaymentSetupFeature.mm in Sources */,
 				FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */,
 				F4F12CB32C48B8C100BC1254 /* CoreIPCPlistArray.mm in Sources */,
 				F4F12CB02C48B2C800BC1254 /* CoreIPCPlistDictionary.mm in Sources */,


### PR DESCRIPTION
#### b9e0ba818f830540e3c4fa6824de10d8174808ca
<pre>
REGRESSION(288484@main): ApplePaySetup.getSetupFeatures() fails because PKPaymentSetupFeature is dropped on the floor during IPC serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=289486">https://bugs.webkit.org/show_bug.cgi?id=289486</a>
<a href="https://rdar.apple.com/145064904">rdar://145064904</a>

Reviewed by Alex Christensen.

Currently, any web-exposed API that passes around ApplePaySetupFeature
(which corresponds to PKPaymentSetupFeature in Cocoa platforms) fails.
This is because after 288484@main, PKPaymentSetupFeature is no longer
decoded through decoding flows pertaining to NSSecureCoding. Moreoever,
our inability to provide a CoreIPC wrapper for the type meant that we
were silently dropping PKPaymentSetupFeature during IPC serialization,
and as such always incorrectly fulfilling the necessary IPC calls
downstream of ApplePaySetup usage.

This commit addresses the bug as such:
1. Provide a CoreIPCPKPaymentSetupFeature wrapper class to continue
   using NSKU.
2. Undo 291313@main. This commit was introduced under the working
   assumption that the WebPaymentCoordinatorProxy resides entirely in
   the networking process on iOS. It turns out that is not true, and is
   indicative of broader architectural issues (since we specifically
   want the coordinator proxy to _not_ live in the UI process on iOS).
   We should fix this separately, tracked in webkit.org/b/289488.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKPaymentSetupFeature&gt;):
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm.
(WebKit::CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature):
(WebKit::CoreIPCPKPaymentSetupFeature::ipcData const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm.
(WebKit::CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature):
(WebKit::CoreIPCPKPaymentSetupFeature::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/291932@main">https://commits.webkit.org/291932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de335e709ae05f8844bf6d4101d79bbc5ef444ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10310 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44233 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81032 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26593 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->