### PR TITLE
Address Safer cpp failures in ControlMac

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -73,7 +73,6 @@ platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h
 platform/graphics/controls/PlatformControl.h
 platform/graphics/cv/GraphicsContextGLCVCocoa.h
-platform/graphics/mac/controls/ControlMac.h
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
 platform/mediastream/MediaStreamPrivate.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1048,7 +1048,6 @@ platform/graphics/displaylists/DisplayListItem.cpp
 platform/graphics/filters/FEDisplacementMap.cpp
 platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/mac/PDFDocumentImageMac.mm
-platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/opentype/OpenTypeMathData.cpp
 platform/graphics/transforms/TransformOperations.cpp
 platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -584,7 +584,6 @@ platform/graphics/displaylists/DisplayListItems.cpp
 platform/graphics/displaylists/DisplayListRecorder.cpp
 platform/graphics/displaylists/DisplayListRecorderImpl.cpp
 platform/graphics/filters/FilterOperations.cpp
-platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -29,6 +29,7 @@
 
 #import "ControlFactoryCocoa.h"
 #import "WebControlView.h"
+#import <wtf/CheckedRef.h>
 #import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSServicesRolloverButtonCell;
@@ -38,8 +39,9 @@ namespace WebCore {
 class FloatRect;
 struct ControlStyle;
 
-class ControlFactoryMac final : public ControlFactoryCocoa {
+class ControlFactoryMac final : public ControlFactoryCocoa, public CanMakeCheckedPtr<ControlFactoryMac> {
     WTF_MAKE_TZONE_ALLOCATED(ControlFactoryMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ControlFactoryMac);
 public:
     using ControlFactoryCocoa::ControlFactoryCocoa;
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -29,6 +29,7 @@
 
 #import "LengthBox.h"
 #import "PlatformControl.h"
+#import <wtf/CheckedRef.h>
 #import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -77,7 +78,7 @@ private:
     void drawCellFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
     void drawCellOrFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, bool drawCell = true);
 
-    ControlFactoryMac& m_controlFactory;
+    const CheckedRef<ControlFactoryMac> m_controlFactory;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -281,7 +281,7 @@ void ControlMac::drawCellInternal(GraphicsContext& context, const FloatRect& rec
         return;
     }
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory->drawingView(rect, style);
     drawCellInView(context, rect, cell, view);
 }
 
@@ -311,7 +311,7 @@ void ControlMac::drawCellFocusRingInternal(GraphicsContext& context, const Float
         return;
     }
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory->drawingView(rect, style);
     drawCellFocusRingInView(context, rect, cell, view);
 }
 


### PR DESCRIPTION
#### 60d0c8e7907d2b973696b5807b284e5de8d99e99
<pre>
Address Safer cpp failures in ControlMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=289575">https://bugs.webkit.org/show_bug.cgi?id=289575</a>
<a href="https://rdar.apple.com/problem/146803983">rdar://problem/146803983</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning in ControlMac.

* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawCellInternal):
(WebCore::ControlMac::drawCellFocusRingInternal):

Canonical link: <a href="https://commits.webkit.org/292015@main">https://commits.webkit.org/292015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9225c2a73e5901cd3f24b14aa7a1f71aa8c0a326

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52583 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/94210 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15862 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81243 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80624 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2577 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14968 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26832 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->