### PR TITLE
[JSC] DFG OSR entry should not use `CallFrame::argument`

### DIFF
--- a/JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument.js
+++ b/JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument.js
@@ -1,0 +1,21 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0.001")
+
+function shouldBe(actual, expected) {
+    if (String(actual) !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+const arr = [[11, 22, 33]];
+class CC {
+  constructor(a) {
+    [a] = arr;
+    for (let i = 0; i < 8; i++) {
+      shouldBe(a, `11,22,33`);
+    }
+    const c = [53255];
+    c[8] = 2;
+  }
+}
+new CC();
+new CC();

--- a/JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument2.js
+++ b/JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument2.js
@@ -1,0 +1,19 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0")
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe)
+
+const v11 = ["abc","abcd", "abcde"];
+const v21 = [1, 2, 3, 4, 5, 6];
+function f22(a26) {
+  [a26] = v11;
+  for (let v37 = 0; v37 < 5; v37++) {}
+  shouldBe(a26 !== undefined, true);
+}
+noInline(f22)
+for (const v44 of v21) {
+  f22();
+  shouldBe(typeof v44, "number");
+}

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -173,12 +173,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     //    OSR at this time.
     
     for (size_t argument = 0; argument < entry->m_expectedValues.numberOfArguments(); ++argument) {
-        JSValue value;
-        if (!argument)
-            value = callFrame->thisValue();
-        else
-            value = callFrame->argument(argument - 1);
-        
+        JSValue value = callFrame->r(virtualRegisterForArgumentIncludingThis(argument)).asanUnsafeJSValue();
         if (!entry->m_expectedValues.argument(argument).validateOSREntryValue(value, FlushedJSValue)) {
             dataLogLnIf(Options::verboseOSR(),
                 "    OSR failed because argument ", argument, " is ", value,


### PR DESCRIPTION
#### 557dbf9f51e85aeddfca649e8338573f70fc3208
<pre>
[JSC] DFG OSR entry should not use `CallFrame::argument`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289449">https://bugs.webkit.org/show_bug.cgi?id=289449</a>
<a href="https://rdar.apple.com/146716339">rdar://146716339</a>

Reviewed by Yijia Huang.

When collecting arguments for DFG OSR entry, we should not use
callFrame::argument function. This is because we will return undefined
if argumentCountIncludingThis is smaller than the specified argument
index, but JS code is already filling these arguments with arity-fixup
and some values are already written to that.
We retrieve an argument as the same way to what FTL OSR entry is doing.

* JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument.js: Added.
(shouldBe):
(CC):
* JSTests/stress/dfg-osr-entry-should-not-use-callframe-argument2.js: Added.
(shouldBe):
(f22):
(noInline.f22):
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::prepareOSREntry):

Canonical link: <a href="https://commits.webkit.org/291944@main">https://commits.webkit.org/291944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dd3f93708ed7d6f1493b6bfe00721d7291aae48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44985 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44304 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87146 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101525 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93113 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21516 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15709 "Failed to checkout and rebase branch from PR 42236") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80463 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14739 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15164 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21493 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115776 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21176 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->