### PR TITLE
WebInspector: window close causes host-app crash under RemoteInspector::listingForInspectionTarget()

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
@@ -89,18 +89,19 @@ void RemoteConnectionToTarget::close()
 {
     RunLoop::currentSingleton().dispatch([this, protectThis = Ref { *this }] {
         Locker locker { m_targetMutex };
-        RefPtr target = m_target.get();
-        if (!target)
-            return;
+        TargetID targetIdentifier = 0;
 
-        auto targetIdentifier = target->targetIdentifier();
+        if (RefPtr target = m_target.get()) {
+            targetIdentifier = target->targetIdentifier();
 
-        if (m_connected)
-            target->disconnect(*this);
+            if (m_connected)
+                target->disconnect(*this);
 
-        m_target = nullptr;
+            m_target = nullptr;
+        }
 
-        RemoteInspector::singleton().updateTargetListing(targetIdentifier);
+        if (targetIdentifier)
+            RemoteInspector::singleton().updateTargetListing(targetIdentifier);
     });
 }
 

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
@@ -215,9 +215,10 @@ void RemoteConnectionToTarget::close()
                 target->disconnect(*this);
 
             m_target = nullptr;
-            if (targetIdentifier)
-                RemoteInspector::singleton().updateTargetListing(targetIdentifier);
         }
+
+        if (targetIdentifier)
+            RemoteInspector::singleton().updateTargetListing(targetIdentifier);
     });
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
@@ -55,8 +55,9 @@ JSGlobalObjectDebuggable::JSGlobalObjectDebuggable(JSGlobalObject& globalObject)
 
 String JSGlobalObjectDebuggable::name() const
 {
-    String name = m_globalObject->name();
-    return name.isEmpty() ? "JSContext"_s : name;
+    if (m_globalObject && !m_globalObject->name().isEmpty())
+        return m_globalObject->name();
+    return "JSContext"_s;
 }
 
 void JSGlobalObjectDebuggable::connect(FrontendChannel& frontendChannel, bool automaticInspection, bool immediatelyPause)


### PR DESCRIPTION
#### b3de1ab9ff924b487d8f003b162195fbdf37a8eb
<pre>
WebInspector: window close causes host-app crash under RemoteInspector::listingForInspectionTarget()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289504">https://bugs.webkit.org/show_bug.cgi?id=289504</a>
<a href="https://rdar.apple.com/146650431">rdar://146650431</a>

Reviewed by BJ Burg.

Calling `JSGlobalObjectDebuggable::name()` on a remote inspection target (aka debuggable)
which no longer has an associated `JSGlobalObject` causes a crash because
it attempts to get the name from that `JSGlobalObject`.

The situation can occur when a Web Inspector window is the only thing that keeps
a `JSGlobalObject` alive via the intentional strong reference created in
`JSGlobalObjectInspectorController::connectFrontend()`.

When inspection is terminated via `RemoteConnectionToTarget::close()`,
the frontend is disconnected (`JSGlobalObjectInspectorController::disconnectFrontend`)
and the strong reference is removed so the `JSGlobalObject` can be destroyed.

Its destructor removes the reference from the debuggable (`JSGlobalObjectDebuggable::globalObjectDestroyed()`)
which should allow for the `JSGlobalObjectDebuggable` to be itself destroyed
(`RemoteControllableTarget::~RemoteControllableTarget()`).
This would remove it from the list of targets tracked by `RemoteInspector`.

But the RefPtr to the target in `RemoteConnectionToTarget::close()` prevents that destruction
so the call to `RemoteInspector::singleton().updateTargetListing()` proceeds with a still alive
`JSGlobalObjectDebuggable` that no longer has an associated `JSGlobalObject`.

This patch moves the call to `RemoteInspector::singleton().updateTargetListing()` outside
the block scope that keeps the target alive due to the RefPtr.

The call is already using a cached target identifier and attempts to match a target tracked by `RemoteInspector`.
If there is no match (the desired scenario because the target was allowed to be destroyed),
it returns early and prevents the condition for the crash.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::close):

* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::close):
Align the implementation with Cocoa version to prevent the RefPtr keeping the debuggable alive.

* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::name const):
Ensure a JSGlobalObject exists before accessing its name.

Canonical link: <a href="https://commits.webkit.org/292048@main">https://commits.webkit.org/292048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c63c00d0611462ba660ec0bc1701fb22d37d1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45058 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3065 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44381 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81148 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26706 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115856 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21254 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->