### PR TITLE
Action command should fall back to extension display name if needed

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -2372,8 +2372,12 @@ void WebExtension::populateCommandsIfNeeded()
         else if (hasPageAction())
             commandIdentifier = "_execute_page_action"_s;
 
-        if (!commandIdentifier.isEmpty())
-            m_commands.append({ commandIdentifier, displayActionLabel(), emptyString(), { } });
+        if (!commandIdentifier.isEmpty()) {
+            auto description = displayActionLabel();
+            if (description.isEmpty())
+                description = displayShortName();
+            m_commands.append({ commandIdentifier, description, emptyString(), { } });
+        }
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -136,6 +136,45 @@ TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifest)
     Util::loadAndRunExtension(emptyCommandsManifest, @{ @"background.js": backgroundScript });
 }
 
+TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifestNoActionName)
+{
+    static auto *emptyCommandsNoActionNameManifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test Commands",
+        @"description": @"Test Commands",
+        @"version": @"1.0",
+
+        @"permissions": @[ @"webNavigation" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"action": @{
+        },
+
+        @"commands": @{
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"let commands = await browser.commands.getAll()",
+        @"browser.test.assertEq(commands.length, 1, 'Should be one command.')",
+
+        @"let executeActionCommand = commands.find(command => command.name === '_execute_action')",
+
+        @"browser.test.assertTrue(!!executeActionCommand, '_execute_action command should exist')",
+        @"browser.test.assertEq(executeActionCommand.description, 'Test Commands', 'The description should be')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(emptyCommandsNoActionNameManifest, @{ @"background.js": backgroundScript });
+}
+
 TEST(WKWebExtensionAPICommands, CommandEvent)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 8d442d6b365cf3f01daa1ad85bd82f11cbe0be34
<pre>
Action command should fall back to extension display name if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=289546">https://bugs.webkit.org/show_bug.cgi?id=289546</a>
<a href="https://rdar.apple.com/146764816">rdar://146764816</a>

Reviewed by Timothy Hatcher.

When generating an action command for an extension that doesn&apos;t specify any commands or an action name, fall back
to the display short name of the extension.

* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::populateCommandsIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifestNoActionName)):

Canonical link: <a href="https://commits.webkit.org/291963@main">https://commits.webkit.org/291963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d84fdba5ece3721aba2dd86ed0daf0d2545f0c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99566 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10750 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52479 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10445 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/3070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44385 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21602 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80524 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25081 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21579 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->