### PR TITLE
Voice detection should be reenabled in case of GPU process crash

### DIFF
--- a/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection-expected.txt
+++ b/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS gpuProcessCrash-voiceDetection
+

--- a/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection.html
+++ b/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection.html
@@ -1,0 +1,63 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<video id=video autoplay playsinline></video>
+<script>
+var voiceActivityCount = 0;
+function detectVoiceActivity()
+{
+    voiceActivityCount = 0;
+    return navigator.mediaSession.setActionHandler("voiceactivity", () => voiceActivityCount++);
+}
+
+function validateVoiceActivityCount(testName, counter, initialVoiceActivityCount)
+{
+    if (!initialVoiceActivityCount)
+        initialVoiceActivityCount = voiceActivityCount;
+    else if (voiceActivityCount > initialVoiceActivityCount)
+        return Promise.resolve();
+
+    if (!counter)
+        counter = 0;
+    else if (counter > 50)
+        return Promise.reject("validateVoiceActivityCount timed out - " + testName);
+
+    return new Promise(resolve => setTimeout(resolve, 100)).then(() => {
+        return validateVoiceActivityCount(testName, ++counter, initialVoiceActivityCount);
+    });
+}
+
+function setMicrophoneActive(value)
+{
+    if (!window.internals)
+        return Promise.reject("no internals");
+    let resolve, reject;
+    let promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    window.internals.withUserGesture(() => {
+        navigator.mediaSession.setMicrophoneActive(value).then(resolve, reject);
+    });
+    return promise;
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    video.srcObject = stream;
+    await video.play();
+
+    await detectVoiceActivity();
+    await setMicrophoneActive(false);
+    await validateVoiceActivityCount("first test");
+
+    if (window.testRunner)
+       testRunner.terminateGPUProcess();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    await validateVoiceActivityCount("second test");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1448,6 +1448,7 @@ http/wpt/mediasession/setCaptureState-audio-category.html [ Skip ]
 
 # Lack of voice activity detection mock
 http/wpt/mediasession/voiceActivityDetection.html [ Skip ]
+http/wpt/mediasession/gpuProcessCrash-voiceDetection.html [ Skip ]
 
 # Seek on live streams not implemented.
 webkit.org/b/280069 imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html [ Failure ]

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -103,7 +103,6 @@ protected:
 
     void forEachClient(NOESCAPE const Function<void(CoreAudioCaptureSource&)>&) const;
     void captureFailed();
-    void continueStartProducingData();
 
     virtual void cleanupAudioUnit() = 0;
     virtual OSStatus startInternal() = 0;
@@ -147,6 +146,9 @@ private:
     // RealtimeMediaSourceCenterObserver
     void devicesChanged() final;
     void deviceWillBeRemoved(const String&) final { }
+
+    void continueStartProducingData();
+    void continueStopProducingData();
 
     bool m_enableEchoCancellation { true };
     double m_volume { 1 };

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -161,7 +161,11 @@ void RemoteRealtimeMediaSource::gpuProcessConnectionDidClose(GPUProcessConnectio
 
     if (isProducingData())
         startProducingData();
-
+    else if (isAudio() && !interrupted()) {
+        // To be able to reenable voice detection, we have to restart the source.
+        startProducingData();
+        stopProducingData();
+    }
 }
 #endif
 


### PR DESCRIPTION
#### 5164f69952f49fd6981669ab325ab7ac71771dfe
<pre>
Voice detection should be reenabled in case of GPU process crash
<a href="https://rdar.apple.com/146752099">rdar://146752099</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289525">https://bugs.webkit.org/show_bug.cgi?id=289525</a>

Reviewed by Eric Carlson.

Remove from WebPageProxy::gpuProcessExited, PLATFORM(MEDIA_STREAM) since it should have been ENABLE(MEDIA_STREAM),
and this code is already within an ENABLE(MEDIA_STREAM) section.

In case of a GPU process crash when microphone is muted, we need to start/stop the microphone capture to set up voice activity again.
We do this in RemoteRealtimeMediaSource::gpuProcessConnectionDidClose and we update BaseAudioSharedUnit::stopProducingData to wait for the warming up of the audio unit.
Otherwise, there is a risk to stop the audio unit before it even starts, which would disable the voice detection code.
We also return early when trying to start the audio unit and all clients have been removed.

* LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection-expected.txt: Added.
* LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::stopProducingData):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::gpuProcessExited):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::gpuProcessConnectionDidClose):

Canonical link: <a href="https://commits.webkit.org/292159@main">https://commits.webkit.org/292159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb519c0c401da668dd59bb1b764def5d3ce2822a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29684 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85691 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52721 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81715 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80777 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2735 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27032 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->