### PR TITLE
Refactor setting the dynamic range limit in CALayers

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -282,6 +282,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
     platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
     platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+    platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
     platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
     platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -404,6 +404,7 @@ platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerContentsDelayedReleaser.mm
+platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
 platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
 platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/ca/cocoa/WebVideoContainerLayer.mm

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4031,12 +4031,7 @@ void MediaPlayerPrivateAVFoundationObjC::setPlatformDynamicRangeLimit(PlatformDy
 {
     assertIsMainThread();
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if ([m_videoLayer respondsToSelector:@selector(setPreferredDynamicRange:)])
-        [m_videoLayer setPreferredDynamicRange:platformDynamicRangeLimitString(platformDynamicRangeLimit)];
-#else // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    UNUSED_PARAM(platformDynamicRangeLimit);
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    setLayerDynamicRangeLimit(m_videoLayer.get(), platformDynamicRangeLimit);
 }
 
 void MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -904,10 +904,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer()
         if ([sampleBufferDisplayLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
             [sampleBufferDisplayLayer setToneMapToStandardDynamicRange:player->shouldDisableHDR()];
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-        if ([sampleBufferDisplayLayer respondsToSelector:@selector(setPreferredDynamicRange:)])
-            [sampleBufferDisplayLayer setPreferredDynamicRange:platformDynamicRangeLimitString(player->platformDynamicRangeLimit())];
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+        setLayerDynamicRangeLimit(sampleBufferDisplayLayer.get(), player->platformDynamicRangeLimit());
 
         m_videoLayerManager->setVideoLayer(sampleBufferDisplayLayer.get(), player->presentationSize());
     }
@@ -1746,12 +1743,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setShouldDisableHDR(bool shouldDisabl
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if (RetainPtr displayLayer = m_sampleBufferDisplayLayer->as<AVSampleBufferDisplayLayer>(); displayLayer && [displayLayer respondsToSelector:@selector(setPreferredDynamicRange:)])
-        [displayLayer setPreferredDynamicRange:platformDynamicRangeLimitString(platformDynamicRangeLimit)];
-#else // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    UNUSED_PARAM(platformDynamicRangeLimit);
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (RetainPtr displayLayer = m_sampleBufferDisplayLayer->as<AVSampleBufferDisplayLayer>())
+        setLayerDynamicRangeLimit(displayLayer.get(), platformDynamicRangeLimit);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::playerContentBoxRectChanged(const LayoutRect& newRect)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -448,12 +448,8 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
 
     sampleBufferDisplayLayer->updateDisplayMode(m_displayMode < PausedImage, hideRootLayer());
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    if ([sampleBufferDisplayLayer->rootLayer() respondsToSelector:@selector(setPreferredDynamicRange:)]) {
-        if (auto player = m_player.get())
-            [sampleBufferDisplayLayer->rootLayer() setPreferredDynamicRange:platformDynamicRangeLimitString(player->platformDynamicRangeLimit())];
-    }
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if (RefPtr player = m_player.get())
+        setLayerDynamicRangeLimit(sampleBufferDisplayLayer->rootLayer(), player->platformDynamicRangeLimit());
 
     m_videoLayerManager->setVideoLayer(sampleBufferDisplayLayer->rootLayer(), size);
 
@@ -1202,14 +1198,10 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setBufferingPolicy(MediaPlayer::Buffe
 
 void MediaPlayerPrivateMediaStreamAVFObjC::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     if (RefPtr sampleBufferDisplayLayer = m_sampleBufferDisplayLayer) {
-        if (auto* rootLayer = sampleBufferDisplayLayer->rootLayer(); rootLayer && [rootLayer respondsToSelector:@selector(setPreferredDynamicRange:)])
-            [rootLayer setPreferredDynamicRange:platformDynamicRangeLimitString(platformDynamicRangeLimit)];
+        if (RetainPtr rootLayer = sampleBufferDisplayLayer->rootLayer())
+            setLayerDynamicRangeLimit(rootLayer.get(), platformDynamicRangeLimit);
     }
-#else // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    UNUSED_PARAM(platformDynamicRangeLimit);
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 }
 
 void MediaPlayerPrivateMediaStreamAVFObjC::audioOutputDeviceChanged()

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
@@ -29,31 +29,21 @@
 
 #import "PlatformDynamicRangeLimit.h"
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-#import <pal/spi/cocoa/QuartzCoreSPI.h>
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-
 namespace WebCore {
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-inline CADynamicRange platformDynamicRangeLimitString(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+using LayerDynamicRangeLimitSetter = void(*)(CALayer *);
+
+WEBCORE_EXPORT LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter(PlatformDynamicRangeLimit);
+
+inline void setLayerDynamicRangeLimit(CALayer* layer, PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
-    // FIXME: Unstage, see follow-up to rdar://145750574
-    static CADynamicRange const WebKitCADynamicRangeStandard = (id) CFSTR ("standard");
-    static CADynamicRange const WebKitCADynamicRangeConstrainedHigh = (id) CFSTR ("constrainedHigh");
-    static CADynamicRange const WebKitCADynamicRangeHigh = (id) CFSTR ("high");
-
-    constexpr auto betweenStandardAndConstrainedHigh = (PlatformDynamicRangeLimit::standard().value() + PlatformDynamicRangeLimit::constrainedHigh().value()) / 2;
-    if (platformDynamicRangeLimit.value() < betweenStandardAndConstrainedHigh)
-        return WebKitCADynamicRangeStandard;
-
-    constexpr auto betweenConstrainedHighAndHigh = (PlatformDynamicRangeLimit::constrainedHigh().value() + PlatformDynamicRangeLimit::noLimit().value()) / 2;
-    if (platformDynamicRangeLimit.value() < betweenConstrainedHighAndHigh)
-        return WebKitCADynamicRangeConstrainedHigh;
-
-    return WebKitCADynamicRangeHigh;
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    layerDynamicRangeLimitSetter(platformDynamicRangeLimit)(layer);
+#else
+    UNUSED_PARAM(layer);
+    UNUSED_PARAM(platformDynamicRangeLimit);
+#endif
 }
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS) else
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import "config.h"
+#import "PlatformDynamicRangeLimitCocoa.h"
+
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+
+namespace WebCore {
+
+LayerDynamicRangeLimitSetter layerDynamicRangeLimitSetter(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    if ([CALayer instancesRespondToSelector:@selector(setPreferredDynamicRange:)]) {
+        // FIXME: Unstage, see follow-up to rdar://145750574
+        static CADynamicRange const WebKitCADynamicRangeStandard = @"standard";
+        static CADynamicRange const WebKitCADynamicRangeConstrainedHigh = @"constrainedHigh";
+        static CADynamicRange const WebKitCADynamicRangeHigh = @"high";
+
+        constexpr auto betweenStandardAndConstrainedHigh = (PlatformDynamicRangeLimit::standard().value() + PlatformDynamicRangeLimit::constrainedHigh().value()) / 2;
+        if (platformDynamicRangeLimit.value() < betweenStandardAndConstrainedHigh)
+            return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeStandard]; };
+
+        constexpr auto betweenConstrainedHighAndHigh = (PlatformDynamicRangeLimit::constrainedHigh().value() + PlatformDynamicRangeLimit::noLimit().value()) / 2;
+        if (platformDynamicRangeLimit.value() < betweenConstrainedHighAndHigh)
+            return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeConstrainedHigh]; };
+
+        return [](CALayer *layer) { [layer setPreferredDynamicRange:WebKitCADynamicRangeHigh]; };
+    }
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    UNUSED_PARAM(platformDynamicRangeLimit);
+    return [](CALayer *) { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -32,15 +32,17 @@
 #import "UTIUtilities.h"
 #import <ImageIO/ImageIO.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-#import <pal/cocoa/LockdownModeSoftLink.h>
 #import <wtf/HashSet.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RobinHoodHashSet.h>
+#import <wtf/text/MakeString.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
+
+#import <pal/cocoa/LockdownModeSoftLink.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -28,9 +28,11 @@
 #include "ProcessIdentity.h"
 #include "SampleMap.h"
 #include <CoreMedia/CMTime.h>
+#include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/OSObjectPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -41,6 +41,7 @@
 #import <wtf/MainThreadDispatcher.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/NativePromise.h>
+#import <wtf/cf/TypeCastsCF.h>
 
 #pragma mark - Soft Linking
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -30,6 +30,7 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
+#import "ImageBuffer.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SwitchMacUtilities.h"


### PR DESCRIPTION
#### 084a860905a9fd5825ccfcdec0a95301dbacd86c
<pre>
Refactor setting the dynamic range limit in CALayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=289500">https://bugs.webkit.org/show_bug.cgi?id=289500</a>
<a href="https://rdar.apple.com/146698266">rdar://146698266</a>

Reviewed by Mike Wyrzykowski.

Refactor repeated code (to set a dynamic range limit into one or more CALayers)
into a single implementation.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Added PlatformDynamicRangeLimitCocoa.mm, and ensure header
PlatformDynamicRangeLimitCocoa.h is accessible from WebKit.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h:
(WebCore::setLayerDynamicRangeLimit):
(WebCore::platformDynamicRangeLimitString): Deleted.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.mm: Added.
(WebCore::layerDynamicRangeLimitSetter):
Hide implementation of setting the dynamic range limit into CALayers.
`layerDynamicRangeLimitSetter` is more efficient when applying the same limit to
multiple layers.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPlatformDynamicRangeLimit):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPlatformDynamicRangeLimit):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setPlatformDynamicRangeLimit):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::setDynamicRangeLimitRecursive):
(WebKit::setDynamicRangeLimit):
(WebKit::WebViewImpl::updateHDRState):
(WebKit::setEDRStrengthRecursive): Deleted.
(WebKit::setEDRStrength): Deleted.
Use the new PlatformDynamicRangeLimitCocoa functions.

* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
Added missing includes due to shuffling of files in unified build.

Canonical link: <a href="https://commits.webkit.org/291990@main">https://commits.webkit.org/291990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e506482fe8e4bf9af6b3ae87581ad7765c2b12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94447 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2376 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26638 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->