### PR TITLE
fast/mediastream/MediaDevices-addEventListener.html is flaky in Debug bots

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-addEventListener.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-addEventListener.html
@@ -19,7 +19,8 @@
 
         testRunner.setUserMediaPermission(true);
 
-        await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        const captureFailurePromise = new Promise(resolve => stream.getAudioTracks()[0].onended = resolve);
 
         let devices = await navigator.mediaDevices.enumerateDevices();
 
@@ -38,6 +39,7 @@
             }, 5000);
             testRunner.addMockCameraDevice("id1", "my camera");
         });
+        return captureFailurePromise;
     }, "Capture 'devicechange' event with addEventListener");
     </script>
 </head>


### PR DESCRIPTION
#### 0c9b33e35086643b4726e2eba732470980120176
<pre>
fast/mediastream/MediaDevices-addEventListener.html is flaky in Debug bots
<a href="https://rdar.apple.com/146938006">rdar://146938006</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289687">https://bugs.webkit.org/show_bug.cgi?id=289687</a>

Reviewed by Eric Carlson.

The test is flaky due to a CONSOLE message stating that a microphone track is failing.
We are waiting for the ended event so that the CONSOLE message is always present.

* LayoutTests/fast/mediastream/MediaDevices-addEventListener.html:

Canonical link: <a href="https://commits.webkit.org/292145@main">https://commits.webkit.org/292145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9165271e1bd459d05188ced985e9ef67b4e10a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72391 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85695 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52722 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10720 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3414 "Found 1 new test failure: fullscreen/full-screen-document-background-color.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81719 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80778 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25348 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21916 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->