### PR TITLE
Changes in the "alg" JWK member for Ed25519

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any-expected.txt
@@ -619,4 +619,10 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: ECDH, namedCurve: P-521
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any.worker-expected.txt
@@ -619,4 +619,10 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: ECDH, namedCurve: P-521
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ecdh': importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
+PASS Invalid 'alg' field 'ECDH': importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any-expected.txt
@@ -619,4 +619,10 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-52
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any.worker-expected.txt
@@ -619,4 +619,10 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-52
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-256}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-384}, true, [sign])
+PASS Invalid 'alg' field 'ecdsa': importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
+PASS Invalid 'alg' field 'ECDSA': importKey(jwk(private), {name: ECDSA, namedCurve: P-521}, true, [sign])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/importKey_failures.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/importKey_failures.js
@@ -267,4 +267,23 @@ function run_test(algorithmNames) {
             });
         });
     });
+
+    // Use an 'alg' field with incorrect casing.
+    testVectors.forEach(function(vector) {
+        var name = vector.name;
+        if (name === "X25519")
+            return; // "X25519" ignores the 'alg' field.
+        allAlgorithmSpecifiersFor(name).forEach(function(algorithm) {
+            getValidKeyData(algorithm).forEach(function(test) {
+                if (test.format === "jwk") {
+                    var data = {crv: test.data.crv, kty: test.data.kty, d: test.data.d, x: test.data.x, d: test.data.d};
+                    var usages =  validUsages(vector, 'jwk', test.data);
+                    [name.toLowerCase(), name.toUpperCase()].forEach(function(algName) {
+                        data.alg = algName;
+                        testError('jwk', algorithm, data, name, usages, true, "DataError", "Invalid 'alg' field '" + data.alg + "'");
+                    });
+                }
+            });
+        });
+    });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any-expected.txt
@@ -3,48 +3,48 @@ PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [ve
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [verify])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify]) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, []) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify]) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), Ed25519, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_equals: Correct number of JWK members expected 7 but got 6
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign]) assert_equals: Correct number of JWK members expected 7 but got 6
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), Ed25519, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_equals: Correct number of JWK members expected 7 but got 6
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign]) assert_equals: Correct number of JWK members expected 7 but got 6
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, false, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [verify])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any.worker-expected.txt
@@ -3,48 +3,48 @@ PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [ve
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [verify])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify]) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, []) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_equals: Correct number of JWK members expected 6 but got 5
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify]) assert_equals: Correct number of JWK members expected 6 but got 5
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(kty, crv, x), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), Ed25519, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), Ed25519, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_equals: Correct number of JWK members expected 7 but got 6
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign]) assert_equals: Correct number of JWK members expected 7 but got 6
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), Ed25519, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_equals: Correct number of JWK members expected 7 but got 6
-FAIL Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
-FAIL Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign]) assert_equals: Correct number of JWK members expected 7 but got 6
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
+PASS Good parameters with JWK alg Ed25519: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
+PASS Good parameters with JWK alg EdDSA: Ed25519 (jwk, object(crv, d, x, kty), Ed25519, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), Ed25519, false, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [verify])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
@@ -265,4 +265,8 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: Ed25519}, true, [sign])
 PASS Invalid 'use' field: importKey(jwk (public) , {name: Ed25519}, true, [verify])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: Ed25519}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Invalid 'alg' field 'ed25519': importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid 'alg' field 'ED25519': importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid 'alg' field 'ed25519': importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Invalid 'alg' field 'ED25519': importKey(jwk (public) , {name: Ed25519}, true, [verify])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
@@ -265,4 +265,8 @@ PASS Invalid 'use' field: importKey(jwk(private), {name: Ed25519}, true, [sign])
 PASS Invalid 'use' field: importKey(jwk (public) , {name: Ed25519}, true, [verify])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: Ed25519}, true, [sign])
 PASS Invalid 'crv' field: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Invalid 'alg' field 'ed25519': importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid 'alg' field 'ED25519': importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid 'alg' field 'ed25519': importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Invalid 'alg' field 'ED25519': importKey(jwk (public) , {name: Ed25519}, true, [verify])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any-expected.txt
@@ -265,4 +265,8 @@ FAIL Invalid 'use' field: importKey(jwk(private), {name: Ed448}, true, [sign]) a
 FAIL Invalid 'use' field: importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'use' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ed448': importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'alg' field 'ed448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ED448': importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'alg' field 'ED448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ed448': importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'alg' field 'ed448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ED448': importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'alg' field 'ED448' not supported. expected "DataError" but got "NotSupportedError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any.worker-expected.txt
@@ -265,4 +265,8 @@ FAIL Invalid 'use' field: importKey(jwk(private), {name: Ed448}, true, [sign]) a
 FAIL Invalid 'use' field: importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'use' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ed448': importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'alg' field 'ed448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ED448': importKey(jwk(private), {name: Ed448}, true, [sign]) assert_equals: Invalid 'alg' field 'ED448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ed448': importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'alg' field 'ed448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'ED448': importKey(jwk (public) , {name: Ed448}, true, [verify]) assert_equals: Invalid 'alg' field 'ED448' not supported. expected "DataError" but got "NotSupportedError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any-expected.txt
@@ -230,4 +230,8 @@ FAIL Import from a non-extractable: importKey(jwk (public) , {name: X448}, true,
 FAIL Invalid 'use' field: importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'use' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'x448': importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'alg' field 'x448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'X448': importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'alg' field 'X448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'x448': importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'alg' field 'x448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'X448': importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'alg' field 'X448' not supported. expected "DataError" but got "NotSupportedError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any.worker-expected.txt
@@ -230,4 +230,8 @@ FAIL Import from a non-extractable: importKey(jwk (public) , {name: X448}, true,
 FAIL Invalid 'use' field: importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'use' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
 FAIL Invalid 'crv' field: importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'crv' field not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'x448': importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'alg' field 'x448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'X448': importKey(jwk(private), {name: X448}, true, [deriveKey, deriveBits]) assert_equals: Invalid 'alg' field 'X448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'x448': importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'alg' field 'x448' not supported. expected "DataError" but got "NotSupportedError"
+FAIL Invalid 'alg' field 'X448': importKey(jwk (public) , {name: X448}, true, []) assert_equals: Invalid 'alg' field 'X448' not supported. expected "DataError" but got "NotSupportedError"
 

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -97,8 +97,7 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
         }
         if (keyData.crv != "Ed25519"_s)
             return nullptr;
-        // FIXME: Do we have tests for these checks ?
-        if (!keyData.alg.isEmpty() && keyData.alg != "EdDSA"_s)
+        if (!keyData.alg.isEmpty() && (keyData.alg != "EdDSA"_s && keyData.alg != "Ed25519"_s))
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sign"_s)
             return nullptr;
@@ -158,6 +157,7 @@ ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
         break;
     case NamedCurve::Ed25519:
         result.crv = Ed25519;
+        result.alg = "Ed25519"_s;
         break;
     }
 


### PR DESCRIPTION
#### 06e608c8a18aa12f0ee2372c3b5a5605ca6f9223
<pre>
Changes in the &quot;alg&quot; JWK member for Ed25519
<a href="https://bugs.webkit.org/show_bug.cgi?id=289535">https://bugs.webkit.org/show_bug.cgi?id=289535</a>

Reviewed by Anne van Kesteren and Pascoe.

Modified the importJWK method to check for the &quot;alg&quot; member and ensure
its value it&apos;s either &quot;EdDSA&quot; and &quot;Ed25519&quot;.

The exportJWK just sets the &quot;alg&quot; member to &quot;Ed25519&quot;.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey_failures_ECDSA.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/importKey_failures.js:
(run_test.):
(run_test):
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_Ed25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed448.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X448.https.any.worker-expected.txt:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::importJwk):
(WebCore::CryptoKeyOKP::exportJwk const):

Canonical link: <a href="https://commits.webkit.org/293089@main">https://commits.webkit.org/293089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/590bafe6f77833b2088918a9a9a482fe80fdb631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48340 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13430 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88397 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6393 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24891 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18128 "Found 1 new test failure: ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84565 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18498 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30021 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->