### PR TITLE
Make URL host and hostname setters handle @ correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
@@ -1141,6 +1141,42 @@
                 "host": "example.com",
                 "hostname": "example.com"
             }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "*",
+            "expected": {
+                "href": "https://*/",
+                "host": "*",
+                "hostname": "*"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "x@x",
+            "expected": {
+                "href": "https://test.invalid/",
+                "host": "test.invalid",
+                "hostname": "test.invalid"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "foo\t\r\nbar",
+            "expected": {
+                "href": "https://foobar/",
+                "host": "foobar",
+                "hostname": "foobar"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "><",
+            "expected": {
+                "href": "https://test.invalid/",
+                "host": "test.invalid",
+                "hostname": "test.invalid"
+            }
         }
     ],
     "hostname": [
@@ -1551,6 +1587,42 @@
                 "href": "https://example.com/",
                 "host": "example.com",
                 "hostname": "example.com"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "*",
+            "expected": {
+                "href": "https://*/",
+                "host": "*",
+                "hostname": "*"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "x@x",
+            "expected": {
+                "href": "https://test.invalid/",
+                "host": "test.invalid",
+                "hostname": "test.invalid"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "foo\t\r\nbar",
+            "expected": {
+                "href": "https://foobar/",
+                "host": "foobar",
+                "hostname": "foobar"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "><",
+            "expected": {
+                "href": "https://test.invalid/",
+                "host": "test.invalid",
+                "hostname": "test.invalid"
             }
         }
     ],

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
@@ -248,6 +248,16 @@ PASS <a>: Setting <https://example.com/>.host = '%C2%AD'
 PASS <area>: Setting <https://example.com/>.host = '%C2%AD'
 PASS <a>: Setting <https://example.com/>.host = 'xn--'
 PASS <area>: Setting <https://example.com/>.host = 'xn--'
+PASS <a>: Setting <https://test.invalid/>.host = '*'
+PASS <area>: Setting <https://test.invalid/>.host = '*'
+PASS <a>: Setting <https://test.invalid/>.host = 'x@x'
+PASS <area>: Setting <https://test.invalid/>.host = 'x@x'
+PASS <a>: Setting <https://test.invalid/>.host = 'foo	\r
+bar'
+PASS <area>: Setting <https://test.invalid/>.host = 'foo	\r
+bar'
+PASS <a>: Setting <https://test.invalid/>.host = '><'
+PASS <area>: Setting <https://test.invalid/>.host = '><'
 PASS <a>: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS <area>: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS <a>: Setting <sc://x/>.hostname = '	'
@@ -334,6 +344,16 @@ PASS <a>: Setting <https://example.com/>.hostname = '%C2%AD'
 PASS <area>: Setting <https://example.com/>.hostname = '%C2%AD'
 PASS <a>: Setting <https://example.com/>.hostname = 'xn--'
 PASS <area>: Setting <https://example.com/>.hostname = 'xn--'
+PASS <a>: Setting <https://test.invalid/>.hostname = '*'
+PASS <area>: Setting <https://test.invalid/>.hostname = '*'
+PASS <a>: Setting <https://test.invalid/>.hostname = 'x@x'
+PASS <area>: Setting <https://test.invalid/>.hostname = 'x@x'
+PASS <a>: Setting <https://test.invalid/>.hostname = 'foo	\r
+bar'
+PASS <area>: Setting <https://test.invalid/>.hostname = 'foo	\r
+bar'
+PASS <a>: Setting <https://test.invalid/>.hostname = '><'
+PASS <area>: Setting <https://test.invalid/>.hostname = '><'
 PASS <a>: Setting <http://example.net>.port = '8080'
 PASS <area>: Setting <http://example.net>.port = '8080'
 PASS <a>: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -105,6 +105,11 @@ PASS URL: Setting <https://example.com/>.host = 'a%C2%ADb'
 PASS URL: Setting <https://example.com/>.host = '­'
 PASS URL: Setting <https://example.com/>.host = '%C2%AD'
 PASS URL: Setting <https://example.com/>.host = 'xn--'
+PASS URL: Setting <https://test.invalid/>.host = '*'
+PASS URL: Setting <https://test.invalid/>.host = 'x@x'
+PASS URL: Setting <https://test.invalid/>.host = 'foo	\r
+bar'
+PASS URL: Setting <https://test.invalid/>.host = '><'
 PASS URL: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS URL: Setting <sc://x/>.hostname = '	'
 PASS URL: Setting <sc://x/>.hostname = '
@@ -144,6 +149,11 @@ PASS URL: Setting <https://example.com/>.hostname = 'a%C2%ADb'
 PASS URL: Setting <https://example.com/>.hostname = '­'
 PASS URL: Setting <https://example.com/>.hostname = '%C2%AD'
 PASS URL: Setting <https://example.com/>.hostname = 'xn--'
+PASS URL: Setting <https://test.invalid/>.hostname = '*'
+PASS URL: Setting <https://test.invalid/>.hostname = 'x@x'
+PASS URL: Setting <https://test.invalid/>.hostname = 'foo	\r
+bar'
+PASS URL: Setting <https://test.invalid/>.hostname = '><'
 PASS URL: Setting <http://example.net>.port = '8080'
 PASS URL: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value
 PASS URL: Setting <http://example.net:8080>.port = '80' Default port number is removed

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
@@ -105,6 +105,11 @@ PASS URL: Setting <https://example.com/>.host = 'a%C2%ADb'
 PASS URL: Setting <https://example.com/>.host = '­'
 PASS URL: Setting <https://example.com/>.host = '%C2%AD'
 PASS URL: Setting <https://example.com/>.host = 'xn--'
+PASS URL: Setting <https://test.invalid/>.host = '*'
+PASS URL: Setting <https://test.invalid/>.host = 'x@x'
+PASS URL: Setting <https://test.invalid/>.host = 'foo	\r
+bar'
+PASS URL: Setting <https://test.invalid/>.host = '><'
 PASS URL: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS URL: Setting <sc://x/>.hostname = '	'
 PASS URL: Setting <sc://x/>.hostname = '
@@ -144,6 +149,11 @@ PASS URL: Setting <https://example.com/>.hostname = 'a%C2%ADb'
 PASS URL: Setting <https://example.com/>.hostname = '­'
 PASS URL: Setting <https://example.com/>.hostname = '%C2%AD'
 PASS URL: Setting <https://example.com/>.hostname = 'xn--'
+PASS URL: Setting <https://test.invalid/>.hostname = '*'
+PASS URL: Setting <https://test.invalid/>.hostname = 'x@x'
+PASS URL: Setting <https://test.invalid/>.hostname = 'foo	\r
+bar'
+PASS URL: Setting <https://test.invalid/>.hostname = '><'
 PASS URL: Setting <http://example.net>.port = '8080'
 PASS URL: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value
 PASS URL: Setting <http://example.net:8080>.port = '80' Default port number is removed

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Research In Motion Limited. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -491,7 +491,10 @@ static bool slashHashOrQuestionMark(UChar c)
 
 void URL::setHost(StringView newHost)
 {
-    if (!m_isValid)
+    if (!m_isValid || hasOpaquePath())
+        return;
+
+    if (newHost.contains('@'))
         return;
 
     if (newHost.contains(':') && !newHost.startsWith('['))
@@ -543,7 +546,10 @@ static unsigned countASCIIDigits(StringView string)
 
 void URL::setHostAndPort(StringView hostAndPort)
 {
-    if (!m_isValid)
+    if (!m_isValid || hasOpaquePath())
+        return;
+
+    if (hostAndPort.contains('@'))
         return;
 
     if (auto index = hostAndPort.find(hasSpecialScheme() ? slashHashOrQuestionMark : forwardSlashHashOrQuestionMark); index != notFound)

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,9 +91,6 @@ void URLDecomposition::setHost(StringView value)
     if (value.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
 
-    if (fullURL.hasOpaquePath())
-        return;
-
     fullURL.setHostAndPort(value);
 
     if (fullURL.isValid())
@@ -109,8 +106,6 @@ void URLDecomposition::setHostname(StringView host)
 {
     auto fullURL = this->fullURL();
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
-        return;
-    if (fullURL.hasOpaquePath())
         return;
     fullURL.setHost(host);
     if (fullURL.isValid())


### PR DESCRIPTION
#### 19b325a67af641aa9ebedf354958c30db4d04672
<pre>
Make URL host and hostname setters handle @ correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=289609">https://bugs.webkit.org/show_bug.cgi?id=289609</a>

Reviewed by Alex Christensen.

@ is a forbidden host code point, but we need to handle it eagerly as
otherwise the re-parse will treat it as the username:password part
preceding the host.

Also move the hasOpaquePath() check up as these methods don&apos;t work for
opaque paths.

New tests are upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/51295">https://github.com/web-platform-tests/wpt/pull/51295</a>

* LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::setHost):
(WTF::URL::setHostAndPort):
* Source/WebCore/html/URLDecomposition.cpp:
(WebCore::URLDecomposition::setHost):
(WebCore::URLDecomposition::setHostname):

Canonical link: <a href="https://commits.webkit.org/292041@main">https://commits.webkit.org/292041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052b0ac7f2413700f6fd81313ae4f21e40893d2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72272 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97737 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10879 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85539 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52603 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44565 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87402 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101796 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93355 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26855 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116048 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21403 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33222 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->