### PR TITLE
Add WebPageProxy::originHasDeviceOrientationAndMotionAccess

### DIFF
--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -46,7 +46,8 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
     documentLoader.setAllowPrivacyProxy(websitePolicies.allowPrivacyProxy);
 
 #if ENABLE(DEVICE_ORIENTATION)
-    documentLoader.setDeviceOrientationAndMotionAccessState(websitePolicies.deviceOrientationAndMotionAccessState);
+    if (auto state = websitePolicies.deviceOrientationAndMotionAccessState)
+        documentLoader.setDeviceOrientationAndMotionAccessState(*state);
 #endif
 
     // Only disable content blockers if it hasn't already been disabled by reloading without content blockers.

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -80,7 +80,7 @@ public:
     WebCore::ColorSchemePreference colorSchemePreference { WebCore::ColorSchemePreference::NoPreference };
     WebContentMode preferredContentMode { WebContentMode::Recommended };
 #if ENABLE(DEVICE_ORIENTATION)
-    WebCore::DeviceOrientationOrMotionPermissionState deviceOrientationAndMotionAccessState { WebCore::DeviceOrientationOrMotionPermissionState::Prompt };
+    std::optional<WebCore::DeviceOrientationOrMotionPermissionState> deviceOrientationAndMotionAccessState;
 #endif
     WebCore::HTTPSByDefaultMode httpsByDefaultMode { WebCore::HTTPSByDefaultMode::Disabled };
     bool idempotentModeAutosizingOnlyHonorsPercentages { false };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -82,7 +82,7 @@ struct WebKit::WebsitePoliciesData {
     WebCore::ColorSchemePreference colorSchemePreference;
     WebKit::WebContentMode preferredContentMode;
 #if ENABLE(DEVICE_ORIENTATION)
-    WebCore::DeviceOrientationOrMotionPermissionState deviceOrientationAndMotionAccessState;
+    std::optional<WebCore::DeviceOrientationOrMotionPermissionState> deviceOrientationAndMotionAccessState;
 #endif
     WebCore::HTTPSByDefaultMode httpsByDefaultMode;
     bool idempotentModeAutosizingOnlyHonorsPercentages;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -61,7 +61,7 @@ public:
     void setAutoplayPolicy(WebKit::WebsiteAutoplayPolicy policy) { m_data.autoplayPolicy = policy; }
 
 #if ENABLE(DEVICE_ORIENTATION)
-    WebCore::DeviceOrientationOrMotionPermissionState deviceOrientationAndMotionAccessState() const { return m_data.deviceOrientationAndMotionAccessState; }
+    std::optional<WebCore::DeviceOrientationOrMotionPermissionState> deviceOrientationAndMotionAccessState() const { return m_data.deviceOrientationAndMotionAccessState; }
     void setDeviceOrientationAndMotionAccessState(WebCore::DeviceOrientationOrMotionPermissionState state) { m_data.deviceOrientationAndMotionAccessState = state; }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -353,7 +353,9 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 - (_WKWebsiteDeviceOrientationAndMotionAccessPolicy)_deviceOrientationAndMotionAccessPolicy
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    return toWKWebsiteDeviceOrientationAndMotionAccessPolicy(_websitePolicies->deviceOrientationAndMotionAccessState());
+    if (auto state = _websitePolicies->deviceOrientationAndMotionAccessState())
+        return toWKWebsiteDeviceOrientationAndMotionAccessPolicy(*state);
+    return _WKWebsiteDeviceOrientationAndMotionAccessPolicyAsk;
 #else
     return _WKWebsiteDeviceOrientationAndMotionAccessPolicyDeny;
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
@@ -79,6 +79,23 @@ DeviceOrientationOrMotionPermissionState WebDeviceOrientationAndMotionAccessCont
     return it->value ? DeviceOrientationOrMotionPermissionState::Granted : DeviceOrientationOrMotionPermissionState::Denied;
 }
 
+void WebDeviceOrientationAndMotionAccessController::setCachedDeviceOrientationPermission(const WebCore::SecurityOriginData& origin, DeviceOrientationOrMotionPermissionState state)
+{
+    if (!m_deviceOrientationPermissionDecisions.isValidKey(origin))
+        return;
+
+    switch (state) {
+    case DeviceOrientationOrMotionPermissionState::Granted:
+        m_deviceOrientationPermissionDecisions.set(origin, true);
+        return;
+    case DeviceOrientationOrMotionPermissionState::Denied:
+        m_deviceOrientationPermissionDecisions.set(origin, false);
+        return;
+    case DeviceOrientationOrMotionPermissionState::Prompt:
+        m_deviceOrientationPermissionDecisions.remove(origin);
+    }
+}
+
 void WebDeviceOrientationAndMotionAccessController::ref() const
 {
     m_websiteDataStore->ref();

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
@@ -50,6 +50,7 @@ public:
     void clearPermissions() { m_deviceOrientationPermissionDecisions.clear(); }
 
     WebCore::DeviceOrientationOrMotionPermissionState cachedDeviceOrientationPermission(const WebCore::SecurityOriginData&) const;
+    void setCachedDeviceOrientationPermission(const WebCore::SecurityOriginData&, WebCore::DeviceOrientationOrMotionPermissionState);
 
 private:
     HashMap<WebCore::SecurityOriginData, bool> m_deviceOrientationPermissionDecisions;


### PR DESCRIPTION
#### addf0f758e1e61fa1e3a4c4cb90b69fa5f2ec2fa
<pre>
Add WebPageProxy::originHasDeviceOrientationAndMotionAccess
<a href="https://rdar.apple.com/146690117">rdar://146690117</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289490">https://bugs.webkit.org/show_bug.cgi?id=289490</a>

Reviewed by Per Arne Vollan.

When deviceOrientationPermissionAPIEnabled is true, UI process keeps track of origins that have access to device
orientation and motion data in `WebDeviceOrientationAndMotionAccessController::m_deviceOrientationPermissionDecisions`;
web process also keeps track of that in `DeviceOrientationAndMotionAccessController::m_accessStatePerOrigin`. Normally,
they should have the same view of data so that they will make consistent decision. However, it turns out they sometimes
don&apos;t due to two issues:
1. UI process doesn&apos;t update LegacySchemeRegistry when registering scheme (`WebPageProxy::setURLSchemeHandlerForScheme`)
while web process does (`WebPage::RegisterURLSchemeHandler`), so an origin might be viewed as opaque in UI process but
not in web process, and it will have different representation in `m_deviceOrientationPermissionDecisions` and
`m_accessStatePerOrigin`.
2. UI process doesn&apos;t update `m_deviceOrientationPermissionDecisions` with permission specified in WebsitePolicies,
while web process does.

These issues are found when I added validaiton for origin in `WebPageProxy::simulateDeviceOrientationChange`: the API
tests that uses `_simulateDeviceOrientationChange` start to time out due to inconsistent view of data. This patch fixes
both issues.

* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _deviceOrientationAndMotionAccessPolicy]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::originHasDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::setURLSchemeHandlerForScheme):
(WebKit::WebPageProxy::simulateDeviceOrientationChange):
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp:
(WebKit::WebDeviceOrientationAndMotionAccessController::setCachedDeviceOrientationPermission):
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h:

Canonical link: <a href="https://commits.webkit.org/292194@main">https://commits.webkit.org/292194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9733130434e7acd5e2c7b20c666339dc75b7a425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85951 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52937 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10978 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81601 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15498 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27341 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->