### PR TITLE
[WPE] WPEPlatform: make WPEView a construct only property of WPEInputMethodContext

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -159,13 +159,13 @@ bool wpeDisplayCheckEGLExtension(WPEDisplay* display, const char* extensionName)
     return addResult.iterator->value;
 }
 
-WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay* display)
+WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay* display, WPEView* view)
 {
     auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
 
-    auto* inputMethodContext = wpeDisplayClass->create_input_method_context ? wpeDisplayClass->create_input_method_context(display) : nullptr;
+    auto* inputMethodContext = wpeDisplayClass->create_input_method_context ? wpeDisplayClass->create_input_method_context(display, view) : nullptr;
     if (!inputMethodContext)
-        inputMethodContext = wpeInputMethodContextNoneNew();
+        inputMethodContext = wpeInputMethodContextNoneNew(view);
     return inputMethodContext;
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -65,7 +65,8 @@ struct _WPEDisplayClass
     const char             *(* get_drm_render_node)           (WPEDisplay *display);
     gboolean                (* use_explicit_sync)             (WPEDisplay *display);
 
-    WPEInputMethodContext   *(* create_input_method_context)    (WPEDisplay *display);
+    WPEInputMethodContext  *(* create_input_method_context)   (WPEDisplay *display,
+                                                               WPEView    *view);
 
     gpointer padding[32];
 };

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h
@@ -26,7 +26,8 @@
 #pragma once
 
 #include "WPEDisplay.h"
+#include "WPEView.h"
 
 WPEView* wpeDisplayCreateView(WPEDisplay*);
 bool wpeDisplayCheckEGLExtension(WPEDisplay*, const char*);
-WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay*);
+WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay*, WPEView*);

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -29,6 +29,7 @@
 #include "WPEDisplayPrivate.h"
 #include "WPEEnumTypes.h"
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
 #include <wtf/glib/WTFGType.h>
 
 struct _WPEInputMethodUnderline {
@@ -156,7 +157,7 @@ const WPEColor* wpe_input_method_underline_get_color(WPEInputMethodUnderline* un
 }
 
 struct _WPEInputMethodContextPrivate {
-    WPEView* view;
+    GWeakPtr<WPEView> view;
     WPEInputPurpose purpose;
     WPEInputHints hints;
 };
@@ -174,6 +175,7 @@ enum {
 
 enum {
     PROP_0,
+    PROP_VIEW,
     PROP_INPUT_PURPOSE,
     PROP_INPUT_HINTS,
     N_PROPERTIES
@@ -187,6 +189,9 @@ static void wpeInputMethodContextSetProperty(GObject* object, guint propId, cons
     auto* ime = WPE_INPUT_METHOD_CONTEXT(object);
 
     switch (propId) {
+    case PROP_VIEW:
+        ime->priv->view.reset(WPE_VIEW(g_value_get_object(value)));
+        break;
     case PROP_INPUT_PURPOSE:
         if (ime->priv->purpose != g_value_get_enum(value)) {
             ime->priv->purpose = static_cast<WPEInputPurpose>(g_value_get_enum(value));
@@ -209,6 +214,9 @@ static void wpeInputMethodContextGetProperty(GObject* object, guint propId, GVal
     auto* ime = WPE_INPUT_METHOD_CONTEXT(object);
 
     switch (propId) {
+    case PROP_VIEW:
+        g_value_set_object(value, wpe_input_method_context_get_view(ime));
+        break;
     case PROP_INPUT_PURPOSE:
         g_value_set_enum(value, ime->priv->purpose);
         break;
@@ -225,6 +233,18 @@ static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klas
     GObjectClass* objectClass = G_OBJECT_CLASS(klass);
     objectClass->set_property = wpeInputMethodContextSetProperty;
     objectClass->get_property = wpeInputMethodContextGetProperty;
+
+    /**
+     * WPEInputMethodContext:view:
+     *
+     * The #WPEView associated to the #WPEInputMethodContext
+     */
+    sObjProperties[PROP_VIEW] =
+        g_param_spec_object(
+            "view",
+            nullptr, nullptr,
+            WPE_TYPE_VIEW,
+            static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY));
 
     /**
      * WPEInputMethodContext:input-purpose:
@@ -352,10 +372,7 @@ WPEInputMethodContext* wpe_input_method_context_new(WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    auto display = wpe_view_get_display(view);
-    auto imeContext = wpeDisplayCreateInputMethodContext(display);
-    imeContext->priv->view = view;
-    return imeContext;
+    return wpeDisplayCreateInputMethodContext(wpe_view_get_display(view), view);
 }
 
 /**
@@ -364,14 +381,14 @@ WPEInputMethodContext* wpe_input_method_context_new(WPEView* view)
  *
  * Get the #WPEView of @context
  *
- * Returns: (transfer none): a #WPEView
+ * Returns: (transfer none) (nullable): a #WPEView
  */
 
 WPEView* wpe_input_method_context_get_view(WPEInputMethodContext   *context)
 {
     g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), nullptr);
 
-    return context->priv->view;
+    return context->priv->view.get();
 }
 
 /**
@@ -386,7 +403,7 @@ WPEDisplay* wpe_input_method_context_get_display(WPEInputMethodContext* context)
 {
     g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), nullptr);
 
-    return wpe_view_get_display(context->priv->view);
+    return context->priv->view ? wpe_view_get_display(context->priv->view.get()) : nullptr;
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -135,7 +135,7 @@ struct _WPEInputMethodContextClass
                                      GList                 **underlines,
                                      guint                 *cursor_offset);
     gboolean (* filter_key_event)   (WPEInputMethodContext *context,
-			                         WPEEvent              *event);
+                                     WPEEvent              *event);
     void     (* focus_in)           (WPEInputMethodContext *context);
     void     (* focus_out)          (WPEInputMethodContext *context);
     void     (* set_cursor_area)    (WPEInputMethodContext *context,

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
@@ -49,7 +49,7 @@ static void wpe_input_method_context_none_class_init(WPEInputMethodContextNoneCl
     imContextClass->get_preedit_string = wpeInputMethodContextNoneGetPreeditString;
 }
 
-WPEInputMethodContext* wpeInputMethodContextNoneNew()
+WPEInputMethodContext* wpeInputMethodContextNoneNew(WPEView* view)
 {
-    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_INPUT_METHOD_CONTEXT_NONE, nullptr));
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_INPUT_METHOD_CONTEXT_NONE, "view", view, nullptr));
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h
@@ -33,6 +33,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_INPUT_METHOD_CONTEXT_NONE (wpe_input_method_context_none_get_type())
 G_DECLARE_FINAL_TYPE(WPEInputMethodContextNone, wpe_input_method_context_none, WPE, INPUT_METHOD_CONTEXT_NONE, WPEInputMethodContext)
 
-WPEInputMethodContext* wpeInputMethodContextNoneNew();
+WPEInputMethodContext* wpeInputMethodContextNoneNew(WPEView*);
 
 G_END_DECLS

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -431,16 +431,16 @@ static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
     return view;
 }
 
-static WPEInputMethodContext* wpeDisplayWaylandCreateInputMethodContext(WPEDisplay* display)
+static WPEInputMethodContext* wpeDisplayWaylandCreateInputMethodContext(WPEDisplay* display, WPEView* view)
 {
     auto* priv = WPE_DISPLAY_WAYLAND(display)->priv;
     if (!priv->wlDisplay || !priv->wlCompositor)
         return nullptr;
 
     if (priv->textInputManagerV3)
-        return wpe_im_context_wayland_v3_new(WPE_DISPLAY_WAYLAND(display));
+        return wpe_im_context_wayland_v3_new(WPE_DISPLAY_WAYLAND(display), view);
     if (priv->textInputManagerV1)
-        return wpe_im_context_wayland_v1_new(WPE_DISPLAY_WAYLAND(display));
+        return wpe_im_context_wayland_v1_new(WPE_DISPLAY_WAYLAND(display), view);
 
     return nullptr;
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
@@ -645,10 +645,11 @@ static void wpe_im_context_wayland_v1_class_init(WPEIMContextWaylandV1Class* kla
     imContextClass->reset = wpeIMContextWaylandV1Reset;
 }
 
-WPEInputMethodContext* wpe_im_context_wayland_v1_new(WPEDisplayWayland* display)
+WPEInputMethodContext* wpe_im_context_wayland_v1_new(WPEDisplayWayland* display, WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_DISPLAY_WAYLAND(display), nullptr);
+    g_return_val_if_fail(WPE_IS_VIEW_WAYLAND(view), nullptr);
 
     textInputV1GetGlobalByDisplay(display); // ensure creation of listener
-    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V1, nullptr));
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V1, "view", view, nullptr));
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h
@@ -35,7 +35,8 @@ G_BEGIN_DECLS
 #define WPE_TYPE_IM_CONTEXT_WAYLAND_V1 (wpe_im_context_wayland_v1_get_type())
 G_DECLARE_FINAL_TYPE (WPEIMContextWaylandV1, wpe_im_context_wayland_v1, WPE, IM_CONTEXT_WAYLAND_V1, WPEInputMethodContext)
 
-WPEInputMethodContext   *wpe_im_context_wayland_v1_new (WPEDisplayWayland *display);
+WPEInputMethodContext *wpe_im_context_wayland_v1_new (WPEDisplayWayland *display,
+                                                      WPEView           *view);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
@@ -602,10 +602,11 @@ static void wpe_im_context_wayland_v3_class_init(WPEIMContextWaylandV3Class* kla
     imContextClass->reset = wpeIMContextWaylandV3Reset;
 }
 
-WPEInputMethodContext* wpe_im_context_wayland_v3_new(WPEDisplayWayland* display)
+WPEInputMethodContext* wpe_im_context_wayland_v3_new(WPEDisplayWayland* display, WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_DISPLAY_WAYLAND(display), nullptr);
+    g_return_val_if_fail(WPE_IS_VIEW_WAYLAND(view), nullptr);
 
     textInputV3GetGlobalByDisplay(display); // ensure creation of listener
-    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V3, nullptr));
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V3, "view", view, nullptr));
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h
@@ -35,7 +35,8 @@ G_BEGIN_DECLS
 #define WPE_TYPE_IM_CONTEXT_WAYLAND_V3 (wpe_im_context_wayland_v3_get_type())
 G_DECLARE_FINAL_TYPE (WPEIMContextWaylandV3, wpe_im_context_wayland_v3, WPE, IM_CONTEXT_WAYLAND_V3, WPEInputMethodContext)
 
-WPEInputMethodContext   *wpe_im_context_wayland_v3_new (WPEDisplayWayland *display);
+WPEInputMethodContext *wpe_im_context_wayland_v3_new (WPEDisplayWayland *display,
+                                                      WPEView           *view);
 
 G_END_DECLS
 

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
@@ -50,7 +50,7 @@ static WPEView* wpeDisplayMockCreateView(WPEDisplay* display)
     return nullptr;
 }
 
-static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display)
+static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display, WPEView*)
 {
     return nullptr;
 }


### PR DESCRIPTION
#### 30ae8ad812abe511f182ca0ed502d93055c8fce9
<pre>
[WPE] WPEPlatform: make WPEView a construct only property of WPEInputMethodContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=289689">https://bugs.webkit.org/show_bug.cgi?id=289689</a>

Reviewed by Adrian Perez de Castro.

We currently set the view after creating the WPEInputMethodContext, but
platform implementations might need to use the view in its constructed
method.

* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplayCreateInputMethodContext):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
(wpeInputMethodContextSetProperty):
(wpeInputMethodContextGetProperty):
(wpe_input_method_context_class_init):
(wpe_input_method_context_new):
(wpe_input_method_context_get_view):
(wpe_input_method_context_get_display):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp:
(wpeInputMethodContextNoneNew):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandCreateInputMethodContext):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp:
(wpe_im_context_wayland_v1_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp:
(wpe_im_context_wayland_v3_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h:
* Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp:
(wpeDisplayMockCreateInputMethodContext):

Canonical link: <a href="https://commits.webkit.org/292082@main">https://commits.webkit.org/292082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeca8eb352a2ac45882de8a01d8b642aa51aa0bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29688 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85697 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52725 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44740 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81721 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80780 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25346 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15182 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15232 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->