### PR TITLE
[Screen Time Refactoring] History fetching API does not work unless WKWebsiteDataStore has a delegate

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -639,6 +639,7 @@ UIProcess/WebAuthentication/Mock/MockLocalService.mm
 UIProcess/WebAuthentication/Mock/MockNfcService.mm
 UIProcess/WebAuthentication/Mock/MockCcidService.mm
 
+UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
 UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 
 UIProcess/XR/ios/PlatformXRARKit.mm

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.h
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SCREEN_TIME)
+
+#include <wtf/Forward.h>
+
+namespace WebKit {
+
+class WebsiteDataStoreConfiguration;
+
+namespace ScreenTimeWebsiteDataSupport {
+
+void getScreenTimeURLs(std::optional<WTF::UUID>, CompletionHandler<void(HashSet<URL>&&)>&&);
+
+void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDataStoreConfiguration&);
+
+void removeScreenTimeDataWithInterval(WallTime, const WebsiteDataStoreConfiguration&);
+
+} // namespace ScreenTimeWebsiteDataSupport
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ScreenTimeWebsiteDataSupport.h"
+
+#if ENABLE(SCREEN_TIME)
+
+#import "WebsiteDataStoreConfiguration.h"
+#import <wtf/HashSet.h>
+#import <wtf/URL.h>
+#import <wtf/UUID.h>
+
+#import <pal/cocoa/ScreenTimeSoftLink.h>
+
+@interface STWebHistory (Staging_140439004)
+- (void)fetchAllHistoryWithCompletionHandler:(void (^)(NSSet<NSURL *> *urls, NSError *error))completionHandler;
+@end
+
+namespace WebKit::ScreenTimeWebsiteDataSupport {
+
+void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<void(HashSet<URL>&&)>&& completionHandler)
+{
+    if (![PAL::getSTWebHistoryClass() instancesRespondToSelector:@selector(fetchAllHistoryWithCompletionHandler:)])
+        return completionHandler({ });
+
+    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    if (identifier)
+        profileIdentifier = identifier->toString();
+
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+
+    // STWebHistory.fetchAllHistoryWithCompletionHandler sometimes deallocates its block instead of calling it.
+    // FIXME: Remove this once rdar://145889845 is widely available.
+    auto completionHandlerWithFinalizer = CompletionHandlerWithFinalizer<void(HashSet<URL>&&)>(WTFMove(completionHandler), [](auto& completionHandler) {
+        completionHandler({ });
+    });
+
+    [webHistory fetchAllHistoryWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandlerWithFinalizer)](NSSet<NSURL *> *urls, NSError *error) mutable {
+        ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), urls = retainPtr(urls), error = retainPtr(error)] mutable {
+            if (error) {
+                completionHandler({ });
+                return;
+            }
+
+            HashSet<URL> result;
+            for (NSURL *site in urls.get()) {
+                URL url { site };
+                if (url.isValid())
+                    result.add(WTFMove(url));
+            }
+
+            completionHandler(WTFMove(result));
+        });
+    }).get()];
+}
+
+void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDataStoreConfiguration& configuration)
+{
+    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    if (configuration.identifier())
+        profileIdentifier = configuration.identifier()->toString();
+
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+
+    for (auto& url : websitesToRemove)
+        [webHistory deleteHistoryForURL:url];
+}
+
+void removeScreenTimeDataWithInterval(WallTime modifiedSince, const WebsiteDataStoreConfiguration& configuration)
+{
+    STWebHistoryProfileIdentifier profileIdentifier = nil;
+    if (configuration.identifier())
+        profileIdentifier = configuration.identifier()->toString();
+
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
+
+    if (!modifiedSince.isNaN()) {
+        NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();
+        RetainPtr date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
+        RetainPtr dateInterval = adoptNS([[NSDateInterval alloc] initWithStartDate:date.get() endDate:NSDate.now]);
+        [webHistory deleteHistoryDuringInterval:dateInterval.get()];
+    }
+}
+
+} // namespace WebKit::ScreenTimeWebsiteDataSupport
+
+#endif

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -67,12 +67,6 @@
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
 #endif
 
-#if ENABLE(SCREEN_TIME)
-@interface STWebHistory (Staging_140439004)
-- (void)fetchAllHistoryWithCompletionHandler:(void (^)(NSSet<NSURL *> *urls, NSError *error))completionHandler;
-@end
-#endif
-
 namespace WebKit {
 
 static NSString* const WebKit2HTTPProxyDefaultsKey = @"WebKit2HTTPProxy";
@@ -341,41 +335,6 @@ void WebsiteDataStore::removeDataStoreWithIdentifier(const WTF::UUID& identifier
         });
     });
 }
-
-#if ENABLE(SCREEN_TIME)
-
-void WebsiteDataStore::removeScreenTimeData(const HashSet<URL>& websitesToRemove)
-{
-    if (![PAL::getSTWebHistoryClass() instancesRespondToSelector:@selector(fetchAllHistoryWithCompletionHandler:)])
-        return;
-
-    STWebHistoryProfileIdentifier profileIdentifier = nil;
-    if (configuration().identifier())
-        profileIdentifier = configuration().identifier()->toString();
-
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
-
-    for (auto& url : websitesToRemove)
-        [webHistory deleteHistoryForURL:url];
-}
-
-void WebsiteDataStore::removeScreenTimeDataWithInterval(WallTime modifiedSince)
-{
-    STWebHistoryProfileIdentifier profileIdentifier = nil;
-    if (configuration().identifier())
-        profileIdentifier = configuration().identifier()->toString();
-
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier]);
-
-    if (!modifiedSince.isNaN()) {
-        NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();
-        NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
-        RetainPtr dateInterval = adoptNS([[NSDateInterval alloc] initWithStartDate:date endDate:NSDate.now]);
-        [webHistory deleteHistoryDuringInterval:dateInterval.get()];
-    }
-}
-
-#endif
 
 String WebsiteDataStore::defaultWebsiteDataStoreDirectory(const WTF::UUID& identifier)
 {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -92,6 +92,7 @@
 
 #if PLATFORM(COCOA)
 #include "DefaultWebBrowserChecks.h"
+#include "ScreenTimeWebsiteDataSupport.h"
 #include "WebPrivacyHelpers.h"
 #endif
 
@@ -772,13 +773,15 @@ private:
 
 #if ENABLE(SCREEN_TIME)
     if (dataTypes.contains(WebsiteDataType::ScreenTime) && isPersistent()) {
-        m_client->getScreenTimeURLs(configuration().identifier(), [callbackAggregator](HashSet<URL> urls) {
+        ScreenTimeWebsiteDataSupport::getScreenTimeURLs(configuration().identifier(), { [callbackAggregator](HashSet<URL> urls) {
             WebsiteData websiteData;
             websiteData.entries = WTF::map(urls, [](auto& url) {
                 return WebsiteData::Entry { SecurityOriginData::fromURL(url), WebsiteDataType::ScreenTime, 0 };
             });
             callbackAggregator->addWebsiteData(WTFMove(websiteData));
-        });
+        }, CompletionHandlerCallThread::AnyThread });
+        // FIXME: Remove CompletionHandlerCallThread::AnyThread above once rdar://145889845 is widely available.
+        // Screen Time might not call the completion handler, so allow the completion handler to be called from any thread.
     }
 #endif
 
@@ -955,7 +958,7 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
 
 #if ENABLE(SCREEN_TIME)
     if (dataTypes.contains(WebsiteDataType::ScreenTime) && isPersistent())
-        removeScreenTimeDataWithInterval(modifiedSince);
+        ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval(modifiedSince, configuration());
 #endif
 }
 
@@ -1059,7 +1062,7 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
                     websitesToRemove.add(origin.toURL());
             }
         }
-        removeScreenTimeData(websitesToRemove);
+        ScreenTimeWebsiteDataSupport::removeScreenTimeData(websitesToRemove, configuration());
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -119,11 +119,6 @@ public:
     {
     }
 
-    virtual void getScreenTimeURLs(std::optional<WTF::UUID>, CompletionHandler<void(HashSet<URL>&&)>&& completionHandler) const
-    {
-        completionHandler({ });
-    }
-
     enum class CanSuspend : bool { No, Yes };
     virtual void didExceedMemoryFootprintThreshold(size_t, const String&, unsigned, Seconds, bool, WebCore::WasPrivateRelayed, CanSuspend)
     {

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -40,6 +40,7 @@
 #import <pal/spi/mac/NSPopoverColorWellSPI.h>
 #import <pal/spi/mac/NSPopoverSPI.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 
 static const size_t maxColorSuggestions = 12;
 static const CGFloat colorPickerMatrixNumColumns = 12.0;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1595,6 +1595,7 @@
 		6BE969C11E54D452008B7483 /* corePrediction_model in Resources */ = {isa = PBXBuildFile; fileRef = 6BE969C01E54D452008B7483 /* corePrediction_model */; };
 		6BE969CB1E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BE969C91E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h */; };
 		6BE969CD1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BE969CC1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h */; };
+		6D4DF20C2D824242001F964C /* ScreenTimeWebsiteDataSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D77DBC22D80D3D6008ED0DD /* ScreenTimeWebsiteDataSupport.h */; };
 		6D9A666E2A27FAE300BD68A0 /* WebTouchEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4001002527D73C00E91DA7 /* WebTouchEvent.h */; };
 		6EE849C81368D9390038D481 /* WKInspectorPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		711725A9228D564300018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */; };
@@ -6487,6 +6488,8 @@
 		6BE969C81E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceLoadStatisticsClassifierCocoa.cpp; sourceTree = "<group>"; };
 		6BE969C91E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsClassifierCocoa.h; sourceTree = "<group>"; };
 		6BE969CC1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsClassifier.h; sourceTree = "<group>"; };
+		6D77DBC22D80D3D6008ED0DD /* ScreenTimeWebsiteDataSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenTimeWebsiteDataSupport.h; sourceTree = "<group>"; };
+		6D77DBC32D80D3EC008ED0DD /* ScreenTimeWebsiteDataSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenTimeWebsiteDataSupport.mm; sourceTree = "<group>"; };
 		6D8A91A511F0EFD100DD01FE /* com.apple.WebProcess.sb.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = com.apple.WebProcess.sb.in; path = WebProcess/com.apple.WebProcess.sb.in; sourceTree = "<group>"; };
 		6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKInspectorPrivateMac.h; path = mac/WKInspectorPrivateMac.h; sourceTree = "<group>"; };
 		711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteLegacyOverflowScrollingTouchPolicy.h; sourceTree = "<group>"; };
@@ -9227,6 +9230,8 @@
 		1A4832C01A965A33008B4DFE /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				6D77DBC22D80D3D6008ED0DD /* ScreenTimeWebsiteDataSupport.h */,
+				6D77DBC32D80D3EC008ED0DD /* ScreenTimeWebsiteDataSupport.mm */,
 				1A4832C11A965A3C008B4DFE /* WebsiteDataStoreCocoa.mm */,
 			);
 			path = Cocoa;
@@ -17262,6 +17267,7 @@
 				E1E552C516AE065F004ED653 /* SandboxInitializationParameters.h in Headers */,
 				E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */,
 				7BAB111025DD02B3008FC479 /* ScopedActiveMessageReceiveQueue.h in Headers */,
+				6D4DF20C2D824242001F964C /* ScreenTimeWebsiteDataSupport.h in Headers */,
 				463BB93A2B9D08D80098C5C3 /* ScriptMessageHandlerIdentifier.h in Headers */,
 				F4E28A362C923814008120DD /* ScriptTelemetry.h in Headers */,
 				E4D54D0421F1D72D007E3C36 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h in Headers */,


### PR DESCRIPTION
#### 6c635bbd1833196a956ee825b51445c775899749
<pre>
[Screen Time Refactoring] History fetching API does not work unless WKWebsiteDataStore has a delegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=289553">https://bugs.webkit.org/show_bug.cgi?id=289553</a>
<a href="https://rdar.apple.com/145017247">rdar://145017247</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Currently, the implemented getScreenTimeURLs does not get called when WKWebsiteDataStore does
not have a delegate. Instead, the virtual function for getScreenTimeURLs is called. Thus, the
current support for Screen Time in fetchDataRecordsOfTypes does not actually work.
As a consequence, since we never receive any records saying that they have Screen Time data,
removeDataOfTypes(forDataRecords specifically) also does not work.

Now, we add a ScreenTimeWebsiteDataSupport namespace that contains all the functions needed
for supporting Screen Time in conjunction with the WKWebsiteDataStore&apos;s fetchDataRecordsOfTypes
and removeDataOfTypes APIs. Due to these new files, WebColorPickerMac.mm has a build error where
it does not recognize its use of WeakPtr so include WeakPtr.

In addition, add an API test to ensure that the Screen Time&apos;s fetchAllHistoryWithCompletionHandler
API is being called. This tests fails with the old implementation.

Also, remove the old implementation from WebsiteDataStoreClient and replace all instances of
the old implementation with the working one.

Finally, in WebsiteDataStore.cpp, fix an assertion by making the completion handler
destructable on any thread. This is due to the problem where
STWebHistory.fetchAllHistoryWithCompletionHandler might not be called and just deallocates its
block. This can be removed once the fix to STWebHistory.fetchAllHistoryWithCompletionHandler
goes in.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.h: Added.
* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm: Added.
(WebKit::ScreenTimeWebsiteDataSupport::getScreenTimeURLs):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeData):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::removeScreenTimeData): Deleted.
(WebKit::WebsiteDataStore::removeScreenTimeDataWithInterval): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::getScreenTimeURLs const): Deleted.
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, FetchData)):

Canonical link: <a href="https://commits.webkit.org/292143@main">https://commits.webkit.org/292143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c127179d4782207dec832f379471759cb5c4160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72536 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44938 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80929 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25494 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15383 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22114 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->