### PR TITLE
Switch ScrollAnchoringController::m_owningScrollableArea to CheckedRef

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,7 +1,6 @@
 Modules/websockets/WorkerThreadableWebSocketChannel.h
 html/parser/HTMLTreeBuilder.h
 loader/WorkerThreadableLoader.h
-page/scrolling/ScrollAnchoringController.h
 platform/ScrollAnimator.h
 platform/Scrollbar.h
 platform/ScrollbarsController.h

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -54,7 +54,7 @@ ScrollAnchoringController::~ScrollAnchoringController()
 
 LocalFrameView& ScrollAnchoringController::frameView()
 {
-    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea))
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
         return renderLayerScrollableArea->layer().renderer().view().frameView();
     return downcast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea));
 }
@@ -327,7 +327,7 @@ void ScrollAnchoringController::chooseAnchorElement(Document& document)
 
 void ScrollAnchoringController::updateAnchorElement()
 {
-    if (m_owningScrollableArea.scrollPosition().isZero() || m_isQueuedForScrollPositionUpdate || frameView().layoutContext().layoutPhase() != LocalFrameViewLayoutContext::LayoutPhase::OutsideLayout)
+    if (m_owningScrollableArea->scrollPosition().isZero() || m_isQueuedForScrollPositionUpdate || frameView().layoutContext().layoutPhase() != LocalFrameViewLayoutContext::LayoutPhase::OutsideLayout)
         return;
 
     RefPtr document = frameView().frame().document();
@@ -364,22 +364,22 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 
     FloatSize adjustment = computeOffsetFromOwningScroller(*renderer) - m_lastOffsetForAnchorElement;
     if (!adjustment.isZero()) {
-        if (m_owningScrollableArea.isUserScrollInProgress()) {
+        if (m_owningScrollableArea->isUserScrollInProgress()) {
             invalidateAnchorElement();
             updateAnchorElement();
             return;
         }
-        auto newScrollPosition = m_owningScrollableArea.scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
-        RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::updateScrollPosition() is main frame: %d, is main scroller: %d, adjusting from: (%d, %d) to: (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea.isRenderLayer(), m_owningScrollableArea.scrollPosition().x(), m_owningScrollableArea.scrollPosition().y(), newScrollPosition.x(), newScrollPosition.y());
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for scroller element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)) << " anchor node: " << *m_anchorElement << "adjusting from: " << m_owningScrollableArea.scrollPosition() << " to: " << newScrollPosition);
+        auto newScrollPosition = m_owningScrollableArea->scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
+        RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::updateScrollPosition() is main frame: %d, is main scroller: %d, adjusting from: (%d, %d) to: (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), m_owningScrollableArea->scrollPosition().x(), m_owningScrollableArea->scrollPosition().y(), newScrollPosition.x(), newScrollPosition.y());
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for scroller element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)) << " anchor node: " << *m_anchorElement << "adjusting from: " << m_owningScrollableArea->scrollPosition() << " to: " << newScrollPosition);
 
         auto options = ScrollPositionChangeOptions::createProgrammatic();
         options.originalScrollDelta = adjustment;
-        auto oldScrollType = m_owningScrollableArea.currentScrollType();
-        m_owningScrollableArea.setCurrentScrollType(ScrollType::Programmatic);
-        if (!m_owningScrollableArea.requestScrollToPosition(newScrollPosition, options))
-            m_owningScrollableArea.scrollToPositionWithoutAnimation(newScrollPosition);
-        m_owningScrollableArea.setCurrentScrollType(oldScrollType);
+        auto oldScrollType = m_owningScrollableArea->currentScrollType();
+        m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
+        if (!m_owningScrollableArea->requestScrollToPosition(newScrollPosition, options))
+            m_owningScrollableArea->scrollToPositionWithoutAnimation(newScrollPosition);
+        m_owningScrollableArea->setCurrentScrollType(oldScrollType);
     }
 }
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -73,7 +73,7 @@ private:
     FloatPoint computeOffsetFromOwningScroller(RenderObject&);
     LocalFrameView& frameView();
 
-    ScrollableArea& m_owningScrollableArea;
+    CheckedRef<ScrollableArea> m_owningScrollableArea;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_anchorElement;
     FloatPoint m_lastOffsetForAnchorElement;
     bool m_midUpdatingScrollPositionForAnchorElement { false };


### PR DESCRIPTION
#### 29ae769f503405a95787f0a53cda07337d18f136
<pre>
Switch ScrollAnchoringController::m_owningScrollableArea to CheckedRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=289699">https://bugs.webkit.org/show_bug.cgi?id=289699</a>

Reviewed by Chris Dumez.

This replaces a single T&amp; with CheckedRef&lt;T&gt; to guard against any future
lifetime issues.

* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::frameView):
(WebCore::ScrollAnchoringController::updateAnchorElement):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/292752@main">https://commits.webkit.org/292752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8918df5066fe86ddfecf708aa94d0646e4c7a83a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72434 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52755 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81439 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80813 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2779 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15226 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15652 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->