### PR TITLE
Make WebDeviceOrientationUpdateProviderProxy validate origin access before registering for change

### DIFF
--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -55,10 +55,10 @@ void DeviceMotionController::suspendUpdates()
     m_client->stopUpdating();
 }
 
-void DeviceMotionController::resumeUpdates()
+void DeviceMotionController::resumeUpdates(const SecurityOriginData& origin)
 {
     if (!m_listeners.isEmpty())
-        m_client->startUpdating();
+        m_client->startUpdating(origin);
 }
 
 #endif

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -47,7 +47,7 @@ public:
     // FIXME: We should look to reconcile the iOS and OpenSource differences with this class
     // so that we can either remove these methods or remove the PLATFORM(IOS_FAMILY)-guard.
     void suspendUpdates();
-    void resumeUpdates();
+    void resumeUpdates(const SecurityOriginData&);
 #endif
 
     void didChangeDeviceMotion(DeviceMotionData*);

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -66,10 +66,10 @@ void DeviceOrientationController::suspendUpdates()
     m_client->stopUpdating();
 }
 
-void DeviceOrientationController::resumeUpdates()
+void DeviceOrientationController::resumeUpdates(const SecurityOriginData& origin)
 {
     if (!m_listeners.isEmpty())
-        m_client->startUpdating();
+        m_client->startUpdating(origin);
 }
 
 #else

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -51,7 +51,7 @@ public:
     // FIXME: We should look to reconcile the iOS and OpenSource differences with this class
     // so that we can either remove these methods or remove the PLATFORM(IOS_FAMILY)-guard.
     void suspendUpdates();
-    void resumeUpdates();
+    void resumeUpdates(const SecurityOriginData&);
 #else
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3538,10 +3538,11 @@ void Document::resumeDeviceMotionAndOrientationUpdates()
         return;
     m_areDeviceMotionAndOrientationUpdatesSuspended = false;
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
+    auto origin = securityOrigin().data();
     if (m_deviceMotionController)
-        m_deviceMotionController->resumeUpdates();
+        m_deviceMotionController->resumeUpdates(origin);
     if (m_deviceOrientationController)
-        m_deviceOrientationController->resumeUpdates();
+        m_deviceOrientationController->resumeUpdates(origin);
 #endif
 }
 

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 class DeviceClient;
+class SecurityOriginData;
 }
 
 namespace WTF {
@@ -45,7 +46,7 @@ class DeviceClient : public CanMakeWeakPtr<DeviceClient> {
 public:
     virtual ~DeviceClient() = default;
 
-    virtual void startUpdating() = 0;
+    virtual void startUpdating(const SecurityOriginData&) = 0;
     virtual void stopUpdating() = 0;
 
     virtual bool isDeviceMotionClient() const { return false; }

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -45,6 +45,10 @@ DeviceController::~DeviceController() = default;
 
 void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
 {
+    RefPtr document = window.document();
+    if (!document)
+        return;
+
     bool wasEmpty = m_listeners.isEmpty();
     m_listeners.add(&window);
 
@@ -55,7 +59,7 @@ void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
     }
 
     if (wasEmpty)
-        m_client->startUpdating();
+        m_client->startUpdating(document->securityOrigin().data());
 }
 
 void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -157,7 +157,7 @@ public:
     String debugString() const { return toString(); }
 #endif
 
-    static bool shouldTreatAsOpaqueOrigin(const URL&);
+    WEBCORE_EXPORT static bool shouldTreatAsOpaqueOrigin(const URL&);
     
     const std::variant<Tuple, ProcessQualified<OpaqueOriginIdentifier>>& data() const { return m_data; }
 private:

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.h
@@ -45,7 +45,7 @@ public:
     DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceMotionClientIOS() override;
     void setController(DeviceMotionController*) override;
-    void startUpdating() override;
+    void startUpdating(const SecurityOriginData&) override;
     void stopUpdating() override;
     DeviceMotionData* lastMotion() const override;
     void deviceMotionControllerDestroyed() override;

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
@@ -51,12 +51,12 @@ void DeviceMotionClientIOS::setController(DeviceMotionController* controller)
     m_controller = controller;
 }
 
-void DeviceMotionClientIOS::startUpdating()
+void DeviceMotionClientIOS::startUpdating(const SecurityOriginData& origin)
 {
     m_updating = true;
 
     if (m_deviceOrientationUpdateProvider) {
-        m_deviceOrientationUpdateProvider->startUpdatingDeviceMotion(*this);
+        m_deviceOrientationUpdateProvider->startUpdatingDeviceMotion(*this, origin);
         return;
     }
 

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.h
@@ -45,7 +45,7 @@ public:
     DeviceOrientationClientIOS(RefPtr<DeviceOrientationUpdateProvider>&&);
     ~DeviceOrientationClientIOS() override;
     void setController(DeviceOrientationController*) override;
-    void startUpdating() override;
+    void startUpdating(const SecurityOriginData&) override;
     void stopUpdating() override;
     DeviceOrientationData* lastOrientation() const override;
     void deviceOrientationControllerDestroyed() override;

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
@@ -51,12 +51,12 @@ void DeviceOrientationClientIOS::setController(DeviceOrientationController* cont
     m_controller = controller;
 }
 
-void DeviceOrientationClientIOS::startUpdating()
+void DeviceOrientationClientIOS::startUpdating(const SecurityOriginData& origin)
 {
     m_updating = true;
 
     if (m_deviceOrientationUpdateProvider) {
-        m_deviceOrientationUpdateProvider->startUpdatingDeviceOrientation(*this);
+        m_deviceOrientationUpdateProvider->startUpdatingDeviceOrientation(*this, origin);
         return;
     }
 

--- a/Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h
+++ b/Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h
@@ -37,10 +37,10 @@ class DeviceOrientationUpdateProvider : public RefCounted<DeviceOrientationUpdat
 public:
     virtual ~DeviceOrientationUpdateProvider() { }
 
-    virtual void startUpdatingDeviceOrientation(MotionManagerClient&) = 0;
+    virtual void startUpdatingDeviceOrientation(MotionManagerClient&, const SecurityOriginData&) = 0;
     virtual void stopUpdatingDeviceOrientation(MotionManagerClient&) = 0;
 
-    virtual void startUpdatingDeviceMotion(MotionManagerClient&) = 0;
+    virtual void startUpdatingDeviceMotion(MotionManagerClient&, const SecurityOriginData&) = 0;
     virtual void stopUpdatingDeviceMotion(MotionManagerClient&) = 0;
 
     virtual void deviceOrientationChanged(double, double, double, double, double) = 0;

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp
@@ -47,7 +47,7 @@ void DeviceOrientationClientMock::setController(DeviceOrientationController* con
     ASSERT(m_controller);
 }
 
-void DeviceOrientationClientMock::startUpdating()
+void DeviceOrientationClientMock::startUpdating(const SecurityOriginData&)
 {
     m_isUpdating = true;
 }

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -48,7 +48,7 @@ public:
 
     // DeviceOrientationClient
     WEBCORE_EXPORT void setController(DeviceOrientationController*) override;
-    WEBCORE_EXPORT void startUpdating() override;
+    WEBCORE_EXPORT void startUpdating(const SecurityOriginData&) override;
     WEBCORE_EXPORT void stopUpdating() override;
     DeviceOrientationData* lastOrientation() const override { return m_orientation.get(); }
     void deviceOrientationControllerDestroyed() override { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12449,6 +12449,7 @@ void WebPageProxy::requestMediaKeySystemPermissionForFrame(IPC::Connection& conn
 }
 
 #if ENABLE(DEVICE_ORIENTATION)
+
 void WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& completionHandler)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameID);
@@ -12457,6 +12458,13 @@ void WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection& 
 
     protectedWebsiteDataStore()->protectedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(*this, *frame, WTFMove(frameInfo), mayPrompt, WTFMove(completionHandler));
 }
+
+bool WebPageProxy::originHasDeviceOrientationAndMotionAccess(const WebCore::SecurityOriginData& origin)
+{
+    // FIXME: implement this.
+    return true;
+}
+
 #endif
 
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2101,6 +2101,7 @@ public:
 
 #if ENABLE(DEVICE_ORIENTATION)
     void shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, bool mayPrompt, CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>&&);
+    bool originHasDeviceOrientationAndMotionAccess(const WebCore::SecurityOriginData&);
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -31,6 +31,9 @@
 #include <WebCore/MotionManagerClient.h>
 #include <wtf/TZoneMalloc.h>
 
+namespace WebCore {
+class SecurityOriginData;
+}
 namespace WebKit {
 
 class WebPageProxy;
@@ -45,10 +48,10 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void startUpdatingDeviceOrientation();
+    void startUpdatingDeviceOrientation(const WebCore::SecurityOriginData&);
     void stopUpdatingDeviceOrientation();
 
-    void startUpdatingDeviceMotion();
+    void startUpdatingDeviceMotion(const WebCore::SecurityOriginData&);
     void stopUpdatingDeviceMotion();
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
@@ -27,9 +27,9 @@
     EnabledBy=DeviceOrientationEventEnabled
 ]
 messages -> WebDeviceOrientationUpdateProviderProxy {
-    StartUpdatingDeviceOrientation();
+    StartUpdatingDeviceOrientation(WebCore::SecurityOriginData origin);
     StopUpdatingDeviceOrientation();
-    StartUpdatingDeviceMotion();
+    StartUpdatingDeviceMotion(WebCore::SecurityOriginData origin);
     StopUpdatingDeviceMotion();
 }
 #endif

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -57,8 +57,12 @@ WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProx
         page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
-void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()
+void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation(const WebCore::SecurityOriginData& origin)
 {
+    RefPtr page = m_page.get();
+    if (!page || !page->originHasDeviceOrientationAndMotionAccess(origin))
+        return;
+
     [[WebCoreMotionManager sharedManager] addOrientationClient:this];
 }
 
@@ -67,8 +71,12 @@ void WebDeviceOrientationUpdateProviderProxy::stopUpdatingDeviceOrientation()
     [[WebCoreMotionManager sharedManager] removeOrientationClient:this];
 }
 
-void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion()
+void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion(const WebCore::SecurityOriginData& origin)
 {
+    RefPtr page = m_page.get();
+    if (!page || !page->originHasDeviceOrientationAndMotionAccess(origin))
+        return;
+
     [[WebCoreMotionManager sharedManager] addMotionClient:this];
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
@@ -50,10 +50,11 @@ WebDeviceOrientationUpdateProvider::~WebDeviceOrientationUpdateProvider()
     WebProcess::singleton().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProvider::messageReceiverName(), m_pageIdentifier);
 }
 
-void WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation(WebCore::MotionManagerClient& client)
+void WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation(WebCore::MotionManagerClient& client, const WebCore::SecurityOriginData& origin)
 {
     if (m_deviceOrientationClients.isEmptyIgnoringNullReferences() && m_page)
-        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation());
+        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation(origin));
+
     m_deviceOrientationClients.add(client);
 }
 
@@ -66,10 +67,11 @@ void WebDeviceOrientationUpdateProvider::stopUpdatingDeviceOrientation(WebCore::
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StopUpdatingDeviceOrientation());
 }
 
-void WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion(WebCore::MotionManagerClient& client)
+void WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion(WebCore::MotionManagerClient& client, const WebCore::SecurityOriginData& origin)
 {
     if (m_deviceMotionClients.isEmptyIgnoringNullReferences() && m_page)
-        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceMotion());
+        m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceMotion(origin));
+
     m_deviceMotionClients.add(client);
 }
 
@@ -77,6 +79,7 @@ void WebDeviceOrientationUpdateProvider::stopUpdatingDeviceMotion(WebCore::Motio
 {
     if (m_deviceMotionClients.isEmptyIgnoringNullReferences())
         return;
+
     m_deviceMotionClients.remove(client);
     if (m_deviceMotionClients.isEmptyIgnoringNullReferences() && m_page)
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StopUpdatingDeviceMotion());

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
@@ -49,9 +49,9 @@ private:
     ~WebDeviceOrientationUpdateProvider();
 
     // WebCore::DeviceOrientationUpdateProvider
-    void startUpdatingDeviceOrientation(WebCore::MotionManagerClient&) final;
+    void startUpdatingDeviceOrientation(WebCore::MotionManagerClient&, const WebCore::SecurityOriginData&) final;
     void stopUpdatingDeviceOrientation(WebCore::MotionManagerClient&) final;
-    void startUpdatingDeviceMotion(WebCore::MotionManagerClient&) final;
+    void startUpdatingDeviceMotion(WebCore::MotionManagerClient&, const WebCore::SecurityOriginData&) final;
     void stopUpdatingDeviceMotion(WebCore::MotionManagerClient&) final;
     void deviceOrientationChanged(double, double, double, double, double) final;
     void deviceMotionChanged(double, double, double, double, double, double, std::optional<double>, std::optional<double>, std::optional<double>) final;

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
@@ -26,6 +26,7 @@
 #import "WebDeviceOrientationProviderMockInternal.h"
 
 #import "WebDeviceOrientationInternal.h"
+#import <WebCore/SecurityOriginData.h>
 #import <wtf/RetainPtr.h>
 
 using namespace WebCore;
@@ -53,7 +54,8 @@ using namespace WebCore;
 
 - (void)startUpdating
 {
-    m_core->startUpdating();
+    auto placeholderOrigin = WebCore::SecurityOriginData { };
+    m_core->startUpdating(placeholderOrigin);
 }
 
 - (void)stopUpdating


### PR DESCRIPTION
#### db03fd0f9e82fec0a5a6cfbc754c78e7e1e11a94
<pre>
Make WebDeviceOrientationUpdateProviderProxy validate origin access before registering for change
<a href="https://bugs.webkit.org/show_bug.cgi?id=289512">https://bugs.webkit.org/show_bug.cgi?id=289512</a>

Reviewed by Per Arne Vollan.

When deviceOrientationPermissionAPIEnabled is true, WebPageProxy would keep track of origins that have access to device
orientation and motion data. WebDeviceOrientationUpdateProviderProxy, as the actual observer of these updates, should
validate requesting origin has access before registering itself to WebCoreMotionManager.

WebPageProxy::originHasDeviceOrientationAndMotionAccess is not implemented yet in this patch, as there is a bug that
WebDeviceOrientationAndMotionAccessController in UI process and DeviceOrientationAndMotionAccessController in web
process have different views of which origin has access.

* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::resumeUpdates):
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::resumeUpdates):
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resumeDeviceMotionAndOrientationUpdates):
* Source/WebCore/page/DeviceClient.h:
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::addDeviceEventListener):
* Source/WebCore/page/SecurityOriginData.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.h:
* Source/WebCore/platform/ios/DeviceMotionClientIOS.mm:
(WebCore::DeviceMotionClientIOS::startUpdating):
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.h:
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm:
(WebCore::DeviceOrientationClientIOS::startUpdating):
* Source/WebCore/platform/ios/DeviceOrientationUpdateProvider.h:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.cpp:
(WebCore::DeviceOrientationClientMock::startUpdating):
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::originHasDeviceOrientationAndMotionAccess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceMotion):
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp:
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion):
(WebKit::WebDeviceOrientationUpdateProvider::stopUpdatingDeviceMotion):
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h:
* Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm:
(-[WebDeviceOrientationProviderMockInternal startUpdating]):

Canonical link: <a href="https://commits.webkit.org/292054@main">https://commits.webkit.org/292054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fe7f203dae00bd1fa575ebd70c8c04a694ca4a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72096 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97482 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10689 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101543 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80472 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26658 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->