### PR TITLE
[Model Element] Always enable restrictive rendering mode

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
@@ -26,11 +26,6 @@
 (allow mach-lookup
     (global-name "com.apple.CARenderServer"))
 
-(allow iokit-open-user-client
-    (iokit-user-client-class "AppleParavirtDeviceUserClient"))
-(allow iokit-open-user-client
-    (iokit-user-client-class "AGXDeviceUserClient"))
-
 (allow syscall-mach (machtrap-number MSC_mk_timer_arm_leeway))
 
 (allow syscall-unix
@@ -42,13 +37,6 @@
         SYS_sendmsg
         SYS_setsockopt
     ))
-
-#if ENABLE(SANDBOX_WORKAROUND_FOR_MODEL_PROCESS)
-;; FIXME: Remove after rdar://124086612 is addressed
-(allow mach-bootstrap
-    (apply-message-filter
-        (allow mach-message-send (message-number 800 804))))
-#endif
 
 ;; FIXME: Remove after rdar://138963941 is addressed
 (deny syscall-unix (with no-report) (syscall-number SYS_necp_open))

--- a/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
@@ -41,7 +41,12 @@ namespace WebKit {
 
 void ModelProcessProxy::updateModelProcessCreationParameters(ModelProcessCreationParameters& parameters)
 {
-    parameters.restrictiveRenderingMode = [[NSUserDefaults standardUserDefaults] boolForKey:@"ModelProcessDebugEnableRestrictiveRenderingMode"];
+    NSString * const debugFlag = @"ModelProcessDebugEnableRestrictiveRenderingMode";
+    bool enableRestrictiveRenderingMode = true;
+    id value = [NSUserDefaults.standardUserDefaults objectForKey:debugFlag];
+    if ([value isKindOfClass:NSNumber.class] || [value isKindOfClass:NSString.class])
+        enableRestrictiveRenderingMode = [NSUserDefaults.standardUserDefaults boolForKey:debugFlag];
+    parameters.restrictiveRenderingMode = enableRestrictiveRenderingMode;
 }
 
 void ModelProcessProxy::requestSharedSimulationConnection(WebCore::ProcessIdentifier webProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler)


### PR DESCRIPTION
#### c0d97c4b4a89ec6a6cadd0a6252d6ccf6b5eff50
<pre>
[Model Element] Always enable restrictive rendering mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289600">https://bugs.webkit.org/show_bug.cgi?id=289600</a>
<a href="https://rdar.apple.com/124086612">rdar://124086612</a>

Reviewed by Per Arne Vollan.

Enable restrictive rendering mode for the model element by
default. Tighten the model process sandbox as that mode no
longer needs some iokit access.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in:
* Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm:
(WebKit::ModelProcessProxy::updateModelProcessCreationParameters):

Canonical link: <a href="https://commits.webkit.org/292101@main">https://commits.webkit.org/292101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8595290bee5a734635321cbaa07caf1a83cd29a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72374 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52706 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10701 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44716 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81371 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80761 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25321 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27012 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->