### PR TITLE
Enable command and commandfor in preview

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2032,6 +2032,20 @@ ColorFilterEnabled:
     WebCore:
       default: false
 
+CommandAttributesEnabled:
+  type: bool
+  status: preview
+  category: html
+  humanReadableName: "HTML command & commandfor attributes"
+  humanReadableDescription: "Enable HTML command & commandfor attribute support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: WebKit has an alternate name for this called 'ShowDebugBorders'. We should standardize on one name.
 CompositingBordersVisible:
   type: bool
@@ -3991,20 +4005,6 @@ InvisibleAutoplayNotPermitted:
       default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
-      default: false
-
-InvokerAttributesEnabled:
-  type: bool
-  status: testable
-  category: html
-  humanReadableName: "HTML command & commandfor attributes"
-  humanReadableDescription: "Enable HTML command & commandfor attribute support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/dom/CommandEvent.idl
+++ b/Source/WebCore/dom/CommandEvent.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledBySetting=InvokerAttributesEnabled,
+    EnabledBySetting=CommandAttributesEnabled,
     Exposed=Window
 ] interface CommandEvent : Event {
     constructor([AtomString] DOMString type, optional CommandEventInit eventInitDict);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2171,7 +2171,7 @@ bool Element::isElementReflectionAttribute(const Settings& settings, const Quali
 {
     return name == HTMLNames::aria_activedescendantAttr
         || (settings.popoverAttributeEnabled() && name == HTMLNames::popovertargetAttr)
-        || (settings.invokerAttributesEnabled() && name == HTMLNames::commandforAttr);
+        || (settings.commandAttributesEnabled() && name == HTMLNames::commandforAttr);
 }
 
 bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)

--- a/Source/WebCore/dom/GlobalEventHandlers.idl
+++ b/Source/WebCore/dom/GlobalEventHandlers.idl
@@ -41,7 +41,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onchange;
     attribute EventHandler onclick;
     attribute EventHandler onclose;
-    [EnabledBySetting=InvokerAttributesEnabled] attribute EventHandler oncommand;
+    [EnabledBySetting=CommandAttributesEnabled] attribute EventHandler oncommand;
     attribute EventHandler oncontentvisibilityautostatechange;
     // attribute EventHandler oncontextlost;
     attribute EventHandler oncontextmenu;

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -120,7 +120,7 @@ void HTMLButtonElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     if (name == typeAttr)
         computeType(newValue);
-    else if ((name == commandAttr || name == commandforAttr) && document().settings().invokerAttributesEnabled())
+    else if ((name == commandAttr || name == commandforAttr) && document().settings().commandAttributesEnabled())
         computeType(attributeWithoutSynchronization(HTMLNames::typeAttr));
     else
         HTMLFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -129,7 +129,7 @@ void HTMLButtonElement::attributeChanged(const QualifiedName& name, const AtomSt
 RefPtr<Element> HTMLButtonElement::commandForElement() const
 {
     auto canInvoke = [](const HTMLFormControlElement& element) -> bool {
-        if (!element.document().settings().invokerAttributesEnabled())
+        if (!element.document().settings().commandAttributesEnabled())
             return false;
         return is<HTMLButtonElement>(element);
     };
@@ -395,7 +395,7 @@ void HTMLButtonElement::computeType(const AtomString& typeAttrValue)
         m_type = BUTTON;
     else if (equalLettersIgnoringASCIICase(typeAttrValue, "submit"_s))
         m_type = SUBMIT;
-    else if (document().settings().invokerAttributesEnabled()) {
+    else if (document().settings().commandAttributesEnabled()) {
         if (hasAttributeWithoutSynchronization(HTMLNames::commandAttr) || hasAttributeWithoutSynchronization(HTMLNames::commandforAttr))
             m_type = BUTTON;
         else

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -35,8 +35,8 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString value;
 
     // Command Invokers
-    [CEReactions=NotNeeded, Reflect=commandfor, EnabledBySetting=InvokerAttributesEnabled] attribute Element? commandForElement;
-    [CEReactions=NotNeeded, EnabledBySetting=InvokerAttributesEnabled] attribute [AtomString] DOMString command;
+    [CEReactions=NotNeeded, Reflect=commandfor, EnabledBySetting=CommandAttributesEnabled] attribute Element? commandForElement;
+    [CEReactions=NotNeeded, EnabledBySetting=CommandAttributesEnabled] attribute [AtomString] DOMString command;
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;


### PR DESCRIPTION
#### 70f3696090aa296a3b3d3fcdc935c0bfbeee3cac
<pre>
Enable command and commandfor in preview
<a href="https://bugs.webkit.org/show_bug.cgi?id=289644">https://bugs.webkit.org/show_bug.cgi?id=289644</a>

Reviewed by Tim Nguyen.

This patch renames InvokerAttributesEnabled to CommandAttributesEnabled,
and sets the status to preview.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/CommandEvent.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
* Source/WebCore/dom/GlobalEventHandlers.idl:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::attributeChanged):
(WebCore::HTMLButtonElement::commandForElement const):
(WebCore::HTMLButtonElement::computeType):
* Source/WebCore/html/HTMLButtonElement.idl:

Canonical link: <a href="https://commits.webkit.org/292069@main">https://commits.webkit.org/292069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e58b0fb75cf3d73b5e7642b5bf97f45a6d021f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72319 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44640 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101870 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93432 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80699 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15072 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26936 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116121 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21479 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->