### PR TITLE
CSSFontFaceSource: Fix Safe C++ issues

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -13,7 +13,6 @@ accessibility/AXCoreObject.h
 accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
-css/CSSFontFaceSource.h
 css/CSSFontSelector.h
 css/CSSPrimitiveValueMappings.h
 css/CSSRuleList.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -415,7 +415,6 @@ css/CSSCursorImageValue.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceRule.cpp
 css/CSSFontFaceSet.cpp
-css/CSSFontFaceSource.cpp
 css/CSSFontFeatureValue.cpp
 css/CSSFontSelector.cpp
 css/CSSFontStyleRangeValue.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -209,7 +209,6 @@ css/CSSComputedStyleDeclaration.cpp
 css/CSSCounterStyleDescriptors.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceSet.cpp
-css/CSSFontFaceSource.cpp
 css/CSSFontSelector.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetValue.cpp

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -34,6 +34,7 @@
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -68,7 +69,7 @@ class StyleRuleFontFace;
 enum class ExternalResourceDownloadPolicy : bool;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFace);
-class CSSFontFace final : public RefCounted<CSSFontFace> {
+class CSSFontFace final : public RefCountedAndCanMakeWeakPtr<CSSFontFace> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSFontFace);
 public:
     static Ref<CSSFontFace> create(CSSFontSelector&, StyleRuleFontFace* cssConnection = nullptr, FontFace* wrapper = nullptr, bool isLocalFallback = false);

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -116,7 +116,7 @@ CSSFontFaceSource::~CSSFontFaceSource()
 
 bool CSSFontFaceSource::shouldIgnoreFontLoadCompletions() const
 {
-    return m_face.shouldIgnoreFontLoadCompletions();
+    return protectedCSSFontFace()->shouldIgnoreFontLoadCompletions();
 }
 
 void CSSFontFaceSource::opportunisticallyStartFontDataURLLoading()
@@ -132,8 +132,6 @@ void CSSFontFaceSource::fontLoaded(FontLoadRequest& fontRequest)
     if (shouldIgnoreFontLoadCompletions())
         return;
 
-    Ref<CSSFontFace> protectedFace(m_face);
-
     // If the font is in the cache, this will be synchronously called from FontLoadRequest::addClient().
     if (m_status == Status::Pending)
         setStatus(Status::Loading);
@@ -148,7 +146,7 @@ void CSSFontFaceSource::fontLoaded(FontLoadRequest& fontRequest)
     else
         setStatus(Status::Success);
 
-    m_face.fontLoaded(*this);
+    protectedCSSFontFace()->fontLoaded(*this);
 }
 
 void CSSFontFaceSource::load(Document* document)
@@ -163,12 +161,12 @@ void CSSFontFaceSource::load(Document* document)
         bool success = false;
         if (m_hasSVGFontFaceElement) {
             if (m_svgFontFaceElement) {
-                if (auto* fontElement = dynamicDowncast<SVGFontElement>(m_svgFontFaceElement->parentNode())) {
+                if (RefPtr fontElement = dynamicDowncast<SVGFontElement>(m_svgFontFaceElement->parentNode())) {
                     ASSERT(!m_inDocumentCustomPlatformData);
                     if (auto otfFont = convertSVGToOTFFont(*fontElement))
                         m_generatedOTFBuffer = SharedBuffer::create(WTFMove(otfFont.value()));
                     if (m_generatedOTFBuffer) {
-                        m_inDocumentCustomPlatformData = FontCustomPlatformData::create(*m_generatedOTFBuffer, String());
+                        m_inDocumentCustomPlatformData = FontCustomPlatformData::create(Ref { *m_generatedOTFBuffer }, String());
                         success = static_cast<bool>(m_inDocumentCustomPlatformData);
                     }
                 }
@@ -176,7 +174,7 @@ void CSSFontFaceSource::load(Document* document)
         } else if (m_immediateSource) {
             ASSERT(!m_immediateFontCustomPlatformData);
             bool wrapping;
-            auto buffer = SharedBuffer::create(m_immediateSource->span());
+            auto buffer = SharedBuffer::create(Ref { *m_immediateSource }->span());
             m_immediateFontCustomPlatformData = CachedFont::createCustomFontData(buffer.get(), String(), wrapping);
             success = static_cast<bool>(m_immediateFontCustomPlatformData);
         } else {
@@ -186,7 +184,7 @@ void CSSFontFaceSource::load(Document* document)
             FontCascadeDescription fontDescription;
             fontDescription.setOneFamily(m_fontFaceName);
             fontDescription.setComputedSize(1);
-            fontDescription.setShouldAllowUserInstalledFonts(m_face.allowUserInstalledFonts());
+            fontDescription.setShouldAllowUserInstalledFonts(protectedCSSFontFace()->allowUserInstalledFonts());
             success = FontCache::forCurrentThread().fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
             if (document && document->settings().webAPIStatisticsEnabled())
                 ResourceLoadObserver::shared().logFontLoad(*document, m_fontFaceName.string(), success);
@@ -205,7 +203,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
         if (m_immediateSource) {
             if (!m_immediateFontCustomPlatformData)
                 return nullptr;
-            return Font::create(CachedFont::platformDataFromCustomData(*m_immediateFontCustomPlatformData, fontDescription, syntheticBold, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+            return Font::create(CachedFont::platformDataFromCustomData(Ref { *m_immediateFontCustomPlatformData }, fontDescription, syntheticBold, syntheticItalic, fontCreationContext), Font::Origin::Remote);
         }
 
         // We're local. Just return a Font from the normal cache.
@@ -235,7 +233,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
         return nullptr;
     if (!m_inDocumentCustomPlatformData)
         return nullptr;
-    return Font::create(m_inDocumentCustomPlatformData->fontPlatformData(fontDescription, syntheticBold, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+    return Font::create(Ref { *m_inDocumentCustomPlatformData }->fontPlatformData(fontDescription, syntheticBold, syntheticItalic, fontCreationContext), Font::Origin::Remote);
 }
 
 bool CSSFontFaceSource::isSVGFontFaceSource() const
@@ -244,6 +242,11 @@ bool CSSFontFaceSource::isSVGFontFaceSource() const
         return true;
     auto* fontRequest = dynamicDowncast<CachedFontLoadRequest>(m_fontRequest.get());
     return fontRequest && is<CachedSVGFont>(fontRequest->cachedFont());
+}
+
+Ref<CSSFontFace> CSSFontFaceSource::protectedCSSFontFace() const
+{
+    return m_face.get();
 }
 
 }

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -84,8 +84,10 @@ private:
 
     void setStatus(Status);
 
+    Ref<CSSFontFace> protectedCSSFontFace() const;
+
     AtomString m_fontFaceName; // Font name for local fonts
-    CSSFontFace& m_face; // Our owning font face.
+    WeakRef<CSSFontFace> m_face; // Our owning font face.
     WeakPtr<CSSFontSelector> m_fontSelector; // For remote fonts, to orchestrate loading.
     const std::unique_ptr<FontLoadRequest> m_fontRequest; // Also for remote fonts, a pointer to the resource request.
 


### PR DESCRIPTION
#### d92058163ef00639cdc83f5047afae2099464a4f
<pre>
CSSFontFaceSource: Fix Safe C++ issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=289519">https://bugs.webkit.org/show_bug.cgi?id=289519</a>
<a href="https://rdar.apple.com/146724800">rdar://146724800</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::shouldIgnoreFontLoadCompletions const):
(WebCore::CSSFontFaceSource::fontLoaded):
(WebCore::CSSFontFaceSource::load):
(WebCore::CSSFontFaceSource::font):
(WebCore::CSSFontFaceSource::protectedCSSFontFace const):
* Source/WebCore/css/CSSFontFaceSource.h:

Canonical link: <a href="https://commits.webkit.org/291989@main">https://commits.webkit.org/291989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7928a444e434cbdbdaac19c45f4dba740b85ed70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29444 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3040 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14799 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21553 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26688 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->