### PR TITLE
Address Safer CPP issues in CSSMediaRule.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -428,7 +428,6 @@ css/CSSImportRule.cpp
 css/CSSKeyframeRule.cpp
 css/CSSKeyframeRule.h
 css/CSSKeyframesRule.cpp
-css/CSSMediaRule.cpp
 css/CSSNestedDeclarations.cpp
 css/CSSOffsetRotateValue.cpp
 css/CSSOffsetRotateValue.h

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -57,6 +57,16 @@ CSSGroupingRule::~CSSGroupingRule()
     }
 }
 
+Ref<const StyleRuleGroup> CSSGroupingRule::protectedGroupRule() const
+{
+    return m_groupRule;
+}
+
+Ref<StyleRuleGroup> CSSGroupingRule::protectedGroupRule()
+{
+    return m_groupRule;
+}
+
 ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsigned index)
 {
     ASSERT(m_childRuleCSSOMWrappers.size() == m_groupRule->childRules().size());

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -45,6 +45,8 @@ protected:
     CSSGroupingRule(StyleRuleGroup&, CSSStyleSheet* parent);
     const StyleRuleGroup& groupRule() const { return m_groupRule; }
     StyleRuleGroup& groupRule() { return m_groupRule; }
+    Ref<const StyleRuleGroup> protectedGroupRule() const;
+    Ref<StyleRuleGroup> protectedGroupRule();
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
     void appendCSSTextWithReplacementURLsForItems(StringBuilder&, const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -38,8 +38,8 @@ CSSMediaRule::CSSMediaRule(StyleRuleMedia& mediaRule, CSSStyleSheet* parent)
 
 CSSMediaRule::~CSSMediaRule()
 {
-    if (m_mediaCSSOMWrapper)
-        m_mediaCSSOMWrapper->detachFromParent();
+    if (RefPtr mediaCSSOMWrapper = m_mediaCSSOMWrapper)
+        mediaCSSOMWrapper->detachFromParent();
 }
 
 const MQ::MediaQueryList& CSSMediaRule::mediaQueries() const
@@ -49,7 +49,7 @@ const MQ::MediaQueryList& CSSMediaRule::mediaQueries() const
 
 void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 {
-    downcast<StyleRuleMedia>(groupRule()).setMediaQueries(WTFMove(queries));
+    downcast<StyleRuleMedia>(protectedGroupRule())->setMediaQueries(WTFMove(queries));
 }
 
 String CSSMediaRule::cssText() const


### PR DESCRIPTION
#### 762dd6d6f6a0b983bfc468689946f714602b2484
<pre>
Address Safer CPP issues in CSSMediaRule.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=289670">https://bugs.webkit.org/show_bug.cgi?id=289670</a>
<a href="https://rdar.apple.com/146923070">rdar://146923070</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::protectedGroupRule const):
(WebCore::CSSGroupingRule::protectedGroupRule):
* Source/WebCore/css/CSSGroupingRule.h:
(WebCore::CSSGroupingRule::protectedGroupRule const):
(WebCore::CSSGroupingRule::protectedGroupRule):
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::~CSSMediaRule):
(WebCore::CSSMediaRule::setMediaQueries):

Canonical link: <a href="https://commits.webkit.org/292126@main">https://commits.webkit.org/292126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73143f9fe8adfd996f69569cb90eece7e2db4c6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22988 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72450 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29745 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80833 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21986 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27108 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->