### PR TITLE
[macOS] Transition to syscall-mig in Networking sandbox

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -759,8 +759,59 @@
 (when (defined? 'SYS_map_with_linking_np)
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
+(define (allowed-mig-syscalls)
+    (kernel-mig-routine
+        _mach_make_memory_entry
+        host_get_io_master
+        host_get_special_port
+        host_info
+        host_request_notification
+        io_connect_method
+        io_iterator_is_valid
+        io_iterator_next
+        io_object_conforms_to
+        io_registry_entry_create_iterator
+        io_registry_entry_from_path
+        io_registry_entry_get_parent_iterator
+        io_registry_entry_get_properties_bin_buf
+        io_registry_entry_get_property_bin_buf
+        io_server_version
+        io_service_add_interest_notification_64
+        io_service_get_matching_service_bin
+        io_service_open_extended
+        mach_exception_raise
+        mach_memory_entry_ownership
+        mach_port_extract_right
+        mach_port_get_context_from_user
+        mach_port_get_refs
+        mach_port_is_connection_for_service
+        mach_port_request_notification
+        mach_port_set_attributes
+        mach_vm_copy
+        mach_vm_map_external
+        mach_vm_remap_external
+        semaphore_create
+        semaphore_destroy
+        task_get_special_port_from_user
+        task_info_from_user
+        task_policy_set
+        task_restartable_ranges_synchronize
+        task_set_exc_guard_behavior
+        task_set_special_port
+        task_threads_from_user
+        thread_info
+        thread_resume
+        thread_suspend))
+
+(when (defined? 'syscall-mig)
+#if HAVE(MACH_RANGE_CREATE)
+    (when (defined? 'mach_vm_range_create)
+        (allow syscall-mig (kernel-mig-routine mach_vm_range_create)))
+#endif
+    (allow syscall-mig (allowed-mig-syscalls)))
+
 #if HAVE(SANDBOX_MESSAGE_FILTERING)
-(when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
+(when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (and (defined? 'mach-kernel-endpoint) (not (defined? 'syscall-mig))))
     (allow mach-kernel-endpoint
         (apply-message-filter
             (deny mach-message-send (with telemetry))
@@ -768,48 +819,7 @@
             (when (defined? 'mach_vm_range_create)
                 (allow mach-message-send (kernel-mig-routine mach_vm_range_create))) ;; <rdar://105161083>
 #endif
-            (allow mach-message-send (kernel-mig-routine
-                _mach_make_memory_entry
-                host_get_io_master
-                host_get_special_port
-                host_info
-                host_request_notification
-                io_connect_method
-                io_iterator_is_valid
-                io_iterator_next
-                io_object_conforms_to
-                io_registry_entry_create_iterator
-                io_registry_entry_from_path
-                io_registry_entry_get_parent_iterator
-                io_registry_entry_get_properties_bin_buf
-                io_registry_entry_get_property_bin_buf
-                io_server_version
-                io_service_add_interest_notification_64
-                io_service_get_matching_service_bin
-                io_service_open_extended
-                mach_exception_raise
-                mach_memory_entry_ownership
-                mach_port_extract_right
-                mach_port_get_context_from_user
-                mach_port_get_refs
-                mach_port_is_connection_for_service
-                mach_port_request_notification
-                mach_port_set_attributes
-                mach_vm_copy
-                mach_vm_map_external
-                mach_vm_remap_external
-                semaphore_create
-                semaphore_destroy
-                task_get_special_port_from_user
-                task_info_from_user
-                task_policy_set
-                task_restartable_ranges_synchronize
-                task_set_exc_guard_behavior
-                task_set_special_port
-                task_threads_from_user
-                thread_info
-                thread_resume
-                thread_suspend)))))
+            (allow mach-message-send (allowed-mig-syscalls)))))
 
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
     (deny syscall-mach)


### PR DESCRIPTION
#### 86feae12e8b44fc1b1d50b1b1212b91f40c71fcd
<pre>
[macOS] Transition to syscall-mig in Networking sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=289538">https://bugs.webkit.org/show_bug.cgi?id=289538</a>
<a href="https://rdar.apple.com/146766604">rdar://146766604</a>

Reviewed by Sihui Liu.

Use the modern syscall-mig syntax instead of message filters.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/292013@main">https://commits.webkit.org/292013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df2ca8f1b7a277bb8370972c44b6a16c639c1f2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29491 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10490 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101681 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80556 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14882 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->