### PR TITLE
Address Safer cpp failures in CSSAnimation

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -71,11 +71,11 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     // simultaneously-applied timeline specified in animation-timeline.
     syncStyleOriginatedTimeline();
 
-    auto& animation = backingAnimation();
-    auto* animationEffect = effect();
+    Ref animation = backingAnimation();
+    RefPtr animationEffect = effect();
 
     if (!m_overriddenProperties.contains(Property::FillMode)) {
-        switch (animation.fillMode()) {
+        switch (animation->fillMode()) {
         case AnimationFillMode::None:
             animationEffect->setFill(FillMode::None);
             break;
@@ -92,7 +92,7 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     }
 
     if (!m_overriddenProperties.contains(Property::Direction)) {
-        switch (animation.direction()) {
+        switch (animation->direction()) {
         case Animation::Direction::Normal:
             animationEffect->setDirection(PlaybackDirection::Normal);
             break;
@@ -109,35 +109,35 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     }
 
     if (!m_overriddenProperties.contains(Property::IterationCount)) {
-        auto iterationCount = animation.iterationCount();
+        auto iterationCount = animation->iterationCount();
         animationEffect->setIterations(iterationCount == Animation::IterationCountInfinite ? std::numeric_limits<double>::infinity() : iterationCount);
     }
 
     if (!m_overriddenProperties.contains(Property::Delay))
-        animationEffect->setDelay(Seconds(animation.delay()));
+        animationEffect->setDelay(Seconds(animation->delay()));
 
     if (!m_overriddenProperties.contains(Property::Duration)) {
-        if (auto duration = animation.duration())
+        if (auto duration = animation->duration())
             animationEffect->setIterationDuration(Seconds(*duration));
         else
             animationEffect->setIterationDuration(std::nullopt);
     }
 
     if (!m_overriddenProperties.contains(Property::CompositeOperation)) {
-        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animationEffect))
-            keyframeEffect->setComposite(animation.compositeOperation());
+        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animationEffect.get()))
+            keyframeEffect->setComposite(animation->compositeOperation());
     }
 
     if (!m_overriddenProperties.contains(Property::RangeStart))
-        setRangeStart(animation.range().start);
+        setRangeStart(animation->range().start);
     if (!m_overriddenProperties.contains(Property::RangeEnd))
-        setRangeEnd(animation.range().end);
+        setRangeEnd(animation->range().end);
 
     effectTimingDidChange();
 
     // Synchronize the play state
     if (!m_overriddenProperties.contains(Property::PlayState)) {
-        auto styleOriginatedPlayState = animation.playState();
+        auto styleOriginatedPlayState = animation->playState();
         if (m_lastStyleOriginatedPlayState != styleOriginatedPlayState) {
             if (styleOriginatedPlayState == AnimationPlayState::Playing && playState() == WebAnimation::PlayState::Paused)
                 play();
@@ -248,9 +248,9 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
     // animation. Similarly, any change to matching @keyframes rules will not be reflected in that animation. However, if the last
     // matching @keyframes rule is removed the animation must still be canceled.
 
-    auto* previousEffect = effect();
+    RefPtr previousEffect = effect();
     StyleOriginatedAnimation::setBindingsEffect(WTFMove(newEffect));
-    if (effect() != previousEffect) {
+    if (effect() != previousEffect.get()) {
         m_overriddenProperties.add(Property::Duration);
         m_overriddenProperties.add(Property::TimingFunction);
         m_overriddenProperties.add(Property::IterationCount);
@@ -347,7 +347,7 @@ void CSSAnimation::keyframesRuleDidChange()
     if (m_overriddenProperties.contains(Property::Keyframes))
         return;
 
-    auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
+    RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
     if (!keyframeEffect)
         return;
 


### PR DESCRIPTION
#### 453df0734b9d31eaeabc898ef0b26bbe3baba327
<pre>
Address Safer cpp failures in CSSAnimation
<a href="https://bugs.webkit.org/show_bug.cgi?id=289652">https://bugs.webkit.org/show_bug.cgi?id=289652</a>
<a href="https://rdar.apple.com/problem/146897089">rdar://problem/146897089</a>

Reviewed by Chris Dumez and Antoine Quint.

Fix a clang static analyzer warning in CSSAnimation.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::setBindingsEffect):
(WebCore::CSSAnimation::keyframesRuleDidChange):

Canonical link: <a href="https://commits.webkit.org/292083@main">https://commits.webkit.org/292083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13947f9e21534d4be64d55df73880b27471c3bc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44665 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101895 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81335 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80718 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2685 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15097 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26961 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->