### PR TITLE
[WPE] Fix missing default values in WPESettings

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -96,10 +96,13 @@ struct _WPESettingsPrivate {
             { WPE_SETTING_FONT_HINTING_STYLE, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_HINTING_STYLE_SLIGHT)) },
             { WPE_SETTING_FONT_SUBPIXEL_LAYOUT, G_VARIANT_TYPE_BYTE, g_variant_ref_sink(g_variant_new_byte(WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB)) },
             { WPE_SETTING_FONT_DPI, G_VARIANT_TYPE_DOUBLE, g_variant_ref_sink(g_variant_new_double(96.0)) },
+            { WPE_SETTING_KEY_REPEAT_DELAY, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(400)) },
+            { WPE_SETTING_KEY_REPEAT_INTERVAL, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(80)) },
             { WPE_SETTING_CURSOR_BLINK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(1200)) },
             { WPE_SETTING_TOPLEVEL_DEFAULT_SIZE, G_VARIANT_TYPE("(uu)"), g_variant_ref_sink(g_variant_new("(uu)", 1024, 768)) },
             { WPE_SETTING_DOUBLE_CLICK_DISTANCE, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(5)) },
             { WPE_SETTING_DOUBLE_CLICK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(400)) },
+            { WPE_SETTING_DRAG_THRESHOLD, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(8)) },
         };
 
         for (auto& setting : defaultSettings)

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -227,16 +227,6 @@ typedef enum {
  * Default: 80
  */
 #define WPE_SETTING_KEY_REPEAT_INTERVAL "/wpe-platform/events/key-repeat/interval"
-/**
- * WPE_SETTING_DRM_SCALE:
- *
- * The scale size of the DRM screen.
- *
- * VariantType: double
- *
- * Default: 1.0
- */
-#define WPE_SETTING_DRM_SCALE "/wpe-platform/drm/scale"
 
 /**
  * WPESettingsSource:

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
@@ -37,6 +37,17 @@
 
 G_BEGIN_DECLS
 
+/**
+ * WPE_SETTING_DRM_SCALE:
+ *
+ * The scale size of the DRM screen.
+ *
+ * VariantType: double
+ *
+ * Default: 1.0
+ */
+#define WPE_SETTING_DRM_SCALE "/wpe-platform/drm/scale"
+
 #define WPE_TYPE_DISPLAY_DRM (wpe_display_drm_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEDisplayDRM, wpe_display_drm, WPE, DISPLAY_DRM, WPEDisplay)
 


### PR DESCRIPTION
#### 11fcf7e9b0b1398eefcb89df179524897dcc39cd
<pre>
[WPE] Fix missing default values in WPESettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=289530">https://bugs.webkit.org/show_bug.cgi?id=289530</a>

Reviewed by Carlos Garcia Campos.

These settings are defined in WPESettings.h but never initialized in
WPESettings.cpp. Added initialization for them in WPESettings.cpp
with the expected default values according with the documentation.

Also relocate DRM scale setting definition in WPESettings to
WPEDisplayDRM.

Related-To: <a href="https://commits.webkit.org/288922@main">https://commits.webkit.org/288922@main</a>

* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(_WPESettingsPrivate::_WPESettingsPrivate):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h:

Canonical link: <a href="https://commits.webkit.org/292007@main">https://commits.webkit.org/292007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89ceef15490d82d78e9f7125e7c837dc2864dc88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29546 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10545 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44538 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101769 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21983 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25179 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14960 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26826 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->