### PR TITLE
[GStreamer] imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2219,8 +2219,6 @@ webrtc/video-maxBitrate-vp8.html [ Failure ]
 # Times out waiting for DTLS transport setup. Some bug related with data-channel, pending investigation.
 webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Skip ]
 
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Failure ]
-
 fast/mediastream/video-rotation2.html [ Failure Pass Timeout ]
 
 # Regressions introduced by https://commits.webkit.org/263750@main

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL setting an encoding to false is reflected in outbound-rtp stats assert_equals: expected 2 but got 0
+FAIL setting an encoding to false is reflected in outbound-rtp stats assert_true: expected true got undefined
 

--- a/LayoutTests/webrtc/video-replace-track-to-null.html
+++ b/LayoutTests/webrtc/video-replace-track-to-null.html
@@ -20,7 +20,7 @@ async function getOutboundRTPStatsNumberOfEncodedFrames(connection)
     var report = await connection.getStats();
     var framesEncoded;
     report.forEach((statItem) => {
-        if (statItem.type === "outbound-rtp") {
+        if (statItem.type === "outbound-rtp" && statItem.kind === "video") {
             framesEncoded = statItem.framesEncoded;
         }
     });

--- a/LayoutTests/webrtc/vp8-then-h264-gpu-process-crash.html
+++ b/LayoutTests/webrtc/vp8-then-h264-gpu-process-crash.html
@@ -56,7 +56,7 @@ async function getInboundRTPStatsNumberOfDecodedFrames(connection)
     var report = await connection.getStats();
     var framesDecoded;
     report.forEach((statItem) => {
-        if (statItem.type === "inbound-rtp")
+        if (statItem.type === "inbound-rtp" && statItem.kind === "video")
             framesDecoded = statItem.framesDecoded;
     });
     return framesDecoded;

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -117,6 +117,9 @@ class GLibPort(Port):
         environment['WEBKIT_GST_ALLOW_PLAYBACK_OF_INVISIBLE_VIDEOS'] = '1'
         environment['WEBKIT_GST_WEBRTC_FORCE_EARLY_VIDEO_DECODING'] = '1'
 
+        # Match our WebRTC stats cache expiration time with LibWebRTC, since some tests actually expect this.
+        environment['WEBKIT_GST_WEBRTC_STATS_CACHE_EXPIRATION_TIME_MS'] = '50'
+
         # Disable SIMD optimization in GStreamer's ORC. Some bots (WPE release) crash in ORC's optimizations.
         environment['ORC_CODE'] = 'backup'
 


### PR DESCRIPTION
#### b09da9f516edbf4d389401a37355de57512eebcf
<pre>
[GStreamer] imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262989">https://bugs.webkit.org/show_bug.cgi?id=262989</a>
&lt;<a href="https://rdar.apple.com/problem/120704315">rdar://problem/120704315</a>&gt;

Reviewed by Xabier Rodriguez-Calvar.

Make sure our WebRTC stats contain at least one rtp-inbound and -outbound stats report. This test
was failing because of that.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::preprocessStats):

Canonical link: <a href="https://commits.webkit.org/292431@main">https://commits.webkit.org/292431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/485816beab8248ac84b31243aa10d14b7d70caf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53544 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/95517 "Found 2 webkitpy test failures: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description, webkit.messages_unittest.GeneratedFileContentsTest.test_message_names") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82250 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26221 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23060 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->