### PR TITLE
[GLib] Add async versions of download_uri methods

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
@@ -122,6 +122,20 @@ WEBKIT_API WebKitDownload *
 webkit_network_session_download_uri                              (WebKitNetworkSession         *session,
                                                                   const char                   *uri);
 
+
+WEBKIT_API void
+webkit_network_session_download_uri_async                        (WebKitNetworkSession         *session,
+                                                                  const char                   *uri,
+                                                                  GCancellable                 *cancellable,
+                                                                  GAsyncReadyCallback           callback,
+                                                                  gpointer                      user_data);
+
+WEBKIT_API WebKitDownload *
+webkit_network_session_download_uri_finish                        (WebKitNetworkSession        *session,
+                                                                   GAsyncResult                *result,
+                                                                   GError                     **error);
+
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -772,6 +772,18 @@ WEBKIT_API WebKitDownload *
 webkit_web_view_download_uri                         (WebKitWebView             *web_view,
                                                       const char                *uri);
 
+WEBKIT_API WebKitDownload*
+webkit_web_view_download_uri_finish                  (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
+
+WEBKIT_API void
+webkit_web_view_download_uri_async                   (WebKitWebView             *web_view,
+                                                      const char                *uri,
+                                                      GCancellable              *cancellable,
+                                                      GAsyncReadyCallback        callback,
+                                                      gpointer                   user_data);
+
 WEBKIT_API gboolean
 webkit_web_view_get_tls_info                         (WebKitWebView             *web_view,
                                                       GTlsCertificate          **certificate,


### PR DESCRIPTION
#### 2822ceaf61b67bcbab54ad910ec2a4cc3320181b
<pre>
[GLib] Add async versions of download_uri methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=289625">https://bugs.webkit.org/show_bug.cgi?id=289625</a>

Reviewed by NOBODY (OOPS!).

WebKit wants to move away from synchronous constructors for WKDownload
so we need to expose async versions in our API.

This covers both WebKitWebView and WebKitNetworkSession.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_download_uri_finish):
(webkit_network_session_download_uri_async):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp:
(runAssertionsForDownloadTest):
(testWebViewDownloadURI):
(testWebViewDownloadURIAsync):
(testSessionDownloadURIAsync):
(beforeAll):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2822ceaf61b67bcbab54ad910ec2a4cc3320181b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80830 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15251 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21982 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27104 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->