### PR TITLE
MediaElementSession::requiresFullscreenForVideoPlayback should not use PLATFORM(MEDIA_STREAM)

### DIFF
--- a/LayoutTests/fast/mediastream/video-media-stream-inline-expected.txt
+++ b/LayoutTests/fast/mediastream/video-media-stream-inline-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS video-media-stream-inline
+

--- a/LayoutTests/fast/mediastream/video-media-stream-inline.html
+++ b/LayoutTests/fast/mediastream/video-media-stream-inline.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id="video" autoplay=""></video>
+<script>
+promise_test(async () => {
+    if (window.internals) {
+        internals.settings.setAllowsInlineMediaPlayback(true);
+        internals.settings.setInlineMediaPlaybackRequiresPlaysInlineAttribute(true);
+    }
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    return video.play();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 58652b72afcabd263bba94e4ecc81b24961baae6
<pre>
MediaElementSession::requiresFullscreenForVideoPlayback should not use PLATFORM(MEDIA_STREAM)
<a href="https://rdar.apple.com/146755971">rdar://146755971</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289528">https://bugs.webkit.org/show_bug.cgi?id=289528</a>

Reviewed by Eric Carlson.

PLATFORM(MEDIA_STREAM) was used instead of ENABLE(MEDIA_STREAM).
Update the code and add test that covers the change.

* LayoutTests/fast/mediastream/video-media-stream-inline-expected.txt: Added.
* LayoutTests/fast/mediastream/video-media-stream-inline.html: Added.
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::requiresFullscreenForVideoPlayback const):

Canonical link: <a href="https://commits.webkit.org/292066@main">https://commits.webkit.org/292066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a029ecd4508c59f034891c63fbd7262f7ba8f83a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72120 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80497 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20173 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26682 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->