### PR TITLE
[CoreText] Measuring the width of multiple characters in one API call

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -182,6 +182,9 @@ public:
     };
 
     float widthForGlyph(Glyph, SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const;
+#if USE(CORE_TEXT)
+    Vector<float, inlineGlyphRunCapacity> widthsForGlyphs(std::span<const Glyph>, SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const;
+#endif
 
     Path pathForGlyph(Glyph) const;
 
@@ -198,6 +201,13 @@ public:
 
     GlyphData glyphDataForCharacter(char32_t) const;
     Glyph glyphForCharacter(char32_t) const;
+
+#if USE(CORE_TEXT)
+    template<typename charType>
+    ALWAYS_INLINE std::pair<Vector<Glyph, inlineGlyphRunCapacity>, Vector<float, inlineGlyphRunCapacity>>
+    glyphsAndWidthsForCharacters(std::span<charType> characters, SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const;
+#endif
+
     bool supportsCodePoint(char32_t) const;
     bool platformSupportsCodePoint(char32_t, std::optional<char32_t> variation = std::nullopt) const;
 
@@ -287,6 +297,9 @@ private:
     Vector<FloatRect, inlineGlyphRunCapacity> platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>&) const;
 #endif
     float platformWidthForGlyph(Glyph) const;
+#if USE(CORE_TEXT)
+    Vector<float, inlineGlyphRunCapacity> platformWidthsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>&) const;
+#endif
     Path platformPathForGlyph(Glyph) const;
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -366,6 +366,24 @@ float FontCascade::width(CodePath codePathToUse, const TextRun& run, SingleThrea
     return it.runWidthSoFar();
 }
 
+#if USE(CORE_TEXT)
+template <typename T, size_t N>
+void processCharacterSpan(GlyphBuffer& glyphBuffer, const Font& font, std::span<T, N> characters)
+{
+    auto [glyphs, widths] = font.glyphsAndWidthsForCharacters(characters);
+
+    for (size_t i = 0; i < glyphs.size(); ++i)
+        glyphBuffer.add(glyphs[i], font, widths[i], i);
+}
+
+template <typename T>
+void processCharacterSpan(GlyphBuffer& glyphBuffer, const Font& font, std::span<T, 1> characters)
+{
+    auto glyph = font.glyphForCharacter(characters[0]);
+    glyphBuffer.add(glyph, font, font.widthForGlyph(glyph), 0);
+}
+#endif
+
 NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDirection textDirection, GlyphGeometryCacheEntry* cacheEntry) const
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
@@ -373,14 +391,28 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
     float result = width(CodePath::Simple, run);
 #else
     GlyphBuffer glyphBuffer;
+    glyphBuffer.reserveInitialCapacity(text.length());
     Ref font = primaryFont();
     ASSERT(!font->syntheticBoldOffset()); // This function should only be called when RenderText::computeCanUseSimplifiedTextMeasuring() returns true, and that function requires no synthetic bold.
 
     auto addGlyphsFromText = [&](GlyphBuffer& glyphBuffer, const Font& font, auto characters) {
+#if USE(CORE_TEXT)
+        if (characters.size() == 1)
+            processCharacterSpan(glyphBuffer, font, characters.template first<1>());
+        else if (characters.size() < 16) {
+            // For short runs profiling indicates its more efficient to use the per-character lookup.
+            for (size_t i = 0; i < characters.size(); ++i) {
+                auto glyph = font.glyphForCharacter(characters[i]);
+                glyphBuffer.add(glyph, font, font.widthForGlyph(glyph), i);
+            }
+        } else
+            processCharacterSpan(glyphBuffer, font, characters);
+#else
         for (size_t i = 0; i < characters.size(); ++i) {
             auto glyph = font.glyphForCharacter(characters[i]);
             glyphBuffer.add(glyph, font, font.widthForGlyph(glyph), i);
         }
+#endif
     };
 
     if (text.is8Bit())

--- a/Source/WebCore/platform/graphics/FontInlines.h
+++ b/Source/WebCore/platform/graphics/FontInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGly
         return { boundsForGlyph(glyphs[0]) };
 
     Vector<Glyph, inlineGlyphRunCapacity> glyphsNeedingMeasurement;
-    Vector<size_t, inlineGlyphRunCapacity> positionsNeedingMeasurement;
+    Vector<uint32_t, inlineGlyphRunCapacity> positionsNeedingMeasurement;
 
     Vector<FloatRect, inlineGlyphRunCapacity> glyphBounds(FillWith { }, glyphCount, FloatRect());
     for (size_t glyphIndex = 0; glyphIndex < glyphCount; ++glyphIndex) {
@@ -112,18 +112,14 @@ ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGly
 }
 #endif
 
-ALWAYS_INLINE float Font::widthForGlyph(Glyph glyph, SyntheticBoldInclusion SyntheticBoldInclusion) const
+ALWAYS_INLINE float Font::widthForGlyph(Glyph glyph, SyntheticBoldInclusion syntheticBoldInclusion) const
 {
-    // The optimization of returning 0 for the zero-width-space glyph is incorrect for the LastResort font,
-    // used in place of the actual font when isLoading() is true on both macOS and iOS.
-    // The zero-width-space glyph in that font does not have a width of zero and, further, that glyph is used
-    // for many other characters and must not be zero width when used for them.
     if (isZeroWidthSpaceGlyph(glyph) && !isInterstitial())
         return 0;
 
     float width = m_glyphToWidthMap.metricsForGlyph(glyph);
     if (width != cGlyphSizeUnknown)
-        return width + (SyntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
+        return width + (syntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
 
 #if ENABLE(OPENTYPE_VERTICAL)
     if (m_verticalData)
@@ -133,7 +129,108 @@ ALWAYS_INLINE float Font::widthForGlyph(Glyph glyph, SyntheticBoldInclusion Synt
         width = platformWidthForGlyph(glyph);
 
     m_glyphToWidthMap.setMetricsForGlyph(glyph, width);
-    return width + (SyntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
+    return width + (syntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
 }
+
+#if USE(CORE_TEXT)
+ALWAYS_INLINE Vector<float, Font::inlineGlyphRunCapacity> Font::widthsForGlyphs(std::span<const Glyph> glyphs, SyntheticBoldInclusion syntheticBoldInclusion) const
+{
+    ASSERT(glyphs.size());
+
+    if (glyphs.size() == 1) [[unlikely]]
+        return { widthForGlyph(glyphs[0], syntheticBoldInclusion) };
+
+    Vector<Glyph, inlineGlyphRunCapacity> glyphsNeedingMeasurement;
+    Vector<uint32_t, inlineGlyphRunCapacity> positionsNeedingMeasurement;
+
+    glyphsNeedingMeasurement.reserveInitialCapacity(glyphs.size());
+    positionsNeedingMeasurement.reserveInitialCapacity(glyphs.size());
+
+    Vector<float, inlineGlyphRunCapacity> glyphWidths(FillWith { }, glyphs.size(), 0.f);
+    const bool isInterstitial = this->isInterstitial();
+    const float syntheticBoldOffset = syntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? this->syntheticBoldOffset() : 0;
+    for (size_t glyphIndex = 0; glyphIndex < glyphs.size(); ++glyphIndex) {
+        const auto& glyph = glyphs[glyphIndex];
+        if (isZeroWidthSpaceGlyph(glyph) && isInterstitial)
+            continue;
+
+        float width = m_glyphToWidthMap.metricsForGlyph(glyph);
+        if (width != cGlyphSizeUnknown) {
+            glyphWidths[glyphIndex] = width + syntheticBoldOffset;
+            continue;
+        }
+
+        glyphsNeedingMeasurement.append(glyph);
+        positionsNeedingMeasurement.append(glyphIndex);
+    }
+
+    if (glyphsNeedingMeasurement.isEmpty())
+        return glyphWidths;
+
+    auto measuredWidths = platformWidthsForGlyphs(glyphsNeedingMeasurement);
+
+    size_t index = 0;
+    for (auto& width : measuredWidths) {
+        const auto measuredGlyph = glyphsNeedingMeasurement[index];
+        const auto measuredGlyphPosition = positionsNeedingMeasurement[index];
+
+        m_glyphToWidthMap.setMetricsForGlyph(measuredGlyph, width);
+        glyphWidths[measuredGlyphPosition] = width + syntheticBoldOffset;
+        ++index;
+    }
+    return glyphWidths;
+}
+#endif
+
+#if USE(CORE_TEXT)
+template<typename charType>
+ALWAYS_INLINE std::pair<Vector<Glyph, Font::inlineGlyphRunCapacity>, Vector<float, Font::inlineGlyphRunCapacity>>
+Font::glyphsAndWidthsForCharacters(std::span<charType> characters, SyntheticBoldInclusion syntheticBoldInclusion) const
+{
+    ASSERT(characters.size());
+
+    Vector<Glyph, inlineGlyphRunCapacity> glyphs;
+    glyphs.reserveInitialCapacity(characters.size());
+
+    Vector<float, inlineGlyphRunCapacity> widths(FillWith { }, characters.size(), 0.f);
+
+    Vector<Glyph, inlineGlyphRunCapacity> uncachedGlyphs;
+    Vector<uint32_t, inlineGlyphRunCapacity> uncachedPositions;
+
+    const bool isInterstitial = this->isInterstitial();
+    const float syntheticBoldOffset = syntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? this->syntheticBoldOffset() : 0;
+
+    for (size_t i = 0; i < characters.size(); ++i) {
+        auto glyph = glyphForCharacter(characters[i]);
+        glyphs.append(glyph);
+
+        if (isZeroWidthSpaceGlyph(glyph) && isInterstitial)
+            continue;
+
+        float width = m_glyphToWidthMap.metricsForGlyph(glyph);
+        if (width != cGlyphSizeUnknown) {
+            widths[i] = width + syntheticBoldOffset;
+            continue;
+        }
+
+        if (uncachedGlyphs.isEmpty()) {
+            uncachedGlyphs.reserveInitialCapacity(characters.size());
+            uncachedPositions.reserveInitialCapacity(characters.size());
+        }
+        uncachedGlyphs.append(glyph);
+        uncachedPositions.append(i);
+    }
+
+    if (!uncachedGlyphs.isEmpty()) {
+        auto measuredWidths = platformWidthsForGlyphs(uncachedGlyphs);
+        for (size_t j = 0; j < measuredWidths.size(); ++j) {
+            m_glyphToWidthMap.setMetricsForGlyph(uncachedGlyphs[j], measuredWidths[j]);
+            widths[uncachedPositions[j]] = measuredWidths[j] + syntheticBoldOffset;
+        }
+    }
+
+    return { WTF::move(glyphs), WTF::move(widths) };
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -63,6 +63,15 @@ public:
         m_offsetsInString.clear();
     }
 
+    void reserveInitialCapacity(size_t capacity)
+    {
+        m_fonts.reserveInitialCapacity(capacity);
+        m_glyphs.reserveInitialCapacity(capacity);
+        m_advances.reserveInitialCapacity(capacity);
+        m_origins.reserveInitialCapacity(capacity);
+        m_offsetsInString.reserveInitialCapacity(capacity);
+    }
+
     std::span<SingleThreadWeakPtr<const Font>> fonts(size_t from = 0, size_t count = std::dynamic_extent) LIFETIME_BOUND { return m_fonts.mutableSpan().subspan(from, count); }
     std::span<GlyphBufferGlyph> glyphs(size_t from = 0, size_t count = std::dynamic_extent) LIFETIME_BOUND { return m_glyphs.mutableSpan().subspan(from, count); }
     std::span<GlyphBufferAdvance> advances(size_t from = 0, size_t count = std::dynamic_extent) LIFETIME_BOUND { return m_advances.mutableSpan().subspan(from, count); }

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov
  *
  * Redistribution and use in source and binary forms, with or without
@@ -615,6 +615,24 @@ float Font::platformWidthForGlyph(Glyph glyph) const
     return advance.width;
 }
 
+Vector<float, Font::inlineGlyphRunCapacity> Font::platformWidthsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>& glyphs) const
+{
+    Vector<CGSize, inlineGlyphRunCapacity> advancesForGlyphs(FillWith { }, glyphs.size(), CGSizeZero);
+
+    if (platformData().size()) {
+        RetainPtr ctFont = this->ctFont();
+        bool horizontal = platformData().orientation() == FontOrientation::Horizontal;
+        CTFontOrientation orientation = horizontal || m_isBrokenIdeographFallback ? kCTFontOrientationHorizontal : kCTFontOrientationVertical;
+        auto advancesForGlyphsSpan = advancesForGlyphs.mutableSpan();
+        CTFontGetAdvancesForGlyphs(ctFont.get(), orientation, glyphs.span().data(), advancesForGlyphsSpan.data(), advancesForGlyphsSpan.size());
+    }
+
+    Vector<float, inlineGlyphRunCapacity> widths(glyphs.size());
+    for (size_t i = 0; i < advancesForGlyphs.size(); ++i)
+        widths[i] = advancesForGlyphs[i].width;
+    return widths;
+}
+
 GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection textDirection) const
 {
     UNUSED_PARAM(requiresShaping);
@@ -798,15 +816,18 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
 
 Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>& glyphs) const
 {
+    RetainPtr ctFont = this->ctFont();
     Vector<CGRect, inlineGlyphRunCapacity> rectsForGlyphs(glyphs.size());
-    CTFontGetBoundingRectsForGlyphs(protect(ctFont()).get(), platformData().orientation() == FontOrientation::Vertical ? kCTFontOrientationVertical : kCTFontOrientationHorizontal, glyphs.span().data(), rectsForGlyphs.mutableSpan().data(), rectsForGlyphs.size());
+    CTFontGetBoundingRectsForGlyphs(ctFont.get(), platformData().orientation() == FontOrientation::Vertical ? kCTFontOrientationVertical : kCTFontOrientationHorizontal, glyphs.span().data(), rectsForGlyphs.mutableSpan().data(), rectsForGlyphs.size());
 
-    return rectsForGlyphs.map<Vector<FloatRect, inlineGlyphRunCapacity>>([&](const auto& rect) -> auto {
-        FloatRect boundingBox(rect);
+    Vector<FloatRect, inlineGlyphRunCapacity> bounds(glyphs.size());
+    for (size_t i = 0; i < rectsForGlyphs.size(); ++i) {
+        FloatRect boundingBox(rectsForGlyphs[i]);
         boundingBox.setY(-boundingBox.maxY());
         boundingBox.setWidth(boundingBox.width() + m_syntheticBoldOffset);
-        return boundingBox;
-    });
+        bounds[i] = boundingBox;
+    }
+    return bounds;
 }
 
 Path Font::platformPathForGlyph(Glyph glyph) const


### PR DESCRIPTION
#### 1b7efd59e1c0fc9df54b64bfdb5e34db9f99e78d
<pre>
[CoreText] Measuring the width of multiple characters in one API call
<a href="https://bugs.webkit.org/show_bug.cgi?id=289642">https://bugs.webkit.org/show_bug.cgi?id=289642</a>
<a href="https://rdar.apple.com/146888513">rdar://146888513</a>

Reviewed by NOBODY (OOPS!).

Instead of calling `CTFontGetAdvancesForGlyphs` on each character, pass a vector of characters
so we only pay to create the graphics context and select a font into it one time (instead of
once for each character).

This patch also tidies up some vector initialization to avoid reallocations, and removes
some unneeded `protect` calls on smart pointers already owned by the current object to
reduce refcount churn.

Profiling indicated that the batch width processing can introduce overhead for sufficiently
short text runs, so we use the single-character logic for runs up to 16 characters, but
batch for longer runs.

* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::processCharacterSpan): Added.
(WebCore::FontCascade::widthForSimpleTextSlow const): Use new multi-character measurement
when appropriate.
* Source/WebCore/platform/graphics/FontInlines.h:
(WebCore::Font::boundsForGlyphs const): Switch from size_t to uint32_t for glyph position
in the span (positionsNeedingMeasurement), which ranges between 0 and 255, and even if
we exceed that range we would still be able to handle a 4.3 billion character span with
the smaller size.
(WebCore::Font::widthForGlyph const):
(WebCore::Font::widthsForGlyphs const): Ditto.
(WebCore::Font::glyphsAndWidthsForCharacters const): Added. Handles glyph and width logic
in the same pass, rather than looping through the characters multiple times.
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::reserveInitialCapacity):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformWidthsForGlyphs const): Added.
(WebCore::Font::platformBoundsForGlyphs const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b7efd59e1c0fc9df54b64bfdb5e34db9f99e78d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113682 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e01281ee-7d82-4bef-9cc4-3cdd8d4430c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123429 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86643 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7502a1bb-8f74-4eca-b2a3-cc0b1cab272a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/759282ef-d727-4aa1-ba10-4b4e94fd90c8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24742 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23183 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15907 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170628 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131629 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131742 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90490 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19489 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98328 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31396 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31551 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->