### PR TITLE
[iPhone] Adjusting video resolution on Wikipedia causes the video to go black

### DIFF
--- a/LayoutTests/media/video-preload-after-user-gesture-expected.txt
+++ b/LayoutTests/media/video-preload-after-user-gesture-expected.txt
@@ -1,0 +1,15 @@
+RUN(window.internals.settings.setRequiresUserGestureForVideoPlayback(true);)
+RUN(video = document.createElement("video"))
+RUN(window.internals.setMediaElementRestrictions(video, "autopreloadingnotpermitted");)
+RUN(video.preload="auto")
+RUN(video.src = findMediaFile("video", "content/test"))
+RUN(video.playsinline = "playsinline")
+RUN(document.body.appendChild(video))
+EVENT(loadedmetadata)
+RUN(video.play())
+EVENT(playing)
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(loadeddata)
+EXPECTED (video.readyState >= '2') OK
+END OF TEST
+

--- a/LayoutTests/media/video-preload-after-user-gesture.html
+++ b/LayoutTests/media/video-preload-after-user-gesture.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>video-preload-after-user-gesture</title>
+    <script src=media-file.js></script>
+    <script src=video-test.js></script>
+    <script>
+    async function runTest() {
+        run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
+        run('video = document.createElement("video")');
+        run('window.internals.setMediaElementRestrictions(video, "autopreloadingnotpermitted");');
+        run('video.preload="auto"');
+        run('video.src = findMediaFile("video", "content/test")');
+        run('video.playsinline = "playsinline"');
+        run('document.body.appendChild(video)');
+        await waitFor(video, 'loadedmetadata');
+        runWithKeyDown(() => {
+            run('video.play()');
+        });
+        await waitFor(video, 'playing');
+        run('video.src = findMediaFile("video", "content/test")');
+        await waitFor(video, 'loadeddata');
+        testExpected("video.readyState", 2, '>=');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8547,6 +8547,7 @@ void HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture(MediaElem
 {
     MediaElementSession::BehaviorRestrictions restrictionsToRemove = mask &
         (MediaElementSession::RequireUserGestureForLoad
+        | MediaElementSession::AutoPreloadingNotPermitted
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
         | MediaElementSession::RequireUserGestureToShowPlaybackTargetPicker
         | MediaElementSession::RequireUserGestureToAutoplayToExternalDevice


### PR DESCRIPTION
#### eabe0e789567841faec0d0de50d62014448ad315
<pre>
[iPhone] Adjusting video resolution on Wikipedia causes the video to go black
<a href="https://bugs.webkit.org/show_bug.cgi?id=289665">https://bugs.webkit.org/show_bug.cgi?id=289665</a>
<a href="https://rdar.apple.com/146443679">rdar://146443679</a>

Reviewed by Youenn Fablet.

On iPhone, an additional restriction exists that prevents the readyState to
move past `HAVE_METADATA`.
Wikipedia to change resolution simply set the mediaElement&apos;s `src` attribute
to another video, it never calls `play()` again expecting the video playback
to autonatically resume once the new video has been loaded, just like it
does on all other platforms.

For now remove `AutoPreloadingNotPermitted` restriction once a user has
interacted with the media element via a gesture.
In a follow-up change will remove this restriction altogether, while it
would have made sense when it was first introduced over 11 years ago,
today with MediaSource now available on iPhone and networks being what they are
it makes little sense to try to prevent loading past the metadata.

Test added to ensure that if a video has played following a user gesture
that if a new source is loaded we will reach readyState = HAVE_DATA.

* LayoutTests/media/video-preload-after-user-gesture-expected.txt: Added.
* LayoutTests/media/video-preload-after-user-gesture.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture):

Canonical link: <a href="https://commits.webkit.org/292087@main">https://commits.webkit.org/292087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29bf10793c2e1ede4ef91828185e0329276a74ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3395 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44722 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101951 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93511 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21924 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81375 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->