### PR TITLE
WebCore::LegacyRenderSVGEllipse::updateShapeFromElement; WebCore::LegacyRenderSVGShape::layout; WebCore::SVGRenderSupport::layoutChildren

### DIFF
--- a/LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -19,6 +19,6 @@ layer at (0,0) size 800x68
                           RenderBlock {DIV} at (0,0) size 784x10
                             RenderBlock {DIV} at (0,0) size 784x10
                               RenderSVGRoot {svg} at (8,58) size 0x0
-                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -19,6 +19,6 @@ layer at (0,0) size 800x72
                           RenderBlock {DIV} at (0,0) size 784x12
                             RenderBlock {DIV} at (0,0) size 784x12
                               RenderSVGRoot {svg} at (8,61) size 0x0
-                                RenderSVGEllipse {circle} at (8,61) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,61) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+                                RenderSVGEllipse {circle} at (8,61) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,61) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt
+++ b/LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt
@@ -19,6 +19,6 @@ layer at (0,0) size 800x68
                           RenderBlock {DIV} at (0,0) size 784x10
                             RenderBlock {DIV} at (0,0) size 784x10
                               RenderSVGRoot {svg} at (8,58) size 0x0
-                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
-                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=NaN]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+                                RenderSVGEllipse {circle} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=0.00] [r=1.00]
+                                RenderSVGRect {rect} at (8,58) size 0x0 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.00]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/svg/crash-ellipse-zero-zoom-expected.txt
+++ b/LayoutTests/svg/crash-ellipse-zero-zoom-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it does not crash.
+

--- a/LayoutTests/svg/crash-ellipse-zero-zoom.html
+++ b/LayoutTests/svg/crash-ellipse-zero-zoom.html
@@ -1,0 +1,33 @@
+<style>
+* { zoom: 0.0005; stroke: green; }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<div>
+  <shadow>
+    <ul charoff="0">
+      <mtable>
+        <mtr>
+          <mtd>
+            <maction>
+              <mtext>
+                <ms>
+                  This test passes if it does not crash.
+                  <table>
+                    <caption>
+                      <svg>
+                        <circle cx="50%" r="1">
+                      </svg>
+                    </caption>
+                  </table>
+                </ms>
+              </mtext>
+            </maction>
+          </mtd>
+        </mtr>
+      </mtable>
+    </ul>
+  </shadow>
+</div>

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -642,7 +642,7 @@ inline bool RenderStyle::setWritingMode(StyleWritingMode mode)
 
 inline bool RenderStyle::setZoom(float zoomLevel)
 {
-    setUsedZoom(usedZoom() * zoomLevel);
+    setUsedZoom(std::max(std::numeric_limits<float>::epsilon(), usedZoom() * zoomLevel));
     if (compareEqual(m_nonInheritedData->rareData->zoom, zoomLevel))
         return false;
     m_nonInheritedData.access().rareData.access().zoom = zoomLevel;


### PR DESCRIPTION
#### c7a38fe2cf5ae25766207b48490386de467fa4fe
<pre>
WebCore::LegacyRenderSVGEllipse::updateShapeFromElement; WebCore::LegacyRenderSVGShape::layout; WebCore::SVGRenderSupport::layoutChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=289381">https://bugs.webkit.org/show_bug.cgi?id=289381</a>

Reviewed by Ryosuke Niwa.

The value of the zoom property gets reset to 1 if an explicit 0 or 0% is specified, but
values close to 0 do not get this treatment. In RenderStyle::setZoom the old used zoom is multiplied by the new
zoom factor to determine the new used zoom, this becomes zero for small zoom property values like in the test case.
Thereafter in currentViewportSizeExcludingZoom there may be a division by zero, leading to NaN values in the viewport size
and ASSERTs later on.

To fix this prevent the used zoom factor from becoming absolute zero.

* LayoutTests/platform/glib/svg/stroke/nan-stroke-width-crash-expected.txt:
* LayoutTests/platform/ios/svg/stroke/nan-stroke-width-crash-expected.txt:
* LayoutTests/platform/mac/svg/stroke/nan-stroke-width-crash-expected.txt:
* LayoutTests/svg/crash-ellipse-zero-zoom-expected.txt: Added.
* LayoutTests/svg/crash-ellipse-zero-zoom.html: Added.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setZoom):

Canonical link: <a href="https://commits.webkit.org/292216@main">https://commits.webkit.org/292216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92a1484ef4be14fadbbb2287f2d60bbf6c3d463a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101831 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81295 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80674 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26891 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->