### PR TITLE
Permissions API reports the state of the Geolocation permission as "prompt" in cases where it should report "denied"

### DIFF
--- a/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-expected.txt
+++ b/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-expected.txt
@@ -1,0 +1,12 @@
+This test checks that Permissions::query() returns the true permission state of the Geolocation API.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS permissionsQueryResult is "prompt"
+PASS permissionsQueryResult is "granted"
+PASS permissionsQueryResult is "denied"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting-expected.txt
+++ b/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting-expected.txt
@@ -1,0 +1,11 @@
+This test tests the fingerprinting countermeasures implemented for querying the Geolocation API with Permissions::query().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS permissionsQueryResult is "prompt"
+PASS permissionsQueryResult is "denied"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting.html
+++ b/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+
+description("This test tests the fingerprinting countermeasures implemented for querying the Geolocation API with Permissions::query().");
+
+window.jsTestIsAsync = true;
+
+function preRequestTest()
+{
+    // Set permission state to 'denied'.
+    testRunner.setGeolocationPermission(false);
+
+    navigator.permissions.query({ name: "geolocation" }).then((status)=>{
+        permissionsQueryResult = status.state;
+        shouldBeEqualToString("permissionsQueryResult", "prompt");
+
+        postRequestTest();
+    });
+}
+
+function postRequestTest()
+{
+    // Make a request to use the Geolocation API.
+    navigator.geolocation.getCurrentPosition(() => {});
+
+    navigator.permissions.query({ name: "geolocation" }).then((status)=>{
+        permissionsQueryResult = status.state;
+        shouldBeEqualToString("permissionsQueryResult", "denied");
+
+        finishJSTest();
+    });
+}
+
+preRequestTest();
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query.html
+++ b/LayoutTests/fast/dom/Geolocation/geolocation-permissions-query.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+
+description("This test checks that Permissions::query() returns the true permission state of the Geolocation API.");
+
+window.jsTestIsAsync = true;
+
+function defaultTest()
+{
+    // No permission state is set.
+    navigator.permissions.query({ name: "geolocation" }).then((status)=>{
+        permissionsQueryResult = status.state;
+        shouldBeEqualToString("permissionsQueryResult", "prompt");
+
+        grantTest();
+    });
+}
+
+function grantTest()
+{
+    // Set permission state to 'granted'.
+    testRunner.setGeolocationPermission(true);
+
+    // Make a request to use the Geolocation API.
+    navigator.geolocation.getCurrentPosition(() => {});
+
+    navigator.permissions.query({ name: "geolocation" }).then((status)=>{
+        permissionsQueryResult = status.state;
+        shouldBeEqualToString("permissionsQueryResult", "granted");
+
+        denyTest();
+    });
+
+}
+
+function denyTest()
+{
+    // Set permission state to 'denied'.
+    testRunner.setGeolocationPermission(false);
+
+    // Make a request to use the Geolocation API.
+    navigator.geolocation.getCurrentPosition(() => {});
+
+    navigator.permissions.query({ name: "geolocation" }).then((status)=>{
+        permissionsQueryResult = status.state;
+        shouldBeEqualToString("permissionsQueryResult", "denied");
+
+        finishJSTest();
+    });
+}
+
+defaultTest();
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2618,6 +2618,8 @@ imported/w3c/web-platform-tests/geolocation/disabled-by-permissions-policy.https
 imported/w3c/web-platform-tests/geolocation/enabled-by-permission-policy-attribute-redirect-on-load.https.sub.html [ Skip Slow ]
 imported/w3c/web-platform-tests/geolocation/enabled-by-permissions-policy.https.sub.html [ Skip Slow ]
 imported/w3c/web-platform-tests/geolocation/enabled-on-self-origin-by-permissions-policy.https.sub.html [ Skip Slow ]
+fast/dom/Geolocation/geolocation-permissions-query.html [ WontFix ]
+fast/dom/Geolocation/geolocation-permissions-query-fingerprinting.html [ WontFix ]
 
 # Per-process limit is only for WK2
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3441,6 +3441,13 @@ void WKPageClearNotificationPermissionState(WKPageRef pageRef)
 #endif
 }
 
+void WKPageClearGeolocationPermissionState(WKPageRef pageRef)
+{
+#if ENABLE(GEOLOCATION)
+    toImpl(pageRef)->clearGeolocationPermissionState();
+#endif
+}
+
 void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value)
 {
     toImpl(pageRef)->executeEditCommand(toImpl(command)->string(), toImpl(value)->string());

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -278,6 +278,7 @@ WK_EXPORT void WKPagePostMessageToInjectedBundle(WKPageRef page, WKStringRef mes
 WK_EXPORT void WKPageSelectContextMenuItem(WKPageRef page, WKContextMenuItemRef item, WKFrameInfoRef frameInfo);
 
 WK_EXPORT void WKPageClearNotificationPermissionState(WKPageRef page);
+WK_EXPORT void WKPageClearGeolocationPermissionState(WKPageRef page);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2493,6 +2493,10 @@ public:
     void clearNotificationPermissionState();
 #endif
 
+#if ENABLE(GEOLOCATION)
+    void clearGeolocationPermissionState();
+#endif
+
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void setInteractionRegionsEnabled(bool);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -401,6 +401,10 @@ public:
     HashSet<WebCore::SecurityOriginData> notificationPermissionRequesters;
 #endif
 
+#if ENABLE(GEOLOCATION)
+    HashSet<WebCore::SecurityOriginData> geolocationPermissionRequesters;
+#endif
+
     CompletionHandler<void(bool)> serviceWorkerLaunchCompletionHandler;
 
 #if ENABLE(SPEECH_SYNTHESIS)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1327,6 +1327,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_isGeolocationPermissionSet = false;
     m_isGeolocationPermissionAllowed = false;
     m_geolocationPermissionQueryOrigins.clear();
+    WKPageClearGeolocationPermissionState(m_mainWebView->page());
 
     // Reset Screen Wake Lock permission.
     m_screenWakeLockPermission = std::nullopt;


### PR DESCRIPTION
#### 09927ef5cfa09e3c306c4803737963ee995efd4c
<pre>
Permissions API reports the state of the Geolocation permission as &quot;prompt&quot; in cases where it should report &quot;denied&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=289664">https://bugs.webkit.org/show_bug.cgi?id=289664</a>
<a href="https://rdar.apple.com/146917202">rdar://146917202</a>

Reviewed by NOBODY (OOPS!).

Consider the following scenario:

1. The user has denied permission for a certain API to be used.
2. A site asks for the permission state of this API without ever having made a request
   for permission to use that API.

In this case, as a fingerprinting countermeasure, the Permissions API will reply that the
permission state is &quot;prompt&quot; rather than &quot;denied&quot;. We do this to reduce the amount of
fingerprinting information that sites may collect from APIs that they don&apos;t intend to use
for actual user-facing functionality.

If a site truly wants to use an API and needs to know the true permission state to do that,
it can request permission to use that API. WebKit will document that this request was made
and any subsequent requests from that site to query the permission state will be given a
truthful response.

We first did this when adding support to the Permissions API for the state of the Notifications
API back in <a href="https://commits.webkit.org/252969@main.">https://commits.webkit.org/252969@main.</a>

The default state is to turn all &quot;denied&quot; states into &quot;prompt&quot; unless we have a record of
an origin requesting permission to use the site. WebKit does not currently record these requests
for the Geolocation API, so it returns &quot;prompt&quot; in all cases where the true result is &quot;denied&quot;.

This patch adds support for making a note of which origins requested use of the Geolocation API so
that the true &quot;denied&quot; result is returned when appropriate.

* LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-expected.txt: Added.
* LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting-expected.txt: Added.
* LayoutTests/fast/dom/Geolocation/geolocation-permissions-query-fingerprinting.html: Added.
* LayoutTests/fast/dom/Geolocation/geolocation-permissions-query.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:

These layout tests verify the both the normal and fingerprinting-avoiding behavior.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageClearGeolocationPermissionState):
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::queryPermission):

The set of requesting origins is added to upon request and checked upon query.

(WebKit::WebPageProxy::clearGeolocationPermissionState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

The set of requesting origins is kept in WebPageProxyInternals.

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):

The set of requesting origns is reset between layout tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09927ef5cfa09e3c306c4803737963ee995efd4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29788 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85815 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52823 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102116 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81498 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27192 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->