### PR TITLE
[xpath] Modernize /fast/xpath tests

### DIFF
--- a/LayoutTests/fast/xpath/4XPath/Borrowed/cz_20030217.html
+++ b/LayoutTests/fast/xpath/4XPath/Borrowed/cz_20030217.html
@@ -2,10 +2,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     SRC = '<?xml version=\'1.0\'?>\
@@ -46,6 +45,5 @@
     shouldBe('nodeset.snapshotLength', '0')
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Borrowed/kd_20010423.html
+++ b/LayoutTests/fast/xpath/4XPath/Borrowed/kd_20010423.html
@@ -2,10 +2,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 SRC_1 = '<?xml version="1.0" encoding="utf-8"?>\
@@ -28,6 +27,5 @@ SRC_1 = '<?xml version="1.0" encoding="utf-8"?>\
     shouldBe('actual', '"abcabcabc"')
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Borrowed/od_20000608.html
+++ b/LayoutTests/fast/xpath/4XPath/Borrowed/od_20000608.html
@@ -56,10 +56,9 @@ Is this the "normal" performance ? Can I do better?
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 
@@ -77,6 +76,5 @@ Is this the "normal" performance ? Can I do better?
     shouldBe('nodeset.snapshotLength', '12')
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Borrowed/rs_20010831.html
+++ b/LayoutTests/fast/xpath/4XPath/Borrowed/rs_20010831.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 test = '<foo>\
@@ -26,6 +25,5 @@ test = '<foo>\
     shouldBe('nodeset.singleNodeValue.nodeValue', '"<cdatatext>"')
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Borrowed/sr_20021217.html
+++ b/LayoutTests/fast/xpath/4XPath/Borrowed/sr_20021217.html
@@ -2,10 +2,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     DOC1 = '<a><b><c/><d/></b></a>'
@@ -24,6 +23,5 @@
     shouldBe('node_names', '"b"')
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_boolean_expr.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_boolean_expr.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 
@@ -60,6 +59,5 @@ shouldBe('doc.evaluate("true() or true()", doc, null, XPathResult.BOOLEAN_TYPE, 
 shouldBe('doc.evaluate("false() or false()", doc, null, XPathResult.BOOLEAN_TYPE, null).booleanValue', 'false');
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_core_functions-expected.txt
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_core_functions-expected.txt
@@ -72,6 +72,7 @@ PASS DOM.evaluate("lang('')", LCHILD2, null, XPathResult.ANY_TYPE, null).boolean
 PASS DOM.evaluate("lang('foo')", LCHILD1, null, XPathResult.ANY_TYPE, null).booleanValue is false
 PASS DOM.evaluate("lang('foo')", LCHILD2, null, XPathResult.ANY_TYPE, null).booleanValue is false
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/xpath/4XPath/Core/test_core_functions.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_core_functions.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     function nsResolver(prefix) {
@@ -108,6 +107,5 @@
     shouldBe('DOM.evaluate("lang(\'foo\')", LCHILD2, null, XPathResult.ANY_TYPE, null).booleanValue', 'false');
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_literal_expr.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_literal_expr.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     shouldBe('document.evaluate(\'""\', document, null, XPathResult.STRING_TYPE, null).stringValue', '""');
@@ -48,6 +47,5 @@
     shouldBe('document.evaluate(\'-42\', document, null, XPathResult.NUMBER_TYPE, null).numberValue', '-42.0');
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_location_path.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_location_path.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     result = DOM.evaluate("//*", CHILD2, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
@@ -25,6 +24,5 @@
     checkSnapshot("child::*/child::*", result, GCHILDREN1.concat(GCHILDREN2, LCHILDREN));
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_node_test.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_node_test.html
@@ -1,11 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     function nsResolver(prefix) {
@@ -55,6 +54,5 @@
     shouldBe("nodeInResult(PI2, result)", "false");
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_nodeset_expr.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_nodeset_expr.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     result = DOM.evaluate("(/ROOT | /ROOT/CHILD1)[true()]", CHILD1, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
@@ -19,6 +18,5 @@
     checkSnapshot("(/ROOT | /ROOT/CHILD1) | (/ROOT)", result, [ROOT, CHILD1]);
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_numeric_expr.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_numeric_expr.html
@@ -1,11 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 /*
@@ -214,6 +213,5 @@
     shouldBe('DOM.evaluate("\'5\' >= @attr31", CHILD1, null, XPathResult.ANY_TYPE, null).booleanValue', 'false');
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_parser.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_parser.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     function nsResolver(prefix) {
@@ -107,6 +106,5 @@
     shouldThrow('DOM.evaluate("\\\\", ROOT, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)');
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_predicate_list.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_predicate_list.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     result = DOM.evaluate("self::node()[true() and false()][true()]", ROOT, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
@@ -41,6 +40,5 @@
     checkSnapshot("//element[descendant::y[.='z']][2]", result, []);
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/4XPath/Core/test_step.html
+++ b/LayoutTests/fast/xpath/4XPath/Core/test_step.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="test.js"></script>
 <script src="../../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     result = DOM.evaluate("ancestor::*", CHILD1, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
@@ -25,6 +24,5 @@
     checkSnapshot("child::GCHILD[1]", result, [GCHILD11]);
 
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/ambiguous-operators-expected.txt
+++ b/LayoutTests/fast/xpath/ambiguous-operators-expected.txt
@@ -1,6 +1,7 @@
 Test that an NCName and * are interpreted as an operator when in binary operator context, and as a NameTest otherwise.
 
-See bug 50366: XPath lexer misinterprets expression starting with "div".
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS div
 PASS   div
@@ -70,4 +71,4 @@ PASS string(mod/@and)
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+See bug 50366: XPath lexer misinterprets expression starting with "div".

--- a/LayoutTests/fast/xpath/ambiguous-operators.html
+++ b/LayoutTests/fast/xpath/ambiguous-operators.html
@@ -1,25 +1,22 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 <style>
 #context {display:none}
 </style>
 </head>
 <body>
-<p>Test that an NCName and * are interpreted as an operator when in
-binary operator context, and as a NameTest otherwise.
 
 <p>See <a href="http://bugs.webkit.org/show_bug.cgi?id=50366">bug 50366</a>:
 XPath lexer misinterprets expression starting with "div".</p>
-
-<div id="console"></div>
 
 <div id="context">
   <div id="two" div="x">2</div>
 </div>
 
 <script>
+description("Test that an NCName and * are interpreted as an operator when in binary operator context, and as a NameTest otherwise.");
 var context = document.getElementById('context');
 var div = document.getElementById('two');
 
@@ -109,6 +106,5 @@ test(xmlDoc2, xmlDoc2, "mod mod mod", 0, null);
 test(xmlDoc2, xmlDoc2, "(mod) mod 5", 3, null);
 test(xmlDoc2, xmlDoc2, "string(mod/@and)", 'x', null);
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/attr-namespace.html
+++ b/LayoutTests/fast/xpath/attr-namespace.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 function nsResolver(prefix) {
@@ -36,6 +35,5 @@ shouldBe('doc.evaluate("//@xmlns", doc, nsResolver, XPathResult.ORDERED_NODE_SNA
 shouldBe('doc.evaluate("//@xmlns:*", doc, nsResolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength', '0');
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/attribute-node-predicate-expected.txt
+++ b/LayoutTests/fast/xpath/attribute-node-predicate-expected.txt
@@ -1,3 +1,8 @@
+XPath Attribute node predicate test.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 PASS //@id[false]
 PASS //@id[1]/parent::*
 PASS //@id[2]/parent::*

--- a/LayoutTests/fast/xpath/attribute-node-predicate.html
+++ b/LayoutTests/fast/xpath/attribute-node-predicate.html
@@ -1,14 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
-
 <script>
-
+description("XPath Attribute node predicate test.");
 var ROOT = document.createElement('div');
 ROOT.innerHTML = '<p>a</p><div><span id="21"></span><span id="22"></span><span id="23"></span></div>';
 var CHILD1 = ROOT.firstChild;
@@ -34,6 +32,5 @@ var CHILD23 = CHILD22.nextSibling;
     checkSnapshot("//@id[string()='22']/parent::*", result, [CHILD22]);
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/detached-subtree-invalidate-iterator-expected.txt
+++ b/LayoutTests/fast/xpath/detached-subtree-invalidate-iterator-expected.txt
@@ -1,5 +1,8 @@
 Test that iterators are invalidated even if the original context is detached.
 
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 PASS result.invalidIteratorState is false
 PASS result.iterateNext().tagName is 'span'
 Modifying the document...

--- a/LayoutTests/fast/xpath/detached-subtree-invalidate-iterator.html
+++ b/LayoutTests/fast/xpath/detached-subtree-invalidate-iterator.html
@@ -1,12 +1,11 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<p>Test that iterators are invalidated even if the original context is detached.</p>
-<div id="console"></div>
 <script>
+description("Test that iterators are invalidated even if the original context is detached.");
 var doc = document.implementation.createDocument(null, "doc", null);
 var root = doc.createElement("div");
 root.appendChild(doc.createElement("span"));
@@ -23,6 +22,5 @@ shouldBe("result.invalidIteratorState", "true");
 shouldThrow("result.iterateNext()");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/document-order.html
+++ b/LayoutTests/fast/xpath/document-order.html
@@ -1,11 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 doc = (new DOMParser).parseFromString(
@@ -165,6 +164,5 @@ checkSnapshot("ancestor-or-self::node() (context = attr1)",
     [doc, doc.documentElement, CHILD1, attr1]);
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/evaluate-twice.html
+++ b/LayoutTests/fast/xpath/evaluate-twice.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     doc = (new DOMParser).parseFromString("<doc><elem>1</elem><elem>2</elem></doc>", "application/xml");
@@ -30,6 +29,5 @@
     shouldBe("expr.evaluate(doc.documentElement.firstChild.nextSibling, XPathResult.NUMBER_TYPE, null).numberValue", "3");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/invalid-functions.html
+++ b/LayoutTests/fast/xpath/invalid-functions.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     shouldThrow('document.createExpression("foobar()", null)');
@@ -21,6 +20,5 @@
     shouldThrow('document.evaluate("boolean()", document, null, XPathResult.ANY_TYPE, null)');
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/node-name-case-sensitivity-expected.txt
+++ b/LayoutTests/fast/xpath/node-name-case-sensitivity-expected.txt
@@ -1,5 +1,3 @@
-strongstrongFOOfoo
-
 HTML //*[@id="sometext"]//strong
 PASS res.snapshotLength is 2
 HTML //*[@id="sometext"]//Strong
@@ -23,4 +21,4 @@ PASS res.snapshotLength is 1
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+strongstrongFOOfoo

--- a/LayoutTests/fast/xpath/node-name-case-sensitivity.html
+++ b/LayoutTests/fast/xpath/node-name-case-sensitivity.html
@@ -1,12 +1,11 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="sometext">
 <STRONG>strong</STRONG><strong>strong</strong><FOO>FOO</FOO><foo>foo</foo>
 </p>
-<div id="console"></div>
 <script type="text/javascript">
 
     function testHTML(query, expectedCount)
@@ -38,6 +37,5 @@
     testXML('//*[@id="sometext"]//FOO', '1');
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/null-namespace-in-html-expected.txt
+++ b/LayoutTests/fast/xpath/null-namespace-in-html-expected.txt
@@ -1,5 +1,8 @@
 This tests that XPath expressions with prefixes work correctly.
 
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 PASS //div
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/xpath/null-namespace-in-html.html
+++ b/LayoutTests/fast/xpath/null-namespace-in-html.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<p>This tests that XPath expressions with prefixes work correctly.</p>
 <div id="console"></div>
 <script>
+    description("This tests that XPath expressions with prefixes work correctly.");
     var xmlString = '<div/>';
     var doc = (new DOMParser()).parseFromString(xmlString, "text/xml");
     document.body.insertBefore(document.importNode(doc.documentElement, null), document.body.firstChild);
@@ -14,8 +14,6 @@
     var expr = document.createExpression("//div", null);
     var result = expr.evaluate(document.documentElement, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
     checkSnapshot("//div", result, [document.getElementById("console")]);
-
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/position.html
+++ b/LayoutTests/fast/xpath/position.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 
@@ -79,6 +78,5 @@ ROOT2.innerHTML = '<p num="1"></p><p num="2" type="warning"></p><p num="3" type=
     shouldBe("document.evaluate('p[5][@type=\"warning\"]/@num', ROOT2, null, XPathResult.STRING_TYPE, null).stringValue", "'5'");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/abbreviations.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/abbreviations.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -173,6 +172,5 @@ doc = (new DOMParser).parseFromString(
 test(doc, doc.documentElement, "employee[@secretary and @assistant]", [doc.getElementsByTagName("employee")[2]]);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/axes.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/axes.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 function arraysAreEqual(array1, array2) {
@@ -118,6 +117,5 @@ for (i = 0; i < allNodes.snapshotLength; ++i) {
 }
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/data.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/data.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -53,6 +52,5 @@ test(doc, doc.documentElement, 'local-name(//element/text())', '', nsResolver);
 test(doc, doc.documentElement, 'namespace-uri(//element/text())', '', nsResolver);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/expressions.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/expressions.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -139,6 +138,5 @@ test(doc, doc.documentElement, '2 > 1', true);
 test(doc, doc.documentElement, '1 > 1', false);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/functions-expected.txt
+++ b/LayoutTests/fast/xpath/py-dom-xpath/functions-expected.txt
@@ -81,6 +81,7 @@ PASS string(number("..1"))
 PASS string(number("1.."))
 PASS string(number(".-1"))
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/xpath/py-dom-xpath/functions.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/functions.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -189,6 +188,5 @@ test(doc, doc, 'string(number("1.."))', 'NaN');
 test(doc, doc, 'string(number(".-1"))', 'NaN');
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/nodetests.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/nodetests.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -89,6 +88,5 @@ test(doc, doc, 'doc/child::processing-instruction()', [PI1, PI2]);
 test(doc, doc, 'doc/child::processing-instruction("one")', [PI1]);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/paths.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/paths.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -252,6 +251,5 @@ var doc = (new DOMParser).parseFromString(
 test(doc, doc.documentElement, "child::*[self::chapter or self::appendix][position()=last()]", [doc.getElementsByTagName("chapter")[1]]);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/py-dom-xpath/predicates.html
+++ b/LayoutTests/fast/xpath/py-dom-xpath/predicates.html
@@ -1,10 +1,9 @@
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../xpath-test-pre.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
 var doc = (new DOMParser).parseFromString(
@@ -46,6 +45,5 @@ test(doc, doc.documentElement, '//group/descendant::item[number(//choice/@index)
 test(doc, doc.documentElement, '(//item[@id="5"]/preceding-sibling::item)[1]', [I2]);
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/string-value.html
+++ b/LayoutTests/fast/xpath/string-value.html
@@ -1,10 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<div id="console"></div>
 
 <script>
     doc = (new DOMParser).parseFromString(
@@ -43,6 +42,5 @@
     shouldBe("doc.evaluate('.', ATTR, null, XPathResult.STRING_TYPE, null).stringValue", "'<&nbsp;>'");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/substring-after-expected.txt
+++ b/LayoutTests/fast/xpath/substring-after-expected.txt
@@ -1,4 +1,7 @@
-Test for bug 15437: XPath substring-after function is broken.
+Test for bug 15437 (http://bugs.webkit.org/show_bug.cgi?id=15437): XPath substring-after function is broken.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS document.evaluate("substring-after('abcde', 'd')", document, null, XPathResult.STRING_TYPE, null).stringValue is 'e'
 PASS document.evaluate("substring-after('abcde', 'f')", document, null, XPathResult.STRING_TYPE, null).stringValue is ''

--- a/LayoutTests/fast/xpath/substring-after.html
+++ b/LayoutTests/fast/xpath/substring-after.html
@@ -1,14 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<p>Test for <a href="http://bugs.webkit.org/show_bug.cgi?id=15437">bug 15437</a>:
-XPath substring-after function is broken.</p>
-<div id="console"></div>
 
 <script>
+    description("Test for bug 15437 (http://bugs.webkit.org/show_bug.cgi?id=15437): XPath substring-after function is broken.");
     shouldBe("document.evaluate(\"substring-after('abcde', 'd')\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'e'");
     shouldBe("document.evaluate(\"substring-after('abcde', 'f')\", document, null, XPathResult.STRING_TYPE, null).stringValue", "''");
     shouldBe("document.evaluate(\"substring-after('abcde', '')\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'abcde'");
@@ -16,6 +14,5 @@ XPath substring-after function is broken.</p>
     shouldBe("document.evaluate(\"substring-after('1999/04/01', '19')\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'99/04/01'");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/substring-nan-position-expected.txt
+++ b/LayoutTests/fast/xpath/substring-nan-position-expected.txt
@@ -1,4 +1,7 @@
-Test for bug 41862: XPath substring function is broken when passing NaN as the position parameter.
+Test for bug 41862 (http://bugs.webkit.org/show_bug.cgi?id=41862): XPath substring function is broken when passing NaN as the position parameter.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS document.evaluate("substring('12345', number('NaN'))", document, null, XPathResult.STRING_TYPE, null).stringValue is ''
 PASS document.evaluate("substring('12345', number('NaN'), 3)", document, null, XPathResult.STRING_TYPE, null).stringValue is ''

--- a/LayoutTests/fast/xpath/substring-nan-position.html
+++ b/LayoutTests/fast/xpath/substring-nan-position.html
@@ -1,14 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<p>Test for <a href="http://bugs.webkit.org/show_bug.cgi?id=41862">bug 41862</a>:
-XPath substring function is broken when passing NaN as the position parameter.</p>
-<div id="console"></div>
 
 <script>
+    description("Test for bug 41862 (http://bugs.webkit.org/show_bug.cgi?id=41862): XPath substring function is broken when passing NaN as the position parameter.");
     shouldBe("document.evaluate(\"substring('12345', number(\'NaN\'))\", document, null, XPathResult.STRING_TYPE, null).stringValue", "''");
     shouldBe("document.evaluate(\"substring('12345', number(\'NaN\'), 3)\", document, null, XPathResult.STRING_TYPE, null).stringValue", "''");
 
@@ -18,6 +16,5 @@ XPath substring function is broken when passing NaN as the position parameter.</
     shouldBe("document.evaluate(\"substring('12345', number(\'NaN\'), number(\'NaN\'))\", document, null, XPathResult.STRING_TYPE, null).stringValue", "''");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/substring-non-positive-postion-expected.txt
+++ b/LayoutTests/fast/xpath/substring-non-positive-postion-expected.txt
@@ -1,4 +1,7 @@
-Test for bug 41913: XPath substring function does not correctly handle non-positive values for the position argument
+Test for bug 41913 (http://bugs.webkit.org/show_bug.cgi?id=41913): XPath substring function does not correctly handle non-positive values for the position argument.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS document.evaluate("substring('abcde', 0)", document, null, XPathResult.STRING_TYPE, null).stringValue is 'abcde'
 PASS document.evaluate("substring('abcde', -2)", document, null, XPathResult.STRING_TYPE, null).stringValue is 'abcde'

--- a/LayoutTests/fast/xpath/substring-non-positive-postion.html
+++ b/LayoutTests/fast/xpath/substring-non-positive-postion.html
@@ -1,20 +1,19 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<p>Test for <a href="http://bugs.webkit.org/show_bug.cgi?id=41913">bug 41913</a>:
-XPath substring function does not correctly handle non-positive values for the position argument</p>
-<div id="console"></div>
+<p>
+</p>
 
 <script>
+    description("Test for bug 41913 (http://bugs.webkit.org/show_bug.cgi?id=41913): XPath substring function does not correctly handle non-positive values for the position argument.");
     shouldBe("document.evaluate(\"substring('abcde', 0)\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'abcde'");
     shouldBe("document.evaluate(\"substring('abcde', -2)\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'abcde'");
     shouldBe("document.evaluate(\"substring('abcde', 0, 5)\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'abcd'");
     shouldBe("document.evaluate(\"substring('abcde', -2, 5)\", document, null, XPathResult.STRING_TYPE, null).stringValue", "'ab'");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash-expected.txt
+++ b/LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash-expected.txt
@@ -1,6 +1,12 @@
 Ensure that using XPath namespace resolver with a detached iframe doesn't crash.
 
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 PASS Did not crash.
 PASS dummyResolverCalled is true
 PASS foundNode.toString() is "[object HTMLDivElement]"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash.html
+++ b/LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash.html
@@ -1,7 +1,8 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script>
+    description("Ensure that using XPath namespace resolver with a detached iframe doesn't crash.");
     if (window.testRunner) {
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
@@ -34,7 +35,5 @@
 </script>
 </head>
 <body onload="test()">
-<p>Ensure that using XPath namespace resolver with a detached iframe doesn't crash.</p>
-<div id="console"></div>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/xpath-detached-import-assert-expected.txt
+++ b/LayoutTests/fast/xpath/xpath-detached-import-assert-expected.txt
@@ -1,6 +1,7 @@
-A test case from https://bugs.webkit.org/show_bug.cgi?id=84793.
+A test case from https://bugs.webkit.org/show_bug.cgi?id=84793. Test passes if it doesn't hit ASSERT(parents.size() >= depth + 1).
 
-Test passes if it doesn't hit ASSERT(parents.size() >= depth + 1).
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS result.numberValue is NaN
 PASS successfullyParsed is true

--- a/LayoutTests/fast/xpath/xpath-detached-import-assert.html
+++ b/LayoutTests/fast/xpath/xpath-detached-import-assert.html
@@ -1,15 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <svg id="svg"></svg>
-<p>A test case from https://bugs.webkit.org/show_bug.cgi?id=84793.
-<p>Test passes if it doesn't hit ASSERT(parents.size() &gt;= depth + 1).
-<div id="console"></div>
 
 <script>
+  description("A test case from https://bugs.webkit.org/show_bug.cgi?id=84793. Test passes if it doesn't hit ASSERT(parents.size() &gt;= depth + 1).");
   resolver = function (prefix) {
     var ns = {
       "svg"    : "http://www.w3.org/2000/svg",
@@ -21,6 +19,5 @@
   var result= document.evaluate("/node()/descendant-or-self::svg:* | node()/ancestor-or-self::node()", document.getElementById("svg").ownerDocument.importNode(document.documentElement), resolver, XPathResult.NUMBER_TYPE, result);
   shouldBe("result.numberValue", "NaN");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/xpath-detached-nodes-expected.txt
+++ b/LayoutTests/fast/xpath/xpath-detached-nodes-expected.txt
@@ -1,5 +1,7 @@
-This tests XPath expressions on detached document fragments and nodes.
-See https://bugs.webkit.org/show_bug.cgi?id=36427
+This tests XPath expressions on detached document fragments and nodes. See https://bugs.webkit.org/show_bug.cgi?id=36427
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
 
 PASS document.evaluate('count(/div)', child, null, XPathResult.NUMBER_TYPE, null).numberValue is 1
 PASS document.evaluate('count(/html)', child, null, XPathResult.NUMBER_TYPE, null).numberValue is 0
@@ -17,4 +19,5 @@ PASS document.evaluate('/* | *', ele, null, XPathResult.NUMBER_TYPE, null).numbe
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+This tests XPath expressions on detached document fragments and nodes.
+See https://bugs.webkit.org/show_bug.cgi?id=36427

--- a/LayoutTests/fast/xpath/xpath-detached-nodes.html
+++ b/LayoutTests/fast/xpath/xpath-detached-nodes.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p>This tests XPath expressions on detached document fragments and nodes.
 <br/>See https://bugs.webkit.org/show_bug.cgi?id=36427
-<div id="console"></div>
+
 
 <script>
+  description("This tests XPath expressions on detached document fragments and nodes. See https://bugs.webkit.org/show_bug.cgi?id=36427");
+
   frag = document.createDocumentFragment();
   child = document.createElement('div');
   frag.appendChild(child);
@@ -43,6 +45,5 @@
   shouldBe("document.evaluate('/* | *', ele, null, XPathResult.NUMBER_TYPE, null).numberValue",
            "NaN");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/xpath-namespaces-expected.txt
+++ b/LayoutTests/fast/xpath/xpath-namespaces-expected.txt
@@ -1,5 +1,8 @@
 This tests that XPath expressions with prefixes work correctly.
 
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
 PASS /ns:foo
 PASS /ns:*
 PASS /foo:*

--- a/LayoutTests/fast/xpath/xpath-namespaces.html
+++ b/LayoutTests/fast/xpath/xpath-namespaces.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="xpath-test-pre.js"></script>
 </head>
 <body>
-<p>This tests that XPath expressions with prefixes work correctly.</p>
-<div id="console"></div>
+<p></p>
 <script>
+    description("This tests that XPath expressions with prefixes work correctly.");
     var xmlString = '<ns:foo xmlns:ns="http://www.example.org" xmlns:foo="urn:foobar"/>';
 
     var doc = (new DOMParser()).parseFromString(xmlString, "text/xml");
@@ -38,6 +38,5 @@
     checkSnapshot("/xmpl:*", result, [doc.documentElement]);
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/xpath/xpath-non-ASCII-case-folding.html
+++ b/LayoutTests/fast/xpath/xpath-non-ASCII-case-folding.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <body>
 <div id="test">
     <p id="English">This paragraph is marked as being in English.</p>
@@ -23,4 +23,3 @@
 
     document.body.removeChild(document.getElementById("test"));
 </script>
-<script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/xpath/xpath-template-element-expected.txt
+++ b/LayoutTests/fast/xpath/xpath-template-element-expected.txt
@@ -1,8 +1,7 @@
-This tests that XPath expressions do not consider (traverse into) template content
-
-A B
 PASS document.evaluate('count(//span)', test, null, XPathResult.NUMBER_TYPE, null).numberValue is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE
+This tests that XPath expressions do not consider (traverse into) template content
 
+A B

--- a/LayoutTests/fast/xpath/xpath-template-element.html
+++ b/LayoutTests/fast/xpath/xpath-template-element.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p>This tests that XPath expressions do not consider (traverse into) template content</p>
@@ -15,12 +15,10 @@
     </template>
 </div>
 
-<div id="console"></div>
 <script>
 var test = document.getElementById('test');
 var result = document.evaluate('count(//span)', test, null, XPathResult.NUMBER_TYPE, null);
 shouldBe("document.evaluate('count(//span)', test, null, XPathResult.NUMBER_TYPE, null).numberValue", "2");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### 8e00808b647919e9d256ff425f6fdd47085a6e6e
<pre>
[xpath] Modernize /fast/xpath tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=289648">https://bugs.webkit.org/show_bug.cgi?id=289648</a>
<a href="https://rdar.apple.com/146892392">rdar://146892392</a>

Reviewed by Tim Nguyen.

Modernize the tests in `fast/xpath` to use `test-js.js` and drop the
console element.

* LayoutTests/fast/xpath/4XPath/Borrowed/cz_20030217.html:
* LayoutTests/fast/xpath/4XPath/Borrowed/kd_20010423.html:
* LayoutTests/fast/xpath/4XPath/Borrowed/od_20000608.html:
* LayoutTests/fast/xpath/4XPath/Borrowed/rs_20010831.html:
* LayoutTests/fast/xpath/4XPath/Borrowed/sr_20021217.html:
* LayoutTests/fast/xpath/4XPath/Core/test_boolean_expr.html:
* LayoutTests/fast/xpath/4XPath/Core/test_core_functions-expected.txt:
* LayoutTests/fast/xpath/4XPath/Core/test_core_functions.html:
* LayoutTests/fast/xpath/4XPath/Core/test_literal_expr.html:
* LayoutTests/fast/xpath/4XPath/Core/test_location_path.html:
* LayoutTests/fast/xpath/4XPath/Core/test_node_test.html:
* LayoutTests/fast/xpath/4XPath/Core/test_nodeset_expr.html:
* LayoutTests/fast/xpath/4XPath/Core/test_numeric_expr.html:
* LayoutTests/fast/xpath/4XPath/Core/test_parser.html:
* LayoutTests/fast/xpath/4XPath/Core/test_predicate_list.html:
* LayoutTests/fast/xpath/4XPath/Core/test_step.html:
* LayoutTests/fast/xpath/ambiguous-operators-expected.txt:
* LayoutTests/fast/xpath/ambiguous-operators.html:
* LayoutTests/fast/xpath/attr-namespace.html:
* LayoutTests/fast/xpath/attribute-node-predicate.html:
* LayoutTests/fast/xpath/detached-subtree-invalidate-iterator.html:
* LayoutTests/fast/xpath/document-order.html:
* LayoutTests/fast/xpath/evaluate-twice.html:
* LayoutTests/fast/xpath/invalid-functions.html:
* LayoutTests/fast/xpath/node-name-case-sensitivity-expected.txt:
* LayoutTests/fast/xpath/node-name-case-sensitivity.html:
* LayoutTests/fast/xpath/null-namespace-in-html-expected.txt:
* LayoutTests/fast/xpath/null-namespace-in-html.html:
* LayoutTests/fast/xpath/position.html:
* LayoutTests/fast/xpath/py-dom-xpath/abbreviations.html:
* LayoutTests/fast/xpath/py-dom-xpath/data.html:
* LayoutTests/fast/xpath/py-dom-xpath/expressions.html:
* LayoutTests/fast/xpath/py-dom-xpath/functions-expected.txt:
* LayoutTests/fast/xpath/py-dom-xpath/functions.html:
* LayoutTests/fast/xpath/py-dom-xpath/nodetests.html:
* LayoutTests/fast/xpath/py-dom-xpath/paths.html:
* LayoutTests/fast/xpath/py-dom-xpath/predicates.html:
* LayoutTests/fast/xpath/reverse-axes.html:
* LayoutTests/fast/xpath/string-value.html:
* LayoutTests/fast/xpath/substring-after-expected.txt:
* LayoutTests/fast/xpath/substring-after.html:
* LayoutTests/fast/xpath/substring-nan-position-expected.txt:
* LayoutTests/fast/xpath/substring-nan-position.html:
* LayoutTests/fast/xpath/substring-non-positive-postion-expected.txt:
* LayoutTests/fast/xpath/substring-non-positive-postion.html:
* LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash-expected.txt:
* LayoutTests/fast/xpath/xpath-detached-iframe-resolver-crash.html:
* LayoutTests/fast/xpath/xpath-detached-import-assert-expected.txt:
* LayoutTests/fast/xpath/xpath-detached-import-assert.html:
* LayoutTests/fast/xpath/xpath-detached-nodes-expected.txt:
* LayoutTests/fast/xpath/xpath-detached-nodes.html:
* LayoutTests/fast/xpath/xpath-namespaces.html:
* LayoutTests/fast/xpath/xpath-non-ASCII-case-folding.html:
* LayoutTests/fast/xpath/xpath-template-element-expected.txt:
* LayoutTests/fast/xpath/xpath-template-element.html:

Canonical link: <a href="https://commits.webkit.org/292122@main">https://commits.webkit.org/292122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/507fcefafbcd92cfeccaccbef9458bdd4eeb7531

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45509 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29769 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3518 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44848 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22053 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2829 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22026 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->