### PR TITLE
[HDR] Enable HDR display for CSS images

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2507,10 +2507,14 @@ fast/images/animated-jpegxl-loop-count.html [ Skip ]
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Skip ]
 compositing/hdr/hdr-basic-image.html [ Skip ]
-compositing/hdr/hdr-css-image.html [ Skip ]
+compositing/hdr/hdr-background-image.html [ Skip ]
+compositing/hdr/hdr-border-image.html [ Skip ]
+compositing/hdr/hdr-pseudo-before-image.html [ Skip ]
 compositing/hdr/hdr-svg-inline-image.html [ Skip ]
 fast/images/hdr-basic-image.html [ Skip ]
-fast/images/hdr-css-image.html [ Skip ]
+fast/images/hdr-background-image.html [ Skip ]
+fast/images/hdr-border-image.html [ Skip ]
+fast/images/hdr-pseudo-before-image.html [ Skip ]
 fast/images/hdr-svg-inline-image.html [ Skip ]
 
 # Experimental H265 support.

--- a/LayoutTests/compositing/hdr/hdr-background-image-expected.txt
+++ b/LayoutTests/compositing/hdr/hdr-background-image-expected.txt
@@ -5,18 +5,17 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 2
+      (children 3
         (GraphicsLayer
           (position 10.00 10.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 204.00)
+              (bounds 200.00 200.00)
               (children 1
                 (GraphicsLayer
                   (bounds 200.00 200.00)
                   (drawsContent 1)
-                  (drawsHDRContent 1)
                 )
               )
             )
@@ -38,9 +37,25 @@
             )
           )
         )
+        (GraphicsLayer
+          (position 430.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
       )
     )
   )
 )
-
+ 
 

--- a/LayoutTests/compositing/hdr/hdr-background-image.html
+++ b/LayoutTests/compositing/hdr/hdr-background-image.html
@@ -6,25 +6,27 @@
         height: 200px;
         will-change: transform;
     }
-    .element {
-        width: 100px;
-        height: 100px;
+    .sdr {
+        background-image: url('../../fast/images/resources/green-400x400.png');
+    }
+    .hdr {
+        background-image: url('../../fast/images/resources/red-100x100.png');
+    }
+    .hdr-sdr {
+        background-image: url('../../fast/images/resources/red-100x100.png'), url('../../fast/images/resources/green-400x400.png');
+        background-repeat: no-repeat;
     }
 </style>
 <body>
     <pre id="layers">Layer tree goes here in DRT</pre>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <img class="container">
+        <div class="container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container">
-            <img class="element">
-        </div>
+        <div class="container"></div>
     </div>
-    <div style="position: fixed; top: 10px; left: 440px;">
-        <div class="container">
-            <img class="element">
-        </div>
+    <div style="position: fixed; top: 10px; left: 430px;">
+        <div class="container"></div>
     </div>
     <script>
         if (window.internals && window.testRunner) {
@@ -42,9 +44,6 @@
                 return new Promise((resolve) => {
                     let image = new Image;
                     image.onload = (e) => {
-                        if (window.internals)
-                            internals.setHasHDRContentForTesting(image);
-
                         resolve({ width: image.width, height: image.height });
                     };
                     image.src = imageSource;
@@ -56,16 +55,14 @@
         (async () => {
             await Promise.all(loadImages());
 
-            const imageElements = document.querySelectorAll("img");
-
-            imageElements[0].src = images[0].src;
-            imageElements[1].src = images[1].src;
-            imageElements[2].src = images[1].src;
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
 
             const containerElements = document.querySelectorAll("div.container");
 
-            containerElements[0].style.backgroundImage = 'url(' + images[0].src + ')';
-            containerElements[1].style.borderImage = 'url(' + images[0].src + ') 30 fill';
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
+            containerElements[2].classList.add("hdr-sdr");
 
             if (window.testRunner) {
                 document.getElementById("layers").textContent = internals.layerTreeAsText(document);

--- a/LayoutTests/compositing/hdr/hdr-border-image-expected.txt
+++ b/LayoutTests/compositing/hdr/hdr-border-image-expected.txt
@@ -5,18 +5,17 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 2
         (GraphicsLayer
           (position 10.00 10.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 204.00)
+              (bounds 200.00 200.00)
               (children 1
                 (GraphicsLayer
                   (bounds 200.00 200.00)
                   (drawsContent 1)
-                  (drawsHDRContent 1)
                 )
               )
             )
@@ -31,23 +30,6 @@
               (children 1
                 (GraphicsLayer
                   (bounds 200.00 200.00)
-                  (drawsContent 1)
-                  (drawsHDRContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 440.00 10.00)
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 200.00 200.00)
-              (children 1
-                (GraphicsLayer
-                  (bounds 200.00 200.00)
-                  (drawsContent 1)
                   (drawsHDRContent 1)
                 )
               )
@@ -58,6 +40,5 @@
     )
   )
 )
-
-
+ 
 

--- a/LayoutTests/compositing/hdr/hdr-border-image.html
+++ b/LayoutTests/compositing/hdr/hdr-border-image.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .sdr {
+        border-image: url('../../fast/images/resources/green-400x400.png') 30 fill;
+    }
+    .hdr {
+        border-image: url('../../fast/images/resources/red-100x100.png') 30 fill;
+    }
+</style>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container"></div></div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["../../fast/images/resources/green-400x400.png", "../../fast/images/resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/compositing/hdr/hdr-pseudo-before-image.html
+++ b/LayoutTests/compositing/hdr/hdr-pseudo-before-image.html
@@ -1,49 +1,50 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-120000" />
 <style>
     .container {
         width: 200px;
         height: 200px;
         will-change: transform;
     }
-    .element {
+    .sdr:before {
+        content: url('../../fast/images/resources/green-400x400.png');
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        overflow: hidden;
+    }
+    .hdr {
+        content: url('../../fast/images/resources/red-100x100.png');
         width: 100px;
         height: 100px;
+        display: inline-block;
+        overflow: hidden;
     }
 </style>
 <body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <img class="container">
+        <div class="container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container">
-            <img class="element">
-        </div>
-    </div>
-    <div style="position: fixed; top: 10px; left: 440px;">
-        <div class="container">
-            <img class="element">
-        </div>
+        <div class="container"></div></div>
     </div>
     <script>
         if (window.internals && window.testRunner) {
             internals.clearMemoryCache();
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
             testRunner.waitUntilDone();
         }
 
         let images = [];
-        let imageSources = ["resources/green-400x400.png", "resources/red-100x100.png"];
+        let imageSources = ["../../fast/images/resources/green-400x400.png", "../../fast/images/resources/red-100x100.png"];
 
         function loadImages() {
             return imageSources.map((imageSource) => {
                 return new Promise((resolve) => {
                     let image = new Image;
                     image.onload = (e) => {
-                        if (window.internals)
-                            internals.setHasHDRContentForTesting(image);
-
                         resolve({ width: image.width, height: image.height });
                     };
                     image.src = imageSource;
@@ -55,19 +56,18 @@
         (async () => {
             await Promise.all(loadImages());
 
-            const imageElements = document.querySelectorAll("img");
-
-            imageElements[0].src = images[0].src;
-            imageElements[1].src = images[1].src;
-            imageElements[2].src = images[1].src;
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
 
             const containerElements = document.querySelectorAll("div.container");
 
-            containerElements[0].style.backgroundImage = 'url(' + images[0].src + ')';
-            containerElements[1].style.borderImage = 'url(' + images[0].src + ') 30 fill';
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
 
-            if (window.testRunner)
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
                 testRunner.notifyDone();
+            }
         })();
     </script>
 </body>

--- a/LayoutTests/fast/images/hdr-background-image-expected.html
+++ b/LayoutTests/fast/images/hdr-background-image-expected.html
@@ -13,16 +13,14 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="container" style="background-color: rgb(255 215 0);">
+        <div class="container" style="background-color: green;"></div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container" style="background-color: green;">
-            <div class="box" style="background-color: rgb(255 215 0);">
-        </div>
+        <div class="container" style="background-color: rgb(255 215 0);"></div>
     </div>
-    <div style="position: fixed; top: 10px; left: 440px;">
+    <div style="position: fixed; top: 10px; left: 430px;">
         <div class="container" style="background-color: green;">
-            <div class="box" style="background-color: rgb(255 215 0);">
+            <div class="box" style="background-color: rgb(255 215 0);"></div>
         </div>
     </div>
 </body>

--- a/LayoutTests/fast/images/hdr-background-image.html
+++ b/LayoutTests/fast/images/hdr-background-image.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-80000" />
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .sdr {
+        background-image: url('resources/green-400x400.png');
+    }
+    .hdr {
+        background-image: url('resources/red-100x100.png');
+    }
+    .hdr-sdr {
+        background-image: url('resources/red-100x100.png'), url('resources/green-400x400.png');
+        background-repeat: no-repeat;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 430px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["resources/green-400x400.png", "resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
+            containerElements[2].classList.add("hdr-sdr");
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
+<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-80000" />
 <style>
     .image-box {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-border-image-expected.html
+++ b/LayoutTests/fast/images/hdr-border-image-expected.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
 <style>
-    .image-box {
+    .container {
         width: 200px;
         height: 200px;
     }
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="image-box" style="background-color: rgb(255 215 0);"></div>
+        <div class="container" style="background-color: green;"></div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="image-box" style="background-color: rgb(255 215 0);"></div>
+        <div class="container" style="background-color: rgb(255 215 0);"></div>
     </div>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-border-image.html
+++ b/LayoutTests/fast/images/hdr-border-image.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .sdr {
+        border-image: url('resources/green-400x400.png') 30 fill;
+    }
+    .hdr {
+        border-image: url('resources/red-100x100.png') 30 fill;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["resources/green-400x400.png", "resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-pseudo-before-image-expected.html
+++ b/LayoutTests/fast/images/hdr-pseudo-before-image-expected.html
@@ -1,17 +1,21 @@
 <!DOCTYPE html>
 <html>
 <style>
-    .image-box {
+    .big-box {
         width: 200px;
         height: 200px;
+    }
+    .small-box {
+        width: 100px;
+        height: 100px;
     }
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="image-box" style="background-color: rgb(255 215 0);"></div>
+        <div class="big-box" style="background-color: green;"></div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="image-box" style="background-color: rgb(255 215 0);"></div>
+        <div class="small-box" style="background-color: rgb(255 215 0);"></div>
     </div>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-pseudo-before-image.html
+++ b/LayoutTests/fast/images/hdr-pseudo-before-image.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-80000" />
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .sdr:before {
+        content: url('resources/green-400x400.png');
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        overflow: hidden;
+    }
+    .hdr:before {
+        content: url('resources/red-100x100.png');
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        overflow: hidden;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container">&nbsp;</div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["resources/green-400x400.png", "resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            if (window.internals)
+                internals.setHasHDRContentForTesting(images[1]);
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].classList.add("sdr");
+            containerElements[1].classList.add("hdr");
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4518,10 +4518,14 @@ fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Pass ]
 compositing/hdr/hdr-basic-image.html [ Pass ]
-compositing/hdr/hdr-css-image.html [ Pass ]
+compositing/hdr/hdr-background-image.html [ Pass ]
+compositing/hdr/hdr-border-image.html [ Pass ]
+compositing/hdr/hdr-pseudo-before-image.html [ Pass ]
 compositing/hdr/hdr-svg-inline-image.html [ Pass ]
 fast/images/hdr-basic-image.html [ Pass ]
-fast/images/hdr-css-image.html [ Pass ]
+fast/images/hdr-background-image.html [ Pass ]
+fast/images/hdr-border-image.html [ Pass ]
+fast/images/hdr-pseudo-before-image.html [ Pass ]
 fast/images/hdr-svg-inline-image.html [ Pass ]
 
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt
@@ -32,6 +32,7 @@
                 (GraphicsLayer
                   (bounds 200.00 200.00)
                   (drawsContent 1)
+                  (drawsHDRContent 1)
                 )
               )
             )

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-pseudo-before-image-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-pseudo-before-image-expected.txt
@@ -11,12 +11,11 @@
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 204.00)
+              (bounds 200.00 200.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 200.00 200.00)
+                  (bounds 200.00 225.00)
                   (drawsContent 1)
-                  (drawsHDRContent 1)
                 )
               )
             )
@@ -27,10 +26,10 @@
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 200.00)
+              (bounds 100.00 105.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 200.00 200.00)
+                  (bounds 100.00 100.00)
                   (drawsContent 1)
                   (drawsHDRContent 1)
                 )
@@ -42,5 +41,5 @@
     )
   )
 )
-
+ 
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1495,10 +1495,14 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 # Only applicable on platforms with HDR support
 [ Sequoia+ ] compositing/hdr/hdr-basic-canvas.html [ Pass ]
 [ Sequoia+ ] compositing/hdr/hdr-basic-image.html [ Pass ]
-[ Sequoia+ ] compositing/hdr/hdr-css-image.html [ Pass ]
+[ Sequoia+ ] compositing/hdr/hdr-background-image.html [ Pass ]
+[ Sequoia+ ] compositing/hdr/hdr-border-image.html [ Pass ]
+[ Sequoia+ ] compositing/hdr/hdr-pseudo-before-image.html [ Pass ]
 [ Sequoia+ ] compositing/hdr/hdr-svg-inline-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-basic-image.html [ Pass ]
-[ Sequoia+ ] fast/images/hdr-css-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-background-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-border-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-pseudo-before-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-svg-inline-image.html [ Pass ]
 
 # The direct image codepath is not used with the remote layer tree.

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-pseudo-before-image-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-pseudo-before-image-expected.txt
@@ -5,18 +5,17 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 2
         (GraphicsLayer
           (position 10.00 10.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 205.00)
+              (bounds 200.00 200.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 200.00 200.00)
+                  (bounds 200.00 222.00)
                   (drawsContent 1)
-                  (drawsHDRContent 1)
                 )
               )
             )
@@ -27,26 +26,10 @@
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 200.00)
+              (bounds 100.00 104.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 200.00 200.00)
-                  (drawsContent 1)
-                  (drawsHDRContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 440.00 10.00)
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 200.00 200.00)
-              (children 1
-                (GraphicsLayer
-                  (bounds 200.00 200.00)
+                  (bounds 100.00 100.00)
                   (drawsContent 1)
                   (drawsHDRContent 1)
                 )
@@ -58,6 +41,5 @@
     )
   )
 )
-
-
+ 
 

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -143,7 +143,10 @@ void BitmapImage::drawPattern(GraphicsContext& context, const FloatRect& destina
     if (tileRect.isEmpty())
         return;
 
-    if (context.drawLuminanceMask())
+    auto headroom = options.headroom();
+    if (headroom == Headroom::FromImage && hasHDRContentForTesting())
+        fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
+    else if (context.drawLuminanceMask())
         drawLuminanceMaskPattern(context, destinationRect, tileRect, transform, phase, spacing, options);
     else
         Image::drawPattern(context, destinationRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -485,9 +485,6 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
             context.setDrawLuminanceMask(bgLayer.maskMode() == MaskMode::Luminance);
 
-            // FIXME: <http://webkit.org/b/288163> Allow HDR display for background images when CSS HDR images are able to set GraphicsLayer::drawHDRContent.
-            auto headroom = Headroom::None;
-
             ImagePaintingOptions options = {
                 op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,
                 bgLayer.blendMode(),
@@ -495,8 +492,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
                 ImageOrientation::Orientation::FromImage,
                 m_renderer.chooseInterpolationQuality(context, *image, &bgLayer, geometry.tileSize),
                 document().settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
-                document().settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No,
-                headroom
+                document().settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
             };
 
             auto drawResult = context.drawTiledImage(*image, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -431,15 +431,8 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
         contentChanged(ContentChangeType::Image);
     }
 
-    if (RefPtr image = dynamicDowncast<HTMLImageElement>(element())) {
+    if (RefPtr image = dynamicDowncast<HTMLImageElement>(element()))
         page().didFinishLoadingImageForElement(*image);
-#if HAVE(SUPPORT_HDR_DISPLAY)
-        if (!document().hasHDRContent()) {
-            if (cachedImage() && cachedImage()->hasHDRContent())
-                document().setHasHDRContent();
-        }
-#endif
-    }
 
     RenderReplaced::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5829,28 +5829,48 @@ static bool rendererHasHDRContent(const RenderElement& renderer)
             if (cachedImage->hasHDRContent())
                 return true;
         }
-        return false;
-    }
-
-    if (CheckedPtr imageRenderer = dynamicDowncast<LegacyRenderSVGImage>(renderer)) {
+    } else if (CheckedPtr imageRenderer = dynamicDowncast<LegacyRenderSVGImage>(renderer)) {
         if (auto* cachedImage = imageRenderer->imageResource().cachedImage()) {
             if (cachedImage->hasHDRContent())
                 return true;
         }
-        return false;
-    }
-
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (CheckedPtr canavsRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
+    } else if (CheckedPtr canavsRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
         if (auto* renderingContext = canavsRenderer->canvasElement().renderingContext()) {
             if (renderingContext->isHDR())
                 return true;
         }
-        return false;
-    }
 #endif
+    }
 
-    return false;
+    auto styleHasHDRContent = [](const auto* style) {
+        if (!style)
+            return false;
+
+        if (style->hasBackgroundImage()) {
+            if (style->backgroundLayers().hasHDRContent())
+                return true;
+        }
+
+        if (style->hasBorderImage()) {
+            auto image = style->borderImage().image();
+            if (auto* cachedImage = image ? image->cachedImage() : nullptr) {
+                if (cachedImage->hasHDRContent())
+                    return true;
+            }
+        }
+
+        if (auto image = style->listStyleImage()) {
+            if (auto* cachedImage = image->cachedImage()) {
+                if (cachedImage->hasHDRContent())
+                    return true;
+            }
+        }
+
+        return false;
+    };
+
+    return styleHasHDRContent(&renderer.style());
 }
 #endif
 

--- a/Source/WebCore/rendering/style/FillLayer.cpp
+++ b/Source/WebCore/rendering/style/FillLayer.cpp
@@ -396,6 +396,18 @@ bool FillLayer::hasImageWithAttachment(FillAttachment attachment) const
     return false;
 }
 
+bool FillLayer::hasHDRContent() const
+{
+    for (auto* layer = this; layer; layer = layer->m_next.get()) {
+        auto image = layer->image();
+        if (auto* cachedImage = image ? image->cachedImage() : nullptr) {
+            if (cachedImage->hasHDRContent())
+                return true;
+        }
+    }
+    return false;
+}
+
 TextStream& operator<<(TextStream& ts, FillSize fillSize)
 {
     return ts << fillSize.type << ' ' << fillSize.size;

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -158,6 +158,7 @@ public:
     bool hasOpaqueImage(const RenderElement&) const;
     bool hasRepeatXY() const;
     bool clipOccludesNextLayers(bool firstLayer) const;
+    bool hasHDRContent() const;
 
     FillLayerType type() const { return static_cast<FillLayerType>(m_type); }
 

--- a/Source/WebCore/rendering/style/NinePieceImage.cpp
+++ b/Source/WebCore/rendering/style/NinePieceImage.cpp
@@ -218,9 +218,6 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
     if (!image)
         return;
 
-    // FIXME: <http://webkit.org/b/288163> Allow HDR display for background images when CSS HDR images are able to set GraphicsLayer::drawHDRContent.
-    auto headroom = Headroom::None;
-
     InterpolationQualityMaintainer interpolationMaintainer(graphicsContext, ImageQualityController::interpolationQualityFromStyle(style));
     for (ImagePiece piece = MinPiece; piece < MaxPiece; ++piece) {
         if ((piece == MiddlePiece && !fill()) || isEmptyPieceRect(piece, destinationRects, sourceRects))
@@ -233,7 +230,7 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
 
         Image::TileRule hRule = isHorizontalPiece(piece) ? static_cast<Image::TileRule>(horizontalRule()) : Image::StretchTile;
         Image::TileRule vRule = isVerticalPiece(piece) ? static_cast<Image::TileRule>(verticalRule()) : Image::StretchTile;
-        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage, headroom });
+        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage });
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -71,16 +71,8 @@ void LegacyRenderSVGImage::notifyFinished(CachedResource& newImage, const Networ
     if (renderTreeBeingDestroyed())
         return;
 
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    if (!document().hasHDRContent()) {
-        CachedImage* cachedImage = imageResource().cachedImage();
-
-        if (cachedImage && cachedImage->hasHDRContent()) {
-            document().setHasHDRContent();
-            page().didFinishLoadingImageForSVGImage(imageElement());
-        }
-    }
-#endif
+    if (RefPtr image = dynamicDowncast<SVGImageElement>(LegacyRenderSVGModelObject::element()))
+        page().didFinishLoadingImageForSVGImage(*image);
 
     LegacyRenderSVGModelObject::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
 }


### PR DESCRIPTION
#### c680aebea33bf4560a419eb2c30798a85c0b56f6
<pre>
[HDR] Enable HDR display for CSS images
<a href="https://bugs.webkit.org/show_bug.cgi?id=289363">https://bugs.webkit.org/show_bug.cgi?id=289363</a>
<a href="https://rdar.apple.com/146509866">rdar://146509866</a>

Reviewed by Simon Fraser.

The CSS images needs to be checked to decide whether rendererHasHDRContent()
returns true. Headroom::FromImage will be passed in the ImagePaintingOptions
when drawing the HDR CSS images.

RenderElement::imageContentChanged() will setHasHDRContent() on Document. It
will also mark contentChanged(Image) on its enclosingCompsitedLayer().

* LayoutTests/TestExpectations:
* LayoutTests/compositing/hdr/hdr-background-image-expected.txt: Renamed from LayoutTests/platform/ios/compositing/hdr/hdr-css-image-expected.txt.
* LayoutTests/compositing/hdr/hdr-background-image.html: Copied from LayoutTests/compositing/hdr/hdr-css-image.html.
* LayoutTests/compositing/hdr/hdr-border-image-expected.txt: Renamed from LayoutTests/platform/mac-wk2/compositing/hdr/hdr-css-image-expected.txt.
* LayoutTests/compositing/hdr/hdr-border-image.html: Copied from LayoutTests/compositing/hdr/hdr-css-image.html.
* LayoutTests/compositing/hdr/hdr-pseudo-before-image.html: Renamed from LayoutTests/compositing/hdr/hdr-css-image.html.
* LayoutTests/fast/images/hdr-background-image-expected.html: Renamed from LayoutTests/fast/images/hdr-css-image-expected.html.
* LayoutTests/fast/images/hdr-background-image.html: Copied from LayoutTests/fast/images/hdr-css-image.html.
* LayoutTests/fast/images/hdr-basic-image-expected.html:
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-border-image-expected.html: Copied from LayoutTests/fast/images/hdr-basic-image-expected.html.
* LayoutTests/fast/images/hdr-border-image.html: Copied from LayoutTests/fast/images/hdr-css-image.html.
* LayoutTests/fast/images/hdr-pseudo-before-image-expected.html: Copied from LayoutTests/fast/images/hdr-basic-image-expected.html.
* LayoutTests/fast/images/hdr-pseudo-before-image.html: Renamed from LayoutTests/fast/images/hdr-css-image.html.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt:
* LayoutTests/platform/ios/compositing/hdr/hdr-pseudo-before-image-expected.txt: Copied from LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-pseudo-before-image-expected.txt: Copied from LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt.
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::drawPattern):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::notifyFinished):
(WebCore::RenderElement::imageContentChanged):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::notifyFinished):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/style/FillLayer.cpp:
(WebCore::FillLayer::hasHDRContent const):
* Source/WebCore/rendering/style/FillLayer.h:
* Source/WebCore/rendering/style/NinePieceImage.cpp:
(WebCore::NinePieceImage::paint const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::notifyFinished):

Canonical link: <a href="https://commits.webkit.org/292305@main">https://commits.webkit.org/292305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4105553260204777dde025b01e9c117050ca668e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72878 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22609 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16515 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81271 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15941 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22577 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->