### PR TITLE
[WPE] WPEPlatform: add getter/setter for WPEInputMethodContext input-purpose and input-hints properties

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
@@ -75,12 +75,12 @@ static WPEInputHints toWPEInputHints(WebKitInputHints hints)
 
 static void inputPurposeChangedCallback(WebKitInputMethodContextImplWPE* context)
 {
-    g_object_set(context->priv->context.get(), "input-purpose", toWPEInputPurpose(webkit_input_method_context_get_input_purpose(WEBKIT_INPUT_METHOD_CONTEXT(context))), nullptr);
+    wpe_input_method_context_set_input_purpose(context->priv->context.get(), toWPEInputPurpose(webkit_input_method_context_get_input_purpose(WEBKIT_INPUT_METHOD_CONTEXT(context))));
 }
 
 static void inputHintsChangedCallback(WebKitInputMethodContextImplWPE* context)
 {
-    g_object_set(context->priv->context.get(), "input-hints", toWPEInputHints(webkit_input_method_context_get_input_hints(WEBKIT_INPUT_METHOD_CONTEXT(context))), nullptr);
+    wpe_input_method_context_set_input_hints(context->priv->context.get(), toWPEInputHints(webkit_input_method_context_get_input_hints(WEBKIT_INPUT_METHOD_CONTEXT(context))));
 }
 
 static void wpeIMContextPreeditStartCallback(WebKitInputMethodContextImplWPE* context)

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -193,16 +193,10 @@ static void wpeInputMethodContextSetProperty(GObject* object, guint propId, cons
         ime->priv->view.reset(WPE_VIEW(g_value_get_object(value)));
         break;
     case PROP_INPUT_PURPOSE:
-        if (ime->priv->purpose != g_value_get_enum(value)) {
-            ime->priv->purpose = static_cast<WPEInputPurpose>(g_value_get_enum(value));
-            g_object_notify_by_pspec(object, paramSpec);
-        }
+        wpe_input_method_context_set_input_purpose(ime, static_cast<WPEInputPurpose>(g_value_get_enum(value)));
         break;
     case PROP_INPUT_HINTS:
-        if (ime->priv->hints != g_value_get_flags(value))  {
-            ime->priv->hints =  static_cast<WPEInputHints>(g_value_get_flags(value));
-            g_object_notify_by_pspec(object, paramSpec);
-        }
+        wpe_input_method_context_set_input_hints(ime, static_cast<WPEInputHints>(g_value_get_flags(value)));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -218,10 +212,10 @@ static void wpeInputMethodContextGetProperty(GObject* object, guint propId, GVal
         g_value_set_object(value, wpe_input_method_context_get_view(ime));
         break;
     case PROP_INPUT_PURPOSE:
-        g_value_set_enum(value, ime->priv->purpose);
+        g_value_set_enum(value, wpe_input_method_context_get_input_purpose(ime));
         break;
     case PROP_INPUT_HINTS:
-        g_value_set_flags(value, ime->priv->hints);
+        g_value_set_flags(value, wpe_input_method_context_get_input_hints(ime));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -404,6 +398,72 @@ WPEDisplay* wpe_input_method_context_get_display(WPEInputMethodContext* context)
     g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), nullptr);
 
     return context->priv->view ? wpe_view_get_display(context->priv->view.get()) : nullptr;
+}
+
+/**
+ * wpe_input_method_context_get_input_purpose:
+ * @context: a #WPEInputMethodContext
+ *
+ * Get the purpose of the text field that @context is connected to.
+ *
+ * Returns: a #WPEInputPurpose
+ */
+WPEInputPurpose wpe_input_method_context_get_input_purpose(WPEInputMethodContext* context)
+{
+    g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), WPE_INPUT_PURPOSE_FREE_FORM);
+
+    return context->priv->purpose;
+}
+
+/**
+ * wpe_input_method_context_set_input_purpose:
+ * @context: a #WPEInputMethodContext
+ * @purpose: a #WPEInputPurpose
+ *
+ * Set the purpose of the text field that @context is connected to.
+ */
+void wpe_input_method_context_set_input_purpose(WPEInputMethodContext* context, WPEInputPurpose purpose)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    if (context->priv->purpose == purpose)
+        return;
+
+    context->priv->purpose = purpose;
+    g_object_notify_by_pspec(G_OBJECT(context), sObjProperties[PROP_INPUT_PURPOSE]);
+}
+
+/**
+ * wpe_input_method_context_get_input_hints:
+ * @context: a #WPEInputMethodContext
+ *
+ * Get hints of @context that allow input methods to fine-tune their behaviour.
+ *
+ * Returns: a #WPEInputHints
+ */
+WPEInputHints wpe_input_method_context_get_input_hints(WPEInputMethodContext* context)
+{
+    g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), WPE_INPUT_HINT_NONE);
+
+    return context->priv->hints;
+}
+
+/**
+ * wpe_input_method_context_set_input_hints:
+ * @context: a #WPEInputMethodContext
+ * @hints: a #WPEInputHints
+ *
+ * Set hints of @context that allow input methods to fine-tune their behaviour.
+ */
+void wpe_input_method_context_set_input_hints(WPEInputMethodContext* context, WPEInputHints hints)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    if (context->priv->hints == hints)
+        return;
+
+    context->priv->hints = hints;
+    g_object_notify_by_pspec(G_OBJECT(context), sObjProperties[PROP_INPUT_HINTS]);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -156,6 +156,12 @@ struct _WPEInputMethodContextClass
 WPE_API WPEInputMethodContext   *wpe_input_method_context_new                (WPEView                 *view);
 WPE_API WPEView                 *wpe_input_method_context_get_view           (WPEInputMethodContext   *context);
 WPE_API WPEDisplay              *wpe_input_method_context_get_display        (WPEInputMethodContext   *context);
+WPE_API WPEInputPurpose          wpe_input_method_context_get_input_purpose  (WPEInputMethodContext   *context);
+WPE_API void                     wpe_input_method_context_set_input_purpose  (WPEInputMethodContext   *context,
+                                                                              WPEInputPurpose          purpose);
+WPE_API WPEInputHints            wpe_input_method_context_get_input_hints    (WPEInputMethodContext   *context);
+WPE_API void                     wpe_input_method_context_set_input_hints    (WPEInputMethodContext   *context,
+                                                                              WPEInputHints            hints);
 WPE_API void                     wpe_input_method_context_get_preedit_string (WPEInputMethodContext   *context,
                                                                               char                    **text,
                                                                               GList                   **underlines,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
@@ -557,8 +557,7 @@ static void wpeIMContextWaylandV1FocusIn(WPEInputMethodContext* context)
     if (global->textInput == nullptr)
         return;
 
-    WPEInputHints hints;
-    g_object_get(context, "input-hints", &hints, nullptr);
+    WPEInputHints hints = wpe_input_method_context_get_input_hints(context);
     if (!(hints & WPE_INPUT_HINT_INHIBIT_OSK)) {
         zwp_text_input_v1_show_input_panel(global->textInput);
         zwp_text_input_v1_activate(global->textInput,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
@@ -348,8 +348,7 @@ static void textInputV3Enable(WPEIMContextWaylandV3* context, TextInputV3Global*
     textInputV3UpdateState(context, ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_OTHER);
 
     // Mutter only pops up the OSK on >1 consecutive zwp_text_input_v3_enable() calls
-    WPEInputHints hints;
-    g_object_get(context, "input-hints", &hints, nullptr);
+    WPEInputHints hints = wpe_input_method_context_get_input_hints(WPE_INPUT_METHOD_CONTEXT(context));
     if (!(hints & WPE_INPUT_HINT_INHIBIT_OSK)) {
         zwp_text_input_v3_enable(global->textInput);
         textInputV3CommitState(context);


### PR DESCRIPTION
#### f04bd6a8c9ab3c4c31a791d83d693dc41292e7d9
<pre>
[WPE] WPEPlatform: add getter/setter for WPEInputMethodContext input-purpose and input-hints properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=289692">https://bugs.webkit.org/show_bug.cgi?id=289692</a>

Reviewed by Patrick Griffis.

* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp:
(inputPurposeChangedCallback):
(inputHintsChangedCallback):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
(wpeInputMethodContextSetProperty):
(wpeInputMethodContextGetProperty):
(wpe_input_method_context_get_input_purpose):
(wpe_input_method_context_set_input_purpose):
(wpe_input_method_context_get_input_hints):
(wpe_input_method_context_set_input_hints):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp:
(wpeIMContextWaylandV1FocusIn):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp:
(textInputV3Enable):

Canonical link: <a href="https://commits.webkit.org/292149@main">https://commits.webkit.org/292149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95a646c1a5ca8ba4dc83576ae937d8ca8b2974c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45405 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22927 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72403 "Found 5 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_HMAC.https.any.html imported/w3c/web-platform-tests/content-security-policy/navigate-to/parent-navigates-child-blocked.html imported/w3c/web-platform-tests/fetch/api/request/request-error.any.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-remove-quickly.html imported/w3c/web-platform-tests/worklets/audio-worklet-service-worker-interception.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29695 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97917 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11022 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85702 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52734 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10730 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81726 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80788 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25351 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15190 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27041 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->