### PR TITLE
Move WebKitTestRunner alert, prompt, and confirm output from injected bundle to UI process

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -108,15 +108,9 @@ private:
     // UI Client
     static void willAddMessageToConsole(WKBundlePageRef, WKStringRef message, uint32_t lineNumber, const void* clientInfo);
     static void willSetStatusbarText(WKBundlePageRef, WKStringRef statusbarText, const void* clientInfo);
-    static void willRunJavaScriptAlert(WKBundlePageRef, WKStringRef message, WKBundleFrameRef frame, const void* clientInfo);
-    static void willRunJavaScriptConfirm(WKBundlePageRef, WKStringRef message, WKBundleFrameRef frame, const void* clientInfo);
-    static void willRunJavaScriptPrompt(WKBundlePageRef, WKStringRef message, WKStringRef defaultValue, WKBundleFrameRef frame, const void* clientInfo);
     static uint64_t didExceedDatabaseQuota(WKBundlePageRef, WKSecurityOriginRef, WKStringRef databaseName, WKStringRef databaseDisplayName, uint64_t currentQuotaBytes, uint64_t currentOriginUsageBytes, uint64_t currentDatabaseUsageBytes, uint64_t expectedUsageBytes, const void* clientInfo);
     void willAddMessageToConsole(WKStringRef message);
     void willSetStatusbarText(WKStringRef statusbarText);
-    void willRunJavaScriptAlert(WKStringRef message, WKBundleFrameRef);
-    void willRunJavaScriptConfirm(WKStringRef message, WKBundleFrameRef);
-    void willRunJavaScriptPrompt(WKStringRef message, WKStringRef defaultValue, WKBundleFrameRef);
     uint64_t didExceedDatabaseQuota(WKSecurityOriginRef, WKStringRef databaseName, WKStringRef databaseDisplayName, uint64_t currentQuotaBytes, uint64_t currentOriginUsageBytes, uint64_t currentDatabaseUsageBytes, uint64_t expectedUsageBytes);
 
     // Editor client

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -130,7 +130,7 @@ static bool handleOptionLocalhostAlias(Options& options, const char*, const char
 static bool parseFeature(std::string_view featureString, TestFeatures& features)
 {
     auto strings = split(featureString, '=');
-    if (strings.empty() || strings.size() > 2)
+    if (strings.isEmpty() || strings.size() > 2)
         return false;
 
     auto featureName = strings[0];

--- a/Tools/WebKitTestRunner/StringFunctions.h
+++ b/Tools/WebKitTestRunner/StringFunctions.h
@@ -30,14 +30,14 @@
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WKString.h>
 #include <WebKit/WKStringPrivate.h>
-#include <sstream>
 #include <string>
-#include <vector>
 #include <wtf/Platform.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTR {
@@ -137,16 +137,16 @@ inline WTF::String toWTFString(JSContextRef context, JSValueRef value)
 }
 
 template<typename StringType>
-inline std::vector<StringType> split(const StringType& string, char delimiter)
+inline Vector<StringType> split(const StringType& string, char delimiter)
 {
-    std::vector<StringType> result;
+    Vector<StringType> result;
 
     size_t i = 0;
     while (i < string.size()) {
         auto foundIndex = string.find_first_of(delimiter, i);
 
         if (foundIndex != i)
-            result.push_back(string.substr(i, foundIndex - i));
+            result.append(string.substr(i, foundIndex - i));
 
         if (foundIndex == StringType::npos)
             break;
@@ -155,6 +155,23 @@ inline std::vector<StringType> split(const StringType& string, char delimiter)
     }
 
     return result;
+}
+
+inline WTF::String stripTrailingSpacesAddNewline(const WTF::String& string)
+{
+    StringBuilder builder;
+    for (auto line : StringView(string).splitAllowingEmptyEntries('\n')) {
+        while (line.endsWith(' '))
+            line = line.left(line.length() - 1);
+        builder.append(line, '\n');
+    }
+    return builder.toString();
+}
+
+inline WTF::String addLeadingSpaceStripTrailingSpacesAddNewline(const WTF::String& string)
+{
+    auto result = stripTrailingSpacesAddNewline(string);
+    return (result.isEmpty() || result.startsWith('\n')) ? result : makeString(' ', result);
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -393,7 +393,9 @@ public:
     uint64_t serverTrustEvaluationCallbackCallsCount() const { return m_serverTrustEvaluationCallbackCallsCount; }
 
     void setShouldDismissJavaScriptAlertsAsynchronously(bool);
-    void handleJavaScriptAlert(WKPageRunJavaScriptAlertResultListenerRef);
+    void handleJavaScriptAlert(WKStringRef, WKPageRunJavaScriptAlertResultListenerRef);
+    void handleJavaScriptConfirm(WKStringRef, WKPageRunJavaScriptConfirmResultListenerRef);
+    void handleJavaScriptPrompt(WKStringRef, WKStringRef, WKPageRunJavaScriptPromptResultListenerRef);
     void abortModal();
 
     bool isDoingMediaCapture() const;


### PR DESCRIPTION
#### 3678d3f1bb37bdddc20b8843f0e1a995617c64d6
<pre>
Move WebKitTestRunner alert, prompt, and confirm output from injected bundle to UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=289581">https://bugs.webkit.org/show_bug.cgi?id=289581</a>

Reviewed by Pascoe.

This is needed for site isolation, where alerts may be coming from different processes.
This also tests functionality that is closer to what WKWebView does.  The alert, prompt,
and confirm functions already send a synchronous message.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::InjectedBundlePage):
(WTR::InjectedBundlePage::willRunJavaScriptAlert): Deleted.
(WTR::InjectedBundlePage::willRunJavaScriptConfirm): Deleted.
(WTR::InjectedBundlePage::willRunJavaScriptPrompt): Deleted.
(WTR::stripTrailingSpacesAddNewline): Deleted.
(WTR::addLeadingSpaceStripTrailingSpacesAddNewline): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:
* Tools/WebKitTestRunner/Options.cpp:
(WTR::parseFeature):
* Tools/WebKitTestRunner/StringFunctions.h:
(WTR::split):
(WTR::stripTrailingSpacesAddNewline):
(WTR::addLeadingSpaceStripTrailingSpacesAddNewline):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::runJavaScriptAlert):
(WTR::runJavaScriptPrompt):
(WTR::runJavaScriptConfirm):
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::createWebViewWithOptions):
(WTR::TestController::handleJavaScriptAlert):
(WTR::TestController::handleJavaScriptPrompt):
(WTR::TestController::handleJavaScriptConfirm):
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/292030@main">https://commits.webkit.org/292030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6ee1f14b9007917efbcc6e93dbdc7fe54f965ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72210 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29513 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81204 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80588 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14914 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21676 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->