### PR TITLE
ASAN_TRAP | WebCore::RenderText::computePreferredLogicalWidths; WebCore::RenderText::trimmedPreferredWidths; WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-expected.txt
@@ -1,0 +1,4 @@
+ Text
+
+PASS Verify effect of font-size-adjust: 0 on normal size SVG Font
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font-expected.txt
@@ -1,0 +1,4 @@
+ Text
+
+PASS Verify effect of font-size-adjust: 0 on no glyphs SVG Font
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Verify effect of font-size-adjust: 0 on a SVG Font without glyphs</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  pre { font-size-adjust: 0; font-family: CustomMonospace }
+</style>
+<svg>
+  <font>
+    <font-face font-family="CustomMonospace"/>
+  </font>
+</svg>
+<pre id="pre">Text
+</pre>
+<script>
+  test((t) => {
+    assert_equals(pre.getBoundingClientRect().height, 0);
+  }, "Verify effect of font-size-adjust: 0 on no glyphs SVG Font");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font-expected.txt
@@ -1,0 +1,4 @@
+ Text
+
+PASS Verify effect of font-size-adjust: 0 on zero height no glyphs SVG Font
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Verify effect of font-size-adjust: 0 on a zero height no glyphs SVG Font</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  pre { font-size-adjust: 0; font-family: CustomMonospace }
+</style>
+<svg>
+  <font>
+    <font-face font-family="CustomMonospace" ascent="0"/>
+  </font>
+</svg>
+<pre id="pre">Text
+</pre>
+<script>
+  test((t) => {
+    assert_equals(pre.getBoundingClientRect().height, 0);
+  }, "Verify effect of font-size-adjust: 0 on zero height no glyphs SVG Font");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Verify effect of font-size-adjust: 0 on a SVG Font</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  pre { font-size-adjust: 0; font-family: CustomMonospace }
+</style>
+<svg>
+  <font>
+    <font-face font-family="CustomMonospace"/>
+    <glyph unicode="e" glyph-name="e" horiz-adv-x="530" d="M500 192V227Q500 296 480 346T428 427T354 474T271 489Q221 489 178 470T101 418T49 340T30 243Q30 204 43 161T87 83T171 24T303 0H482V94H298Q250 94 217 108T165 144T137 192T128 244Q128 276 139 303T171 351T218 383T275 395Q301 395 322 386T360 362T386 327T402 286H277Q253 286 240 272T226 239Q226 223 237 208T277 192H500Z"/>
+  </font>
+</svg>
+<pre id="pre">Text
+</pre>
+<script>
+  test((t) => {
+    assert_equals(pre.getBoundingClientRect().height, 0);
+  }, "Verify effect of font-size-adjust: 0 on normal size SVG Font");
+</script>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1957,3 +1957,7 @@ webkit.org/b/213782 webanimations/accelerated-animation-with-easing.html [ Failu
 
 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-scroller-004.html [ ImageOnlyFailure ]
 webkit.org/b/290133 svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
+
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font.html [ Failure ]
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font.html [ Failure ]
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1721,3 +1721,7 @@ webkit.org/b/287572 svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg [ ImageOn
 
 imported/w3c/web-platform-tests/css/css-position/hypothetical-box-scroll-parent.html [ ImageOnlyFailure ]
 webkit.org/b/290133 svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
+
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font.html [ Failure ]
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font.html [ Failure ]
+webkit.org/b/290449 imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust.html [ Failure ]

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -98,6 +98,11 @@ void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSi
     if (!fontSizeAdjust.value)
         return;
 
+    if (!*fontSizeAdjust.value) {
+        updateSize(0);
+        return;
+    }
+
     auto tmpFont = FontCache::forCurrentThread().fontForPlatformData(*this);
     auto adjustedFontSize = Style::adjustedFontSize(computedSize, fontSizeAdjust, tmpFont->fontMetrics());
 

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -183,6 +183,7 @@ int legacyFontSizeForPixelSize(int pixelFontSize, bool shouldUseFixedDefaultSize
 
 static float adjustedFontSize(float size, float sizeAdjust, float metricValue)
 {
+    ASSERT(sizeAdjust > 0);
     if (!size)
         return 0;
 


### PR DESCRIPTION
#### 771310bdbcaf492206a9dfa9a6863a937e52bb73
<pre>
ASAN_TRAP | WebCore::RenderText::computePreferredLogicalWidths; WebCore::RenderText::trimmedPreferredWidths; WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths
<a href="https://bugs.webkit.org/show_bug.cgi?id=288444">https://bugs.webkit.org/show_bug.cgi?id=288444</a>

Reviewed by Vitor Roriz.

In Style::adjustedFontSize a NaN value can be returned for font-size-adjust of zero. This causes the
FontPlatformData comparison operator for font size to be broken since a NaN will never match anything including other NaNs,
resulting in ASSERTs.

To fix this return early with zero size when font-size-adjust is zero, this is according to spec [1].

[1] <a href="https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop">https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-font.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust-no-glyphs-zero-height-font.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/fonts/zero-font-size-adjust.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::updateSizeWithFontSizeAdjust):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::adjustedFontSize):

Canonical link: <a href="https://commits.webkit.org/292754@main">https://commits.webkit.org/292754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/632f90452d54cac2c29e1470f7ccbc6685cfeaf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31137 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54256 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/96527 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5621 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104141 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82969 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24078 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29226 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->