### PR TITLE
GroupActivitiesCoordinator should always invoke its completion handler

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -56,8 +56,11 @@
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePlayCommand:(AVDelegatingPlaybackCoordinatorPlayCommand *)playCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
         RefPtr parent = _parent.get();
-        if (!parent)
+        if (!parent) {
+            completionHandler();
             return;
+        }
+
         parent->issuePlayCommand(playCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
@@ -67,8 +70,11 @@
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePauseCommand:(AVDelegatingPlaybackCoordinatorPauseCommand *)pauseCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
         RefPtr parent = _parent.get();
-        if (!parent)
+        if (!parent) {
+            completionHandler();
             return;
+        }
+
         parent->issuePauseCommand(pauseCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
@@ -78,8 +84,11 @@
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueSeekCommand:(AVDelegatingPlaybackCoordinatorSeekCommand *)seekCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
         RefPtr parent = _parent.get();
-        if (!parent)
+        if (!parent) {
+            completionHandler();
             return;
+        }
+
         parent->issueSeekCommand(seekCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
@@ -89,8 +98,11 @@
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueBufferingCommand:(AVDelegatingPlaybackCoordinatorBufferingCommand *)bufferingCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
         RefPtr parent = _parent.get();
-        if (!parent)
+        if (!parent) {
+            completionHandler();
             return;
+        }
+
         parent->issueBufferingCommand(bufferingCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });


### PR DESCRIPTION
#### 770163d96e7480603d115ff7a06b1a108ce07d97
<pre>
GroupActivitiesCoordinator should always invoke its completion handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=289552">https://bugs.webkit.org/show_bug.cgi?id=289552</a>
<a href="https://rdar.apple.com/146776772">rdar://146776772</a>

Reviewed by Chris Dumez.

Otherwise we might cause a storage leak, or some other never-ending task inconsistency.

* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePlayCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePauseCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueSeekCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueBufferingCommand:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/291992@main">https://commits.webkit.org/291992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adae077c796d704ff45a257e85c686b15ea7814c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72155 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10452 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44398 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101622 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14834 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->