### PR TITLE
[macOS] Transition to syscall-mig in the WebContent process sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1785,19 +1785,41 @@
     io_registry_get_root_entry
     io_service_close))
 
-(define (allow-mach-exceptions)
+(define (allow-mach-exceptions operation)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
     (when (equal? (param "CPU") "arm64")
         (with-filter (require-not (webcontent-process-launched))
-            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
-        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler)))
+            (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
+        (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
     (when (not (equal? (param "CPU") "arm64"))
-        (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))))
+        (allow operation (kernel-mig-routine thread_set_exception_ports))))
 #else
-    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+    (allow operation (kernel-mig-routine thread_set_exception_ports)))
 #endif
 
-(if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
+(when (defined? 'syscall-mig)
+    (deny syscall-mig)
+    (with-filter (require-not (lockdown-mode))
+        (allow-mach-exceptions syscall-mig)
+        (allow syscall-mig (kernel-mig-routines-blocked-in-lockdown-mode)))
+    (with-filter (lockdown-mode)
+        (deny syscall-mig (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
+    (allow syscall-mig (kernel-mig-routines-in-use))
+#if HAVE(MACH_RANGE_CREATE)
+    (with-filter (require-not (webcontent-process-launched))
+        (when (defined? 'mach_vm_range_create)
+            (allow syscall-mig (kernel-mig-routine mach_vm_range_create))))
+#endif
+    (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+        (allow syscall-mig (kernel-mig-routines-downlevels))
+        (allow syscall-mig (kernel-mig-routines-iokit))
+        (allow syscall-mig (kernel-mig-routines-iokit-service)))
+    (with-filter (state-flag "BlockIOKitInWebContentSandbox")
+        (deny syscall-mig (with no-report) (kernel-mig-routines-iokit-service)))
+    (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
+        (allow syscall-mig (kernel-mig-routines-downlevels-blocked-in-lockdown-mode))))
+
+(if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (and (defined? 'mach-kernel-endpoint) (not (defined? 'syscall-mig))))
     (allow mach-kernel-endpoint
         (apply-message-filter
             (deny mach-message-send)
@@ -1806,7 +1828,7 @@
             (with-filter (lockdown-mode)
                 (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
             (with-filter (require-not (lockdown-mode))
-                (allow-mach-exceptions))
+                (allow-mach-exceptions mach-message-send))
 
             (allow mach-message-send (kernel-mig-routines-in-use))
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000


### PR DESCRIPTION
#### df54090e4bbc12ff43451c68e23e1bb796b55203
<pre>
[macOS] Transition to syscall-mig in the WebContent process sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=289641">https://bugs.webkit.org/show_bug.cgi?id=289641</a>
<a href="https://rdar.apple.com/146887617">rdar://146887617</a>

Reviewed by Sihui Liu.

Use the modern syscall-mig syntax instead of message filters.

Canonical link: <a href="https://commits.webkit.org/292281@main">https://commits.webkit.org/292281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14d5175f5501196e9fc7174d918bdafd70cf3ffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45292 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72315 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29616 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10636 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81315 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80695 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15064 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15375 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26928 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->