### PR TITLE
[JSC] Add wasm tailcall tests for 291918@main

### DIFF
--- a/JSTests/wasm/stress/tail-call-subtype-checks.js
+++ b/JSTests/wasm/stress/tail-call-subtype-checks.js
@@ -1,0 +1,41 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+    // (module
+    //  (func $bar (param $x i32) (result (ref i31))
+    //        (ref.i31 (local.get $x)))
+    //  (func $foo (export "foo") (param $x i32) (result (ref null i31))
+    //        (if (result (ref null i31))
+    //            (i32.eqz (local.get $x))
+    //            (then (ref.null i31))
+    //            (else (return_call $bar (local.get $x))))))
+    const wasmCode = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 12, 2, 96, 1, 127, 1, 100, 108, 96, 1, 127, 1, 108, 3, 3, 2, 0, 1, 7, 7, 1, 3, 102, 111, 111, 0, 1, 10, 24, 2, 6, 0, 32, 0, 251, 28, 11, 15, 0, 32, 0, 69, 4, 108, 208, 108, 5, 32, 0, 18, 0, 11, 11, 0, 31, 4, 110, 97, 109, 101, 1, 11, 2, 0, 3, 98, 97, 114, 1, 3, 102, 111, 111, 2, 11, 2, 0, 1, 0, 1, 120, 1, 1, 0, 1, 120]);
+    const wasmModule = new WebAssembly.Module(wasmCode);
+    const wasmInstance = new WebAssembly.Instance(wasmModule);
+
+    shouldBe(wasmInstance.exports.foo(42), 42);
+}
+
+{
+    // (module
+    //   (table 2 funcref)
+    //   (elem (i32.const 0) $bar)
+    //   (type $i32_to_ref_i31 (func (param i32) (result (ref i31))))
+    //   (func $bar (param $x i32) (result (ref i31))
+    //     (ref.i31 (local.get $x)))
+    //   (func $foo (export "foo") (param $x i32) (result (ref null i31))
+    //     (if (result (ref null i31))
+    //       (i32.eqz (local.get $x))
+    //       (then (ref.null i31))
+    //       (else (return_call_indirect (type $i32_to_ref_i31)
+    //                                   (local.get $x)
+    //                                   (i32.const 0))))))
+    const wasmCode = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 12, 2, 96, 1, 127, 1, 100, 108, 96, 1, 127, 1, 108, 3, 3, 2, 0, 1, 4, 4, 1, 112, 0, 2, 7, 7, 1, 3, 102, 111, 111, 0, 1, 9, 7, 1, 0, 65, 0, 11, 1, 0, 10, 27, 2, 6, 0, 32, 0, 251, 28, 11, 18, 0, 32, 0, 69, 4, 108, 208, 108, 5, 32, 0, 65, 0, 19, 0, 0, 11, 11, 0, 50, 4, 110, 97, 109, 101, 1, 11, 2, 0, 3, 98, 97, 114, 1, 3, 102, 111, 111, 2, 11, 2, 0, 1, 0, 1, 120, 1, 1, 0, 1, 120, 4, 17, 1, 0, 14, 105, 51, 50, 95, 116, 111, 95, 114, 101, 102, 95, 105, 51, 49]);
+    const wasmModule = new WebAssembly.Module(wasmCode);
+    const wasmInstance = new WebAssembly.Instance(wasmModule);
+
+    shouldBe(wasmInstance.exports.foo(42), 42);
+}


### PR DESCRIPTION
#### 55848556565cb8ba4a5c3250530bd2eabe6abd19
<pre>
[JSC] Add wasm tailcall tests for 291918@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=289511">https://bugs.webkit.org/show_bug.cgi?id=289511</a>

Reviewed by Yusuke Suzuki.

Wasm tail calls should check if the result type is a subtype
of the expected type. 291918@main[1] fixed it. But the patch
didn&apos;t add tests.

This patch add tests for it.

[1]: <a href="https://commits.webkit.org/291918@main">https://commits.webkit.org/291918@main</a>

* JSTests/wasm/stress/tail-call-subtype-checks.js: Added.
(shouldBe):
(throw.new.Error):

Canonical link: <a href="https://commits.webkit.org/291943@main">https://commits.webkit.org/291943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d40bd2a09638f7fde87d63a1c2f7831adafd932

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29408 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97461 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10672 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52416 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10366 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition.html (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44301 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87145 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101522 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93112 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2386 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21490 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115773 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21173 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->