### PR TITLE
Add implementation for loading source of ResourceMonitor URL list.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -172,6 +172,12 @@ typedef void (^WPRuleListPreparationCompletionHandler)(WKContentRuleList *, bool
 @interface WPResources (Staging_141646051)
 - (void)prepareResouceMonitorRulesForStore:(WKContentRuleListStore *)store completionHandler:(WPRuleListPreparationCompletionHandler)completionHandler;
 @end
+
+typedef void (^WPRuleListGetSourceCompletionHandler)(NSString *, NSError *);
+
+@interface WPResources (Staging_146076707)
+- (void)requestResouceMonitorRulesSource:(WPResourceRequestOptions *)options completionHandler:(WPRuleListGetSourceCompletionHandler)completion;
+@end
 #endif
 
 WTF_EXTERN_C_BEGIN

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -191,11 +191,14 @@ public:
     static ResourceMonitorURLsController& singleton();
 
     void prepare(CompletionHandler<void(WKContentRuleList *, bool)>&&);
+    void getSource(CompletionHandler<void(String&&)>&&);
 
 private:
     friend class NeverDestroyed<ResourceMonitorURLsController, MainThreadAccessTraits>;
     ResourceMonitorURLsController() = default;
 };
+
+#define HAVE_RESOURCE_MONITOR_URLS_GET_SOURCE 1
 
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 

--- a/Source/WebKit/UIProcess/AboutSchemeHandler.h
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.h
@@ -37,7 +37,7 @@ public:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         virtual ~OpaquePathHandler() = default;
-        virtual void loadContent(URL, CompletionHandler<void(WebCore::ResourceResponse&&, Ref<WebCore::SharedBuffer>&&)>) = 0;
+        virtual void loadContent(URL, CompletionHandler<void(WebCore::ResourceResponse&&, Ref<WebCore::SharedBuffer>&&)>&&) = 0;
     };
 
     static AboutSchemeHandler& singleton();


### PR DESCRIPTION
#### e45bde4747b5b715a2bba6f9e333d0fea538d499
<pre>
Add implementation for loading source of ResourceMonitor URL list.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289659">https://bugs.webkit.org/show_bug.cgi?id=289659</a>
<a href="https://rdar.apple.com/146904640">rdar://146904640</a>

Reviewed by Wenson Hsieh.

Add implementation for loading source of ResourceMonitor URL list in WebPrivacyHelper.
Also bug fix of interface of AboutSchemeHandler is included.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::getSource):
* Source/WebKit/UIProcess/AboutSchemeHandler.h:

Canonical link: <a href="https://commits.webkit.org/292110@main">https://commits.webkit.org/292110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d59693e5c1567a7dd934ee2db548c7461b01284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52794 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3506 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/44837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102074 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22042 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25414 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22015 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21672 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->