### PR TITLE
[UnifiedPDF] [iOS Debug] Web content process crashes immediately when a PDF document is loaded

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -542,7 +542,9 @@ private:
     WebCore::IntRect frameForPageNumberIndicatorInRootViewCoordinates() const;
     bool pageNumberIndicatorEnabled() const;
     bool shouldShowPageNumberIndicator() const;
-    void updatePageNumberIndicatorVisibility();
+
+    enum class IndicatorVisible : bool { No, Yes };
+    IndicatorVisible updatePageNumberIndicatorVisibility();
     void updatePageNumberIndicatorLocation();
     void updatePageNumberIndicatorCurrentPage(const std::optional<WebCore::IntRect>& unobscuredContentRectInRootView);
     void updatePageNumberIndicator(const std::optional<WebCore::IntRect>& unobscuredContentRectInRootView = { });

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3727,15 +3727,18 @@ bool UnifiedPDFPlugin::shouldShowPageNumberIndicator() const
     return true;
 }
 
-void UnifiedPDFPlugin::updatePageNumberIndicatorVisibility()
+auto UnifiedPDFPlugin::updatePageNumberIndicatorVisibility() -> IndicatorVisible
 {
     if (!m_frame || !m_frame->page())
-        return;
+        return IndicatorVisible::No;
 
-    if (shouldShowPageNumberIndicator())
+    if (shouldShowPageNumberIndicator()) {
         m_frame->protectedPage()->createPDFPageNumberIndicator(*this, frameForPageNumberIndicatorInRootViewCoordinates(), m_documentLayout.pageCount());
-    else
-        m_frame->protectedPage()->removePDFPageNumberIndicator(*this);
+        return IndicatorVisible::Yes;
+    }
+
+    m_frame->protectedPage()->removePDFPageNumberIndicator(*this);
+    return IndicatorVisible::No;
 }
 
 void UnifiedPDFPlugin::updatePageNumberIndicatorLocation()
@@ -3772,7 +3775,8 @@ void UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage(const std::optional<
 
 void UnifiedPDFPlugin::updatePageNumberIndicator(const std::optional<IntRect>& maybeUnobscuredContentRectInRootView)
 {
-    updatePageNumberIndicatorVisibility();
+    if (updatePageNumberIndicatorVisibility() == IndicatorVisible::No)
+        return;
     updatePageNumberIndicatorLocation();
     updatePageNumberIndicatorCurrentPage(maybeUnobscuredContentRectInRootView);
 }


### PR DESCRIPTION
#### e46278c3187befc399b1c4ff4004e60d9d45c38c
<pre>
[UnifiedPDF] [iOS Debug] Web content process crashes immediately when a PDF document is loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=289588">https://bugs.webkit.org/show_bug.cgi?id=289588</a>
<a href="https://rdar.apple.com/146814007">rdar://146814007</a>

Reviewed by Tim Horton.

Currently, in debug configurations, loading a PDF document crashes the
WCP immediately with this backtrace:

```
Thread 0 name:   Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   WebKit                                     0x11bec9df4 WTFCrashWithInfo(int, char const*, char const*, int) + 100
1   WebKit                                     0x11ede484c WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint(WebCore::FloatPoint, std::__1::optional&lt;WebKit::PDFLayoutRow&gt; const&amp;) const + 152
2   WebKit                                     0x11edeaa58 WebKit::PDFPresentationController::nearestPageIndexForDocumentPoint(WebCore::FloatPoint const&amp;) const + 168
3   WebKit                                     0x11ee547bc WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage(std::__1::optional&lt;WebCore::IntRect&gt; const&amp;) + 260
4   WebKit                                     0x11ee40300 WebKit::UnifiedPDFPlugin::updatePageNumberIndicator(std::__1::optional&lt;WebCore::IntRect&gt; const&amp;) + 56
5   WebKit                                     0x11ee46770 WebKit::UnifiedPDFPlugin::visibilityDidChange(bool) + 68
6   WebKit                                     0x11fe28c84 WebKit::PluginView::viewVisibilityDidChange() + 156
7   WebKit                                     0x11fe28778 WebKit::PluginView::initializePlugin() + 188
8   WebKit                                     0x11fe29a8c WebKit::PluginView::setParent(WebCore::ScrollView*) + 60
9   WebCore                                    0x306262460 WebCore::ScrollView::addChild(WebCore::Widget&amp;) + 300
10  WebCore                                    0x305f17354 WebCore::LocalFrameView::addChild(WebCore::Widget&amp;) + 148
11  WebCore                                    0x306ffe388 WebCore::WidgetHierarchyUpdatesSuspensionScope::moveWidgets() + 472
12  WebCore                                    0x30214f160 WebCore::WidgetHierarchyUpdatesSuspensionScope::~WidgetHierarchyUpdatesSuspensionScope() + 196
13  WebCore                                    0x30213ca94 WebCore::WidgetHierarchyUpdatesSuspensionScope::~WidgetHierarchyUpdatesSuspensionScope() + 32
14  WebCore                                    0x305f0dd20 WebCore::LocalFrameView::updateEmbeddedObjects() + 368
15  WebCore                                    0x305ef6b68 WebCore::LocalFrameView::updateEmbeddedObjectsTimerFired() + 68
16  WebCore                                    0x305f0dfe0 WebCore::LocalFrameView::flushAnyPendingPostLayoutTasks() + 64
```

We&apos;re unconditionally calling into updatePageNumberIndicatorCurrentPage()
during plugin initialization. However, this is wrong because the plugin
document is not fully installed yet, and so we don&apos;t have valid document
data or a complete page count.

We fix this bug by gating the rest of the page number indicator update
cycle behind the outcome of updatePageNumberIndicatorVisibility().
Specifically, the indicator&apos;s page count and location should only be
updated if we requested the UI process to make the indicator visible to
begin with.

No additional tests required. Without this patch, PDF API tests are all
crashy on debug iOS anyway, and we progress that significantly here.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorVisibility):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicator):

Canonical link: <a href="https://commits.webkit.org/292012@main">https://commits.webkit.org/292012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14222c21def71eb52c60c48af9509eb91587a7e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45167 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72215 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10511 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80594 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25151 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14920 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26799 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->