### PR TITLE
[Cocoa] Continue fine-tuning fixed-position page sampling heuristics

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
@@ -1,0 +1,6 @@
+PASS colorBeforeFading.top is "rgba(255, 100, 0, 0.8)"
+PASS colorAfterFading.top is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+            margin: 0;
+        }
+
+        header {
+            text-align: center;
+            position: fixed;
+            top: 0px;
+            left: 0;
+            font-size: 32px;
+            width: 100%;
+            height: 250px;
+            background: rgba(255, 100, 0, 0.8);
+        }
+
+        .top {
+            width: 100%;
+            height: 40px;
+            background: black;
+            position: absolute;
+            top: 0;
+        }
+
+        .tall {
+            width: 100%;
+            height: 2000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.ensurePresentationUpdate();
+        colorBeforeFading = await UIHelper.fixedContainerEdgeColors();
+
+        document.querySelector("header").style.opacity = 0.01;
+        await UIHelper.ensurePresentationUpdate();
+        colorAfterFading = await UIHelper.fixedContainerEdgeColors();
+
+        shouldBeEqualToString("colorBeforeFading.top", "rgba(255, 100, 0, 0.8)");
+        shouldBeNull("colorAfterFading.top");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="top">
+<div class="tall"></div>
+<header></header>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text-expected.txt
@@ -1,0 +1,15 @@
+PASS sampledTopColors[0] is "rgb(255, 100, 0)"
+PASS sampledTopColors[1] is "rgb(255, 100, 0)"
+PASS sampledTopColors[2] is "rgb(255, 100, 0)"
+PASS sampledTopColors[3] is "rgb(255, 100, 0)"
+PASS sampledTopColors[4] is "rgb(255, 100, 0)"
+PASS sampledTopColors[5] is "rgb(255, 100, 0)"
+PASS sampledTopColors[6] is "rgb(255, 100, 0)"
+PASS sampledTopColors[7] is "rgb(255, 100, 0)"
+PASS sampledTopColors[8] is "rgb(255, 100, 0)"
+PASS sampledTopColors[9] is "rgb(255, 100, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+        }
+
+        header {
+            text-align: center;
+            position: fixed;
+            top: 0px;
+            left: 0;
+            font-size: 32px;
+            width: 100%;
+            height: 250px;
+            background: rgb(255, 100, 0);
+            color: white;
+            overflow: hidden;
+            font-weight: bold;
+            letter-spacing: -6px;
+        }
+
+        .tall {
+            width: 10px;
+            height: 2000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        let header = document.querySelector("header");
+        sampledTopColors = []
+        for (let i = 0; i < 10; ++i) {
+            header.style.top = `${i * 11 - 100}px`;
+            await UIHelper.ensurePresentationUpdate();
+            const edgeColors = await UIHelper.fixedContainerEdgeColors();
+            sampledTopColors.push(edgeColors?.top);
+        }
+
+        for (let i = 0; i < 10; ++i)
+            shouldBeEqualToString(`sampledTopColors[${i}]`, "rgb(255, 100, 0)");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</header>
+<div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt
@@ -1,0 +1,7 @@
+PASS Loaded iframe
+PASS color.top is "rgb(255, 100, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+        }
+
+        header {
+            text-align: center;
+            position: fixed;
+            top: 0px;
+            left: 0;
+            font-size: 32px;
+            width: 100%;
+            height: 250px;
+        }
+
+        iframe {
+            width: 100%;
+            height: 250px;
+        }
+
+        .tall {
+            width: 10px;
+            height: 2000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        let frame = document.querySelector("iframe");
+        await UIHelper.callFunctionAndWaitForEvent(() => {
+            frame.srcdoc = `
+                <body style='margin: 0; width: 100%; height: 100%; background: rgb(255, 100, 0);'>
+                    <p>Hello world</p>
+                </body>`;
+        }, frame, "load");
+
+        testPassed("Loaded iframe");
+
+        await UIHelper.ensurePresentationUpdate();
+        color = await UIHelper.fixedContainerEdgeColors();
+
+        shouldBeEqualToString("color.top", "rgb(255, 100, 0)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header><iframe frameborder="0"></iframe></header>
+<div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -105,8 +105,12 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame& frame, const IntRect& 
         paintBehavior.add(PaintBehavior::SelectionAndBackgroundsOnly);
     if (options.flags.contains(SnapshotFlags::PaintEverythingExcludingSelection))
         paintBehavior.add(PaintBehavior::ExcludeSelection);
-    if (options.flags.contains(SnapshotFlags::ExcludeReplacedContent))
-        paintBehavior.add(PaintBehavior::ExcludeReplacedContent);
+    if (options.flags.contains(SnapshotFlags::ExcludeReplacedContentExceptForIFrames))
+        paintBehavior.add(PaintBehavior::ExcludeReplacedContentExceptForIFrames);
+    if (options.flags.contains(SnapshotFlags::ExcludeText))
+        paintBehavior.add(PaintBehavior::ExcludeText);
+    if (options.flags.contains(SnapshotFlags::FixedAndStickyLayersOnly))
+        paintBehavior.add(PaintBehavior::FixedAndStickyLayersOnly);
 
     // Other paint behaviors are set by paintContentsForSnapshot.
     frame.view()->setPaintBehavior(paintBehavior);

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -45,17 +45,19 @@ class LocalFrame;
 class Node;
 
 enum class SnapshotFlags : uint16_t {
-    ExcludeSelectionHighlighting = 1 << 0,
-    PaintSelectionOnly = 1 << 1,
-    InViewCoordinates = 1 << 2,
-    ForceBlackText = 1 << 3,
-    PaintSelectionAndBackgroundsOnly = 1 << 4,
-    PaintEverythingExcludingSelection = 1 << 5,
-    PaintWithIntegralScaleFactor = 1 << 6,
-    Shareable = 1 << 7,
-    Accelerated = 1 << 8,
-    ExcludeReplacedContent = 1 << 9,
-    PaintWith3xBaseScale = 1 << 10,
+    ExcludeSelectionHighlighting            = 1 << 0,
+    PaintSelectionOnly                      = 1 << 1,
+    InViewCoordinates                       = 1 << 2,
+    ForceBlackText                          = 1 << 3,
+    PaintSelectionAndBackgroundsOnly        = 1 << 4,
+    PaintEverythingExcludingSelection       = 1 << 5,
+    PaintWithIntegralScaleFactor            = 1 << 6,
+    Shareable                               = 1 << 7,
+    Accelerated                             = 1 << 8,
+    ExcludeReplacedContentExceptForIFrames  = 1 << 9,
+    PaintWith3xBaseScale                    = 1 << 10,
+    ExcludeText                             = 1 << 11,
+    FixedAndStickyLayersOnly                = 1 << 12,
 };
 
 struct SnapshotOptions {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4767,7 +4767,15 @@ void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&,
     paintingState.paintBehavior = m_paintBehavior;
     
     if (auto* parentView = parentFrameView()) {
-        constexpr OptionSet<PaintBehavior> flagsToCopy { PaintBehavior::FlattenCompositingLayers, PaintBehavior::Snapshotting, PaintBehavior::DefaultAsynchronousImageDecode, PaintBehavior::ForceSynchronousImageDecode, PaintBehavior::ExcludeReplacedContent };
+        static constexpr OptionSet flagsToCopy {
+            PaintBehavior::FlattenCompositingLayers,
+            PaintBehavior::Snapshotting,
+            PaintBehavior::DefaultAsynchronousImageDecode,
+            PaintBehavior::ForceSynchronousImageDecode,
+            PaintBehavior::ExcludeReplacedContentExceptForIFrames,
+            PaintBehavior::ExcludeText,
+            PaintBehavior::FixedAndStickyLayersOnly,
+        };
         m_paintBehavior.add(parentView->paintBehavior() & flagsToCopy);
     }
 

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -155,7 +155,7 @@ static SnapshotOptions snapshotOptionsForTextIndicatorOptions(OptionSet<TextIndi
                 snapshotOptions.flags.add(SnapshotFlags::ForceBlackText);
         }
         if (options.contains(TextIndicatorOption::SkipReplacedContent))
-            snapshotOptions.flags.add(SnapshotFlags::ExcludeReplacedContent);
+            snapshotOptions.flags.add(SnapshotFlags::ExcludeReplacedContentExceptForIFrames);
     } else
         snapshotOptions.flags.add(SnapshotFlags::ExcludeSelectionHighlighting);
 

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -55,27 +55,29 @@ enum class PaintPhase : uint16_t {
 };
 
 enum class PaintBehavior : uint32_t {
-    Normal                              = 0,
-    SelectionOnly                       = 1 << 0,
-    SkipSelectionHighlight              = 1 << 1,
-    ForceBlackText                      = 1 << 2,
-    ForceWhiteText                      = 1 << 3,
-    ForceBlackBorder                    = 1 << 4,
-    RenderingSVGClipOrMask              = 1 << 5,
-    SkipRootBackground                  = 1 << 6,
-    RootBackgroundOnly                  = 1 << 7,
-    SelectionAndBackgroundsOnly         = 1 << 8,
-    ExcludeSelection                    = 1 << 9,
-    FlattenCompositingLayers            = 1 << 10, // Paint doesn't stop at compositing layer boundaries.
-    ForceSynchronousImageDecode         = 1 << 11, // Paint should always complete image decoding of painted images.
-    DefaultAsynchronousImageDecode      = 1 << 12, // Paint should always start asynchronous image decode of painted images, unless otherwise specified.
-    CompositedOverflowScrollContent     = 1 << 13,
-    AnnotateLinks                       = 1 << 14, // Collect all renderers with links to annotate their URLs (e.g. PDFs)
-    EventRegionIncludeForeground        = 1 << 15, // FIXME: Event region painting should use paint phases.
-    EventRegionIncludeBackground        = 1 << 16,
-    Snapshotting                        = 1 << 17, // Paint is updating external backing store and visits all content, including composited content and always completes image decoding of painted images. FIXME: Will be removed.
-    DontShowVisitedLinks                = 1 << 18,
-    ExcludeReplacedContent              = 1 << 19,
+    Normal                                      = 0,
+    SelectionOnly                               = 1 << 0,
+    SkipSelectionHighlight                      = 1 << 1,
+    ForceBlackText                              = 1 << 2,
+    ForceWhiteText                              = 1 << 3,
+    ForceBlackBorder                            = 1 << 4,
+    RenderingSVGClipOrMask                      = 1 << 5,
+    SkipRootBackground                          = 1 << 6,
+    RootBackgroundOnly                          = 1 << 7,
+    SelectionAndBackgroundsOnly                 = 1 << 8,
+    ExcludeSelection                            = 1 << 9,
+    FlattenCompositingLayers                    = 1 << 10, // Paint doesn't stop at compositing layer boundaries.
+    ForceSynchronousImageDecode                 = 1 << 11, // Paint should always complete image decoding of painted images.
+    DefaultAsynchronousImageDecode              = 1 << 12, // Paint should always start asynchronous image decode of painted images, unless otherwise specified.
+    CompositedOverflowScrollContent             = 1 << 13,
+    AnnotateLinks                               = 1 << 14, // Collect all renderers with links to annotate their URLs (e.g. PDFs)
+    EventRegionIncludeForeground                = 1 << 15, // FIXME: Event region painting should use paint phases.
+    EventRegionIncludeBackground                = 1 << 16,
+    Snapshotting                                = 1 << 17, // Paint is updating external backing store and visits all content, including composited content and always completes image decoding of painted images. FIXME: Will be removed.
+    DontShowVisitedLinks                        = 1 << 18,
+    ExcludeReplacedContentExceptForIFrames      = 1 << 19,
+    ExcludeText                                 = 1 << 20,
+    FixedAndStickyLayersOnly                    = 1 << 21,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -346,7 +346,7 @@ bool RenderReplaced::shouldPaint(PaintInfo& paintInfo, const LayoutPoint& paintO
     if ((paintInfo.paintBehavior.contains(PaintBehavior::ExcludeSelection)) && isSelected())
         return false;
 
-    if (paintInfo.paintBehavior.contains(PaintBehavior::ExcludeReplacedContent))
+    if (paintInfo.paintBehavior.contains(PaintBehavior::ExcludeReplacedContentExceptForIFrames) && !isRenderIFrame())
         return false;
 
     if (paintInfo.phase != PaintPhase::Foreground

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -98,6 +98,9 @@ InlineIterator::TextBoxIterator TextBoxPainter::makeIterator() const
 
 void TextBoxPainter::paint()
 {
+    if (m_paintInfo.paintBehavior.contains(PaintBehavior::ExcludeText))
+        return;
+
     if (m_paintInfo.phase == PaintPhase::Selection && !m_haveSelection)
         return;
 


### PR DESCRIPTION
#### 48d3a2b6aeb68c595ab0a00d54828145095e09c6
<pre>
[Cocoa] Continue fine-tuning fixed-position page sampling heuristics
<a href="https://bugs.webkit.org/show_bug.cgi?id=289573">https://bugs.webkit.org/show_bug.cgi?id=289573</a>
<a href="https://rdar.apple.com/146801107">rdar://146801107</a>

Reviewed by Abrar Rahman Protyasha.

Make various adjustments to the page color sampling heuristic. See below for more details.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html: Added.

Add a test to verify that sampling doesn&apos;t include content behind the fixed-position container, if
the fixed-position container is partially transparent.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html: Added.

Add a test to verify that text painting is skipped for the purposes of color sampling. To check
this, we include lots of white text inside an orange fixed-position container (with a fairly large
font size, and also decreased `letter-spacing` to maximize the likelihood of sampling the text). At
various offsets relative to the top of the viewport, the sampled color should always remain orange.

* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html: Added.

Add a test to verify that content inside subframes in fixed-position containers are included in the
sampled color.

* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::snapshotFrameRectWithClip):
* Source/WebCore/page/FrameSnapshotting.h:

Make several changes to the frame snapshotting flags:

•   `ExcludeReplacedContent`: rename this to `ExcludeReplacedContentExceptForIFrames`. Adjust
    `RenderReplaced::shouldPaint` below to avoid bailing for subframes.

•   `ExcludeText`: add a flag to exclude text from being painted in the snapshot. This is passed
    down as a `PaintBehavior` flag, and eventually checked in `TextBoxPainter::paint`.

•   `FixedAndStickyLayersOnly`: add a flag to limit painting to content in fixed and sticky layers,
    or layers underneath fixed layers. Add a FIXME to include layers inside sticky layers, once we
    have the ability to (quickly) check if we have a sticky ancestor.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willPaintContents):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

If the sampled color is close to being totally transparent, revert to returning an invalid color.

* Source/WebCore/page/TextIndicator.cpp:
(WebCore::snapshotOptionsForTextIndicatorOptions):
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paint):

Canonical link: <a href="https://commits.webkit.org/292000@main">https://commits.webkit.org/292000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7e957a4aec808c798f4acb9b3823c11ff58d3c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72203 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44488 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81197 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25140 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14904 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21666 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26786 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->