### PR TITLE
[visionOS] Allow clients to get notified when the now playing media session exits external playback.

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -110,8 +110,8 @@ public:
     WEBCORE_EXPORT void preparedToReturnToStandby();
     bool changingStandbyOnly() { return m_changingStandbyOnly; }
     WEBCORE_EXPORT void failedToRestoreFullscreen();
-    WEBCORE_EXPORT virtual void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)>&&);
-    WEBCORE_EXPORT virtual void exitExternalPlayback(CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT virtual void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)>&&, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT virtual void exitExternalPlayback();
 
     enum class ExitFullScreenReason {
         DoneButtonTapped,

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -389,14 +389,14 @@ void VideoPresentationInterfaceIOS::externalPlaybackChanged(bool enabled, Playba
     [playerLayerView() setHidden:enabled];
 }
 
-void VideoPresentationInterfaceIOS::enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)>&& completionHandler)
+void VideoPresentationInterfaceIOS::enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)>&& enterHandler, CompletionHandler<void(bool)>&& exitHandler)
 {
-    completionHandler(false, nil);
+    enterHandler(false, nil);
+    exitHandler(false);
 }
 
-void VideoPresentationInterfaceIOS::exitExternalPlayback(CompletionHandler<void(bool)>&& completionHandler)
+void VideoPresentationInterfaceIOS::exitExternalPlayback()
 {
-    completionHandler(false);
 }
 
 void VideoPresentationInterfaceIOS::setInlineRect(const FloatRect& inlineRect, bool visible)

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -369,7 +369,7 @@ void PlaybackSessionInterfaceLMK::supportsLinearMediaPlayerChanged(bool supports
         // If the player is in external presentation (which uses LinearMediaPlayer) but the current
         // media engine does not support it, exit external presentation.
         if (RefPtr videoPresentationInterface = m_videoPresentationInterface.get())
-            videoPresentationInterface->exitExternalPlayback([](bool) { });
+            videoPresentationInterface->exitExternalPlayback();
         break;
     case WKSLinearMediaPresentationStateInline:
     case WKSLinearMediaPresentationStateExitingFullscreen:

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -65,8 +65,8 @@ private:
     void setupPlayerViewController() final;
     void invalidatePlayerViewController() final;
     UIViewController *playerViewController() const final;
-    void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)> &&) final;
-    void exitExternalPlayback(CompletionHandler<void(bool)>&&) final;
+    void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)> &&, CompletionHandler<void(bool)>&&) final;
+    void exitExternalPlayback() final;
     void tryToStartPictureInPicture() final { }
     void stopPictureInPicture() final { }
     void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
@@ -93,6 +93,8 @@ private:
     String m_spatialTrackingLabel;
     RetainPtr<CALayer> m_spatialTrackingLayer;
 #endif
+
+    CompletionHandler<void(bool)> m_exitExternalPlaybackHandler;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -759,8 +759,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @interface WKWebView (WKPrivateVision)
 @property (copy, setter=_setDefaultSTSLabel:) NSString *_defaultSTSLabel;
 
-- (void)_enterExternalPlaybackForNowPlayingMediaSessionWithCompletionHandler:(void (^)(UIViewController *nowPlayingViewController, NSError *error))completionHandler WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-- (void)_exitExternalPlaybackWithCompletionHandler:(void (^)(NSError *error))completionHandler WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)_enterExternalPlaybackForNowPlayingMediaSessionWithEnterCompletionHandler:(void (^)(UIViewController *nowPlayingViewController, NSError *error))enterHandler exitCompletionHandler:(void (^)(NSError *error))exitHandler WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)_exitExternalPlayback WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 @end
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -634,36 +634,34 @@ void WebPageProxy::removeMediaUsageManagerSession(WebCore::MediaSessionIdentifie
 #endif
 
 #if PLATFORM(VISION)
-void WebPageProxy::enterExternalPlaybackForNowPlayingMediaSession(CompletionHandler<void(bool, UIViewController *)>&& completionHandler)
+void WebPageProxy::enterExternalPlaybackForNowPlayingMediaSession(CompletionHandler<void(bool, UIViewController *)>&& enterHandler, CompletionHandler<void(bool)>&& exitHandler)
 {
     if (!m_videoPresentationManager) {
-        completionHandler(false, nil);
+        enterHandler(false, nil);
+        exitHandler(false);
         return;
     }
 
     RefPtr videoPresentationInterface = m_videoPresentationManager->controlsManagerInterface();
     if (!videoPresentationInterface) {
-        completionHandler(false, nil);
+        enterHandler(false, nil);
+        exitHandler(false);
         return;
     }
 
-    videoPresentationInterface->enterExternalPlayback(WTFMove(completionHandler));
+    videoPresentationInterface->enterExternalPlayback(WTFMove(enterHandler), WTFMove(exitHandler));
 }
 
-void WebPageProxy::exitExternalPlayback(CompletionHandler<void(bool)>&& completionHandler)
+void WebPageProxy::exitExternalPlayback()
 {
-    if (!m_videoPresentationManager) {
-        completionHandler(false);
+    if (!m_videoPresentationManager)
         return;
-    }
 
     RefPtr videoPresentationInterface = m_videoPresentationManager->controlsManagerInterface();
-    if (!videoPresentationInterface) {
-        completionHandler(false);
+    if (!videoPresentationInterface)
         return;
-    }
 
-    videoPresentationInterface->exitExternalPlayback(WTFMove(completionHandler));
+    videoPresentationInterface->exitExternalPlayback();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2306,8 +2306,8 @@ public:
 #endif
 
 #if PLATFORM(VISION)
-    void enterExternalPlaybackForNowPlayingMediaSession(CompletionHandler<void(bool, UIViewController *)>&&);
-    void exitExternalPlayback(CompletionHandler<void(bool)>&&);
+    void enterExternalPlaybackForNowPlayingMediaSession(CompletionHandler<void(bool, UIViewController *)>&&, CompletionHandler<void(bool)>&&);
+    void exitExternalPlayback();
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)


### PR DESCRIPTION
#### 49ccab1f5091bb4c3bd2bc32dbfe6bf1bed0c132
<pre>
[visionOS] Allow clients to get notified when the now playing media session exits external playback.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289673">https://bugs.webkit.org/show_bug.cgi?id=289673</a>
<a href="https://rdar.apple.com/145495395">rdar://145495395</a>

Reviewed by Andy Estes.

Move the completion handler from exitExternalPlayback to enterExternalPlayback
and store it on the now playing interface (LMK) so that whether a client
requests to exit external playback, or WebKit does this as part of fullscreen
cleanup or media engine changes, the client has a way to react to such changes
in LMK&apos;s presentation state.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::enterExternalPlayback):
(WebCore::VideoPresentationInterfaceIOS::exitExternalPlayback):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::supportsLinearMediaPlayerChanged):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::enterExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::exitExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::cleanupExternalPlayback):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _enterExternalPlaybackForNowPlayingMediaSessionWithEnterCompletionHandler:exitCompletionHandler:]):
(-[WKWebView _exitExternalPlayback]):
(-[WKWebView _enterExternalPlaybackForNowPlayingMediaSessionWithCompletionHandler:]): Deleted.
(-[WKWebView _exitExternalPlaybackWithCompletionHandler:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::enterExternalPlaybackForNowPlayingMediaSession):
(WebKit::WebPageProxy::exitExternalPlayback):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/292118@main">https://commits.webkit.org/292118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fecb3980b34be877b56e823924e31ac11bbd3dab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100056 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98028 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52810 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3524 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/44865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102101 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22069 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80875 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25435 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22042 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21699 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->