### PR TITLE
Address Safer CPP failures in UIProcess/mac

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -111,12 +111,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-UIProcess/mac/WKSharingServicePickerDelegate.mm
-UIProcess/mac/WKTextFinderClient.mm
-UIProcess/mac/WKViewLayoutStrategy.mm
-UIProcess/mac/WebContextMenuProxyMac.mm
-UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
-UIProcess/mac/WebDateTimePickerMac.mm
 WebDriverBidiBackendDispatchers.cpp
 WebDriverBidiFrontendDispatchers.cpp
 WebProcess/ApplePay/WebPaymentCoordinator.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -14,7 +14,6 @@ UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKDownload.mm
-UIProcess/mac/WebContextMenuProxyMac.mm
 WebProcess/Automation/WebAutomationSessionProxy.cpp
 WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -45,6 +45,11 @@ WebContextMenuProxy::WebContextMenuProxy(WebPageProxy& page, ContextMenuContextD
 
 WebContextMenuProxy::~WebContextMenuProxy() = default;
 
+RefPtr<WebPageProxy> WebContextMenuProxy::protectedPage() const
+{
+    return page();
+}
+
 Vector<Ref<WebContextMenuItem>> WebContextMenuProxy::proposedItems() const
 {
     return WTF::map(m_context.menuItems(), [](auto& item) {

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -51,6 +51,7 @@ public:
     virtual void show();
 
     WebPageProxy* page() const { return m_page.get(); }
+    RefPtr<WebPageProxy> protectedPage() const;
 
 #if PLATFORM(COCOA)
     virtual NSMenu *platformMenu() const = 0;

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -178,13 +178,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     // FIXME: We should adopt replaceSelectionWithAttributedString instead of bouncing through the (fake) pasteboard.
     if (RefPtr menuProxy = _menuProxy.get())
-        menuProxy->page()->replaceSelectionWithPasteboardData(types, dataReference);
+        menuProxy->protectedPage()->replaceSelectionWithPasteboardData(types, dataReference);
 }
 
 - (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope
 {
     if (RefPtr menuProxy = _menuProxy.get())
-        return _menuProxy->window();
+        return menuProxy->window();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm
+++ b/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm
@@ -150,7 +150,7 @@
     if (!self)
         return nil;
 
-    page.get().setUseFixedLayout(false);
+    Ref { page.get() }->setUseFixedLayout(false);
 
     return self;
 }
@@ -170,7 +170,7 @@
     if (!self)
         return nil;
 
-    page.get().setUseFixedLayout(true);
+    Ref { page.get() }->setUseFixedLayout(true);
 
     return self;
 }
@@ -190,7 +190,7 @@
     if (!self)
         return nil;
 
-    page.get().setUseFixedLayout(true);
+    Ref { page.get() }->setUseFixedLayout(true);
 
     return self;
 }
@@ -230,7 +230,7 @@
     if (!self)
         return nil;
 
-    _page->setShouldScaleViewToFitDocument(true);
+    Ref { *_page }->setShouldScaleViewToFitDocument(true);
 
     return self;
 }
@@ -241,8 +241,9 @@
 
 - (void)willChangeLayoutStrategy
 {
-    _page->setShouldScaleViewToFitDocument(false);
-    _page->scaleView(1);
+    RefPtr page = _page.get();
+    page->setShouldScaleViewToFitDocument(false);
+    page->scaleView(1);
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -94,21 +94,23 @@ void WebDataListSuggestionsDropdownMac::show(WebCore::DataListSuggestionInformat
 
 void WebDataListSuggestionsDropdownMac::didSelectOption(const String& selectedOption)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
-    m_page->didSelectOption(selectedOption);
+    page->didSelectOption(selectedOption);
     close();
 }
 
 void WebDataListSuggestionsDropdownMac::selectOption()
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     String selectedOption = [m_dropdownUI currentSelectedString];
     if (!selectedOption.isNull())
-        m_page->didSelectOption(selectedOption);
+        page->didSelectOption(selectedOption);
 
     close();
 }
@@ -485,7 +487,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     if (!selectedString)
         return;
 
-    _dropdown->didSelectOption(selectedString);
+    Ref { *_dropdown }->didSelectOption(selectedString);
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -95,10 +95,8 @@ void WebDateTimePickerMac::showDateTimePicker(WebCore::DateTimeChooserParameters
 
 void WebDateTimePickerMac::didChooseDate(StringView date)
 {
-    if (!m_page)
-        return;
-
-    m_page->didChooseDate(date);
+    if (RefPtr page = m_page.get())
+        page->didChooseDate(date);
 }
 
 } // namespace WebKit
@@ -282,7 +280,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
         return;
 
     String dateString = [_dateFormatter stringFromDate:[_datePicker dateValue]];
-    _picker->didChooseDate(StringView(dateString));
+    Ref { *_picker }->didChooseDate(StringView(dateString));
 }
 
 - (NSString *)dateFormatStringForType:(NSString *)type


### PR DESCRIPTION
#### 0bdc53c9de9feeb3c845e3c428f7bbbe2e7ba53b
<pre>
Address Safer CPP failures in UIProcess/mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=289591">https://bugs.webkit.org/show_bug.cgi?id=289591</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
(WebKit::WebContextMenuProxy::protectedPage const):
* Source/WebKit/UIProcess/WebContextMenuProxy.h:
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
(-[WKSharingServicePickerDelegate sharingService:sourceWindowForShareItems:sharingContentScope:]):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
(-[WKTextFinderClient initWithPage:view:usePlatformFindUI:]):
(-[WKTextFinderClient willDestroyView:]):
(-[WKTextFinderClient _protectedPage]):
(-[WKTextFinderClient replaceMatches:withString:inSelectionOnly:resultCollector:]):
(-[WKTextFinderClient findMatchesForString:relativeToMatch:findOptions:maxResults:resultCollector:]):
(-[WKTextFinderClient getSelectedText:]):
(-[WKTextFinderClient selectFindMatch:completionHandler:]):
(-[WKTextFinderClient scrollFindMatchToVisible:]):
(-[WKTextFinderClient didGetImageForMatchResult:]):
(-[WKTextFinderClient getImageForMatchResult:completionHandler:]):
* Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm:
(-[WKViewViewSizeLayoutStrategy initWithPage:view:viewImpl:mode:]):
(-[WKViewFixedSizeLayoutStrategy initWithPage:view:viewImpl:mode:]):
(-[WKViewDynamicSizeComputedFromViewScaleLayoutStrategy initWithPage:view:viewImpl:mode:]):
(-[WKViewDynamicSizeComputedFromMinimumDocumentSizeLayoutStrategy initWithPage:view:viewImpl:mode:]):
(-[WKViewDynamicSizeComputedFromMinimumDocumentSizeLayoutStrategy willChangeLayoutStrategy]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuTarget forwardContextMenuAction:]):
(-[WKMenuTarget performShare:]):
(-[WKMenuDelegate menuWillOpen:]):
(-[WKMenuDelegate menuDidClose:]):
(WebKit::WebContextMenuProxyMac::contextMenuItemSelected):
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::WebContextMenuProxyMac::appendRemoveBackgroundItemToControlledImageMenuIfNeeded):
(WebKit::WebContextMenuProxyMac::removeBackgroundFromControlledImage):
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::WebContextMenuProxyMac::showAfterPostProcessingContextData):
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):
(WebKit::WebContextMenuProxyMac::showContextMenuWithItems):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(WebKit::WebDataListSuggestionsDropdownMac::didSelectOption):
(WebKit::WebDataListSuggestionsDropdownMac::selectOption):
(-[WKDataListSuggestionsController selectedRow:]):
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(WebKit::WebDateTimePickerMac::didChooseDate):
(-[WKDateTimePicker didChooseDate:]):

Canonical link: <a href="https://commits.webkit.org/292060@main">https://commits.webkit.org/292060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c612bf10b6fe7605905a5007f21ba750ca2896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99876 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22870 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97860 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52685 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/44687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80736 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25301 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21866 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21526 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/24997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->