### PR TITLE
Enable WebTransport API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -61,8 +61,7 @@ static void validateChallenge(NSURLAuthenticationChallenge *challenge, uint16_t 
     verifyCertificateAndPublicKey(challenge.protectionSpace.serverTrust);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
-TEST(WebTransport, DISABLED_ClientBidirectional)
+TEST(WebTransport, ClientBidirectional)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> Task {
         auto connection = co_await group.receiveIncomingConnection();
@@ -106,8 +105,7 @@ TEST(WebTransport, DISABLED_ClientBidirectional)
     EXPECT_TRUE(challenged);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
-TEST(WebTransport, DISABLED_Datagram)
+TEST(WebTransport, Datagram)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> Task {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
@@ -150,8 +148,7 @@ TEST(WebTransport, DISABLED_Datagram)
     EXPECT_TRUE(challenged);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
-TEST(WebTransport, DISABLED_Unidirectional)
+TEST(WebTransport, Unidirectional)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> Task {
         auto connection = co_await group.receiveIncomingConnection();
@@ -198,7 +195,7 @@ TEST(WebTransport, DISABLED_Unidirectional)
     EXPECT_TRUE(challenged);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
+// FIXME: Fix and enable this test.
 TEST(WebTransport, DISABLED_ServerBidirectional)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> Task {
@@ -248,8 +245,7 @@ TEST(WebTransport, DISABLED_ServerBidirectional)
     EXPECT_TRUE(challenged);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
-TEST(WebTransport, DISABLED_NetworkProcessCrash)
+TEST(WebTransport, NetworkProcessCrash)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> Task {
         auto datagramConnection = group.createWebTransportConnection(ConnectionGroup::ConnectionType::Datagram);
@@ -421,8 +417,7 @@ TEST(WebTransport, DISABLED_NetworkProcessCrash)
     EXPECT_EQ(obj, nil);
 }
 
-// FIXME: Fix WebTransportServer constructor and re-enable these tests once rdar://141009498 is available in OS builds.
-TEST(WebTransport, DISABLED_Worker)
+TEST(WebTransport, Worker)
 {
     WebTransportServer transportServer([](ConnectionGroup group) -> Task {
         auto connection = co_await group.receiveIncomingConnection();

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -52,8 +52,7 @@ WebTransportServer::WebTransportServer(Function<Task(ConnectionGroup)>&& connect
     auto configureWebTransport = [](nw_protocol_options_t options) {
         nw_webtransport_options_set_is_datagram(options, true);
         nw_webtransport_options_set_is_unidirectional(options, false);
-        // FIXME: Add a call to nw_webtransport_options_set_connection_max_sessions(options, 1)
-        // here when enabling tests after rdar://141009498 is available in OS builds.
+        nw_webtransport_options_set_connection_max_sessions(options, 1);
     };
 
     auto configureTLS = [](nw_protocol_options_t options) {


### PR DESCRIPTION
#### da1f4ba32426fb0e49aac683c28655cb9d70295b
<pre>
Enable WebTransport API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=289532">https://bugs.webkit.org/show_bug.cgi?id=289532</a>
<a href="https://rdar.apple.com/146759523">rdar://146759523</a>

Reviewed by Matthew Finkel.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ClientBidirectional)):
(TestWebKitAPI::TEST(WebTransport, Datagram)):
(TestWebKitAPI::TEST(WebTransport, Unidirectional)):
(TestWebKitAPI::TEST(WebTransport, NetworkProcessCrash)):
(TestWebKitAPI::TEST(WebTransport, Worker)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientBidirectional)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_Datagram)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_Unidirectional)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_NetworkProcessCrash)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_Worker)): Deleted.
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::WebTransportServer):

Canonical link: <a href="https://commits.webkit.org/291950@main">https://commits.webkit.org/291950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93f7f9f06299d68fc7e1874576e76e65760b8a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29443 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97523 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52460 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3046 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44360 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101584 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81130 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80506 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25058 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14800 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15165 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21554 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->