### PR TITLE
Make `CompactRefPtrTuple` copyable

### DIFF
--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -99,6 +99,11 @@ public:
 
     uint64_t data() const { return m_data; }
 
+    void swap(CompactPointerTuple& other)
+    {
+        std::swap(m_data, other.m_data);
+    }
+
 private:
     static constexpr uint64_t encodeType(Type type)
     {
@@ -134,6 +139,12 @@ public:
     void setPointer(PointerType pointer) { m_pointer = pointer; }
     Type type() const { return m_type; }
     void setType(Type type) { m_type = type; }
+
+    void swap(CompactPointerTuple& other)
+    {
+        std::swap(m_pointer, other.m_pointer);
+        std::swap(m_type, other.m_type);
+    }
 
 private:
     PointerType m_pointer { nullptr };

--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -34,11 +34,44 @@ namespace WTF {
 template<typename T, typename Type>
 class CompactRefPtrTuple final {
     WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(CompactRefPtrTuple);
 
     static_assert(::allowCompactPointers<T>());
 public:
     CompactRefPtrTuple() = default;
+    CompactRefPtrTuple(T* pointer, Type type)
+    {
+        setPointer(pointer);
+        setType(type);
+    }
+
+    CompactRefPtrTuple(const CompactRefPtrTuple& other)
+    {
+        setPointer(other.pointer());
+        setType(other.type());
+    }
+
+    CompactRefPtrTuple(CompactRefPtrTuple&& other)
+    {
+        m_data.setPointer(other.pointer());
+        m_data.setType(other.type());
+        other.m_data.setPointer(nullptr);
+        other.m_data.setType({ });
+    }
+
+    CompactRefPtrTuple& operator=(const CompactRefPtrTuple& other)
+    {
+        CompactRefPtrTuple copied(other);
+        swap(copied);
+        return *this;
+    }
+
+    CompactRefPtrTuple& operator=(CompactRefPtrTuple&& other)
+    {
+        CompactRefPtrTuple moved(WTFMove(other));
+        swap(moved);
+        return *this;
+    }
+
     ~CompactRefPtrTuple()
     {
         WTF::DefaultRefDerefTraits<T>::derefIfNotNull(m_data.pointer());
@@ -76,6 +109,11 @@ public:
     void setType(Type type)
     {
         m_data.setType(type);
+    }
+
+    void swap(CompactRefPtrTuple<T, Type>& other)
+    {
+        m_data.swap(other.m_data);
     }
 
 private:


### PR DESCRIPTION
#### e4a223a3ae594310cbde431c906d32fcd7dc0e27
<pre>
Make `CompactRefPtrTuple` copyable
<a href="https://bugs.webkit.org/show_bug.cgi?id=289596">https://bugs.webkit.org/show_bug.cgi?id=289596</a>
<a href="https://rdar.apple.com/146823802">rdar://146823802</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

For <a href="https://bugs.webkit.org/show_bug.cgi?id=289595">https://bugs.webkit.org/show_bug.cgi?id=289595</a>, we&apos;ll want to make `CompactRefPtrTuple` copyable.

* Source/WTF/wtf/CompactPointerTuple.h:
* Source/WTF/wtf/CompactRefPtrTuple.h:
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtrTuple.cpp:
(TestWebKitAPI::TEST(WTF_CompactRefPtrTuple, Basic)):
(TestWebKitAPI::TEST(WTF_CompactRefPtrTuple, Copy)):
(TestWebKitAPI::TEST(WTF_CompactRefPtrTuple, Move)):
(TestWebKitAPI::TEST(WTF_CompactRefPtrTuple, Swap)):

Canonical link: <a href="https://commits.webkit.org/292011@main">https://commits.webkit.org/292011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f90c12fae27daf3ba52eee3fcd30c853074b91c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44530 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87366 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93320 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80618 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14949 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15196 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26818 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116013 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21367 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->