### PR TITLE
AX: Page constantly scrolls up and down when moving VoiceOver focus through YouTube comments

### DIFF
--- a/LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element-expected.txt
+++ b/LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element-expected.txt
@@ -1,0 +1,12 @@
+This test ensures that elements with empty intrinsic bounding boxes use their nearest-ancestor bounding box, preventing erroneous scrolls to 0,0.
+
+PASS: window.scrollY === 0
+PASS: window.scrollY >= 4000 === true
+PASS: scrollCounter === 1
+PASS: scrollCounter === 1
+PASS: scrollCounter === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Like  Dislike

--- a/LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element.html
+++ b/LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div role="group" aria-label="controls" style="margin-top: 5000px">
+    <button id="before-button">Like</button>
+    <x-tooltip id="tooltip" role="tooltip" tabindex="-1" aria-label="tooltip" style=""></x-tooltip>
+    <button id="after-button">Dislike</button>
+</div>
+
+<script>
+var output = "This test ensures that elements with empty intrinsic bounding boxes use their nearest-ancestor bounding box, preventing erroneous scrolls to 0,0.\n\n";
+
+class XTooltip extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open", delegatesFocus: true });
+        const fragment = document.createRange().createContextualFragment("");
+        this.shadowRoot.append(fragment.cloneNode(true));
+    }
+}
+customElements.define("x-tooltip", XTooltip);
+
+var scrollCounter = 0;
+window.addEventListener("scroll", () => {
+    scrollCounter++;
+});
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("window.scrollY", "0");
+    accessibilityController.accessibleElementById("before-button").scrollToMakeVisible();
+    setTimeout(async function() {
+        // The button is offset from the top of the page by 5000px, so expect to have scrolled somewhere close to that.
+        output += await expectAsync("window.scrollY >= 4000", "true");
+        output += await expectAsync("scrollCounter", "1");
+        accessibilityController.accessibleElementById("tooltip").scrollToMakeVisible();
+        // Wait some time for the scroll to happen (which should only happen if we have a bug).
+        await sleep(60);
+        output += expect("scrollCounter", "1");
+
+        accessibilityController.accessibleElementById("after-button").scrollToMakeVisible();
+        // Wait some time for the scroll to happen (which should only happen if we have a bug).
+        await sleep(60);
+        output += expect("scrollCounter", "1");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/accessibility/checkbox-radio-element-rect-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/checkbox-radio-element-rect-expected.txt
@@ -2,7 +2,7 @@ This test ensures we calculate the frame correctly for checkboxes (inclusive of 
 
 #test-checkbox-without-label: {width: 12, height: 12}
 #test-radio-without-label: {width: 12, height: 12}
-#test-switch-without-label: {width: 0, height: 0}
+#test-switch-without-label: {width: 784, height: 10}
 #test-checkbox: {width: 784, height: 19}
 #test-checkbox: {width: 784, height: 19}
 #test-checkbox-switch: {width: 784, height: 18}

--- a/LayoutTests/platform/gtk/accessibility/gtk/xml-roles-exposed-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/gtk/xml-roles-exposed-expected.txt
@@ -6,8 +6,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 AXRole: AXNotification
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -25,8 +25,8 @@ AXPlatformAttributes: atomic:true, computed-role:alert, container-atomic:true, c
 AXRole: AXAlert
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -44,8 +44,8 @@ AXPlatformAttributes: computed-role:alertdialog, container-live:assertive, conta
 AXRole: AXEmbedded
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -63,8 +63,8 @@ AXPlatformAttributes: computed-role:application, tag:div, xml-roles:application
 AXRole: AXArticle
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -82,8 +82,8 @@ AXPlatformAttributes: computed-role:article, tag:div, xml-roles:article
 AXRole: AXLandmarkBanner
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -101,8 +101,8 @@ AXPlatformAttributes: computed-role:banner, tag:div, xml-roles:banner
 AXRole: AXBlockquote
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -120,8 +120,8 @@ AXPlatformAttributes: computed-role:blockquote, tag:div, xml-roles:blockquote
 AXRole: AXButton
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -139,8 +139,8 @@ AXPlatformAttributes: computed-role:button, tag:div, xml-roles:button
 AXRole: AXCaption
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -158,8 +158,8 @@ AXPlatformAttributes: computed-role:caption, tag:div, xml-roles:caption
 AXRole: AXCheckBox
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -177,8 +177,8 @@ AXPlatformAttributes: computed-role:checkbox, readonly:false, tag:div, xml-roles
 AXRole: AXComboBox
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -196,8 +196,8 @@ AXPlatformAttributes: computed-role:combobox, haspopup:listbox, readonly:false, 
 AXRole: AXLandmarkComplementary
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -215,8 +215,8 @@ AXPlatformAttributes: computed-role:complementary, tag:div, xml-roles:complement
 AXRole: AXLandmarkContentInfo
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -234,8 +234,8 @@ AXPlatformAttributes: computed-role:contentinfo, tag:div, xml-roles:contentinfo
 AXRole: AXDefinition
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -253,8 +253,8 @@ AXPlatformAttributes: computed-role:definition, tag:div, xml-roles:definition
 AXRole: AXDeletion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -272,8 +272,8 @@ AXPlatformAttributes: computed-role:deletion, tag:div, xml-roles:deletion
 AXRole: AXDialog
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -291,8 +291,8 @@ AXPlatformAttributes: computed-role:dialog, tag:div, xml-roles:dialog
 AXRole: AXList
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -310,8 +310,8 @@ AXPlatformAttributes: computed-role:list, tag:div, xml-roles:directory
 AXRole: AXDocument
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -329,8 +329,8 @@ AXPlatformAttributes: computed-role:document, tag:div, xml-roles:document
 AXRole: AXGroup
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -348,8 +348,8 @@ AXPlatformAttributes: computed-role:feed, tag:div, xml-roles:feed
 AXRole: AXGroup
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -367,8 +367,8 @@ AXPlatformAttributes: computed-role:figure, roledescription:figure, tag:div, xml
 AXRole: AXGroup
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -386,8 +386,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:group
 AXRole: AXHeading
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -405,8 +405,8 @@ AXPlatformAttributes: computed-role:heading, tag:div, xml-roles:heading
 AXRole: AXImage
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -425,8 +425,8 @@ AXPlatformAttributes: computed-role:image, tag:div, xml-roles:img
 AXRole: AXInsertion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -444,8 +444,8 @@ AXPlatformAttributes: computed-role:insertion, tag:div, xml-roles:insertion
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -464,8 +464,8 @@ AXPlatformAttributes: computed-role:link, tag:div, xml-roles:link
 AXRole: AXLog
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -483,8 +483,8 @@ AXPlatformAttributes: computed-role:log, container-live:polite, container-live-r
 AXRole: AXLandmarkMain
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -502,8 +502,8 @@ AXPlatformAttributes: computed-role:main, tag:div, xml-roles:main
 AXRole: AXMarquee
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -521,8 +521,8 @@ AXPlatformAttributes: computed-role:marquee, container-live:off, container-live-
 AXRole: AXMath
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -540,8 +540,8 @@ AXPlatformAttributes: computed-role:math, tag:div, xml-roles:math
 AXRole: AXLevelIndicator
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -559,8 +559,8 @@ AXPlatformAttributes: computed-role:meter, tag:div, xml-roles:meter
 AXRole: AXLandmarkNavigation
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -578,8 +578,8 @@ AXPlatformAttributes: computed-role:navigation, tag:div, xml-roles:navigation
 AXRole: AXComment
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -597,8 +597,8 @@ AXPlatformAttributes: computed-role:note, tag:div, xml-roles:note
 AXRole: AXParagraph
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -616,8 +616,8 @@ AXPlatformAttributes: computed-role:paragraph, tag:div, xml-roles:paragraph
 AXRole: AXProgressIndicator
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -635,8 +635,8 @@ AXPlatformAttributes: computed-role:progressbar, tag:div, xml-roles:progressbar
 AXRole: AXRadioButton
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -654,8 +654,8 @@ AXPlatformAttributes: computed-role:radio, tag:div, xml-roles:radio
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle: X
 AXDescription:
 AXValue:
@@ -692,8 +692,8 @@ AXPlatformAttributes: computed-role:generic, tag:div, xml-roles:region
 AXRole: AXScrollBar
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -711,8 +711,8 @@ AXPlatformAttributes: computed-role:scrollbar, tag:div, xml-roles:scrollbar
 AXRole: AXLandmarkSearch
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -730,8 +730,8 @@ AXPlatformAttributes: computed-role:search, tag:div, xml-roles:search
 AXRole: AXTextField
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -749,8 +749,8 @@ AXPlatformAttributes: computed-role:searchbox, readonly:false, tag:div, xml-role
 AXRole: AXSeparator
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -768,8 +768,8 @@ AXPlatformAttributes: computed-role:separator, tag:div, xml-roles:separator
 AXRole: AXSlider
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -787,8 +787,8 @@ AXPlatformAttributes: computed-role:slider, readonly:false, tag:div, xml-roles:s
 AXRole: AXSpinButton
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -806,8 +806,8 @@ AXPlatformAttributes: computed-role:spinbutton, readonly:false, tag:div, xml-rol
 AXRole: AXStatusBar
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -825,8 +825,8 @@ AXPlatformAttributes: atomic:true, computed-role:status, container-atomic:true, 
 AXRole: AXSubscript
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -844,8 +844,8 @@ AXPlatformAttributes: computed-role:subscript, tag:div, xml-roles:subscript
 AXRole: AXSuperscript
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -863,8 +863,8 @@ AXPlatformAttributes: computed-role:superscript, tag:div, xml-roles:superscript
 AXRole: AXToggleButton
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -882,8 +882,8 @@ AXPlatformAttributes: computed-role:switch, readonly:false, tag:div, xml-roles:s
 AXRole: AXDescriptionTerm
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -901,8 +901,8 @@ AXPlatformAttributes: computed-role:term, tag:div, xml-roles:term
 AXRole: AXTextField
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -920,8 +920,8 @@ AXPlatformAttributes: computed-role:textbox, readonly:false, tag:div, xml-roles:
 AXRole: AXStatic
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -939,8 +939,8 @@ AXPlatformAttributes: computed-role:time, tag:div, xml-roles:time
 AXRole: AXTimer
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -958,8 +958,8 @@ AXPlatformAttributes: computed-role:timer, container-live:off, container-live-ro
 AXRole: AXToolbar
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -977,8 +977,8 @@ AXPlatformAttributes: computed-role:toolbar, tag:div, xml-roles:toolbar
 AXRole: AXUserInterfaceTooltip
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -996,8 +996,8 @@ AXPlatformAttributes: computed-role:tooltip, tag:div, xml-roles:tooltip
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1015,8 +1015,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-abstract
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1034,8 +1034,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-acknowledgmen
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1053,8 +1053,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-afterword
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1072,8 +1072,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-appendix
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1092,8 +1092,8 @@ AXPlatformAttributes: computed-role:link, tag:div, xml-roles:doc-backlink
 AXRole: AXListItem
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1111,8 +1111,8 @@ AXPlatformAttributes: computed-role:listitem, tag:div, xml-roles:doc-biblioentry
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1130,8 +1130,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-bibliography
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1150,8 +1150,8 @@ AXPlatformAttributes: computed-role:link, tag:div, xml-roles:doc-biblioref
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1169,8 +1169,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-chapter
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1188,8 +1188,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-colophon
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1207,8 +1207,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-conclusion
 AXRole: AXImage
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1226,8 +1226,8 @@ AXPlatformAttributes: computed-role:image, tag:div, xml-roles:doc-cover
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1245,8 +1245,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-credit
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1264,8 +1264,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-credits
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1283,8 +1283,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-dedication
 AXRole: AXListItem
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1302,8 +1302,8 @@ AXPlatformAttributes: computed-role:listitem, tag:div, xml-roles:doc-endnote
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1321,8 +1321,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-endnotes
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1340,8 +1340,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-epigraph
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1359,8 +1359,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-epilogue
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1378,8 +1378,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-errata
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1397,8 +1397,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-example
 AXRole: AXFootnote
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1416,8 +1416,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-footnote
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1435,8 +1435,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-foreword
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1454,8 +1454,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-glossary
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1474,8 +1474,8 @@ AXPlatformAttributes: computed-role:link, tag:div, xml-roles:doc-glossref
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1493,8 +1493,8 @@ AXPlatformAttributes: computed-role:navigation, tag:div, xml-roles:doc-index
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1512,8 +1512,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-introduction
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1532,8 +1532,8 @@ AXPlatformAttributes: computed-role:link, tag:div, xml-roles:doc-noteref
 AXRole: AXComment
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1551,8 +1551,8 @@ AXPlatformAttributes: computed-role:note, tag:div, xml-roles:doc-notice
 AXRole: AXSeparator
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1570,8 +1570,8 @@ AXPlatformAttributes: computed-role:separator, tag:div, xml-roles:doc-pagebreak
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1589,8 +1589,8 @@ AXPlatformAttributes: computed-role:navigation, tag:div, xml-roles:doc-pagelist
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1608,8 +1608,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-part
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1627,8 +1627,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-preface
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1646,8 +1646,8 @@ AXPlatformAttributes: computed-role:region, tag:div, xml-roles:doc-prologue
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1665,8 +1665,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-pullquote
 AXRole: AXSection
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1684,8 +1684,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:doc-qna
 AXRole: AXHeading
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1703,8 +1703,8 @@ AXPlatformAttributes: computed-role:heading, tag:div, xml-roles:doc-subtitle
 AXRole: AXComment
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1722,8 +1722,8 @@ AXPlatformAttributes: computed-role:note, tag:div, xml-roles:doc-tip
 AXRole: AXLandmarkRegion
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1741,8 +1741,8 @@ AXPlatformAttributes: computed-role:navigation, tag:div, xml-roles:doc-toc
 AXRole: AXDocument
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1760,8 +1760,8 @@ AXPlatformAttributes: computed-role:document, tag:div, xml-roles:graphics-docume
 AXRole: AXGroup
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:
@@ -1779,8 +1779,8 @@ AXPlatformAttributes: computed-role:group, tag:div, xml-roles:graphics-object
 AXRole: AXImage
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition:  { 0.00000, 0.00000 }
-AXSize: { 0.00000, 0.00000 }
+AXPosition:  { 8.00000, 8.00000 }
+AXSize: { 784.000, 10.0000 }
 AXTitle:
 AXDescription:
 AXValue:

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -259,6 +259,11 @@ LayoutRect AccessibilityNodeObject::boundingBoxRect() const
     // Instead, let's return a box at the position of an ancestor that does have a position, make it
     // the width of that ancestor, and about the height of a line of text, so it's clear this object is
     // a descendant of that ancestor.
+    return nonEmptyAncestorBoundingBox();
+}
+
+LayoutRect AccessibilityNodeObject::nonEmptyAncestorBoundingBox() const
+{
     for (RefPtr<AccessibilityObject> ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
         if (!ancestor->renderer())
             continue;
@@ -271,7 +276,8 @@ LayoutRect AccessibilityNodeObject::boundingBoxRect() const
             LayoutSize(ancestorRect.width(), LayoutUnit(std::min(10.0f, ancestorRect.height().toFloat())))
         };
     }
-    return { };
+    // Fallback to returning a default, non-empty rect at 0, 0.
+    return { 0, 0, 1, 1 };
 }
 
 Document* AccessibilityNodeObject::document() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -195,6 +195,7 @@ protected:
     Vector<Ref<Element>> ariaLabeledByElements() const;
     String descriptionForElements(const Vector<Ref<Element>>&) const;
     LayoutRect boundingBoxRect() const override;
+    LayoutRect nonEmptyAncestorBoundingBox() const;
     String ariaDescribedByAttribute() const final;
 
     AccessibilityObject* captionForFigure() const;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -870,6 +870,8 @@ LayoutRect AccessibilityRenderObject::boundingBoxRect() const
     if (isWebArea())
         result.setSize(renderer->view().frameView().contentsSize());
 
+    if (result.isEmpty())
+        return nonEmptyAncestorBoundingBox();
     return result;
 }
 


### PR DESCRIPTION
#### 54bd0ad4968ca36a60f6561960c52631efed969b
<pre>
AX: Page constantly scrolls up and down when moving VoiceOver focus through YouTube comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=289569">https://bugs.webkit.org/show_bug.cgi?id=289569</a>
<a href="https://rdar.apple.com/146797846">rdar://146797846</a>

Reviewed by Chris Fleizach.

On YouTube, there is a tooltip custom element with rect {0, 0, 0, 0} (zero size, absolutely positioned at the page origin).
This means that when VoiceOver requests scrollToMakeVisible() on it, we scroll to the top of the page, then back down
when moving to a &quot;normally&quot; positioned element.

This commit solves the issue by adding a fallback to AccessibilityRenderObject::boundingBoxRect when we can&apos;t compute
a size for an element. This fallback takes the rect of the nearest ancestor with geometry. We actually already had
this fallback in place for AccessibilityNodeObjects, so let&apos;s use it for AccessibilityRenderObjects too. This is
generally more sensible, as some ATs may ignore elements with empty geometry, even though they truly be useful to
expose. It also makes it much less likely for scrolling to flicker as happened before this commit.

* LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element-expected.txt: Added.
* LayoutTests/accessibility/scroll-to-make-visible-empty-bounding-box-element.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::boundingBoxRect const):
(WebCore::AccessibilityNodeObject::nonEmptyAncestorBoundingBox const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::boundingBoxRect const):

Canonical link: <a href="https://commits.webkit.org/292022@main">https://commits.webkit.org/292022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbbbeea48b455ebc252f4eca7cebf68b451c3cd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72230 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29531 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97696 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10836 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101756 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81226 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14941 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->