### PR TITLE
Fix 32-bit build flag and add clangd flags

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2849,10 +2849,10 @@ sub generateBuildSystemFromCMakeProject
         # files in Debian-based systems, for the others
         # CMAKE_PREFIX_PATH will get us /usr/lib, which should be the
         # right path for 32bit. See FindPkgConfig.cmake.
-        push @cmakeArgs, '-DFORCE_32BIT=ON -DCMAKE_PREFIX_PATH="/usr" -DCMAKE_LIBRARY_ARCHITECTURE=armv7-a+fp';
-        $ENV{"CFLAGS"} =  "-m32 -march=armv7-a+fp" . ($ENV{"CFLAGS"} || "");
-        $ENV{"CXXFLAGS"} = "-m32 -march=armv7-a+fp" . ($ENV{"CXXFLAGS"} || "");
-        $ENV{"LDFLAGS"} = "-m32 -march=armv7-a+fp" . ($ENV{"LDFLAGS"} || "");
+        push @cmakeArgs, '-DFORCE_32BIT=ON -DCMAKE_PREFIX_PATH="/usr" -DCMAKE_LIBRARY_ARCHITECTURE=armv7-a+fp ';
+        $ENV{"CFLAGS"} =  "-m32 -march=armv7-a+fp " . ($ENV{"CFLAGS"} || "");
+        $ENV{"CXXFLAGS"} = "-m32 -march=armv7-a+fp " . ($ENV{"CXXFLAGS"} || "");
+        $ENV{"LDFLAGS"} = "-m32 -march=armv7-a+fp " . ($ENV{"LDFLAGS"} || "");
     }
     push @args, @cmakeArgs if @cmakeArgs;
 

--- a/Tools/clangd/clangd-config.yaml.tpl
+++ b/Tools/clangd/clangd-config.yaml.tpl
@@ -10,6 +10,7 @@ CompileFlags:
         -Wno-maybe-uninitialized,
     ]
     Add: [
+        $platform_specific_flags
         "-ferror-limit=0",  # https://github.com/WebKit/WebKit/pull/30784#issuecomment-2257495415
         "-Wno-unknown-warning-option",
     ]
@@ -25,6 +26,7 @@ If:
 CompileFlags:
     Add: [
         $header_file_platform_specific_flags
+        $platform_specific_flags
         --include=config.h,
         -std=c++2a,
     ]
@@ -32,10 +34,9 @@ CompileFlags:
 If:
     PathMatch: [.*\.mm]
 CompileFlags:
-    Add: [-xobjective-c++, --include=config.h, -std=c++2a]
+    Add: [$platform_specific_flags -xobjective-c++, --include=config.h, -std=c++2a]
 ---
 If:
     PathMatch: [.*\.m]
 CompileFlags:
-    Add: [-xobjective-c, --include=config.h]
-
+    Add: [$platform_specific_flags -xobjective-c, --include=config.h]

--- a/Tools/clangd/update-clangd-config
+++ b/Tools/clangd/update-clangd-config
@@ -34,6 +34,7 @@ from pathlib import Path
 import argparse
 import os
 import re
+import platform
 import sys
 import shutil
 import logging
@@ -60,8 +61,11 @@ def is_dir_virtually_empty(dir_path: Union[Path, str]) -> None:
 
 def gen_template_environment():
     env = {}
+    is_arm32_on_arm64 = platform.architecture()[0] == "32bit"
     env["header_file_platform_specific_flags"] = \
         "-xobjective-c++," if sys.platform == "darwin" else ""
+    env["platform_specific_flags"] = \
+        "-m32,-march=armv7-a+fp," if is_arm32_on_arm64 else ""
     return env
 
 # This warning is better placed in the code than in the template file, as


### PR DESCRIPTION
#### 073dab78fe984ec1d5a08b68e97bc591078781c2
<pre>
Fix 32-bit build flag and add clangd flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=289565">https://bugs.webkit.org/show_bug.cgi?id=289565</a>

Reviewed by Yusuke Suzuki.

* Tools/Scripts/webkitdirs.pm:
(generateBuildSystemFromCMakeProject):
* Tools/clangd/clangd-config.yaml.tpl:
* Tools/clangd/update-clangd-config:
(gen_template_environment):

Canonical link: <a href="https://commits.webkit.org/292018@main">https://commits.webkit.org/292018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df49266268d453355262e2dbcd56918860646afe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44438 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87280 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101664 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93243 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80551 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14868 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21630 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115915 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21303 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->