### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for DeviceClient

### DIFF
--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -40,9 +40,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceMotionClient);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceMotionController);
 
 DeviceMotionController::DeviceMotionController(DeviceMotionClient& client)
-    : DeviceController(client)
+    : m_client(client)
 {
-    deviceMotionClient().setController(this);
+    client.setController(this);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -57,7 +57,7 @@ void DeviceMotionController::suspendUpdates()
 
 void DeviceMotionController::resumeUpdates(const SecurityOriginData& origin)
 {
-    if (!m_listeners.isEmpty())
+    if (hasListeners())
         m_client->startUpdating(origin);
 }
 
@@ -68,19 +68,14 @@ void DeviceMotionController::didChangeDeviceMotion(DeviceMotionData* deviceMotio
     dispatchDeviceEvent(DeviceMotionEvent::create(eventNames().devicemotionEvent, deviceMotionData));
 }
 
-DeviceMotionClient& DeviceMotionController::deviceMotionClient()
-{
-    return downcast<DeviceMotionClient>(m_client.get());
-}
-
 bool DeviceMotionController::hasLastData()
 {
-    return deviceMotionClient().lastMotion();
+    return m_client->lastMotion();
 }
 
 RefPtr<Event> DeviceMotionController::getLastEvent()
 {
-    RefPtr lastMotion = deviceMotionClient().lastMotion();
+    RefPtr lastMotion = m_client->lastMotion();
     return DeviceMotionEvent::create(eventNames().devicemotionEvent, lastMotion.get());
 }
 
@@ -99,6 +94,11 @@ bool DeviceMotionController::isActiveAt(Page* page)
     if (DeviceMotionController* self = DeviceMotionController::from(page))
         return self->isActive();
     return false;
+}
+
+DeviceClient& DeviceMotionController::client()
+{
+    return m_client.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -51,14 +51,17 @@ public:
 #endif
 
     void didChangeDeviceMotion(DeviceMotionData*);
-    DeviceMotionClient& deviceMotionClient();
 
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;
+    DeviceClient& client() final;
 
     static ASCIILiteral supplementName();
     static DeviceMotionController* from(Page*);
     static bool isActiveAt(Page*);
+
+private:
+    WeakRef<DeviceMotionClient> m_client;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -41,19 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationClient);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceOrientationController);
 
 DeviceOrientationController::DeviceOrientationController(DeviceOrientationClient& client)
-    : DeviceController(client)
+    : m_client(client)
 {
-    deviceOrientationClient().setController(this);
+    client.setController(this);
 }
 
 void DeviceOrientationController::didChangeDeviceOrientation(DeviceOrientationData* orientation)
 {
     dispatchDeviceEvent(DeviceOrientationEvent::create(eventNames().deviceorientationEvent, orientation));
-}
-
-DeviceOrientationClient& DeviceOrientationController::deviceOrientationClient()
-{
-    return static_cast<DeviceOrientationClient&>(m_client.get());
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -68,7 +63,7 @@ void DeviceOrientationController::suspendUpdates()
 
 void DeviceOrientationController::resumeUpdates(const SecurityOriginData& origin)
 {
-    if (!m_listeners.isEmpty())
+    if (hasListeners())
         m_client->startUpdating(origin);
 }
 
@@ -76,12 +71,12 @@ void DeviceOrientationController::resumeUpdates(const SecurityOriginData& origin
 
 bool DeviceOrientationController::hasLastData()
 {
-    return deviceOrientationClient().lastOrientation();
+    return m_client->lastOrientation();
 }
 
 RefPtr<Event> DeviceOrientationController::getLastEvent()
 {
-    RefPtr orientation = deviceOrientationClient().lastOrientation();
+    RefPtr orientation = m_client->lastOrientation();
     return DeviceOrientationEvent::create(eventNames().deviceorientationEvent, orientation.get());
 }
 
@@ -102,6 +97,11 @@ bool DeviceOrientationController::isActiveAt(Page* page)
     if (DeviceOrientationController* self = DeviceOrientationController::from(page))
         return self->isActive();
     return false;
+}
+
+DeviceClient& DeviceOrientationController::client()
+{
+    return m_client.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -45,7 +45,6 @@ public:
     virtual ~DeviceOrientationController() = default;
 
     void didChangeDeviceOrientation(DeviceOrientationData*);
-    DeviceOrientationClient& deviceOrientationClient();
 
 #if PLATFORM(IOS_FAMILY)
     // FIXME: We should look to reconcile the iOS and OpenSource differences with this class
@@ -56,10 +55,14 @@ public:
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;
 #endif
+    DeviceClient& client() final;
 
     static ASCIILiteral supplementName();
     static DeviceOrientationController* from(Page*);
     static bool isActiveAt(Page*);
+
+private:
+    WeakRef<DeviceOrientationClient> m_client;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
@@ -34,15 +35,11 @@ class DeviceClient;
 class SecurityOriginData;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DeviceClient> : std::true_type { };
-}
-
 namespace WebCore {
 
-class DeviceClient : public CanMakeWeakPtr<DeviceClient> {
+class DeviceClient : public CanMakeWeakPtr<DeviceClient>, public CanMakeCheckedPtr<DeviceClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(DeviceClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceClient);
 public:
     virtual ~DeviceClient() = default;
 

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -35,9 +35,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceController);
 
-DeviceController::DeviceController(DeviceClient& client)
-    : m_client(client)
-    , m_timer(*this, &DeviceController::fireDeviceEvent)
+DeviceController::DeviceController()
+    : m_timer(*this, &DeviceController::fireDeviceEvent)
 {
 }
 
@@ -59,7 +58,7 @@ void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
     }
 
     if (wasEmpty)
-        m_client->startUpdating(document->securityOrigin().data());
+        checkedClient()->startUpdating(document->securityOrigin().data());
 }
 
 void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
@@ -67,7 +66,7 @@ void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
     m_listeners.remove(&window);
     m_lastEventListeners.remove(&window);
     if (m_listeners.isEmpty())
-        m_client->stopUpdating();
+        checkedClient()->stopUpdating();
 }
 
 void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
@@ -75,7 +74,7 @@ void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
     m_listeners.removeAll(&window);
     m_lastEventListeners.removeAll(&window);
     if (m_listeners.isEmpty())
-        m_client->stopUpdating();
+        checkedClient()->stopUpdating();
 }
 
 bool DeviceController::hasDeviceEventListener(LocalDOMWindow& window) const
@@ -92,11 +91,6 @@ void DeviceController::dispatchDeviceEvent(Event& event)
     }
 }
 
-DeviceClient& DeviceController::client()
-{
-    return m_client.get();
-}
-
 void DeviceController::fireDeviceEvent()
 {
     ASSERT(hasLastData());
@@ -111,6 +105,11 @@ void DeviceController::fireDeviceEvent()
                 listener->dispatchEvent(*lastEvent);
         }
     }
+}
+
+CheckedRef<DeviceClient> DeviceController::checkedClient()
+{
+    return client();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -43,9 +43,10 @@ class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr<Devic
     WTF_MAKE_TZONE_ALLOCATED(DeviceController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceController);
 public:
-    explicit DeviceController(DeviceClient&);
+    DeviceController();
     virtual ~DeviceController();
 
+    bool hasListeners() { return !m_listeners.isEmpty(); }
     void addDeviceEventListener(LocalDOMWindow&);
     void removeDeviceEventListener(LocalDOMWindow&);
     void removeAllDeviceEventListeners(LocalDOMWindow&);
@@ -53,17 +54,17 @@ public:
 
     void dispatchDeviceEvent(Event&);
     bool isActive() { return !m_listeners.isEmpty(); }
-    DeviceClient& client();
+    virtual DeviceClient& client() = 0;
 
     virtual bool hasLastData() { return false; }
     virtual RefPtr<Event> getLastEvent() { return nullptr; }
 
-protected:
+private:
     void fireDeviceEvent();
+    CheckedRef<DeviceClient> checkedClient();
 
     HashCountedSet<RefPtr<LocalDOMWindow>> m_listeners;
     HashCountedSet<RefPtr<LocalDOMWindow>> m_lastEventListeners;
-    WeakRef<DeviceClient> m_client;
     Timer m_timer;
 };
 

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -40,9 +40,8 @@ class DeviceOrientationController;
 // A mock implementation of DeviceOrientationClient used to test the feature in
 // DumpRenderTree. Embedders should should configure the Page object to use this
 // client when running DumpRenderTree.
-class DeviceOrientationClientMock final : public DeviceOrientationClient, public CanMakeCheckedPtr<DeviceOrientationClientMock> {
+class DeviceOrientationClientMock final : public DeviceOrientationClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DeviceOrientationClientMock, WEBCORE_EXPORT);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientMock);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
 


### PR DESCRIPTION
#### b445326fff96f518a1a2d4bd459052894b4ee7ea
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for DeviceClient
<a href="https://rdar.apple.com/146721489">rdar://146721489</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289515">https://bugs.webkit.org/show_bug.cgi?id=289515</a>

Reviewed by Ryosuke Niwa and Per Arne Vollan.

Also, make DeviceController data members private.

* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::DeviceMotionController):
(WebCore::DeviceMotionController::resumeUpdates):
(WebCore::DeviceMotionController::hasLastData):
(WebCore::DeviceMotionController::getLastEvent):
(WebCore::DeviceMotionController::client):
(WebCore::DeviceMotionController::deviceMotionClient): Deleted.
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::DeviceOrientationController):
(WebCore::DeviceOrientationController::resumeUpdates):
(WebCore::DeviceOrientationController::hasLastData):
(WebCore::DeviceOrientationController::getLastEvent):
(WebCore::DeviceOrientationController::client):
(WebCore::DeviceOrientationController::deviceOrientationClient): Deleted.
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/page/DeviceClient.h:
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::DeviceController):
(WebCore::DeviceController::addDeviceEventListener):
(WebCore::DeviceController::removeDeviceEventListener):
(WebCore::DeviceController::removeAllDeviceEventListeners):
(WebCore::DeviceController::checkedClient):
(WebCore::DeviceController::client): Deleted.
* Source/WebCore/page/DeviceController.h:
(WebCore::DeviceController::hasListeners):
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:

Canonical link: <a href="https://commits.webkit.org/292374@main">https://commits.webkit.org/292374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f634e61b5a435c92dee99ea93ef142c2379daedf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100904 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4323 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102934 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22913 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81491 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26075 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22876 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->