### PR TITLE
[ResourceMonitor] Cannot go back to previous page by Back button after unloading of iframe.

### DIFF
--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -199,7 +199,7 @@ String HTMLIFrameElement::srcdoc() const
     return attributeWithoutSynchronization(srcdocAttr);
 }
 
-ExceptionOr<void> HTMLIFrameElement::setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&& value)
+ExceptionOr<void> HTMLIFrameElement::setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&& value, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
     auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(value), "HTMLIFrameElement srcdoc"_s);
 
@@ -207,6 +207,7 @@ ExceptionOr<void> HTMLIFrameElement::setSrcdoc(std::variant<RefPtr<TrustedHTML>,
         return stringValueHolder.releaseException();
 
     setAttributeWithoutSynchronization(srcdocAttr, AtomString { stringValueHolder.releaseReturnValue() });
+    m_srcdocSessionHistoryVisibility = sessionHistoryVisibility;
     return { };
 }
 

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -25,6 +25,7 @@
 
 #include "HTMLFrameElementBase.h"
 #include "PermissionsPolicy.h"
+#include "SubstituteData.h"
 
 namespace WebCore {
 
@@ -50,7 +51,8 @@ public:
     void setLoading(const AtomString&);
 
     String srcdoc() const;
-    ExceptionOr<void> setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&&);
+    ExceptionOr<void> setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&&, SubstituteData::SessionHistoryVisibility = SubstituteData::SessionHistoryVisibility::Visible);
+    SubstituteData::SessionHistoryVisibility srcdocSessionHistoryVisibility() const { return m_srcdocSessionHistoryVisibility; };
 
     LazyLoadFrameObserver& lazyLoadFrameObserver();
 
@@ -84,12 +86,13 @@ private:
     bool isLazyLoadObserverActive() const final;
 
     std::unique_ptr<DOMTokenList> m_sandbox;
-#if ENABLE(FULLSCREEN_API)
-    bool m_IFrameFullscreenFlag { false };
-#endif
     std::unique_ptr<LazyLoadFrameObserver> m_lazyLoadFrameObserver;
 #if ENABLE(CONTENT_EXTENSIONS)
     URL m_initiatorSourceURL;
+#endif
+    SubstituteData::SessionHistoryVisibility m_srcdocSessionHistoryVisibility { SubstituteData::SessionHistoryVisibility::Visible };
+#if ENABLE(FULLSCREEN_API)
+    bool m_IFrameFullscreenFlag { false };
 #endif
 };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -72,6 +72,7 @@
 #include "FrameTree.h"
 #include "GCController.h"
 #include "HTMLFormElement.h"
+#include "HTMLIFrameElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
@@ -1663,12 +1664,16 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
 {
     if (!shouldTreatURLAsSrcdocDocument(url))
         return SubstituteData();
-    auto& srcdoc = m_frame->ownerElement()->attributeWithoutSynchronization(srcdocAttr);
+    RefPtr iframeElement = dynamicDowncast<HTMLIFrameElement>(m_frame->ownerElement());
+    if (!iframeElement)
+        return SubstituteData();
+
+    auto& srcdoc = iframeElement->attributeWithoutSynchronization(srcdocAttr);
     ASSERT(!srcdoc.isNull());
     CString encodedSrcdoc = srcdoc.string().utf8();
 
     ResourceResponse response(URL(), textHTMLContentTypeAtom(), encodedSrcdoc.length(), "UTF-8"_s);
-    return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), response, SubstituteData::SessionHistoryVisibility::Visible);
+    return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), response, iframeElement->srcdocSessionHistoryVisibility());
 }
 
 void FrameLoader::load(FrameLoadRequest&& request)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1490,7 +1490,7 @@ void LocalFrame::showResourceMonitoringError()
         colorScheme = document->resolvedColorScheme(style.get());
 #endif
 
-    iframeElement->setSrcdoc(generateResourceMonitorErrorHTML(colorScheme));
+    iframeElement->setSrcdoc(generateResourceMonitorErrorHTML(colorScheme), SubstituteData::SessionHistoryVisibility::Hidden);
 }
 
 void LocalFrame::reportResourceMonitoringWarning()


### PR DESCRIPTION
#### 1dea6a26618ba91c0e3a6dee256faa09b1e473ef
<pre>
[ResourceMonitor] Cannot go back to previous page by Back button after unloading of iframe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289623">https://bugs.webkit.org/show_bug.cgi?id=289623</a>
<a href="https://rdar.apple.com/146671361">rdar://146671361</a>

Reviewed by Brady Eidson.

When ResourceMonitor unloads iframe, a placeholder is displayed using `srcdoc`. Setting `srcdoc` is
a navigation so this action is pushed onto the history. This is not expected behavior.

Adding optional parameter to set the visibility of the navigation in the history when setting `srcdoc`.
The visibility is stored in iframe element and used when SubstituteData is created.

* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::setSrcdoc):
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::defaultSubstituteDataForURL):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::showResourceMonitoringError):

Canonical link: <a href="https://commits.webkit.org/292053@main">https://commits.webkit.org/292053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6e53e9aef0300c31900c6bd0e19dd5cb56032d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72316 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85604 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52648 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44634 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2663 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->