### PR TITLE
[JSC] Use 3-operand instructions more in Baseline / DFG

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -2337,7 +2337,7 @@ public:
 
     void lshift32(Imm32 amount, RegisterID shiftAmount, RegisterID dest)
     {
-        lshift32(trustedImm32ForShift(amount), shiftAmount, dest);
+        lshift32(amount.asTrustedImm32(), shiftAmount, dest);
     }
     
     void rshift32(Imm32 imm, RegisterID dest)
@@ -2349,7 +2349,12 @@ public:
     {
         rshift32(src, trustedImm32ForShift(amount), dest);
     }
-    
+
+    void rshift32(Imm32 amount, RegisterID shiftAmount, RegisterID dest)
+    {
+        rshift32(amount.asTrustedImm32(), shiftAmount, dest);
+    }
+
     void urshift32(Imm32 imm, RegisterID dest)
     {
         urshift32(trustedImm32ForShift(imm), dest);
@@ -2358,6 +2363,11 @@ public:
     void urshift32(RegisterID src, Imm32 amount, RegisterID dest)
     {
         urshift32(src, trustedImm32ForShift(amount), dest);
+    }
+
+    void urshift32(Imm32 amount, RegisterID shiftAmount, RegisterID dest)
+    {
+        urshift32(amount.asTrustedImm32(), shiftAmount, dest);
     }
 
     void mul32(TrustedImm32 imm, RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1321,6 +1321,12 @@ public:
         m_assembler.asr<32>(dest, src, imm.m_value & 0x1f);
     }
 
+    void rshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        move(imm, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.asr<32>(dest, dataTempRegister, shiftAmount);
+    }
+
     void rshift32(RegisterID shiftAmount, RegisterID dest)
     {
         rshift32(dest, shiftAmount, dest);
@@ -1483,6 +1489,12 @@ public:
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
         m_assembler.lsr<32>(dest, src, imm.m_value & 0x1f);
+    }
+
+    void urshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        move(imm, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.lsr<32>(dest, dataTempRegister, shiftAmount);
     }
 
     void urshift32(RegisterID shiftAmount, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -606,6 +606,14 @@ public:
         rshift32(dest, imm, dest);
     }
 
+    void rshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        // Clamp the shift to the range 0..31
+        m_assembler.ARM_and(dest, shiftAmount, ARMThumbImmediate::makeEncodedImm(0x1f));
+        move(imm, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.asr(dest, dataTempRegister, dest);
+    }
+
     void urshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
     {
         RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
@@ -633,6 +641,14 @@ public:
     void urshift32(TrustedImm32 imm, RegisterID dest)
     {
         urshift32(dest, imm, dest);
+    }
+
+    void urshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        // Clamp the shift to the range 0..31
+        m_assembler.ARM_and(dest, shiftAmount, ARMThumbImmediate::makeEncodedImm(0x1f));
+        move(imm, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.lsr(dest, dataTempRegister, dest);
     }
 
     void addUnsignedRightShift32(RegisterID src1, RegisterID src2, TrustedImm32 amount, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -728,6 +728,14 @@ public:
         m_assembler.maskRegister<32>(dest);
     }
 
+    void rshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        auto temp = temps<Data>();
+        move(imm, temp.data());
+        m_assembler.srawInsn(dest, temp.data(), shiftAmount);
+        m_assembler.maskRegister<32>(dest);
+    }
+
     void rshift64(RegisterID shiftAmount, RegisterID dest)
     {
         rshift64(dest, shiftAmount, dest);
@@ -769,6 +777,14 @@ public:
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
         m_assembler.srliwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void urshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        auto temp = temps<Data>();
+        move(imm, temp.data());
+        m_assembler.srlwInsn(dest, temp.data(), shiftAmount);
         m_assembler.maskRegister<32>(dest);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -801,6 +801,18 @@ public:
         rshift32(imm, dest);
     }
 
+    void rshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        if (shiftAmount == dest) {
+            move(imm, scratchRegister());
+            rshift32(shiftAmount, scratchRegister());
+            move(scratchRegister(), dest);
+        } else {
+            move(imm, dest);
+            rshift32(shiftAmount, dest);
+        }
+    }
+
     void urshift32(RegisterID shift_amount, RegisterID dest)
     {
         if (shift_amount == X86Registers::ecx)
@@ -834,6 +846,18 @@ public:
     {
         move32IfNeeded(src, dest);
         urshift32(imm, dest);
+    }
+
+    void urshift32(TrustedImm32 imm, RegisterID shiftAmount, RegisterID dest)
+    {
+        if (shiftAmount == dest) {
+            move(imm, scratchRegister());
+            urshift32(shiftAmount, scratchRegister());
+            move(scratchRegister(), dest);
+        } else {
+            move(imm, dest);
+            urshift32(shiftAmount, dest);
+        }
     }
 
     void rotateRight32(TrustedImm32 imm, RegisterID dest)
@@ -912,6 +936,10 @@ public:
         if (dest == right) {
             neg32(dest);
             add32(left, dest);
+            return;
+        }
+        if (left == right) {
+            move(TrustedImm32(0), dest);
             return;
         }
         move(left, dest);
@@ -5539,16 +5567,19 @@ public:
         m_assembler.subq_rr(src, dest);
     }
     
-    void sub64(RegisterID a, RegisterID b, RegisterID dest)
+    void sub64(RegisterID left, RegisterID right, RegisterID dest)
     {
-        if (b != dest) {
-            move(a, dest);
-            sub64(b, dest);
-        } else if (a != b) {
-            neg64(b);
-            add64(a, b);
-        } else
+        if (dest == right) {
+            neg64(dest);
+            add64(left, dest);
+            return;
+        }
+        if (left == right) {
             move(TrustedImm32(0), dest);
+            return;
+        }
+        move(left, dest);
+        sub64(right, dest);
     }
 
     void sub64(TrustedImm32 imm, RegisterID dest)

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -397,8 +397,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
                 jit.load8(AssemblyHelpers::Address(scratch1, Structure::indexingModeIncludingHistoryOffset()), scratch1);
 #endif
                 jit.and32(AssemblyHelpers::TrustedImm32(IndexingModeMask), scratch1);
-                jit.move(AssemblyHelpers::TrustedImm32(1), scratch2);
-                jit.lshift32(scratch1, scratch2);
+                jit.lshift32(AssemblyHelpers::TrustedImm32(1), scratch1, scratch2);
                 storeArrayModes.link(&jit);
                 jit.or32(scratch2, AssemblyHelpers::AbsoluteAddress(arrayProfile->addressOfArrayModes()));
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -5140,15 +5140,18 @@ void SpeculativeJIT::compileArithSub(Node* node)
             int32_t imm2 = node->child2()->asInt32();
             GPRTemporary result(this);
 
-            if (!shouldCheckOverflow(node->arithMode())) {
-                move(op1.gpr(), result.gpr());
-                sub32(Imm32(imm2), result.gpr());
-            } else {
+            GPRReg op1GPR = op1.gpr();
+            GPRReg resultGPR = result.gpr();
+
+            if (!shouldCheckOverflow(node->arithMode()))
+                sub32(op1GPR, Imm32(imm2), resultGPR);
+            else {
                 GPRTemporary scratch(this);
-                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op1.gpr(), Imm32(imm2), result.gpr(), scratch.gpr()));
+                GPRReg scratchGPR = scratch.gpr();
+                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op1GPR, Imm32(imm2), resultGPR, scratchGPR));
             }
 
-            strictInt32Result(result.gpr(), node);
+            strictInt32Result(resultGPR, node);
             return;
         }
             
@@ -5156,12 +5159,15 @@ void SpeculativeJIT::compileArithSub(Node* node)
             int32_t imm1 = node->child1()->asInt32();
             SpeculateInt32Operand op2(this, node->child2());
             GPRTemporary result(this);
+
+            GPRReg op2GPR = op2.gpr();
+            GPRReg resultGPR = result.gpr();
                 
-            move(Imm32(imm1), result.gpr());
+            move(Imm32(imm1), resultGPR);
             if (!shouldCheckOverflow(node->arithMode()))
-                sub32(op2.gpr(), result.gpr());
+                sub32(op2GPR, resultGPR);
             else
-                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op2.gpr(), result.gpr()));
+                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op2GPR, resultGPR));
                 
             strictInt32Result(result.gpr(), node);
             return;
@@ -5171,13 +5177,16 @@ void SpeculativeJIT::compileArithSub(Node* node)
         SpeculateInt32Operand op2(this, node->child2());
         GPRTemporary result(this);
 
-        if (!shouldCheckOverflow(node->arithMode())) {
-            move(op1.gpr(), result.gpr());
-            sub32(op2.gpr(), result.gpr());
-        } else
-            speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op1.gpr(), op2.gpr(), result.gpr()));
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
 
-        strictInt32Result(result.gpr(), node);
+        if (!shouldCheckOverflow(node->arithMode()))
+            sub32(op1GPR, op2GPR, resultGPR);
+        else
+            speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchSub32(Overflow, op1GPR, op2GPR, resultGPR));
+
+        strictInt32Result(resultGPR, node);
         return;
     }
         
@@ -5193,20 +5202,31 @@ void SpeculativeJIT::compileArithSub(Node* node)
             SpeculateWhicheverInt52Operand op1(this, node->child1());
             SpeculateWhicheverInt52Operand op2(this, node->child2(), op1);
             GPRTemporary result(this, Reuse, op1);
-            move(op1.gpr(), result.gpr());
-            sub64(op2.gpr(), result.gpr());
-            int52Result(result.gpr(), node, op1.format());
+
+            GPRReg op1GPR = op1.gpr();
+            GPRReg op2GPR = op2.gpr();
+            GPRReg resultGPR = result.gpr();
+
+            sub64(op1GPR, op2GPR, resultGPR);
+            int52Result(resultGPR, node, op1.format());
             return;
         }
         
         SpeculateInt52Operand op1(this, node->child1());
         SpeculateInt52Operand op2(this, node->child2());
         GPRTemporary result(this);
-        move(op1.gpr(), result.gpr());
-        speculationCheck(
-            Int52Overflow, JSValueRegs(), nullptr,
-            branchSub64(Overflow, op2.gpr(), result.gpr()));
-        int52Result(result.gpr(), node);
+
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+
+#if CPU(ARM64)
+        speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branchSub64(Overflow, op1GPR, op2GPR, resultGPR));
+#else
+        move(op1GPR, resultGPR);
+        speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branchSub64(Overflow, op2GPR, resultGPR));
+#endif
+        int52Result(resultGPR, node);
         return;
     }
 #endif // USE(JSVALUE64)
@@ -5216,11 +5236,12 @@ void SpeculativeJIT::compileArithSub(Node* node)
         SpeculateDoubleOperand op2(this, node->child2());
         FPRTemporary result(this, op1);
 
-        FPRReg reg1 = op1.fpr();
-        FPRReg reg2 = op2.fpr();
-        subDouble(reg1, reg2, result.fpr());
+        FPRReg op1FPR = op1.fpr();
+        FPRReg op2FPR = op2.fpr();
+        FPRReg resultFPR = result.fpr();
 
-        doubleResult(result.fpr(), node);
+        subDouble(op1FPR, op2FPR, resultFPR);
+        doubleResult(resultFPR, node);
         return;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -278,8 +278,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
                 notTypedArray.link(&jit);
                 jit.load8(MacroAssembler::Address(GPRInfo::regT0, JSCell::indexingTypeAndMiscOffset()), GPRInfo::regT1);
                 jit.and32(MacroAssembler::TrustedImm32(IndexingModeMask), GPRInfo::regT1);
-                jit.move(MacroAssembler::TrustedImm32(1), GPRInfo::regT2);
-                jit.lshift32(GPRInfo::regT1, GPRInfo::regT2);
+                jit.lshift32(MacroAssembler::TrustedImm32(1), GPRInfo::regT1, GPRInfo::regT2);
                 storeArrayModes.link(&jit);
                 jit.or32(GPRInfo::regT2, CCallHelpers::Address(GPRInfo::regT3, ArrayProfile::offsetOfArrayModes()));
             }

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -855,18 +855,15 @@ void emitRandomThunkImpl(AssemblyHelpers& jit, GPRReg scratch0, GPRReg scratch1,
     storeToLow(scratch1);
 
     // x ^= x << 23;
-    jit.move(scratch0, scratch2);
-    jit.lshift64(AssemblyHelpers::TrustedImm32(23), scratch2);
+    jit.lshift64(scratch0, AssemblyHelpers::TrustedImm32(23), scratch2);
     jit.xor64(scratch2, scratch0);
 
     // x ^= x >> 17;
-    jit.move(scratch0, scratch2);
-    jit.rshift64(AssemblyHelpers::TrustedImm32(17), scratch2);
+    jit.rshift64(scratch0, AssemblyHelpers::TrustedImm32(17), scratch2);
     jit.xor64(scratch2, scratch0);
 
     // x ^= y ^ (y >> 26);
-    jit.move(scratch1, scratch2);
-    jit.rshift64(AssemblyHelpers::TrustedImm32(26), scratch2);
+    jit.rshift64(scratch1, AssemblyHelpers::TrustedImm32(26), scratch2);
     jit.xor64(scratch1, scratch2);
     jit.xor64(scratch2, scratch0);
 
@@ -877,8 +874,7 @@ void emitRandomThunkImpl(AssemblyHelpers& jit, GPRReg scratch0, GPRReg scratch1,
     jit.add64(scratch1, scratch0);
 
     // Extract random 53bit. [0, 53] bit is safe integer number ranges in double representation.
-    jit.move(AssemblyHelpers::TrustedImm64((1ULL << 53) - 1), scratch1);
-    jit.and64(scratch1, scratch0);
+    jit.and64(AssemblyHelpers::TrustedImm64((1ULL << 53) - 1), scratch0);
     // Now, scratch0 is always in range of int64_t. Safe to convert it to double with cvtsi2sdq.
     jit.convertInt64ToDouble(scratch0, result);
 
@@ -1240,39 +1236,31 @@ void AssemblyHelpers::wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch)
 {
     GPRReg input = inputAndResult;
     // key += ~(key << 32);
-    move(input, scratch);
-    lshift64(TrustedImm32(32), scratch);
+    lshift64(input, TrustedImm32(32), scratch);
     not64(scratch);
     add64(scratch, input);
     // key ^= (key >> 22);
-    move(input, scratch);
-    urshift64(TrustedImm32(22), scratch);
+    urshift64(input, TrustedImm32(22), scratch);
     xor64(scratch, input);
     // key += ~(key << 13);
-    move(input, scratch);
-    lshift64(TrustedImm32(13), scratch);
+    lshift64(input, TrustedImm32(13), scratch);
     not64(scratch);
     add64(scratch, input);
     // key ^= (key >> 8);
-    move(input, scratch);
-    urshift64(TrustedImm32(8), scratch);
+    urshift64(input, TrustedImm32(8), scratch);
     xor64(scratch, input);
     // key += (key << 3);
-    move(input, scratch);
-    lshift64(TrustedImm32(3), scratch);
+    lshift64(input, TrustedImm32(3), scratch);
     add64(scratch, input);
     // key ^= (key >> 15);
-    move(input, scratch);
-    urshift64(TrustedImm32(15), scratch);
+    urshift64(input, TrustedImm32(15), scratch);
     xor64(scratch, input);
     // key += ~(key << 27);
-    move(input, scratch);
-    lshift64(TrustedImm32(27), scratch);
+    lshift64(input, TrustedImm32(27), scratch);
     not64(scratch);
     add64(scratch, input);
     // key ^= (key >> 31);
-    move(input, scratch);
-    urshift64(TrustedImm32(31), scratch);
+    urshift64(input, TrustedImm32(31), scratch);
     xor64(scratch, input);
 
     // return static_cast<unsigned>(result)

--- a/Source/JavaScriptCore/jit/JITBitAndGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitAndGenerator.cpp
@@ -55,7 +55,7 @@ void JITBitAndGenerator::generateFastPath(CCallHelpers& jit)
 #if USE(JSVALUE64)
             jit.and64(CCallHelpers::Imm32(constOpr.asConstInt32()), var.payloadGPR(), m_result.payloadGPR());
             if (constOpr.asConstInt32() >= 0)
-                jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+                jit.boxInt32(m_result.payloadGPR(), m_result);
 #else
             jit.moveValueRegs(var, m_result);
             jit.and32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
@@ -69,7 +69,7 @@ void JITBitAndGenerator::generateFastPath(CCallHelpers& jit)
     if (m_leftOperand.definitelyIsBoolean() && m_rightOperand.definitelyIsBoolean()) {
         jit.and32(m_left.payloadGPR(), m_right.payloadGPR(), m_result.payloadGPR());
         jit.and32(CCallHelpers::TrustedImm32(1), m_result.payloadGPR());
-        jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+        jit.boxInt32(m_result.payloadGPR(), m_result);
         return;
     }
 #endif

--- a/Source/JavaScriptCore/jit/JITBitOrGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitOrGenerator.cpp
@@ -45,13 +45,7 @@ void JITBitOrGenerator::generateFastPath(CCallHelpers& jit)
 
         if (constOpr.asConstInt32()) {
 #if USE(JSVALUE64)
-#if CPU(ARM64)
             jit.or64(CCallHelpers::TrustedImm64(static_cast<uint64_t>(static_cast<uint32_t>(constOpr.asConstInt32()))), var.payloadGPR(), m_result.payloadGPR());
-#else
-            jit.moveValueRegs(var, m_result);
-            jit.or32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
-            jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
-#endif
 #else
             jit.moveValueRegs(var, m_result);
             jit.or32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
@@ -65,7 +59,7 @@ void JITBitOrGenerator::generateFastPath(CCallHelpers& jit)
     if (m_leftOperand.definitelyIsBoolean() && m_rightOperand.definitelyIsBoolean()) {
         jit.or32(m_left.payloadGPR(), m_right.payloadGPR(), m_result.payloadGPR());
         jit.and32(CCallHelpers::TrustedImm32(1), m_result.payloadGPR());
-        jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+        jit.boxInt32(m_result.payloadGPR(), m_result);
         return;
     }
 #endif

--- a/Source/JavaScriptCore/jit/JITBitXorGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitXorGenerator.cpp
@@ -45,7 +45,7 @@ void JITBitXorGenerator::generateFastPath(CCallHelpers& jit)
         
 #if USE(JSVALUE64)
         jit.xor32(CCallHelpers::Imm32(constOpr.asConstInt32()), var.payloadGPR(), m_result.payloadGPR());
-        jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+        jit.boxInt32(m_result.payloadGPR(), m_result);
 #else
         jit.moveValueRegs(var, m_result);
         jit.xor32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
@@ -57,7 +57,7 @@ void JITBitXorGenerator::generateFastPath(CCallHelpers& jit)
     if (m_leftOperand.definitelyIsBoolean() && m_rightOperand.definitelyIsBoolean()) {
         jit.xor32(m_left.payloadGPR(), m_right.payloadGPR(), m_result.payloadGPR());
         jit.and32(CCallHelpers::TrustedImm32(1), m_result.payloadGPR());
-        jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+        jit.boxInt32(m_result.payloadGPR(), m_result);
         return;
     }
 #endif
@@ -70,7 +70,7 @@ void JITBitXorGenerator::generateFastPath(CCallHelpers& jit)
 
 #if USE(JSVALUE64)
     jit.xor32(m_right.payloadGPR(), m_left.payloadGPR(), m_result.payloadGPR());
-    jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+    jit.boxInt32(m_result.payloadGPR(), m_result);
 #else
     jit.moveValueRegs(m_left, m_result);
     jit.xor32(m_right.payloadGPR(), m_result.payloadGPR());

--- a/Source/JavaScriptCore/jit/JITDivGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITDivGenerator.cpp
@@ -123,7 +123,6 @@ void JITDivGenerator::generateFastPath(CCallHelpers& jit)
 #if USE(JSVALUE64)
     jit.moveDoubleTo64(m_leftFPR, m_scratchGPR);
     CCallHelpers::Jump notDoubleZero = jit.branchTest64(CCallHelpers::NonZero, m_scratchGPR);
-
     jit.move(GPRInfo::numberTagRegister, m_result.payloadGPR());
     m_endJumpList.append(jit.jump());
 

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -420,8 +420,7 @@ ALWAYS_INLINE void JIT::emitPutVirtualRegister(VirtualRegister dst, RegisterID f
 
 ALWAYS_INLINE JIT::Jump JIT::emitJumpIfNotInt(RegisterID reg1, RegisterID reg2, RegisterID scratch)
 {
-    move(reg1, scratch);
-    and64(reg2, scratch);
+    and64(reg1, reg2, scratch);
     return branchIfNotInt32(scratch);
 }
 

--- a/Source/JavaScriptCore/jit/JITNegGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITNegGenerator.cpp
@@ -66,13 +66,7 @@ JITMathICInlineResult JITNegGenerator::generateInline(CCallHelpers& jit, MathICG
         state.slowPathJumps.append(jit.branchIfInt32(m_src));
         state.slowPathJumps.append(jit.branchIfNotNumber(m_src, m_scratchGPR));
 #if USE(JSVALUE64)
-        if (m_src.payloadGPR() != m_result.payloadGPR()) {
-            jit.move(CCallHelpers::TrustedImm64(static_cast<int64_t>(1ull << 63)), m_result.payloadGPR());
-            jit.xor64(m_src.payloadGPR(), m_result.payloadGPR());
-        } else {
-            jit.move(CCallHelpers::TrustedImm64(static_cast<int64_t>(1ull << 63)), m_scratchGPR);
-            jit.xor64(m_scratchGPR, m_result.payloadGPR());
-        }
+        jit.xor64(CCallHelpers::TrustedImm64(static_cast<int64_t>(1ull << 63)), m_src.payloadGPR(), m_result.payloadGPR());
 #else
         jit.moveValueRegs(m_src, m_result);
         jit.xor32(CCallHelpers::TrustedImm32(1 << 31), m_result.tagGPR());
@@ -110,8 +104,7 @@ bool JITNegGenerator::generateFastPath(CCallHelpers& jit, CCallHelpers::JumpList
 
     // For a double, all we need to do is to invert the sign bit.
 #if USE(JSVALUE64)
-    jit.move(CCallHelpers::TrustedImm64((int64_t)(1ull << 63)), m_scratchGPR);
-    jit.xor64(m_scratchGPR, m_result.payloadGPR());
+    jit.xor64(CCallHelpers::TrustedImm64((int64_t)(1ull << 63)), m_result.payloadGPR());
 #else
     jit.xor32(CCallHelpers::TrustedImm32(1 << 31), m_result.tagGPR());
 #endif

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -891,8 +891,7 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     emitPutVirtualRegister(dst, regT5);
 #else // if !USE(BIGINT32)
     // Jump slow if both are cells (to cover strings).
-    move(regT0, regT2);
-    or64(regT1, regT2);
+    or64(regT1, regT0, regT2);
     addSlowCase(branchIfCell(regT2));
 
     // Jump slow if either is a double. First test if it's an integer, which is fine, and then test
@@ -1060,8 +1059,7 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     }
 #else // if !USE(BIGINT32)
     // Jump slow if both are cells (to cover strings).
-    move(regT0, regT2);
-    or64(regT1, regT2);
+    or64(regT1, regT0, regT2);
     addSlowCase(branchIfCell(regT2));
 
     // Jump slow if either is a double. First test if it's an integer, which is fine, and then test

--- a/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp
@@ -44,6 +44,7 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
 
     m_didEmitFastPath = true;
 
+#if USE(JSVALUE32_64)
     if (m_rightOperand.isConstInt32()) {
         // Try to do (intVar >> intConstant).
         CCallHelpers::Jump notInt = jit.branchIfNotInt32(m_left);
@@ -55,97 +56,143 @@ void JITRightShiftGenerator::generateFastPath(CCallHelpers& jit)
                 jit.rshift32(CCallHelpers::Imm32(shiftAmount), m_result.payloadGPR());
             else
                 jit.urshift32(CCallHelpers::Imm32(shiftAmount), m_result.payloadGPR());
-#if USE(JSVALUE64)
-            jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
-#endif
         }
+        m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
 
-        if (jit.supportsFloatingPointTruncate()) {
-            m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
+        // Try to do (doubleVar >> intConstant).
+        notInt.link(&jit);
 
-            // Try to do (doubleVar >> intConstant).
-            notInt.link(&jit);
+        m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
 
-            m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+        m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
 
-            jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
-#if CPU(ARM64)
-            if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
-                jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);
-            else
-#endif
-            {
-                m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
-            }
-
-            if (shiftAmount) {
-                if (m_shiftType == SignedShift)
-                    jit.rshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
-                else
-                    jit.urshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
-            }
-            jit.boxInt32(m_scratchGPR, m_result);
-
-        } else
-            m_slowPathJumpList.append(notInt);
-
-    } else {
-        // Try to do (intConstant >> intVar) or (intVar >> intVar).
-        m_slowPathJumpList.append(jit.branchIfNotInt32(m_right));
-
-        GPRReg rightOperandGPR = m_right.payloadGPR();
-        if (rightOperandGPR == m_result.payloadGPR())
-            rightOperandGPR = m_scratchGPR;
-
-        CCallHelpers::Jump leftNotInt;
-        if (m_leftOperand.isConstInt32()) {
-            jit.move(m_right.payloadGPR(), rightOperandGPR);
-#if USE(JSVALUE32_64)
-            jit.move(m_right.tagGPR(), m_result.tagGPR());
-#endif
-            jit.move(CCallHelpers::Imm32(m_leftOperand.asConstInt32()), m_result.payloadGPR());
-        } else {
-            leftNotInt = jit.branchIfNotInt32(m_left);
-            jit.move(m_right.payloadGPR(), rightOperandGPR);
-            jit.moveValueRegs(m_left, m_result);
-        }
-
-        if (m_shiftType == SignedShift)
-            jit.rshift32(rightOperandGPR, m_result.payloadGPR());
-        else
-            jit.urshift32(rightOperandGPR, m_result.payloadGPR());
-#if USE(JSVALUE64)
-        jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
-#endif
-        if (m_leftOperand.isConstInt32())
-            return;
-
-        if (jit.supportsFloatingPointTruncate()) {
-            m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
-
-            // Try to do (doubleVar >> intVar).
-            leftNotInt.link(&jit);
-
-            m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
-            jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
-#if CPU(ARM64)
-            if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
-                jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);
-            else
-#endif
-            {
-                m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
-            }
-
+        if (shiftAmount) {
             if (m_shiftType == SignedShift)
-                jit.rshift32(m_right.payloadGPR(), m_scratchGPR);
+                jit.rshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
             else
-                jit.urshift32(m_right.payloadGPR(), m_scratchGPR);
-            jit.boxInt32(m_scratchGPR, m_result);
-
-        } else
-            m_slowPathJumpList.append(leftNotInt);
+                jit.urshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
+        }
+        jit.boxInt32(m_scratchGPR, m_result);
+        return;
     }
+
+    // Try to do (intConstant >> intVar) or (intVar >> intVar).
+    m_slowPathJumpList.append(jit.branchIfNotInt32(m_right));
+
+    GPRReg rightOperandGPR = m_right.payloadGPR();
+    if (rightOperandGPR == m_result.payloadGPR())
+        rightOperandGPR = m_scratchGPR;
+
+    CCallHelpers::Jump leftNotInt;
+    if (m_leftOperand.isConstInt32()) {
+        jit.move(m_right.payloadGPR(), rightOperandGPR);
+        jit.move(m_right.tagGPR(), m_result.tagGPR());
+        jit.move(CCallHelpers::Imm32(m_leftOperand.asConstInt32()), m_result.payloadGPR());
+    } else {
+        leftNotInt = jit.branchIfNotInt32(m_left);
+        jit.move(m_right.payloadGPR(), rightOperandGPR);
+        jit.moveValueRegs(m_left, m_result);
+    }
+
+    if (m_shiftType == SignedShift)
+        jit.rshift32(rightOperandGPR, m_result.payloadGPR());
+    else
+        jit.urshift32(rightOperandGPR, m_result.payloadGPR());
+    if (m_leftOperand.isConstInt32())
+        return;
+
+    m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
+
+    // Try to do (doubleVar >> intVar).
+    leftNotInt.link(&jit);
+
+    m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+    jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+    m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
+
+    if (m_shiftType == SignedShift)
+        jit.rshift32(m_right.payloadGPR(), m_scratchGPR);
+    else
+        jit.urshift32(m_right.payloadGPR(), m_scratchGPR);
+    jit.boxInt32(m_scratchGPR, m_result);
+#else
+    if (m_rightOperand.isConstInt32()) {
+        // Try to do (intVar >> intConstant).
+        CCallHelpers::Jump notInt = jit.branchIfNotInt32(m_left);
+
+        int32_t shiftAmount = m_rightOperand.asConstInt32() & 0x1f;
+        if (shiftAmount) {
+            if (m_shiftType == SignedShift)
+                jit.rshift32(m_left.payloadGPR(), CCallHelpers::Imm32(shiftAmount), m_result.payloadGPR());
+            else
+                jit.urshift32(m_left.payloadGPR(), CCallHelpers::Imm32(shiftAmount), m_result.payloadGPR());
+            jit.boxInt32(m_result.payloadGPR(), m_result);
+        } else
+            jit.moveValueRegs(m_left, m_result);
+        m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
+
+        // Try to do (doubleVar >> intConstant).
+        notInt.link(&jit);
+        m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+        jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+#if CPU(ARM64)
+        if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
+            jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);
+        else
+#endif
+        {
+            m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
+        }
+
+        if (shiftAmount) {
+            if (m_shiftType == SignedShift)
+                jit.rshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
+            else
+                jit.urshift32(CCallHelpers::Imm32(shiftAmount), m_scratchGPR);
+        }
+        jit.boxInt32(m_scratchGPR, m_result);
+        return;
+    }
+    // Try to do (intConstant >> intVar) or (intVar >> intVar).
+    m_slowPathJumpList.append(jit.branchIfNotInt32(m_right));
+
+    if (m_leftOperand.isConstInt32()) {
+        if (m_shiftType == SignedShift)
+            jit.rshift32(CCallHelpers::Imm32(m_leftOperand.asConstInt32()), m_right.payloadGPR(), m_result.payloadGPR());
+        else
+            jit.urshift32(CCallHelpers::Imm32(m_leftOperand.asConstInt32()), m_right.payloadGPR(), m_result.payloadGPR());
+        jit.boxInt32(m_result.payloadGPR(), m_result);
+        return;
+    }
+
+    CCallHelpers::Jump leftNotInt = jit.branchIfNotInt32(m_left);
+    if (m_shiftType == SignedShift)
+        jit.rshift32(m_left.payloadGPR(), m_right.payloadGPR(), m_result.payloadGPR());
+    else
+        jit.urshift32(m_left.payloadGPR(), m_right.payloadGPR(), m_result.payloadGPR());
+    jit.boxInt32(m_result.payloadGPR(), m_result);
+    m_endJumpList.append(jit.jump()); // Terminate the above case before emitting more code.
+
+    // Try to do (doubleVar >> intVar).
+    leftNotInt.link(&jit);
+    m_slowPathJumpList.append(jit.branchIfNotNumber(m_left, m_scratchGPR));
+    jit.unboxDoubleNonDestructive(m_left, m_leftFPR, m_scratchGPR);
+#if CPU(ARM64)
+    if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
+        jit.convertDoubleToInt32UsingJavaScriptSemantics(m_leftFPR, m_scratchGPR);
+    else
+#endif
+    {
+        m_slowPathJumpList.append(jit.branchTruncateDoubleToInt32(m_leftFPR, m_scratchGPR));
+    }
+
+    if (m_shiftType == SignedShift)
+        jit.rshift32(m_right.payloadGPR(), m_scratchGPR);
+    else
+        jit.urshift32(m_right.payloadGPR(), m_scratchGPR);
+    jit.boxInt32(m_scratchGPR, m_result);
+#endif
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/SetupVarargsFrame.cpp
+++ b/Source/JavaScriptCore/jit/SetupVarargsFrame.cpp
@@ -36,22 +36,19 @@ namespace JSC {
 
 void emitSetVarargsFrame(CCallHelpers& jit, GPRReg lengthGPR, bool lengthIncludesThis, GPRReg numUsedSlotsGPR, GPRReg resultGPR)
 {
-    jit.move(numUsedSlotsGPR, resultGPR);
     // We really want to make sure the size of the new call frame is a multiple of
     // stackAlignmentRegisters(), however it is easier to accomplish this by
     // rounding numUsedSlotsGPR to the next multiple of stackAlignmentRegisters().
     // Together with the rounding below, we will assure that the new call frame is
     // located on a stackAlignmentRegisters() boundary and a multiple of
     // stackAlignmentRegisters() in size.
-    jit.addPtr(CCallHelpers::TrustedImm32(stackAlignmentRegisters() - 1), resultGPR);
+    jit.addPtr(CCallHelpers::TrustedImm32(stackAlignmentRegisters() - 1), numUsedSlotsGPR, resultGPR);
     jit.andPtr(CCallHelpers::TrustedImm32(~(stackAlignmentRegisters() - 1)), resultGPR);
 
-    jit.addPtr(lengthGPR, resultGPR);
-    jit.addPtr(CCallHelpers::TrustedImm32(CallFrame::headerSizeInRegisters + (lengthIncludesThis ? 0 : 1)), resultGPR);
-    
     // resultGPR now has the required frame size in Register units
     // Round resultGPR to next multiple of stackAlignmentRegisters()
-    jit.addPtr(CCallHelpers::TrustedImm32(stackAlignmentRegisters() - 1), resultGPR);
+    jit.addPtr(lengthGPR, resultGPR);
+    jit.addPtr(CCallHelpers::TrustedImm32(CallFrame::headerSizeInRegisters + (lengthIncludesThis ? 0 : 1) + (stackAlignmentRegisters() - 1)), resultGPR);
     jit.andPtr(CCallHelpers::TrustedImm32(~(stackAlignmentRegisters() - 1)), resultGPR);
     
     // Now resultGPR has the right stack frame offset in Register units.

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3103,8 +3103,7 @@ class YarrGenerator final : public YarrJITInfo {
                             static_assert(sizeof(BoyerMooreBitmap::Map::WordType) == sizeof(uint64_t));
                             static_assert(1 << 6 == 64);
                             static_assert(1 << (6 + 1) == BoyerMooreBitmap::Map::size());
-                            m_jit.move(m_regs.regT0, m_regs.regT2);
-                            m_jit.urshift32(MacroAssembler::TrustedImm32(6), m_regs.regT2);
+                            m_jit.urshift32(m_regs.regT0, MacroAssembler::TrustedImm32(6), m_regs.regT2);
                             m_jit.and32(MacroAssembler::TrustedImm32(1), m_regs.regT2);
                             m_jit.load64(MacroAssembler::BaseIndex(m_regs.regT1, m_regs.regT2, MacroAssembler::TimesEight), m_regs.regT2);
                             matched.append(m_jit.branchTestBit64(MacroAssembler::NonZero, m_regs.regT2, m_regs.regT0)); // We can ignore upper bits since modulo-64 is performed.


### PR DESCRIPTION
#### 07c88b96b2232cb51aaa281cccd40b72c2631a46
<pre>
[JSC] Use 3-operand instructions more in Baseline / DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=289521">https://bugs.webkit.org/show_bug.cgi?id=289521</a>
<a href="https://rdar.apple.com/146728227">rdar://146728227</a>

Reviewed by Michael Saboff.

Use 3-operand instructions more in Baseline / DFG as it can reduce code
size in ARM64.

* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::rshift32):
(JSC::MacroAssembler::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::rshift32):
(JSC::MacroAssemblerARM64::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::rshift32):
(JSC::MacroAssemblerARMv7::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::rshift32):
(JSC::MacroAssemblerRISCV64::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::rshift32):
(JSC::MacroAssemblerX86_64::urshift32):
(JSC::MacroAssemblerX86_64::sub32):
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::nonSpeculativeNonPeepholeCompareNullOrUndefined):
(JSC::DFG::SpeculativeJIT::nonSpeculativePeepholeBranchNullOrUndefined):
(JSC::DFG::SpeculativeJIT::compileObjectToObjectOrOtherEquality):
(JSC::DFG::SpeculativeJIT::compilePeepHoleObjectToObjectOrOtherEquality):
(JSC::DFG::SpeculativeJIT::compileToBooleanObjectOrOther):
(JSC::DFG::SpeculativeJIT::compileToBoolean):
(JSC::DFG::SpeculativeJIT::emitObjectOrOtherBranch):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::emitRandomThunkImpl):
(JSC::AssemblyHelpers::wangsInt64Hash):
* Source/JavaScriptCore/jit/JITBitAndGenerator.cpp:
(JSC::JITBitAndGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITBitOrGenerator.cpp:
(JSC::JITBitOrGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITBitXorGenerator.cpp:
(JSC::JITBitXorGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITDivGenerator.cpp:
(JSC::JITDivGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::emitJumpIfNotInt):
* Source/JavaScriptCore/jit/JITLeftShiftGenerator.cpp:
(JSC::JITLeftShiftGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITNegGenerator.cpp:
(JSC::JITNegGenerator::generateInline):
(JSC::JITNegGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
* Source/JavaScriptCore/jit/JITRightShiftGenerator.cpp:
(JSC::JITRightShiftGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITSubGenerator.cpp:
(JSC::JITSubGenerator::generateInline):
(JSC::JITSubGenerator::generateFastPath):
* Source/JavaScriptCore/jit/SetupVarargsFrame.cpp:
(JSC::emitSetVarargsFrame):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/292008@main">https://commits.webkit.org/292008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84f13e6a428acc22b436be745413d2534985bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72242 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29545 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44537 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87373 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101768 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93327 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81238 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21982 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80619 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25178 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14956 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15195 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26825 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116020 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21374 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->