### PR TITLE
Respect the CSS `image-rendering` property when drawing the SVG <image> element

### DIFF
--- a/LayoutTests/svg/custom/svg-image-rendering-pixelated-expected.html
+++ b/LayoutTests/svg/custom/svg-image-rendering-pixelated-expected.html
@@ -1,0 +1,11 @@
+<style>
+    img {
+        image-rendering: pixelated;
+    }
+</style>
+<body>
+    <img
+        width="400"
+        height="200"
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAGCAYAAAAVMmT4AAAACXBIWXMAAAsSAAALEgHS3X78AAAAPElEQVQYlXWPQQoAMAjDWtn/v5ydhOJcLkqJigbQwLaWWLWJWb9yC4CAZ6A20fZ64Uyxyb5/sCRyYzKzCxB6IBTQCx2aAAAAAElFTkSuQmCC"/>
+</body>

--- a/LayoutTests/svg/custom/svg-image-rendering-pixelated.html
+++ b/LayoutTests/svg/custom/svg-image-rendering-pixelated.html
@@ -1,0 +1,14 @@
+<style>
+    svg image {
+        image-rendering: pixelated;
+    }
+</style>
+<body>
+    <svg width="400" height="200">
+        <image
+            width="100%"
+            height="100%"
+            preserveAspectRatio="none"
+            href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAGCAYAAAAVMmT4AAAACXBIWXMAAAsSAAALEgHS3X78AAAAPElEQVQYlXWPQQoAMAjDWtn/v5ydhOJcLkqJigbQwLaWWLWJWb9yC4CAZ6A20fZ64Uyxyb5/sCRyYzKzCxB6IBTQCx2aAAAAAElFTkSuQmCC" />
+    </svg>
+</body>

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -117,6 +117,18 @@ std::optional<InterpolationQuality> ImageQualityController::interpolationQuality
     return std::nullopt;
 }
 
+InterpolationQuality ImageQualityController::chooseInterpolationQualityForSVG(GraphicsContext& context, RenderObject* object, Image& image)
+{
+    // If the image is not a bitmap image, then none of this is relevant and we just paint at high quality.
+    if (!(image.isBitmapImage() || image.isPDFDocumentImage()) || context.paintingDisabled())
+        return InterpolationQuality::Default;
+
+    if (auto styleInterpolation = interpolationQualityFromStyle(object->style()))
+        return *styleInterpolation;
+
+    return InterpolationQuality::Default;
+}
+
 InterpolationQuality ImageQualityController::chooseInterpolationQuality(GraphicsContext& context, RenderBoxModelObject* object, Image& image, const void* layer, const LayoutSize& size)
 {
     // If the image is not a bitmap image, then none of this is relevant and we just paint at high quality.

--- a/Source/WebCore/rendering/ImageQualityController.h
+++ b/Source/WebCore/rendering/ImageQualityController.h
@@ -36,6 +36,7 @@ class GraphicsContext;
 class Image;
 class LayoutSize;
 class RenderBoxModelObject;
+class RenderObject;
 class RenderView;
 class RenderStyle;
 
@@ -46,6 +47,7 @@ public:
     explicit ImageQualityController(const RenderView&);
 
     static std::optional<InterpolationQuality> interpolationQualityFromStyle(const RenderStyle&);
+    static InterpolationQuality chooseInterpolationQualityForSVG(GraphicsContext&, RenderObject*, Image&);
     InterpolationQuality chooseInterpolationQuality(GraphicsContext&, RenderBoxModelObject*, Image&, const void* layer, const LayoutSize&);
 
     void rendererWillBeDestroyed(RenderBoxModelObject& renderer) { removeObject(&renderer); }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -34,6 +34,7 @@
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "ImageBuffer.h"
+#include "ImageQualityController.h"
 #include "LayoutRepainter.h"
 #include "PointerEventsHitRules.h"
 #include "RenderElementInlines.h"
@@ -180,7 +181,7 @@ ImageDrawResult RenderSVGImage::paintIntoRect(PaintInfo& paintInfo, const FloatR
         CompositeOperator::SourceOver,
         DecodingMode::Synchronous,
         imageOrientation(),
-        InterpolationQuality::Default,
+        ImageQualityController::chooseInterpolationQualityForSVG(paintInfo.context(), this, *image),
         settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
         settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
     };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -29,6 +29,7 @@
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
+#include "ImageQualityController.h"
 #include "LayoutRepainter.h"
 #include "LegacyRenderSVGResource.h"
 #include "PointerEventsHitRules.h"
@@ -232,7 +233,12 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
 
     imageElement().preserveAspectRatio().transformRect(destRect, srcRect);
 
-    paintInfo.context().drawImage(*image, destRect, srcRect);
+    ImagePaintingOptions options = {
+        imageOrientation(),
+        ImageQualityController::chooseInterpolationQualityForSVG(paintInfo.context(), this, *image)
+    };
+
+    paintInfo.context().drawImage(*image, destRect, srcRect, options);
 }
 
 void LegacyRenderSVGImage::invalidateBufferedForeground()


### PR DESCRIPTION
#### aa625040b398c606811e99a2e40dd1a916094c59
<pre>
Respect the CSS `image-rendering` property when drawing the SVG &lt;image&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=286906">https://bugs.webkit.org/show_bug.cgi?id=286906</a>
<a href="https://rdar.apple.com/144507619">rdar://144507619</a>

Reviewed by Cameron McCormack.

Calculate the image quality from the RenderStyle for the SVGImageElement.

* LayoutTests/svg/custom/svg-image-rendering-pixelated-expected.html: Added.
* LayoutTests/svg/custom/svg-image-rendering-pixelated.html: Added.
* Source/WebCore/rendering/ImageQualityController.cpp:
(WebCore::ImageQualityController::chooseInterpolationQualityForSVG):
* Source/WebCore/rendering/ImageQualityController.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintIntoRect):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::paintForeground):

Canonical link: <a href="https://commits.webkit.org/292202@main">https://commits.webkit.org/292202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e574286f9ab8543f9453a06a9d95d505da2216a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4751 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/100337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98296 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3755 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25634 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22311 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->