### PR TITLE
[css-anchor-position-1] Use single bit for anchor and container interleaving

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2781,10 +2781,9 @@ void Document::resolveStyle(ResolveStyleType type)
             Style::TreeResolver resolver(*this, WTFMove(m_pendingRenderTreeUpdate));
             auto styleUpdate = resolver.resolve();
 
-            while (resolver.hasUnresolvedQueryContainers() || resolver.hasUnresolvedAnchorPositionedElements()) {
+            while (resolver.needsInterleavedLayout()) {
                 if (styleUpdate) {
-                    SetForScope resolvingContainerQueriesScope(m_isResolvingContainerQueries, resolver.hasUnresolvedQueryContainers());
-                    SetForScope resolvingAnchorPositionedElementsScope(m_isResolvingAnchorPositionedElements, resolver.hasUnresolvedAnchorPositionedElements());
+                    SetForScope interleavedLayoutScope(m_isInStyleInterleavedLayout, true);
 
                     updateRenderTree(WTFMove(styleUpdate));
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1560,8 +1560,7 @@ public:
 
     bool inStyleRecalc() const { return m_inStyleRecalc; }
     bool inRenderTreeUpdate() const { return m_inRenderTreeUpdate; }
-    bool isResolvingContainerQueries() const { return m_isResolvingContainerQueries; }
-    bool isInStyleInterleavedLayout() const { return m_isResolvingContainerQueries || m_isResolvingAnchorPositionedElements; };
+    bool isInStyleInterleavedLayout() const { return m_isInStyleInterleavedLayout; };
     bool isInStyleInterleavedLayoutForSelfOrAncestor() const;
     bool isResolvingTreeStyle() const { return m_isResolvingTreeStyle; }
     void setIsResolvingTreeStyle(bool);
@@ -2615,8 +2614,7 @@ private:
     bool m_inStyleRecalc { false };
     bool m_inRenderTreeUpdate { false };
     bool m_isResolvingTreeStyle { false };
-    bool m_isResolvingContainerQueries { false };
-    bool m_isResolvingAnchorPositionedElements { false };
+    bool m_isInStyleInterleavedLayout { false };
 
     bool m_gotoAnchorNeededAfterStylesheetsLoad { false };
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1001,6 +1001,8 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
     for (auto& anchorRenderer : m_document->renderView()->anchors()) {
         auto rect = anchorRenderer.absoluteBoundingBoxRect();
 
+        m_anchorRectsOnLastUpdate.add(anchorRenderer, rect);
+
         auto it = previousAnchorRects.find(anchorRenderer);
         bool changed = it == previousAnchorRects.end() || it->value != rect;
         if (!changed)
@@ -1009,8 +1011,6 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
         auto anchoredElements = anchorMap.getOptional(anchorRenderer);
         if (!anchoredElements)
             continue;
-
-        m_anchorRectsOnLastUpdate.add(anchorRenderer, rect);
 
         for (auto& anchoredElement : *anchoredElements) {
             if (!context.invalidatedAnchorPositioned.add(anchoredElement.get()).isNewEntry)

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -65,8 +65,7 @@ public:
 
     std::unique_ptr<Update> resolve();
 
-    bool hasUnresolvedQueryContainers() const { return m_hasUnresolvedQueryContainers; }
-    bool hasUnresolvedAnchorPositionedElements() const { return m_hasUnresolvedAnchorPositionedElements; }
+    bool needsInterleavedLayout() const { return m_needsInterleavedLayout; }
 
 private:
     enum class ResolutionType : uint8_t { RebuildUsingExisting, AnimationOnly, FastPathInherit, FullWithMatchResultCache, Full };
@@ -76,11 +75,10 @@ private:
 
     const RenderStyle* existingStyle(const Element&);
 
-    enum class AnchorPositionedElementAction : bool { None, SkipDescendants };
-    enum class QueryContainerAction : uint8_t { None, Resolve, Continue };
+    enum class LayoutInterleavingAction : uint8_t { None, SkipDescendants };
     enum class DescendantsToResolve : uint8_t { None, RebuildAllUsingExisting, ChildrenWithExplicitInherit, Children, All };
 
-    QueryContainerAction updateStateForQueryContainer(Element&, const RenderStyle*, Change&, DescendantsToResolve&);
+    LayoutInterleavingAction updateStateForQueryContainer(Element&, const RenderStyle*, Change&, DescendantsToResolve&);
 
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
@@ -149,7 +147,7 @@ private:
     const RenderStyle* parentBoxStyle() const;
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
 
-    AnchorPositionedElementAction updateAnchorPositioningState(Element&, const RenderStyle*, Change);
+    LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*, Change);
 
     void generatePositionOptionsIfNeeded(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);
@@ -165,6 +163,7 @@ private:
     struct QueryContainerState {
         Change change { Change::None };
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
+        bool invalidated { false };
     };
 
     CheckedRef<Document> m_document;
@@ -175,8 +174,7 @@ private:
     bool m_didSeePendingStylesheet { false };
 
     UncheckedKeyHashMap<Ref<Element>, std::optional<QueryContainerState>> m_queryContainerStates;
-    bool m_hasUnresolvedQueryContainers { false };
-    bool m_hasUnresolvedAnchorPositionedElements { false };
+    bool m_needsInterleavedLayout { false };
 
     // This state gets passes to the style builder and holds state for a single tree resolution, including over any interleaving.
     TreeResolutionState m_treeResolutionState;


### PR DESCRIPTION
#### a7912e41074f1b8198d89c91cb8e3f1171810b91
<pre>
[css-anchor-position-1] Use single bit for anchor and container interleaving
<a href="https://bugs.webkit.org/show_bug.cgi?id=289526">https://bugs.webkit.org/show_bug.cgi?id=289526</a>
<a href="https://rdar.apple.com/146753606">rdar://146753606</a>

Reviewed by Alan Baradlay.

Replace hasUnresolvedQueryContainers and hasUnresolvedAnchorPositionedElements with a single
needsInterleavedLayout bit in TreeResolver and Document.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/dom/Document.h:
(WebCore::Document::isInStyleInterleavedLayout const):
(WebCore::Document::isResolvingContainerQueries const): Deleted.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::updateStateForQueryContainer):

Also unify the return enum for interleaving functions.

(WebCore::Style::TreeResolver::resolve):

Also ensure container query invalidation is done only once per container.

(WebCore::Style::TreeResolver::updateAnchorPositioningState):
* Source/WebCore/style/StyleTreeResolver.h:
(WebCore::Style::TreeResolver::needsInterleavedLayout const):
(WebCore::Style::TreeResolver::hasUnresolvedQueryContainers const): Deleted.
(WebCore::Style::TreeResolver::hasUnresolvedAnchorPositionedElements const): Deleted.

Canonical link: <a href="https://commits.webkit.org/291962@main">https://commits.webkit.org/291962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd35e932726113989af2eb45a31f1aae22a344d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44364 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21581 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81137 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80511 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25064 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14804 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26692 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->