### PR TITLE
Don't assume character is ASCII in PatternParser::atomCharacterClassAtom

### DIFF
--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -184,7 +184,10 @@ public:
         if (hasError())
             return;
 
-        ASSERT(isASCII(character));
+        if (!isASCII(character)) {
+            fail(URLFilterParser::NonASCII);
+            return;
+        }
 
         m_floatingTerm.addCharacter(character, m_patternIsCaseSensitive);
     }
@@ -356,7 +359,7 @@ private:
             m_sunkTerms.removeLast();
     }
 
-    bool m_patternIsCaseSensitive;
+    const bool m_patternIsCaseSensitive;
 
     Deque<Term> m_openGroups;
     Vector<Term> m_sunkTerms;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -1364,3 +1364,15 @@ TEST_F(WKContentRuleListStoreTest, ExtensionPath)
         TestWebKitAPI::Util::spinRunLoop();
     EXPECT_WK_STREQ([redirectedURL absoluteString], "extension-scheme://extension-host/redirected-to-extension%3Fno-query%23no-fragment");
 }
+
+TEST_F(WKContentRuleListStoreTest, NonASCIIEscaped)
+{
+    NSString *source = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"t,[{`\\\\\\\\\\\\20442=OvI6\",\"\":[\"\"]}}]";
+    __block bool done { false };
+    [[WKContentRuleListStore defaultStore] compileContentRuleListForIdentifier:@"test" encodedContentRuleList:source completionHandler:^(WKContentRuleList *filter, NSError *error) {
+        EXPECT_NULL(filter);
+        EXPECT_NOT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}


### PR DESCRIPTION
#### d6dbe62c08c17b5174af025d2695a0e3ad0a3e43
<pre>
Don&apos;t assume character is ASCII in PatternParser::atomCharacterClassAtom
<a href="https://bugs.webkit.org/show_bug.cgi?id=289496">https://bugs.webkit.org/show_bug.cgi?id=289496</a>
<a href="https://rdar.apple.com/146696055">rdar://146696055</a>

Reviewed by Pascoe and Timothy Hatcher.

With enough escaping you can get YARR to put a non-ASCII character into that function
from ASCII escape characters.  If this happens, fail with the non-ASCII failure instead
of asserting.  The resulting regex will be run on a canonicalized URL, which is why
we already had an error code for non-ASCII regexes, which are never needed.

* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::atomCharacterClassAtom):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, NonASCIIEscaped)):

Canonical link: <a href="https://commits.webkit.org/291938@main">https://commits.webkit.org/291938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df80c03fe0d60ba0c2f8afc698259a881608dec7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10631 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85245 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44252 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80418 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2347 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14688 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15160 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21440 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26608 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->