### PR TITLE
non standard new Date('2024-12-3') yields to Invalid Date

### DIFF
--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -450,6 +450,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // Parses a date with the format YYYY[-MM[-DD]].
 // Year parsing is lenient, allows any number of digits, and +/-.
+// This also allows to relax date parsing for months and days.
+// It is not explicitly forbidden per spec, but it is also not per spec,
+// but it would help with compatibility with Firefox and Chrome for new Date('2024-12-3').
 // Returns 0 if a parse error occurs, else returns the end of the parsed portion of the string.
 static bool parseES5DatePortion(std::span<const LChar>& currentPosition, int& year, long& month, long& day)
 {
@@ -463,30 +466,37 @@ static bool parseES5DatePortion(std::span<const LChar>& currentPosition, int& ye
         return false;
 
     // Check for presence of -MM portion.
-    if (!skipExactly(currentPosition, '-'))
+    if (currentPosition.empty() || currentPosition.front() != '-')
         return true;
-    
+    currentPosition = currentPosition.subspan(1);
     if (currentPosition.empty() || !isASCIIDigit(currentPosition.front()))
         return false;
     auto postParsePosition = currentPosition;
     if (!parseLong(postParsePosition, 10, &month))
         return false;
-    if ((postParsePosition.data() - currentPosition.data()) != 2)
+
+    // Allow for both single and double digit months (1-12 or 01-12)
+    auto monthDigits = postParsePosition.data() - currentPosition.data();
+    if (monthDigits != 1 && monthDigits != 2)
         return false;
     currentPosition = postParsePosition;
 
     // Check for presence of -DD portion.
-    if (!skipExactly(currentPosition, '-'))
+    if (currentPosition.empty() || currentPosition.front() != '-')
         return true;
-    
+    currentPosition = currentPosition.subspan(1);
     if (currentPosition.empty() || !isASCIIDigit(currentPosition.front()))
         return false;
     postParsePosition = currentPosition;
     if (!parseLong(postParsePosition, 10, &day))
         return false;
-    if ((postParsePosition.data() - currentPosition.data()) != 2)
+
+    // Allow for both single and double digit days (1-31 or 01-31)
+    auto dayDigits = postParsePosition.data() - currentPosition.data();
+    if (dayDigits != 1 && dayDigits != 2)
         return false;
     currentPosition = postParsePosition;
+
     return true;
 }
 


### PR DESCRIPTION
#### ab671bcf7110b9cae361eee03d1a01d2b257f8cf
<pre>
non standard new Date(&apos;2024-12-3&apos;) yields to Invalid Date
<a href="https://bugs.webkit.org/show_bug.cgi?id=283825">https://bugs.webkit.org/show_bug.cgi?id=283825</a>
<a href="https://rdar.apple.com/141044926">rdar://141044926</a>

Reviewed by NOBODY (OOPS!).

This relaxes parsing rules for months and days to allow
dates such as 2025-3-16 for 2025-3-16 (16 March 2025)
or dates such as 2025-10-3 for 2025-10-03 (3 October 2025).

The constraint is a common request from web developers to
be more compatible with Firefox and Chrome behaviors.

So instead of Safari returning:

  new Date(&apos;2024-12-3&apos;) yields to: Invalid Date
  Date.parse(&apos;2024-12-3&apos;) yields to: NaN

It will now return:
  new Date(&apos;2024-12-3&apos;) yields to: Date Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)
  Date.parse(&apos;2024-12-3&apos;) yields to: 1733180400000

This is not conforming to the specification, but the specification
doesn&apos;t disallow it either.
<a href="https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format">https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format</a>

* Source/WTF/wtf/DateMath.cpp:
(WTF::parseES5DatePortion):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab671bcf7110b9cae361eee03d1a01d2b257f8cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44519 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87353 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101749 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93308 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80603 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14936 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26810 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116001 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21359 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33215 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/regress/llint-callee-saves-without-fast-memory.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->