### PR TITLE
[CoreIPC] TRAP in WebCore::CloneSerializer::write

### DIFF
--- a/LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash-expected.txt
+++ b/LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash.html
+++ b/LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash.html
@@ -1,0 +1,63 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    window.setTimeout(async () => {
+        if (!window.IPC)
+            return window.testRunner?.notifyDone();
+        const { CoreIPC } = await import('./coreipc.js');
+        CoreIPC.UI.WebProcessProxy.SerializeAndWrapCryptoKey(0, {
+            key: {
+                keyClass: 5,
+                algorithmIdentifier: 14,
+                extractable: false,
+                usages: 57,
+                key: {
+                    optionalValue: [166, 24, 193, 205]
+                },
+                jwk: {
+                    optionalValue: {
+                        kty: '',
+                        use: '',
+                        key_ops: {
+                            optionalValue: []
+                        },
+                        usages: 9693558,
+                        alg: '',
+                        ext: {
+                            optionalValue: false
+                        },
+                        crv: '',
+                        x: '',
+                        y: '',
+                        d: '',
+                        n: '',
+                        e: '',
+                        p: '',
+                        q: '',
+                        dp: '',
+                        dq: 'A',
+                        qi: '',
+                        oth: {
+                            optionalValue: []
+                        },
+                        k: ''
+                    }
+                },
+                hashAlgorithmIdentifier: {},
+                namedCurveString: {
+                    optionalValue: ''
+                },
+                lengthBits: {
+                    optionalValue: 185
+                },
+                type: {}
+            }
+        });
+        globalThis.testRunner?.notifyDone();
+    }, 10);
+</script>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13290,6 +13290,7 @@ void WebPageProxy::serializeAndWrapCryptoKey(IPC::Connection& connection, WebCor
     auto key = WebCore::CryptoKey::create(WTFMove(keyData));
     MESSAGE_CHECK_COMPLETION_BASE(key, connection, completionHandler(std::nullopt));
     MESSAGE_CHECK_COMPLETION_BASE(key->isValid(), connection, completionHandler(std::nullopt));
+    MESSAGE_CHECK_COMPLETION_BASE(key->algorithmIdentifier() != CryptoAlgorithmIdentifier::DEPRECATED_SHA_224, connection, completionHandler(std::nullopt));
 
     auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(*key);
     wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2842,6 +2842,7 @@ void WebProcessProxy::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData
     auto key = WebCore::CryptoKey::create(WTFMove(keyData));
     MESSAGE_CHECK_COMPLETION(key, completionHandler(std::nullopt));
     MESSAGE_CHECK_COMPLETION(key->isValid(), completionHandler(std::nullopt));
+    MESSAGE_CHECK_COMPLETION(key->algorithmIdentifier() != CryptoAlgorithmIdentifier::DEPRECATED_SHA_224, completionHandler(std::nullopt));
 
     auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(*key);
     wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));


### PR DESCRIPTION
#### f79fe4fc53f7406834bb57b2e3cf3a4dc29e1491
<pre>
[CoreIPC] TRAP in WebCore::CloneSerializer::write
<a href="https://bugs.webkit.org/show_bug.cgi?id=289615">https://bugs.webkit.org/show_bug.cgi?id=289615</a>
<a href="https://rdar.apple.com/145051575">rdar://145051575</a>

Reviewed by Nitin Mahendru.

Added a message check for deprecated crypto algo SHA_224.

* LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash-expected.txt: Added.
* LayoutTests/ipc/clone-serializer-invalid-crypto-algo-crash.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::serializeAndWrapCryptoKey):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::serializeAndWrapCryptoKey):

Canonical link: <a href="https://commits.webkit.org/292295@main">https://commits.webkit.org/292295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b851f1992fb12008bf65cd3a086f39020b9f844

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46037 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30125 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98535 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11552 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102616 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3286 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15913 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22550 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22209 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->