### PR TITLE
Make WorkQueueMessageReceiver thread safe

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -620,7 +620,7 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID, CompletionHandler<
         Ref storageManager = session->storageManager();
         m_closingStorageManagers.add(storageManager.copyRef());
         storageManager->close([this, protectedThis = Ref { *this }, storageManager, completionHandler = std::exchange(completionHandler, { })]() mutable {
-            m_closingStorageManagers.remove(storageManager.ptr());
+            m_closingStorageManagers.remove(storageManager);
             completionHandler();
             stopRunLoopIfNecessary();
         });

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -631,7 +631,7 @@ private:
     Seconds m_serviceWorkerFetchTimeout { defaultServiceWorkerFetchTimeout };
 
     HashMap<WebCore::PageIdentifier, Vector<WebCore::UserContentURLPattern>> m_extensionCORSDisablingPatterns;
-    HashSet<RefPtr<NetworkStorageManager>> m_closingStorageManagers;
+    HashSet<Ref<NetworkStorageManager>> m_closingStorageManagers;
     HashSet<String> m_localhostAliasesForTesting;
     HashSet<WebPageProxyIdentifier> m_pagesWithRelaxedThirdPartyCookieBlocking;
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -394,7 +394,7 @@ protected:
         double currentMovingAverage { 0 };
     } m_recentHTTPSConnectionTiming;
 
-    Ref<NetworkStorageManager> m_storageManager;
+    const Ref<NetworkStorageManager> m_storageManager;
     String m_cacheStorageDirectory;
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -63,11 +63,10 @@ private:
     void updateToStorage(CompletionHandler<void()>&&);
     void updateTimerFired() { updateToStorage([] { }); }
 
-    CheckedPtr<NetworkStorageManager> checkedManager() const;
     RefPtr<WebCore::SWServer> protectedServer() const;
 
     WeakPtr<WebCore::SWServer> m_server;
-    WeakPtr<NetworkStorageManager> m_manager;
+    ThreadSafeWeakPtr<NetworkStorageManager> m_manager;
     WebCore::Timer m_updateTimer;
     HashMap<WebCore::ServiceWorkerRegistrationKey, std::optional<WebCore::ServiceWorkerContextData>> m_updates;
 };

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -44,7 +44,7 @@ struct BackgroundFetchState;
 
 class BackgroundFetchStoreImpl :  public WebCore::BackgroundFetchStore {
 public:
-    static Ref<BackgroundFetchStoreImpl> create(WeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server) { return adoptRef(*new BackgroundFetchStoreImpl(WTFMove(manager), WTFMove(server))); }
+    static Ref<BackgroundFetchStoreImpl> create(ThreadSafeWeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server) { return adoptRef(*new BackgroundFetchStoreImpl(WTFMove(manager), WTFMove(server))); }
     ~BackgroundFetchStoreImpl();
 
     void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);
@@ -55,7 +55,7 @@ public:
     void clickBackgroundFetch(const String&, CompletionHandler<void()>&&);
 
 private:
-    BackgroundFetchStoreImpl(WeakPtr<NetworkStorageManager>&&, WeakPtr<WebCore::SWServer>&&);
+    BackgroundFetchStoreImpl(ThreadSafeWeakPtr<NetworkStorageManager>&&, WeakPtr<WebCore::SWServer>&&);
 
     void initializeFetches(const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
     void clearFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&&) final;
@@ -78,7 +78,7 @@ private:
 
     RefPtr<WebCore::SWServer> protectedServer();
 
-    WeakPtr<NetworkStorageManager> m_manager;
+    ThreadSafeWeakPtr<NetworkStorageManager> m_manager;
 
     using FetchIdentifier = std::pair<String, String>; // < service worker registration scope, background fetch identifier >
     struct PerClientOriginFetches {

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -97,9 +97,8 @@ class ServiceWorkerStorageManager;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
-class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>, public CanMakeCheckedPtr<NetworkStorageManager> {
+class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkStorageManager);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkStorageManager);
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -461,7 +461,8 @@ void Connection::removeMessageReceiver(ReceiverName receiverName, uint64_t desti
     removeMessageReceiveQueue(ReceiverMatcher::createWithZeroAsAnyDestination(receiverName, destinationID));
 }
 
-void Connection::dispatchMessageReceiverMessage(MessageReceiver& messageReceiver, UniqueRef<Decoder>&& decoder)
+template<typename MessageReceiverType>
+void Connection::dispatchMessageReceiverMessage(MessageReceiverType& messageReceiver, UniqueRef<Decoder>&& decoder)
 {
     if (decoder->isSyncMessage()) {
         auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, decoder->syncRequestID().toUInt64());
@@ -481,6 +482,9 @@ void Connection::dispatchMessageReceiverMessage(MessageReceiver& messageReceiver
     if (!decoder->isValid())
         dispatchDidReceiveInvalidMessage(decoder->messageName(), decoder->indexOfObjectFailingDecoding());
 }
+
+template void Connection::dispatchMessageReceiverMessage<MessageReceiver>(MessageReceiver&, UniqueRef<Decoder>&&);
+template void Connection::dispatchMessageReceiverMessage<WorkQueueMessageReceiverBase>(WorkQueueMessageReceiverBase&, UniqueRef<Decoder>&&);
 
 void Connection::setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWorkQueueCallback callback)
 {

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -492,7 +492,7 @@ public:
     DecoderOrError waitForMessageForTesting(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
 #endif
 
-    void dispatchMessageReceiverMessage(MessageReceiver&, UniqueRef<Decoder>&&);
+    template<typename MessageReceiverType> void dispatchMessageReceiverMessage(MessageReceiverType&, UniqueRef<Decoder>&&);
     // Can be called from any thread.
     void dispatchDidReceiveInvalidMessage(MessageName, int32_t indexOfObjectFailingDecoding);
     void dispatchDidCloseAndInvalidate();

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -46,7 +46,7 @@ public:
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
         m_dispatcher.dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = Ref { m_receiver.get() }]() mutable {
-            connection->dispatchMessageReceiverMessage(receiver, WTFMove(message));
+            connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
         });
     }
 private:

--- a/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
@@ -30,9 +30,22 @@
 
 namespace IPC {
 
-class WorkQueueMessageReceiverBase : public MessageReceiver {
+class Connection;
+
+class WorkQueueMessageReceiverBase : public AbstractRefCounted {
 protected:
     WorkQueueMessageReceiverBase() = default;
+public:
+    virtual ~WorkQueueMessageReceiverBase() { }
+private:
+    friend class Connection;
+    virtual void didReceiveMessage(Connection&, Decoder&) { ASSERT_NOT_REACHED(); }
+    virtual void didReceiveMessageWithReplyHandler(Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) { ASSERT_NOT_REACHED(); }
+    virtual bool didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
+    {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
 };
 
 template<WTF::DestructionThread destructionThread>

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -222,7 +222,7 @@ private:
     RefPtr<WebCore::SharedMemory> m_getPixelBufferSharedMemory;
     WebCore::Timer m_destroyGetPixelBufferSharedMemoryTimer { *this, &RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory };
     HashMap<MarkSurfacesAsVolatileRequestIdentifier, CompletionHandler<void(bool)>> m_markAsVolatileRequests;
-    HashMap<RemoteImageBufferSetIdentifier, WeakPtr<RemoteImageBufferSetProxy>> m_bufferSets;
+    HashMap<RemoteImageBufferSetIdentifier, ThreadSafeWeakPtr<RemoteImageBufferSetProxy>> m_bufferSets;
     Ref<WorkQueue> m_queue;
 
     RenderingUpdateID m_renderingUpdateID;

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -187,13 +187,6 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
 
 bool NetworkProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
-        ASSERT(SWContextManager::singleton().connection());
-        if (auto* contextManagerConnection = SWContextManager::singleton().connection())
-            return downcast<WebSWContextManagerConnection>(*contextManagerConnection).didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return false;
-    }
-
 #if ENABLE(APPLE_PAY_REMOTE_UI)
     if (decoder.messageReceiverName() == Messages::WebPaymentCoordinator::messageReceiverName()) {
         if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(decoder.destinationID())))


### PR DESCRIPTION
#### 24c5a57441b2ab436ef5000d292d9597464740c3
<pre>
Make WorkQueueMessageReceiver thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=289502">https://bugs.webkit.org/show_bug.cgi?id=289502</a>
<a href="https://rdar.apple.com/131599226">rdar://131599226</a>

Reviewed by Chris Dumez.

NetworkStorageManager had WeakPtr, ThreadSafeWeakPtr, and CheckedPtr all keeping it &quot;safe&quot;,
but only one of the three was thread safe.  It only inherited from CanMakeWeakPtr because
it inherited from MessageReceiver.  This fixes NetworkStorageManager&apos;s lifetime management
and prevents other types from accidentally making non-thread-safe WeakPtrs to them by making
WorkQueueMessageReceiver not inherit MessageReceiver&apos;s CanMakeWeakPtr.

I also found that NetworkProcessConnection::dispatchSyncMessage was calling
WebSWContextManagerConnection::didReceiveSyncMessage, but WebSWContextManagerConnection has
no synchronous messages it can receive, so I removed it.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::destroySession):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::clearAll):
(WebKit::WebSWRegistrationStore::closeFiles):
(WebKit::WebSWRegistrationStore::importRegistrations):
(WebKit::WebSWRegistrationStore::updateToStorage):
(WebKit::WebSWRegistrationStore::checkedManager const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::BackgroundFetchStoreImpl):
(WebKit::BackgroundFetchStoreImpl::initializeFetches):
(WebKit::BackgroundFetchStoreImpl::initializeFetchesInternal):
(WebKit::BackgroundFetchStoreImpl::clearFetch):
(WebKit::BackgroundFetchStoreImpl::clearFetchInternal):
(WebKit::BackgroundFetchStoreImpl::clearAllFetches):
(WebKit::BackgroundFetchStoreImpl::clearAllFetchesInternal):
(WebKit::BackgroundFetchStoreImpl::storeFetch):
(WebKit::BackgroundFetchStoreImpl::storeFetchInternal):
(WebKit::BackgroundFetchStoreImpl::storeFetchResponseBodyChunk):
(WebKit::BackgroundFetchStoreImpl::storeFetchResponseBodyChunkInternal):
(WebKit::BackgroundFetchStoreImpl::retrieveResponseBody):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
(WebKit::BackgroundFetchStoreImpl::create):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
* Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h:
(IPC::WorkQueueMessageReceiverBase::~WorkQueueMessageReceiverBase):
(IPC::WorkQueueMessageReceiverBase::didReceiveSyncMessage):
(IPC::WorkQueueMessageReceiverBase::didReceiveMessage):
(IPC::WorkQueueMessageReceiverBase::didReceiveMessageWithReplyHandler):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::didMarkLayersAsVolatile):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/291946@main">https://commits.webkit.org/291946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f410addebf030d053aeb4cd68fe77dd007af51f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45002 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29417 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10380 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101545 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81098 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26660 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->