### PR TITLE
7x TestWebKitAPI.iOSMouseSupport* (api-tests) are constant failures on some builds

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "PlatformUtilities.h"
+#import "TestCocoa.h"
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import <CoreServices/CoreServices.h>
@@ -66,12 +67,8 @@
 static RetainPtr<TestWKWebView> createWebViewForClipboardTests()
 {
 #if PLATFORM(IOS_FAMILY)
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // UIPasteboard's type coercion codepaths only take effect when the UIApplication has been initialized.
-        UIApplicationInitialize();
-    });
-#endif // PLATFORM(IOS_FAMILY)
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
+#endif
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration preferences] _setDOMPasteAllowed:YES];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "PasteboardUtilities.h"
+#import "TestCocoa.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRefPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -38,7 +39,7 @@
 RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataEnabled(bool colorFilterEnabled)
 {
 #if PLATFORM(IOS_FAMILY)
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
 #endif
 
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -32,6 +32,7 @@
 #import "NSItemProviderAdditions.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestProtocol.h"
 #import "TestWKWebView.h"
@@ -2653,7 +2654,7 @@ TEST(WKAttachmentTestsIOS, InsertPastedContactAsAttachment)
 
 TEST(WKAttachmentTestsIOS, InsertPastedMapItemAsAttachment)
 {
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     UIPasteboard.generalPasteboard.itemProviders = @[ mapItemForTesting().get() ];
     auto webView = webViewForTestingAttachments();
     ObserveAttachmentUpdatesForScope observer(webView.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -32,6 +32,7 @@
 #import "MouseSupportUIDelegate.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
@@ -126,7 +127,15 @@ struct PointerInfo {
 
 #endif // HAVE(UI_POINTER_INTERACTION)
 
-TEST(iOSMouseSupport, DoNotChangeSelectionWithRightClick)
+class iOSMouseSupport : public testing::Test {
+public:
+    void SetUp() final
+    {
+        TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
+    }
+};
+
+TEST_F(iOSMouseSupport, DoNotChangeSelectionWithRightClick)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -149,7 +158,7 @@ TEST(iOSMouseSupport, DoNotChangeSelectionWithRightClick)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, RightClickOutsideOfTextNodeDoesNotSelect)
+TEST_F(iOSMouseSupport, RightClickOutsideOfTextNodeDoesNotSelect)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -166,7 +175,7 @@ TEST(iOSMouseSupport, RightClickOutsideOfTextNodeDoesNotSelect)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, RightClickDoesNotShowMenuIfPreventDefault)
+TEST_F(iOSMouseSupport, RightClickDoesNotShowMenuIfPreventDefault)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -190,7 +199,7 @@ TEST(iOSMouseSupport, RightClickDoesNotShowMenuIfPreventDefault)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, TrackButtonMaskFromTouchStart)
+TEST_F(iOSMouseSupport, TrackButtonMaskFromTouchStart)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -218,7 +227,7 @@ TEST(iOSMouseSupport, TrackButtonMaskFromTouchStart)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, MouseTimestampTimebase)
+TEST_F(iOSMouseSupport, MouseTimestampTimebase)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -250,7 +259,7 @@ TEST(iOSMouseSupport, MouseTimestampTimebase)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, EndedTouchesTriggerClick)
+TEST_F(iOSMouseSupport, EndedTouchesTriggerClick)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -272,7 +281,7 @@ TEST(iOSMouseSupport, EndedTouchesTriggerClick)
     EXPECT_TRUE(wasClicked);
 }
 
-TEST(iOSMouseSupport, CancelledTouchesDoNotTriggerClick)
+TEST_F(iOSMouseSupport, CancelledTouchesDoNotTriggerClick)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -294,7 +303,7 @@ TEST(iOSMouseSupport, CancelledTouchesDoNotTriggerClick)
     EXPECT_FALSE(wasClicked);
 }
 
-TEST(iOSMouseSupport, MouseDidMoveOverElement)
+TEST_F(iOSMouseSupport, MouseDidMoveOverElement)
 {
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -323,7 +332,7 @@ static void handleUpdatedSelection(id, SEL)
     selectionUpdated = true;
 }
 
-TEST(iOSMouseSupport, SelectionUpdatesBeforeContextMenuAppears)
+TEST_F(iOSMouseSupport, SelectionUpdatesBeforeContextMenuAppears)
 {
     InstanceMethodSwizzler swizzler { UIWKTextInteractionAssistant.class, @selector(selectionChanged), reinterpret_cast<IMP>(handleUpdatedSelection) };
 
@@ -344,7 +353,7 @@ TEST(iOSMouseSupport, SelectionUpdatesBeforeContextMenuAppears)
 
 constexpr auto largeResponsiveHelloMarkup = "<meta name='viewport' content='width=device-width'><span style='font-size: 400px;'>Hello</span>";
 
-TEST(iOSMouseSupport, DisablingTextIteractionPreventsSelectionWhenShowingContextMenu)
+TEST_F(iOSMouseSupport, DisablingTextIteractionPreventsSelectionWhenShowingContextMenu)
 {
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration preferences].textInteractionEnabled = NO;
@@ -361,7 +370,7 @@ TEST(iOSMouseSupport, DisablingTextIteractionPreventsSelectionWhenShowingContext
     EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
 }
 
-TEST(iOSMouseSupport, ShowingContextMenuSelectsEditableText)
+TEST_F(iOSMouseSupport, ShowingContextMenuSelectsEditableText)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setEditable:YES];
@@ -377,7 +386,7 @@ TEST(iOSMouseSupport, ShowingContextMenuSelectsEditableText)
     EXPECT_FALSE(CGRectIsEmpty([webView selectionViewRectsInContentCoordinates].firstObject.CGRectValue));
 }
 
-TEST(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)
+TEST_F(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:@(largeResponsiveHelloMarkup)];
@@ -401,7 +410,7 @@ static void simulateEditContextMenuAppearance(TestWKWebView *webView, CGPoint lo
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(iOSMouseSupport, ContextClickAtEndOfSelection)
+TEST_F(iOSMouseSupport, ContextClickAtEndOfSelection)
 {
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"try-text-select-with-disabled-text-interaction"];
@@ -450,7 +459,7 @@ TEST(iOSMouseSupport, ContextClickAtEndOfSelection)
 
 #if ENABLE(IOS_TOUCH_EVENTS)
 
-TEST(iOSMouseSupport, WebsiteMouseEventPolicies)
+TEST_F(iOSMouseSupport, WebsiteMouseEventPolicies)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
@@ -496,7 +505,7 @@ TEST(iOSMouseSupport, WebsiteMouseEventPolicies)
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
 
-TEST(iOSMouseSupport, MouseInitiallyDisconnected)
+TEST_F(iOSMouseSupport, MouseInitiallyDisconnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
@@ -531,7 +540,7 @@ TEST(iOSMouseSupport, MouseInitiallyDisconnected)
     EXPECT_FALSE([webView evaluateMediaQuery:@"any-pointer: fine"]);
 }
 
-TEST(iOSMouseSupport, MouseInitiallyConnected)
+TEST_F(iOSMouseSupport, MouseInitiallyConnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
@@ -566,7 +575,7 @@ TEST(iOSMouseSupport, MouseInitiallyConnected)
     EXPECT_TRUE([webView evaluateMediaQuery:@"any-pointer: fine"]);
 }
 
-TEST(iOSMouseSupport, MouseLaterDisconnected)
+TEST_F(iOSMouseSupport, MouseLaterDisconnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
@@ -603,7 +612,7 @@ TEST(iOSMouseSupport, MouseLaterDisconnected)
     EXPECT_FALSE([webView evaluateMediaQuery:@"any-pointer: fine"]);
 }
 
-TEST(iOSMouseSupport, MouseLaterConnected)
+TEST_F(iOSMouseSupport, MouseLaterConnected)
 {
     WKMouseDeviceObserver *mouseDeviceObserver = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
 
@@ -644,7 +653,7 @@ TEST(iOSMouseSupport, MouseLaterConnected)
 
 #if PLATFORM(MACCATALYST)
 
-TEST(iOSMouseSupport, MouseAlwaysConnected)
+TEST_F(iOSMouseSupport, MouseAlwaysConnected)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
@@ -673,7 +682,7 @@ TEST(iOSMouseSupport, MouseAlwaysConnected)
 
 #if HAVE(UI_POINTER_INTERACTION)
 
-TEST(iOSMouseSupport, BasicPointerInteractionRegions)
+TEST_F(iOSMouseSupport, BasicPointerInteractionRegions)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"cursor-styles"];

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -29,6 +29,7 @@
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "TestWKWebViewController.h"
@@ -93,7 +94,7 @@ static UIViewController *overrideViewControllerForFullscreenPresentation()
 TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingViewController)
 {
     IPadUserInterfaceSwizzler iPadUserInterface;
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
 
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     auto window = adoptNS([[TestWKWebViewControllerWindow alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
@@ -244,7 +245,7 @@ static void presentActionSheetAndChooseAction(WKWebView *webView, ActionSheetObs
 
 TEST(ActionSheetTests, CopyImageElementWithHREFAndTitle)
 {
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
@@ -285,7 +286,7 @@ TEST(ActionSheetTests, CopyImageElementWithHREFAndTitle)
 
 TEST(ActionSheetTests, CopyImageElementWithHREF)
 {
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
@@ -325,7 +326,7 @@ TEST(ActionSheetTests, CopyImageElementWithHREF)
 
 TEST(ActionSheetTests, CopyImageElementWithoutHREF)
 {
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
@@ -352,7 +353,7 @@ TEST(ActionSheetTests, CopyImageElementWithoutHREF)
 
 TEST(ActionSheetTests, CopyLinkWritesURLAndPlainText)
 {
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -30,6 +30,7 @@
 #import "ClassMethodSwizzler.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
+#import "TestCocoa.h"
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -92,7 +93,7 @@ NSData *dataForPasteboardType(CFStringRef type)
 RetainPtr<TestWKWebView> setUpWebViewForPasteboardTests(NSString *pageName)
 {
     // UIPasteboard's type coercion codepaths only take effect when the UIApplication has been initialized.
-    UIApplicationInitialize();
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
 
     [UIPasteboard generalPasteboard].items = @[];
     EXPECT_TRUE(!dataForPasteboardType(kUTTypeUTF8PlainText).length);

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.h
@@ -39,6 +39,10 @@ static inline ::testing::AssertionResult assertNSObjectsAreEqual(const char* exp
     return ::testing::internal::EqFailure(expectedExpression, actualExpression, toSTD([expected description]), toSTD([actual description]), false /* ignoring_case */);
 }
 
+#if PLATFORM(IOS_FAMILY)
+void instantiateUIApplicationIfNeeded(Class customApplicationClass = nil);
+#endif
+
 } // namespace Util
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.mm
@@ -26,6 +26,10 @@
 #import "config.h"
 #import "TestCocoa.h"
 
+#if PLATFORM(IOS_FAMILY)
+#import "UIKitSPIForTesting.h"
+#endif
+
 template<typename T>
 static inline std::ostream& ostreamRectCommon(std::ostream& os, const T& rect)
 {
@@ -56,6 +60,19 @@ std::ostream& operator<<(std::ostream& os, const NSRect& rect)
 bool operator==(const NSRect& a, const NSRect& b)
 {
     return NSEqualRects(a, b);
+}
+
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+
+void TestWebKitAPI::Util::instantiateUIApplicationIfNeeded(Class customApplicationClass)
+{
+    if (UIApplication.sharedApplication)
+        return;
+
+    UIApplicationInitialize();
+    UIApplicationInstantiateSingleton(customApplicationClass ?: UIApplication.class);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -32,6 +32,7 @@
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "Utilities.h"
 
@@ -826,8 +827,7 @@ static void setOverriddenApplicationKeyWindow(UIWindow *window)
 
     if (!UIApplication.sharedApplication) {
         InstanceMethodSwizzler bundleIdentifierSwizzler(NSBundle.class, @selector(bundleIdentifier), reinterpret_cast<IMP>(overrideBundleIdentifier));
-        UIApplicationInitialize();
-        UIApplicationInstantiateSingleton(UIApplication.class);
+        TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     }
 
     static dispatch_once_t onceToken;

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
@@ -161,7 +161,7 @@ void MouseEventTestHarness::mouseCancel()
     m_buttonMask = 0;
     [m_mouseTouchGestureRecognizer touchesCancelled:activeTouches() withEvent:m_unusedEvent.get()];
     m_modifierFlags = 0;
-    EXPECT_EQ(m_mouseTouchGestureRecognizer.state, UIGestureRecognizerStateCancelled);
+    EXPECT_TRUE(m_mouseTouchGestureRecognizer.state == UIGestureRecognizerStateCancelled || m_mouseTouchGestureRecognizer.state == UIGestureRecognizerStateFailed);
 }
 
 };

--- a/Tools/TestWebKitAPI/ios/UserInterfaceSwizzler.h
+++ b/Tools/TestWebKitAPI/ios/UserInterfaceSwizzler.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "InstanceMethodSwizzler.h"
+#import "TestCocoa.h"
 #import "UIKitSPIForTesting.h"
 #import <UIKit/UIKit.h>
 
@@ -39,10 +40,7 @@ public:
     UserInterfaceSwizzler()
         : InstanceMethodSwizzler { UIDevice.class, @selector(userInterfaceIdiom), reinterpret_cast<IMP>(effectiveUserInterfaceIdiom) }
     {
-        if (!UIApplication.sharedApplication) {
-            UIApplicationInitialize();
-            UIApplicationInstantiateSingleton(UIApplication.class);
-        }
+        TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     }
 
 private:


### PR DESCRIPTION
#### a524d52158ab97104f3f92cf32f400541ce3a54c
<pre>
7x TestWebKitAPI.iOSMouseSupport* (api-tests) are constant failures on some builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=289599">https://bugs.webkit.org/show_bug.cgi?id=289599</a>
<a href="https://rdar.apple.com/145178841">rdar://145178841</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Some UIKit changes have resulted in a UIApp being required in order to manually
drive gesture recognizers, like we do in WKMouseTouchGestureRecognizer.
Factor out UIApp initialization and adopt it in all of these tests.

Additionally, these changes result in Cancelled state getting folded into Failed,
so adjust one assertion to accept either state for now.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm:
(createWebViewForClipboardTests):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteboardUtilities.mm:
(createWebViewWithCustomPasteboardDataEnabled):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTestsIOS, InsertPastedMapItemAsAttachment)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(TestWebKitAPI::TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingViewController)):
(TestWebKitAPI::TEST(ActionSheetTests, CopyImageElementWithHREFAndTitle)):
(TestWebKitAPI::TEST(ActionSheetTests, CopyImageElementWithHREF)):
(TestWebKitAPI::TEST(ActionSheetTests, CopyImageElementWithoutHREF)):
(TestWebKitAPI::TEST(ActionSheetTests, CopyLinkWritesURLAndPlainText)):
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:
(TestWebKitAPI::setUpWebViewForPasteboardTests):
* Tools/TestWebKitAPI/cocoa/TestCocoa.h:
* Tools/TestWebKitAPI/cocoa/TestCocoa.mm:
(TestWebKitAPI::Util::instantiateUIApplicationIfNeeded):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(setOverriddenApplicationKeyWindow):
* Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm:
(TestWebKitAPI::MouseEventTestHarness::mouseCancel):
* Tools/TestWebKitAPI/ios/UserInterfaceSwizzler.h:

Canonical link: <a href="https://commits.webkit.org/292056@main">https://commits.webkit.org/292056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b267e8e2c115ee9ea8b5b9bf617cb55ebfc95de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45265 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72297 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97777 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10923 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3285 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44605 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15037 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15222 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21781 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->