### PR TITLE
[SwiftUI] Update the set of supported view modifiers on WebView

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -30,12 +30,15 @@ extension View {
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public func webViewBackForwardNavigationGestures(_ value: WebView.BackForwardNavigationGesturesBehavior = .automatic) -> some View {
+    public nonisolated func webViewBackForwardNavigationGestures(_ value: WebView.BackForwardNavigationGesturesBehavior) -> some View {
         environment(\.webViewAllowsBackForwardNavigationGestures, value)
     }
 
-    @_spi(Private)
-    public func webViewMagnificationGestures(_ value: WebView.MagnificationGesturesBehavior) -> some View {
+    /// Determines whether magnify gestures change the view’s magnification.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewMagnificationGestures(_ value: WebView.MagnificationGesturesBehavior) -> some View {
         environment(\.webViewMagnificationGestures, value)
     }
 
@@ -43,37 +46,40 @@ extension View {
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public func webViewLinkPreviews(_ value: WebView.LinkPreviewBehavior = .automatic) -> some View {
+    public nonisolated func webViewLinkPreviews(_ value: WebView.LinkPreviewBehavior) -> some View {
         environment(\.webViewAllowsLinkPreview, value)
     }
 
     @_spi(Private)
-    public func webViewTextSelection<S>(_ selectability: S) -> some View where S : TextSelectability {
+    public nonisolated func webViewTextSelection<S>(_ selectability: S) -> some View where S : TextSelectability {
         environment(\.webViewTextSelection, S.allowsSelection)
     }
 
-    @_spi(Private)
-    public func webViewAllowsElementFullscreen(_ value: Bool = true) -> some View {
-        environment(\.webViewAllowsElementFullscreen, value)
+    /// Determines whether a web view can display content full screen.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewElementFullscreenBehavior(_ value: WebView.ElementFullscreenBehavior) -> some View {
+        environment(\.webViewElementFullscreenBehavior, value)
     }
 
     @_spi(Private)
-    public func webViewFindNavigator(isPresented: Binding<Bool>) -> some View {
+    public nonisolated func webViewFindNavigator(isPresented: Binding<Bool>) -> some View {
         environment(\.webViewFindContext, .init(isPresented: isPresented))
     }
 
     @_spi(Private)
-    public func webViewFindDisabled(_ isDisabled: Bool = true) -> some View {
+    public nonisolated func webViewFindDisabled(_ isDisabled: Bool = true) -> some View {
         transformEnvironment(\.webViewFindContext) { $0.canFind = !isDisabled }
     }
 
     @_spi(Private)
-    public func webViewReplaceDisabled(_ isDisabled: Bool = true) -> some View {
+    public nonisolated func webViewReplaceDisabled(_ isDisabled: Bool = true) -> some View {
         transformEnvironment(\.webViewFindContext) { $0.canReplace = !isDisabled }
     }
 
     @_spi(Private)
-    public func webViewContextMenu<M>(@ViewBuilder menuItems: @escaping (WebPage.ElementInfo) -> M) -> some View where M: View {
+    public nonisolated func webViewContextMenu<M>(@ViewBuilder menuItems: @escaping (WebPage.ElementInfo) -> M) -> some View where M: View {
 #if os(macOS)
         let converted = { (info: WebPage.ElementInfo) in
             let menuView = menuItems(info)
@@ -87,12 +93,22 @@ extension View {
     }
 
     @_spi(Private)
-    public func webViewContentBackground(_ visibility: Visibility) -> some View {
+    public nonisolated func webViewContentBackground(_ visibility: Visibility) -> some View {
         environment(\.webViewContentBackground, visibility)
     }
 
-    @_spi(Private)
-    public func webViewOnScrollGeometryChange<T>(
+    /// Adds an action to be performed when a value, created from a scroll geometry, changes.
+    ///
+    /// - Parameters:
+    ///   - type: The type of value transformed from a ``ScrollGeometry``.
+    ///   - transform: A closure that transforms a ``ScrollGeometry`` to your type.
+    ///   - action: A closure to run when the transformed data changes.
+    ///
+    /// - Note: The content size of web content may exceed the current size of the view's frame, however it will never be smaller than it.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewOnScrollGeometryChange<T>(
         for type: T.Type,
         of transform: @escaping (ScrollGeometry) -> T,
         action: @escaping (T, T) -> Void
@@ -106,8 +122,25 @@ extension View {
         return environment(\.webViewOnScrollGeometryChange, change)
     }
 
-    @_spi(Private)
-    public func webViewScrollPosition(_ position: Binding<ScrollPosition>) -> some View {
+    /// Associates a binding to a scroll position with the web view.
+    ///
+    /// - Note: ``WebView`` does not support scrolling to a view with an identity. It only supports scrolling to a concrete offset, or to an edge.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewScrollPosition(_ position: Binding<ScrollPosition>) -> some View {
         environment(\.webViewScrollPositionContext, .init(position: position))
+    }
+
+    /// Enables or disables scrolling in web views when using particular inputs.
+    ///
+    /// - Parameters:
+    ///   - behavior: Whether scrolling should be enabled or disabled for this input.
+    ///   - input: The input for which to enable or disable scrolling.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewScrollInputBehavior(_ behavior: ScrollInputBehavior, for input: ScrollInputKind) -> some View {
+        environment(\.webViewScrollInputBehaviorContext, .init(behavior: behavior, input: input))
     }
 }

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -70,7 +70,9 @@ extension WebView {
         let value: Value
     }
 
-    @_spi(Private)
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct MagnificationGesturesBehavior: Sendable {
         enum Value {
             case automatic
@@ -106,6 +108,29 @@ extension WebView {
         public static let enabled: LinkPreviewBehavior = .init(.enabled)
 
         public static let disabled: LinkPreviewBehavior = .init(.disabled)
+
+        init(_ value: Value) {
+            self.value = value
+        }
+
+        let value: Value
+    }
+
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct ElementFullscreenBehavior: Sendable {
+        enum Value {
+            case automatic
+            case enabled
+            case disabled
+        }
+
+        public static let automatic: ElementFullscreenBehavior = .init(.automatic)
+
+        public static let enabled: ElementFullscreenBehavior = .init(.enabled)
+
+        public static let disabled: ElementFullscreenBehavior = .init(.disabled)
 
         init(_ value: Value) {
             self.value = value

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -39,7 +39,7 @@ extension EnvironmentValues {
     var webViewTextSelection = true
 
     @Entry
-    var webViewAllowsElementFullscreen = false
+    var webViewElementFullscreenBehavior = WebView.ElementFullscreenBehavior.automatic
 
     @Entry
     var webViewFindContext: FindContext = .init()
@@ -55,4 +55,7 @@ extension EnvironmentValues {
 
     @Entry
     var webViewScrollPositionContext = ScrollPositionContext()
+
+    @Entry
+    var webViewScrollInputBehaviorContext: ScrollInputBehaviorContext? = nil
 }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -44,3 +44,8 @@ struct FindContext {
 struct ScrollPositionContext {
     var position: Binding<ScrollPosition>?
 }
+
+struct ScrollInputBehaviorContext {
+    let behavior: ScrollInputBehavior
+    let input: ScrollInputKind
+}

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -86,7 +86,7 @@ struct WebViewRepresentable {
         }
 
         webView.configuration.preferences.isTextInteractionEnabled = environment.webViewTextSelection
-        webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewAllowsElementFullscreen
+        webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewElementFullscreenBehavior.value == .enabled // automatic -> false
 
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -234,7 +234,7 @@ struct ContentView: View {
                 .webViewMagnificationGestures(.enabled)
                 .webViewLinkPreviews(.enabled)
                 .webViewTextSelection(.enabled)
-                .webViewAllowsElementFullscreen()
+                .webViewElementFullscreenBehavior(.enabled)
                 .webViewFindNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     // FIXME: Observe navigation changes.


### PR DESCRIPTION
#### e162576195430e23148ccb690534960ac416771f
<pre>
[SwiftUI] Update the set of supported view modifiers on WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=289594">https://bugs.webkit.org/show_bug.cgi?id=289594</a>
<a href="https://rdar.apple.com/146397319">rdar://146397319</a>

Reviewed by Abrar Rahman Protyasha.

Update the interface for some of the view modifiers.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
(View.webViewBackForwardNavigationGestures(_:)):
(View.webViewMagnificationGestures(_:)):
(View.webViewLinkPreviews(_:)):
(View.webViewElementFullscreenBehavior(_:)):
(View.webViewFindNavigator(_:)):
(View.webViewFindDisabled(_:)):
(View.webViewReplaceDisabled(_:)):
(View.webViewContentBackground(_:)):
(View.webViewScrollPosition(_:)):
(View.webViewScrollInputBehavior(_:for:)):
(View.webViewAllowsElementFullscreen(_:)): Deleted.
* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
(EnvironmentValues.webViewScrollInputBehaviorContext):
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/292023@main">https://commits.webkit.org/292023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f2a576713d9c0708fd6d1e270ca47bc49d5f8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72225 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29528 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44518 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80602 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2553 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14935 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26809 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->