### PR TITLE
Address Safer CPP failures in UIProcess/Extensions

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -111,10 +111,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
-UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
-UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
-UIProcess/Extensions/WebExtensionCommand.cpp
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
 UIProcess/Inspector/WebPageInspectorController.cpp
 UIProcess/Inspector/mac/WKInspectorViewController.mm

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -283,7 +283,7 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
     result.keyEquivalent = activationKey();
     result.keyEquivalentModifierMask = modifierFlags().toRaw();
     if (RefPtr context = extensionContext())
-        result.image = toCocoaImage(context->extension().icon(WebCore::FloatSize(16, 16)));
+        result.image = toCocoaImage(context->protectedExtension()->icon(WebCore::FloatSize(16, 16)));
 
     return result;
 #else

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
@@ -54,7 +54,7 @@ bool WebExtensionCommand::isActionCommand() const
     if (!context)
         return false;
 
-    if (context->extension().supportsManifestVersion(3))
+    if (context->protectedExtension()->supportsManifestVersion(3))
         return identifier() == "_execute_action"_s;
 
     return identifier() == "_execute_browser_action"_s || identifier() == "_execute_page_action"_s;


### PR DESCRIPTION
#### bc5aeab7938e4c86683f94a3c425710f711d51ea
<pre>
Address Safer CPP failures in UIProcess/Extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=289564">https://bugs.webkit.org/show_bug.cgi?id=289564</a>

Reviewed by Timothy Hatcher and Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[_WKWebExtensionActionWebViewDelegate webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]):
(-[_WKWebExtensionActionWebViewDelegate webViewWebContentProcessDidTerminate:]):
(-[_WKWebExtensionActionWebViewDelegate webViewDidClose:]):
(-[_WKWebExtensionActionWebViewDelegate webView:didFailProvisionalNavigation:withError:]):
(-[_WKWebExtensionActionWebViewDelegate webView:didFailNavigation:withError:]):
(-[_WKWebExtensionActionWebViewDelegate _webView:navigationDidFinishDocumentLoad:]):
(-[_WKWebExtensionActionWebView _contentSizeHasStabilized]):
(-[_WKWebExtensionActionViewController _viewControllerDismissalTransitionDidEnd:]):
(-[_WKWebExtensionActionPopover popoverDidClose:]):
(WebKit::WebExtensionAction::fallbackAction const):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::popupPath const):
(WebKit::WebExtensionAction::popupWebViewInspectionName):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::label const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp:
(WebKit::WebExtensionCommand::isActionCommand const):

Canonical link: <a href="https://commits.webkit.org/292016@main">https://commits.webkit.org/292016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b165c05bc1c157882e66b76d1fc68262869283da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99741 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45213 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22731 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72256 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10558 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44552 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80633 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14983 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26840 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->