### PR TITLE
Move CoroutineUtilities to WTF

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -906,6 +906,7 @@
 		EBEE51132D2DF488004FEC23 /* ContinuousApproximateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EBEE51142D2DF488004FEC23 /* ContinuousApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBEE51122D2DF488004FEC23 /* ContinuousApproximateTime.cpp */; };
 		FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0C387A2BEAD56B00583842 /* SmallMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FAC31B9D2D80083D006CCA20 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC31B9C2D80083D006CCA20 /* CoroutineUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
 		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1943,6 +1944,7 @@
 		F6D67D3226F90142006E0349 /* Int128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Int128.h; sourceTree = "<group>"; };
 		F72BBDB107FA424886178B9E /* SymbolImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolImpl.cpp; sourceTree = "<group>"; };
 		FA0C387A2BEAD56B00583842 /* SmallMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SmallMap.h; sourceTree = "<group>"; };
+		FAC31B9C2D80083D006CCA20 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
 		FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFConfig.cpp; sourceTree = "<group>"; };
 		FE032AD12463E43B0012D7C7 /* WTFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFConfig.h; sourceTree = "<group>"; };
 		FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TZoneMallocInlines.h; sourceTree = "<group>"; };
@@ -2246,6 +2248,7 @@
 				EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */,
 				EB33ED2D2D2DD91B00521B7B /* ContinuousTime.cpp */,
 				EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */,
+				FAC31B9C2D80083D006CCA20 /* CoroutineUtilities.h */,
 				0F8E85DA1FD485B000691889 /* CountingLock.cpp */,
 				0FFBCBFA1FD37E0F0072AAF0 /* CountingLock.h */,
 				E38C41261EB4E0680042957D /* CPUTime.cpp */,
@@ -3355,6 +3358,7 @@
 				EBEE51132D2DF488004FEC23 /* ContinuousApproximateTime.h in Headers */,
 				EB33ED2E2D2DD91B00521B7B /* ContinuousTime.h in Headers */,
 				DDF307C627C086DF006A526F /* ConversionMode.h in Headers */,
+				FAC31B9D2D80083D006CCA20 /* CoroutineUtilities.h in Headers */,
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
 				DD3DC92627A4BF8E007E5B61 /* CPUTime.h in Headers */,
 				DDF3071127C086CC006A526F /* CrashReporter.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -59,6 +59,7 @@ set(WTF_PUBLIC_HEADERS
     Condition.h
     ContinuousApproximateTime.h
     ContinuousTime.h
+    CoroutineUtilities.h
     CountingLock.h
     CrossThreadCopier.h
     CrossThreadQueue.h

--- a/Source/WTF/wtf/CoroutineUtilities.h
+++ b/Source/WTF/wtf/CoroutineUtilities.h
@@ -25,12 +25,10 @@
 
 #pragma once
 
-#include <concepts>
 #include <coroutine>
 #include <wtf/CompletionHandler.h>
-#include <wtf/TZoneMallocInlines.h>
 
-namespace WebKit {
+namespace WTF {
 
 template<typename PromiseType>
 class CoroutineHandle {
@@ -60,11 +58,14 @@ private:
 
 template<typename T>
 class [[nodiscard]] Awaitable {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     class PromiseBase {
         WTF_MAKE_FAST_ALLOCATED;
     public:
         struct final_awaitable {
+            WTF_FORBID_HEAP_ALLOCATION;
+        public:
             bool await_ready() const noexcept { return false; }
             template<typename Promise>
             std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> coroutine) noexcept { return coroutine.promise().handle(); }
@@ -98,6 +99,7 @@ public:
     using promise_type = Promise<T>;
 
     class AwaitableHelper {
+        WTF_FORBID_HEAP_ALLOCATION;
     public:
         AwaitableHelper(std::coroutine_handle<promise_type> coroutine)
             : m_coroutine(coroutine) { }
@@ -119,6 +121,8 @@ private:
 };
 
 struct Task {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
     struct promise_type {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         Task get_return_object() { return { }; }
@@ -130,6 +134,7 @@ struct Task {
 };
 
 template<typename T> class [[nodiscard]] AwaitableFromCompletionHandler {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     using Callback = CompletionHandler<void(CompletionHandler<void(T&&)>)>;
     AwaitableFromCompletionHandler(Callback&& callback)
@@ -148,6 +153,7 @@ private:
     std::optional<T> m_result;
 };
 template<> class [[nodiscard]] AwaitableFromCompletionHandler<void> {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     using Callback = CompletionHandler<void(CompletionHandler<void(void)>)>;
     AwaitableFromCompletionHandler(Callback&& callback)
@@ -165,3 +171,8 @@ private:
 };
 
 }
+
+using WTF::Awaitable;
+using WTF::AwaitableFromCompletionHandler;
+using WTF::CoroutineHandle;
+using WTF::Task;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -94,6 +94,7 @@ using SegmentedVectorMalloc = FastMalloc;
 
 template<typename> struct DefaultRefDerefTraits;
 
+template<typename> class Awaitable;
 template<typename> class CompactPtr;
 template<typename> class CompletionHandler;
 template<typename, size_t = 0> class Deque;
@@ -196,6 +197,7 @@ using WTF::AbstractLocker;
 using WTF::AtomString;
 using WTF::AtomStringImpl;
 using WTF::AtomicObjectIdentifier;
+using WTF::Awaitable;
 using WTF::BinarySemaphore;
 using WTF::CString;
 using WTF::CompletionHandler;

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -26,12 +26,12 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include "CoroutineUtilities.h"
 #include "Logging.h"
 #include "MessageArgumentDescriptions.h"
 #include "MessageNames.h"
 #include "StreamServerConnection.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/StdLibExtras.h>
@@ -175,7 +175,7 @@ void callMemberFunction(T* object, MF U::* function, Connection& connection, Arg
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> WebKit::Task {
+    [&] (auto completionHandler) -> Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -187,7 +187,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, ArgsTuple&& tuple,
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutine(T* object, MF U::* function, Connection& connection, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> WebKit::Task {
+    [&] (auto completionHandler) -> Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         completionHandler(co_await std::apply([&](auto&&... args) {
@@ -199,7 +199,7 @@ void callMemberFunctionCoroutine(T* object, MF U::* function, Connection& connec
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> WebKit::Task {
+    [&] (auto completionHandler) -> Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {
@@ -212,7 +212,7 @@ void callMemberFunctionCoroutineVoid(T* object, MF U::* function, ArgsTuple&& tu
 template<typename T, typename U, typename MF, typename ArgsTuple, typename CH>
 void callMemberFunctionCoroutineVoid(T* object, MF U::* function, Connection& connection, ArgsTuple&& tuple, CompletionHandler<CH>&& completionHandler)
 {
-    [&] (auto completionHandler) -> WebKit::Task {
+    [&] (auto completionHandler) -> Task {
         Ref protectedObject { *object };
         // Use of object without protection is safe here since std::apply() runs synchronously and object is protected for the lifetime of the Task.
         co_await std::apply([&](auto&&... args) {
@@ -277,11 +277,11 @@ struct MethodSignatureValidation<R(MethodArgumentTypes...) const>
 };
 
 template<typename> struct AwaitableReturnTuple;
-template<> struct AwaitableReturnTuple<WebKit::Awaitable<void>> {
+template<> struct AwaitableReturnTuple<Awaitable<void>> {
     using Type = std::tuple<>;
     static constexpr bool hasParameters = false;
 };
-template<typename... T> struct AwaitableReturnTuple<WebKit::Awaitable<T...>> {
+template<typename... T> struct AwaitableReturnTuple<Awaitable<T...>> {
     using Type = std::tuple<T...>;
     static constexpr bool hasParameters = true;
 };

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -30,7 +30,6 @@
 
 #include "APIFullscreenClient.h"
 #include "APIPageConfiguration.h"
-#include "CoroutineUtilities.h"
 #include "MessageSenderInlines.h"
 #include "RemotePageFullscreenManagerProxy.h"
 #include "WebAutomationSession.h"
@@ -44,6 +43,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -55,7 +55,6 @@ class WebFullScreenManagerProxy;
 class WebPageProxy;
 class WebProcessProxy;
 struct SharedPreferencesForWebProcess;
-template<typename> class Awaitable;
 
 class WebFullScreenManagerProxyClient : public CanMakeCheckedPtr<WebFullScreenManagerProxyClient> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -72,7 +72,6 @@
 #include "CallbackID.h"
 #include "ColorControlSupportsAlpha.h"
 #include "Connection.h"
-#include "CoroutineUtilities.h"
 #include "DidFilterKnownLinkDecoration.h"
 #include "DownloadManager.h"
 #include "DownloadProxy.h"
@@ -264,6 +263,7 @@
 #include <optional>
 #include <stdio.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/FileSystem.h>
 #include <wtf/ListHashSet.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -617,7 +617,6 @@ enum class WebEventModifier : uint8_t;
 enum class WebEventType : uint8_t;
 enum class WindowKind : uint8_t;
 
-template<typename> class Awaitable;
 template<typename> class MonotonicObjectIdentifier;
 
 using ActivityStateChangeID = uint64_t;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2568,7 +2568,6 @@
 		FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
 		FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */; };
-		FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */; };
 		FAE61CE62D0A5608000D238D /* UnifiedSource132.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */; };
 		FAE61CE72D0A5608000D238D /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */; };
 		FAE61CE82D0A5608000D238D /* UnifiedSource136.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */; };
@@ -8504,7 +8503,6 @@
 		FAC8498B2A9E92DE00D407EF /* WebTransportSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebTransportSession.cpp; path = Network/WebTransportSession.cpp; sourceTree = "<group>"; };
 		FAC8498C2A9E92DE00D407EF /* WebTransportSession.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = WebTransportSession.messages.in; path = Network/WebTransportSession.messages.in; sourceTree = "<group>"; };
 		FAC8498E2A9E92DF00D407EF /* WebTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSession.h; path = Network/WebTransportSession.h; sourceTree = "<group>"; };
-		FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
 		FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource132.cpp; sourceTree = "<group>"; };
 		FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource134.cpp; sourceTree = "<group>"; };
 		FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource136.cpp; sourceTree = "<group>"; };
@@ -15140,7 +15138,6 @@
 				1A7E814E1152D2240003695B /* mac */,
 				CE1A0BCA1A48E6C60054EF74 /* spi */,
 				51B15A7D138439B200321AD8 /* unix */,
-				FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */,
 				ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */,
 				ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */,
 				E3C788F02D035CED00D6C13D /* LogClient.cpp */,
@@ -16825,7 +16822,6 @@
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,
 				1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */,
 				F43E893D2AEDBB9000097D2D /* CoreTelephonyUtilities.h in Headers */,
-				FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */,
 				B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */,
 				57597EBD218184900037F924 /* CtapAuthenticator.h in Headers */,
 				526C5722284ADCBC00E08955 /* CtapCcidDriver.h in Headers */,

--- a/Tools/TestWebKitAPI/CoroutineUtilities.h
+++ b/Tools/TestWebKitAPI/CoroutineUtilities.h
@@ -25,28 +25,13 @@
 
 #pragma once
 
-#import <coroutine>
+#import <wtf/CoroutineUtilities.h>
 
 namespace TestWebKitAPI {
 
-template<typename PromiseType>
-struct CoroutineHandle {
-    CoroutineHandle(std::coroutine_handle<PromiseType>&& handle)
-        : handle(WTFMove(handle)) { }
-    CoroutineHandle(const CoroutineHandle&) = delete;
-    CoroutineHandle(CoroutineHandle&& other)
-        : handle(std::exchange(other.handle, nullptr)) { }
-    ~CoroutineHandle()
-    {
-        if (handle)
-            handle.destroy();
-    }
-    std::coroutine_handle<PromiseType> handle;
-};
-
-struct Task {
+struct ConnectionTask {
     struct promise_type {
-        Task get_return_object() { return { std::coroutine_handle<promise_type>::from_promise(*this) }; }
+        ConnectionTask get_return_object() { return { std::coroutine_handle<promise_type>::from_promise(*this) }; }
         std::suspend_never initial_suspend() { return { }; }
         std::suspend_always final_suspend() noexcept { return { }; }
         void unhandled_exception() { }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
@@ -115,7 +115,7 @@ TEST(WKHTTPCookieStore, CookiePolicy)
     done = false;
 
     bool requestHadCookie { false };
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         requestHadCookie = strnstr(request.data(), "Cookie", request.size());
         co_await connection.awaitableSend(HTTPResponse({ { "Set-Cookie"_s, "testCookie=42"_s } }, "hi"_s).serialize());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -237,7 +237,7 @@ TEST(WebKit, LoadMoreThan4GB)
         return static_cast<uint8_t>('a');
     }));
 
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         if (path == "/"_s)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -4056,7 +4056,7 @@ PrivateTokenTestSetupState setupWebViewForPrivateTokenTests(bool& didDecideServi
         return requestView.substring(headerValueStart, headerEnd - headerValueStart).toStringWithoutCopying();
     };
 
-    auto server = makeUnique<HTTPServer>(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    auto server = makeUnique<HTTPServer>(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
@@ -516,7 +516,7 @@ TEST(_WKDataTask, Basic)
     constexpr auto html = "<script>document.cookie='testkey=value'</script>"_s;
     constexpr auto secondResponse = "second response"_s;
     Vector<char> secondRequest;
-    auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -845,7 +845,7 @@ TEST(WKWebView, CrossOriginDoubleRedirectAuthentication)
         return memmem(request.data(), request.size(), field, strlen(field));
     };
 
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1889,7 +1889,7 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
 {
     using namespace TestWebKitAPI;
 
-    HTTPServer httpServer { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer httpServer { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
 
@@ -2025,7 +2025,7 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
 
     bool didSetSite2CookieHeader { false };
     bool didSendSite2CookieHeader { false };
-    HTTPServer httpServer { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer httpServer { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -869,7 +869,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
-    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task {
+    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -926,7 +926,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
         { "/simple.html"_s, { SimpleHtml } },
         { "/simple2.html"_s, { SimpleHtml } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
-    TestWebKitAPI::HTTPServer server2(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task {
+    TestWebKitAPI::HTTPServer server2(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -984,7 +984,7 @@ TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
         { "/simple.html"_s, { SimpleHtml } },
         { "/simple.html?name=test"_s, { "<html><body>FAIL</body></html>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
-    TestWebKitAPI::HTTPServer server2(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task {
+    TestWebKitAPI::HTTPServer server2(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -4201,7 +4201,7 @@ TEST(ServiceWorker, FocusNotYetLoadedClient)
     auto dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
     [[configuration websiteDataStore] set_delegate:dataStoreDelegate.get()];
 
-    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::Task {
+    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = TestWebKitAPI::HTTPServer::parsePath(request);
@@ -4448,7 +4448,7 @@ TEST(ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)
     }).get();
     webView2.get().navigationDelegate = navigationDelegate.get();
 
-    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::Task {
+    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = TestWebKitAPI::HTTPServer::parsePath(request);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -259,7 +259,7 @@ TEST(SiteIsolation, LoadingCallbacksAndPostMessage)
 
     bool finishedLoading { false };
     size_t framesCommitted { 0 };
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -686,7 +686,7 @@ TEST(SiteIsolation, PostMessageWithNotAllowedTargetOrigin)
     "</script>"_s;
 
     bool finishedLoading { false };
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -2696,7 +2696,7 @@ TEST(SiteIsolation, ApplicationNameForUserAgent)
     auto mainframeHTML = "<iframe src='https://domain2.com/subframe'></iframe>"_s;
     auto subframeHTML = "<script src='https://domain3.com/request_from_subframe'></script>"_s;
     bool receivedRequestFromSubframe = false;
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -2736,7 +2736,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgent)
     auto subframeHTML = "<script src='https://domain3.com/request_from_subframe'></script>"_s;
     bool receivedRequestFromSubframe = false;
     bool firstRequest = true;
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -2797,7 +2797,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringCrossSiteProvisionalNavi
     auto mainframeHTML = "<iframe id='frame' src='https://domain2.com/subframe'></iframe>"_s;
     auto subframeHTML = "<script src='https://domain2.com/request_from_subframe'></script>"_s;
     bool receivedRequestFromSubframe = false;
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -2901,7 +2901,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringSameSiteProvisionalNavig
     auto mainframeHTML = "<iframe id='frame' src='https://domain2.com/subframe'></iframe>"_s;
     auto subframeHTML = "<script src='https://domain2.com/request_from_subframe'></script>"_s;
     bool receivedRequestFromSubframe = false;
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
@@ -3592,7 +3592,7 @@ TEST(SiteIsolation, SandboxFlags)
 TEST(SiteIsolation, SandboxFlagsDuringNavigation)
 {
     bool receivedIframe2Request { false };
-    HTTPServer server { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
+    HTTPServer server { HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto path = HTTPServer::parsePath(co_await connection.awaitableReceiveHTTPRequest());
             if (path == "/example"_s) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -362,7 +362,7 @@ TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
 
         std::optional<bool> requestHadCookieResult;
 
-        HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task {
+        HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask {
             while (true) {
                 auto request = co_await connection.awaitableReceiveHTTPRequest();
                 auto path = HTTPServer::parsePath(request);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -832,7 +832,7 @@ TEST(WKHTTPCookieStore, WebSocketCookies)
     using namespace TestWebKitAPI;
     bool receivedThirdRequest { false };
     uint16_t serverPort { 0 };
-    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         request.append(0);
@@ -872,7 +872,7 @@ TEST(WKHTTPCookieStore, WebSocketCookiesFromRedirect)
     using namespace TestWebKitAPI;
     bool receivedWebSocket { false };
     uint16_t serverPort { 0 };
-    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         request.append(0);
@@ -929,7 +929,7 @@ TEST(WKHTTPCookieStore, WebSocketCookiesThroughRedirect)
     using namespace TestWebKitAPI;
     bool receivedWebSocket { false };
     uint16_t serverPort { 0 };
-    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         request.append(0);
@@ -978,7 +978,7 @@ TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughFirstPartyRedirect)
     using namespace TestWebKitAPI;
     bool receivedWebSocket { false };
     uint16_t serverPort { 0 };
-    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         request.append(0);
@@ -1020,7 +1020,7 @@ TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughRedirectToThirdParty)
     using namespace TestWebKitAPI;
     bool receivedWebSocket { false };
     uint16_t serverPort { 0 };
-    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+    HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
         auto request = co_await connection.awaitableReceiveHTTPRequest();
         auto path = HTTPServer::parsePath(request);
         request.append(0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -447,7 +447,7 @@ String longString(LChar c)
 
 TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
 {
-    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::Task {
+    TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::ConnectionTask {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = TestWebKitAPI::HTTPServer::parsePath(request);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -362,7 +362,7 @@ TEST(WebKit, EvaluateJavaScriptInAttachments)
     // Evaluating JavaScript in such a document should fail and result in an error.
 
     using namespace TestWebKitAPI;
-    HTTPServer server(HTTPServer::UseCoroutines::Yes, [](Connection connection) -> Task {
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [](Connection connection) -> ConnectionTask {
         co_await connection.awaitableReceiveHTTPRequest();
         co_await connection.awaitableSend("HTTP/1.1 200 OK\r\n"
             "Content-Length: 12\r\n"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -63,7 +63,7 @@ static void validateChallenge(NSURLAuthenticationChallenge *challenge, uint16_t 
 
 TEST(WebTransport, ClientBidirectional)
 {
-    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         co_await connection.awaitableSend(WTFMove(request));
@@ -107,7 +107,7 @@ TEST(WebTransport, ClientBidirectional)
 
 TEST(WebTransport, Datagram)
 {
-    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
         auto request = co_await datagramConnection.awaitableReceiveBytes();
         co_await datagramConnection.awaitableSend(WTFMove(request));
@@ -150,7 +150,7 @@ TEST(WebTransport, Datagram)
 
 TEST(WebTransport, Unidirectional)
 {
-    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverUnidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Unidirectional);
@@ -198,7 +198,7 @@ TEST(WebTransport, Unidirectional)
 // FIXME: Fix and enable this test.
 TEST(WebTransport, DISABLED_ServerBidirectional)
 {
-    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
@@ -247,7 +247,7 @@ TEST(WebTransport, DISABLED_ServerBidirectional)
 
 TEST(WebTransport, NetworkProcessCrash)
 {
-    WebTransportServer echoServer([](ConnectionGroup group) -> Task {
+    WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
         co_await datagramConnection.awaitableSend(@"abc");
         auto bidiConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);
@@ -419,7 +419,7 @@ TEST(WebTransport, NetworkProcessCrash)
 
 TEST(WebTransport, Worker)
 {
-    WebTransportServer transportServer([](ConnectionGroup group) -> Task {
+    WebTransportServer transportServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();
         auto request = co_await connection.awaitableReceiveBytes();
         auto serverBidirectionalStream = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Bidirectional);

--- a/Tools/TestWebKitAPI/WebTransportServer.h
+++ b/Tools/TestWebKitAPI/WebTransportServer.h
@@ -35,7 +35,7 @@ namespace TestWebKitAPI {
 
 class WebTransportServer {
 public:
-    WebTransportServer(Function<Task(ConnectionGroup)>&&);
+    WebTransportServer(Function<ConnectionTask(ConnectionGroup)>&&);
     ~WebTransportServer();
 
     uint16_t port() const;

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -36,17 +36,17 @@
 namespace TestWebKitAPI {
 
 struct WebTransportServer::Data : public RefCounted<WebTransportServer::Data> {
-    static Ref<Data> create(Function<Task(ConnectionGroup)>&& connectionGroupHandler) { return adoptRef(*new Data(WTFMove(connectionGroupHandler))); }
-    Data(Function<Task(ConnectionGroup)>&& connectionGroupHandler)
+    static Ref<Data> create(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler) { return adoptRef(*new Data(WTFMove(connectionGroupHandler))); }
+    Data(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler)
         : connectionGroupHandler(WTFMove(connectionGroupHandler)) { }
 
-    Function<Task(ConnectionGroup)> connectionGroupHandler;
+    Function<ConnectionTask(ConnectionGroup)> connectionGroupHandler;
     RetainPtr<nw_listener_t> listener;
     Vector<ConnectionGroup> connectionGroups;
-    Vector<CoroutineHandle<Task::promise_type>> coroutineHandles;
+    Vector<CoroutineHandle<ConnectionTask::promise_type>> coroutineHandles;
 };
 
-WebTransportServer::WebTransportServer(Function<Task(ConnectionGroup)>&& connectionGroupHandler)
+WebTransportServer::WebTransportServer(Function<ConnectionTask(ConnectionGroup)>&& connectionGroupHandler)
     : m_data(Data::create(WTFMove(connectionGroupHandler)))
 {
     auto configureWebTransport = [](nw_protocol_options_t options) {

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -50,7 +50,7 @@ public:
     HTTPServer(std::initializer_list<std::pair<String, HTTPResponse>>, Protocol = Protocol::Http, CertificateVerifier&& = nullptr, SecIdentityRef = nullptr, std::optional<uint16_t> port = { });
     HTTPServer(Function<void(Connection)>&&, Protocol = Protocol::Http);
     enum class UseCoroutines : bool { Yes };
-    HTTPServer(UseCoroutines, Function<Task(Connection)>&&, Protocol = Protocol::Http);
+    HTTPServer(UseCoroutines, Function<ConnectionTask(Connection)>&&, Protocol = Protocol::Http);
     ~HTTPServer();
     uint16_t port() const;
     String origin() const;

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -55,7 +55,7 @@ struct HTTPServer::RequestData : public ThreadSafeRefCounted<RequestData, WTF::D
     size_t requestCount { 0 };
     HashMap<String, HTTPResponse> requestMap;
     Vector<Connection> connections;
-    Vector<CoroutineHandle<Task::promise_type>> coroutineHandles;
+    Vector<CoroutineHandle<ConnectionTask::promise_type>> coroutineHandles;
 };
 
 static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol protocol)
@@ -235,7 +235,7 @@ HTTPServer::HTTPServer(Function<void(Connection)>&& connectionHandler, Protocol 
     startListening(m_listener.get());
 }
 
-HTTPServer::HTTPServer(UseCoroutines, WTF::Function<Task(Connection)>&& connectionHandler, Protocol protocol)
+HTTPServer::HTTPServer(UseCoroutines, Function<ConnectionTask(Connection)>&& connectionHandler, Protocol protocol)
     : m_requestData(adoptRef(*new RequestData({ })))
     , m_listener(adoptNS(nw_listener_create(listenerParameters(protocol, nullptr, nullptr, { }).get())))
     , m_protocol(protocol)


### PR DESCRIPTION
#### 68287047515be9aded0d35f94cc0df8be7c86c5f
<pre>
Move CoroutineUtilities to WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=289520">https://bugs.webkit.org/show_bug.cgi?id=289520</a>
<a href="https://rdar.apple.com/146725359">rdar://146725359</a>

Reviewed by Abrar Rahman Protyasha.

They are low-level utilities with no dependencies except C++20.
This allows us to share CoroutineHandle.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CoroutineUtilities.h: Renamed from Source/WebKit/Platform/CoroutineUtilities.h.
(WTF::CoroutineHandle::CoroutineHandle):
(WTF::CoroutineHandle::operator=):
(WTF::CoroutineHandle::~CoroutineHandle):
(WTF::CoroutineHandle::handle const):
(WTF::Task::promise_type::get_return_object):
(WTF::Task::promise_type::initial_suspend):
(WTF::Task::promise_type::unhandled_exception):
(WTF::Task::promise_type::return_void):
* Source/WTF/wtf/Forward.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::callMemberFunctionCoroutine):
(IPC::callMemberFunctionCoroutineVoid):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/CoroutineUtilities.h:
(TestWebKitAPI::ConnectionTask::promise_type::get_return_object):
(TestWebKitAPI::CoroutineHandle::CoroutineHandle): Deleted.
(TestWebKitAPI::CoroutineHandle::~CoroutineHandle): Deleted.
(TestWebKitAPI::Task::promise_type::get_return_object): Deleted.
(TestWebKitAPI::Task::promise_type::initial_suspend): Deleted.
(TestWebKitAPI::Task::promise_type::unhandled_exception): Deleted.
(TestWebKitAPI::Task::promise_type::return_void): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:
(TEST(WKHTTPCookieStore, CookiePolicy)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST(WebKit, LoadMoreThan4GB)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(setupWebViewForPrivateTokenTests):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(TEST(_WKDataTask, Basic)):
(TEST(WKWebView, CrossOriginDoubleRedirectAuthentication)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)):
(TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorker, FocusNotYetLoadedClient)):
((ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, LoadingCallbacksAndPostMessage)):
(TestWebKitAPI::TEST(SiteIsolation, PostMessageWithNotAllowedTargetOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, ApplicationNameForUserAgent)):
(TestWebKitAPI::TEST(SiteIsolation, WebsitePoliciesCustomUserAgent)):
(TestWebKitAPI::TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringCrossSiteProvisionalNavigation)):
(TestWebKitAPI::TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringSameSiteProvisionalNavigation)):
(TestWebKitAPI::TEST(SiteIsolation, SandboxFlagsDuringNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, WebSocketCookies)):
(TEST(WKHTTPCookieStore, WebSocketCookiesFromRedirect)):
(TEST(WKHTTPCookieStore, WebSocketCookiesThroughRedirect)):
(TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughFirstPartyRedirect)):
(TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughRedirectToThirdParty)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WebKit, EvaluateJavaScriptInAttachments)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_Datagram)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_Unidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ServerBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_NetworkProcessCrash)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_Worker)):
* Tools/TestWebKitAPI/WebTransportServer.h:
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::Data::create):
(TestWebKitAPI::WebTransportServer::Data::Data):
(TestWebKitAPI::WebTransportServer::WebTransportServer):
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPServer::HTTPServer):

Canonical link: <a href="https://commits.webkit.org/291972@main">https://commits.webkit.org/291972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79ff9d3f3a35371e3388d91da9b985aac7d17819

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94489 "23 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44330 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101552 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93138 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80481 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14759 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26663 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115803 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21199 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->