### PR TITLE
PlatformDynamicRangeLimit now has static initial values

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1363,7 +1363,7 @@ private:
     WeakPtr<const MediaResourceLoader> m_lastMediaResourceLoaderForTesting;
 
     std::optional<DynamicRangeMode> m_overrideDynamicRangeMode;
-    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::constrainedHigh() };
+    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::initialValueForVideos() };
 
     friend class TrackDisplayUpdateScope;
 

--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.h
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.h
@@ -126,7 +126,7 @@ private:
 #endif
     ShowDebugBackground m_showDebugBackground : 1 { ShowDebugBackground::No };
     Headroom m_headroom { Headroom::FromImage };
-    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::noLimit() };
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
 };
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, ImagePaintingOptions);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -845,7 +845,7 @@ private:
     bool m_shouldPrepareToRender { false };
     bool m_initializingMediaEngine { false };
     DynamicRangeMode m_preferredDynamicRangeMode;
-    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::constrainedHigh() };
+    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::initialValueForVideos() };
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
     RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
 

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -40,11 +40,12 @@ struct DynamicRangeLimit;
 
 class PlatformDynamicRangeLimit {
 public:
-    constexpr PlatformDynamicRangeLimit() = default;
-
     static constexpr PlatformDynamicRangeLimit standard() { return PlatformDynamicRangeLimit(standardValue); }
     static constexpr PlatformDynamicRangeLimit constrainedHigh() { return PlatformDynamicRangeLimit(constrainedHighValue); }
     static constexpr PlatformDynamicRangeLimit noLimit() { return PlatformDynamicRangeLimit(noLimitValue); }
+
+    static constexpr PlatformDynamicRangeLimit initialValue() { return constrainedHigh(); }
+    static constexpr PlatformDynamicRangeLimit initialValueForVideos() { return noLimit(); }
 
     static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return standard(); }
     static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDRInVideos() { return constrainedHigh(); }

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -27,6 +27,7 @@
 
 #include <WebCore/PlatformDynamicRangeLimit.h>
 
+#include <WebCore/RenderStyleInlines.h>
 #include <WebCore/StyleDynamicRangeLimit.h>
 
 namespace TestWebKitAPI {
@@ -36,12 +37,16 @@ static_assert(WebCore::PlatformDynamicRangeLimit::standard().value() == 0.0f);
 static_assert(WebCore::PlatformDynamicRangeLimit::constrainedHigh().value() == 0.5f);
 static_assert(WebCore::PlatformDynamicRangeLimit::noLimit().value() == 1.0f);
 
-TEST(PlatformDynamicRangeLimit, DefaultConstruction)
+TEST(PlatformDynamicRangeLimit, Values)
 {
-    auto def = WebCore::PlatformDynamicRangeLimit();
-    EXPECT_EQ(def.value(), 0.5f);
+    static_assert(!std::is_default_constructible_v<WebCore::PlatformDynamicRangeLimit>);
+    static_assert(!std::is_constructible_v<WebCore::PlatformDynamicRangeLimit, float>);
 
-    static_assert(WebCore::PlatformDynamicRangeLimit().value() == 0.5);
+    static_assert(WebCore::PlatformDynamicRangeLimit::initialValue().value() == WebCore::PlatformDynamicRangeLimit::constrainedHigh().value());
+    static_assert(WebCore::PlatformDynamicRangeLimit::initialValueForVideos().value() == WebCore::PlatformDynamicRangeLimit::noLimit().value());
+
+    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR().value() == WebCore::PlatformDynamicRangeLimit::standard().value());
+    static_assert(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos().value() == WebCore::PlatformDynamicRangeLimit::constrainedHigh().value());
 }
 
 static WebCore::PlatformDynamicRangeLimit mix(float standard, float constrainedHigh, float noLimit)
@@ -85,6 +90,12 @@ TEST(PlatformDynamicRangeLimit, StaticValues)
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::standard(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::constrainedHigh(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit());
     EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::noLimit(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit());
+
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::initialValue(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
+    EXPECT_GE(WebCore::PlatformDynamicRangeLimit::initialValueForVideos(), WebCore::Style::DynamicRangeLimit(WebCore::RenderStyle::initialDynamicRangeLimit()).toPlatformDynamicRangeLimit());
+
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit());
 }
 
 #if ASSERT_ENABLED


### PR DESCRIPTION
#### f4cf0e014e176898aed97ac0fc8d3f163775717d
<pre>
PlatformDynamicRangeLimit now has static initial values
<a href="https://bugs.webkit.org/show_bug.cgi?id=289685">https://bugs.webkit.org/show_bug.cgi?id=289685</a>
<a href="https://rdar.apple.com/146936785">rdar://146936785</a>

Reviewed by Mike Wyrzykowski and Anne van Kesteren.

PlatformDynamicRangeLimit doesn&apos;t have a default constructor anymore.
Users must explicitly pick an initial value, or construct another way
like Style::DynamicRangeLimit::toPlatformDynamicRangeLimit().

Note the distinct initial value for videos.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/ImagePaintingOptions.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
(WebCore::PlatformDynamicRangeLimit::initialValue):
(WebCore::PlatformDynamicRangeLimit::initialValueForVideos):
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp:
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, Values)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, StaticValues)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, DefaultConstruction)): Deleted.

Canonical link: <a href="https://commits.webkit.org/292117@main">https://commits.webkit.org/292117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9f431d7c9d7042ea934b671bb6397e094cfa8c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72397 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29691 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85692 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52728 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44735 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101965 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81716 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80783 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20203 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15175 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->