### PR TITLE
[css-anchor-position-1] Sort position options based on position-try-order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt
@@ -8,28 +8,28 @@ PASS normal --right, --left, --bottom, --top | --right
 PASS normal --top, --left, --bottom, --right | --top
 PASS most-block-size --right, --left | --right
 PASS most-height --right, --left | --right
-FAIL most-inline-size --right, --left | --left assert_equals: offsetLeft expected 110 but got 300
-FAIL most-width --right, --left | --left assert_equals: offsetLeft expected 110 but got 300
+PASS most-inline-size --right, --left | --left
+PASS most-width --right, --left | --left
 PASS most-inline-size --bottom, --top | --bottom
 PASS most-width --bottom, --top | --bottom
-FAIL most-block-size --bottom, --top | --top assert_equals: offsetTop expected 160 but got 350
-FAIL most-height --bottom, --top | --top assert_equals: offsetTop expected 160 but got 350
-FAIL most-inline-size --right, --left, --bottom, --top | --bottom assert_equals: offsetLeft expected 0 but got 300
-FAIL most-inline-size --right, --left, --top, --bottom | --top assert_equals: offsetLeft expected 0 but got 300
-FAIL most-block-size --bottom, --top, --right, --left | --right assert_equals: offsetLeft expected 300 but got 0
-FAIL most-block-size --bottom, --top, --left, --right | --left assert_equals: offsetLeft expected 110 but got 0
+PASS most-block-size --bottom, --top | --top
+PASS most-height --bottom, --top | --top
+PASS most-inline-size --right, --left, --bottom, --top | --bottom
+PASS most-inline-size --right, --left, --top, --bottom | --top
+PASS most-block-size --bottom, --top, --right, --left | --right
+PASS most-block-size --bottom, --top, --left, --right | --left
 PASS most-inline-size --left-sweep, --bottom-sweep | --left-sweep
 PASS most-inline-size --bottom-sweep, --left-sweep | --bottom-sweep
 PASS most-block-size --left-sweep, --bottom-sweep | --left-sweep
-FAIL most-block-size --bottom-sweep, --left-sweep | --left-sweep assert_equals: offsetLeft expected 110 but got 205
-FAIL most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep assert_equals: offsetLeft expected 110 but got 300
-FAIL most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep assert_equals: offsetLeft expected 205 but got 300
+PASS most-block-size --bottom-sweep, --left-sweep | --left-sweep
+PASS most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep
+PASS most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep
 FAIL most-inline-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --left-sweep assert_equals: offsetLeft expected 110 but got 300
-FAIL most-block-size
+   | --left-sweep assert_equals: offsetLeft expected 110 but got 0
+PASS most-block-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --right assert_equals: offsetTop expected 0 but got 255
+   | --right
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt
@@ -8,28 +8,28 @@ PASS normal --right, --left, --bottom, --top | --right
 PASS normal --top, --left, --bottom, --right | --top
 PASS most-block-size --right, --left | --right
 PASS most-height --right, --left | --right
-FAIL most-inline-size --right, --left | --left assert_equals: offsetLeft expected 0 but got 300
-FAIL most-width --right, --left | --left assert_equals: offsetLeft expected 0 but got 300
+PASS most-inline-size --right, --left | --left
+PASS most-width --right, --left | --left
 PASS most-inline-size --bottom, --top | --bottom
 PASS most-width --bottom, --top | --bottom
-FAIL most-block-size --bottom, --top | --top assert_equals: offsetTop expected 0 but got 350
-FAIL most-height --bottom, --top | --top assert_equals: offsetTop expected 0 but got 350
-FAIL most-inline-size --right, --left, --bottom, --top | --bottom assert_equals: offsetLeft expected 0 but got 300
-FAIL most-inline-size --right, --left, --top, --bottom | --top assert_equals: offsetLeft expected 0 but got 300
-FAIL most-block-size --bottom, --top, --right, --left | --right assert_equals: offsetLeft expected 300 but got 0
-FAIL most-block-size --bottom, --top, --left, --right | --left assert_equals: offsetTop expected 0 but got 350
+PASS most-block-size --bottom, --top | --top
+PASS most-height --bottom, --top | --top
+PASS most-inline-size --right, --left, --bottom, --top | --bottom
+PASS most-inline-size --right, --left, --top, --bottom | --top
+PASS most-block-size --bottom, --top, --right, --left | --right
+PASS most-block-size --bottom, --top, --left, --right | --left
 PASS most-inline-size --left-sweep, --bottom-sweep | --left-sweep
 PASS most-inline-size --bottom-sweep, --left-sweep | --bottom-sweep
 PASS most-block-size --left-sweep, --bottom-sweep | --left-sweep
-FAIL most-block-size --bottom-sweep, --left-sweep | --left-sweep assert_equals: offsetLeft expected 0 but got 150
-FAIL most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep assert_equals: offsetLeft expected 0 but got 300
-FAIL most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep assert_equals: offsetLeft expected 150 but got 300
+PASS most-block-size --bottom-sweep, --left-sweep | --left-sweep
+PASS most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep
+PASS most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep
 FAIL most-inline-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --left-sweep assert_equals: offsetLeft expected 0 but got 300
-FAIL most-block-size
+   | --left-sweep assert_equals: offsetTop expected 200 but got 350
+PASS most-block-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --right assert_equals: offsetTop expected 0 but got 200
+   | --right
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2628,6 +2628,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/OutlineValue.h
     rendering/style/PositionArea.h
     rendering/style/PositionTryFallback.h
+    rendering/style/PositionTryOrder.h
     rendering/style/RenderStyle.h
     rendering/style/RenderStyleConstants.h
     rendering/style/RenderStyleInlines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2955,6 +2955,7 @@ rendering/style/OffsetRotation.cpp
 rendering/style/QuotesData.cpp
 rendering/style/PositionArea.cpp
 rendering/style/PositionTryFallback.cpp
+rendering/style/PositionTryOrder.cpp
 rendering/style/RenderStyle.cpp
 rendering/style/RenderStyleConstants.cpp
 rendering/style/SVGRenderStyle.cpp

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -71,7 +71,8 @@ private:
 // Convenience struct to package constraints and inputs.
 struct PositionedLayoutConstraints {
 public:
-    PositionedLayoutConstraints(const RenderBox&, const RenderBoxModelObject& container, LogicalBoxAxis);
+    PositionedLayoutConstraints(const RenderBox&, const RenderStyle&, LogicalBoxAxis);
+    PositionedLayoutConstraints(const RenderBox&, LogicalBoxAxis);
 
     // Logical top or left wrt containing block.
     Length marginBefore() const { return m_marginBefore; }
@@ -101,9 +102,6 @@ public:
     LayoutUnit insetAfterValue() const { return minimumValueForLength(m_insetAfter, containingSize()); }
     LayoutUnit availableContentSpace() const { return containingSize() - insetBeforeValue() - marginBeforeValue() - bordersPlusPadding() - marginAfterValue() - insetAfterValue(); } // This may be negative.
 
-    void computeInlineStaticDistance(const RenderBox&);
-    void computeBlockStaticDistance(const RenderBox&);
-
     void convertLogicalLeftValue(LayoutUnit&) const;
     void convertLogicalTopValue(LayoutUnit&, const RenderBox&, const LayoutUnit logicalHeightValue) const;
 
@@ -116,6 +114,9 @@ private:
     void captureInsets(const RenderBox&, const LogicalBoxAxis selfAxis);
     void computeAnchorGeometry(const RenderBox&);
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
+
+    void computeInlineStaticDistance(const RenderBox&);
+    void computeBlockStaticDistance(const RenderBox&);
 
 private:
     // These values are captured by the constructor and may be tweaked by the user.

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4008,10 +4008,7 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
 
     // We don't use containingBlock(), since we may be positioned by an enclosing
     // relative positioned inline.
-    PositionedLayoutConstraints inlineConstraints(*this, downcast<RenderBoxModelObject>(*container()), LogicalBoxAxis::Inline);
-
-    // Calculate the static distance if needed.
-    inlineConstraints.computeInlineStaticDistance(*this);
+    PositionedLayoutConstraints inlineConstraints(*this, LogicalBoxAxis::Inline);
 
     // Calculate the used width. See CSS2 § 10.3.7.
     const RenderStyle& styleToUse = style();
@@ -4138,10 +4135,7 @@ void RenderBox::computePositionedLogicalHeight(LogicalExtentComputedValues& comp
     }
 
     // We don't use containingBlock(), since we may be positioned by an enclosing relpositioned inline.
-    PositionedLayoutConstraints blockConstraints(*this, downcast<RenderBoxModelObject>(*container()), LogicalBoxAxis::Block);
-
-    // Calculate the static distance if needed.
-    blockConstraints.computeBlockStaticDistance(*this);
+    PositionedLayoutConstraints blockConstraints(*this, LogicalBoxAxis::Block);
 
     // Calculate the used height. See CSS2 § 10.6.4.
     const RenderStyle& styleToUse = style();
@@ -4239,8 +4233,7 @@ void RenderBox::computePositionedLogicalWidthReplaced(LogicalExtentComputedValue
 {
     // We don't use containingBlock(), since we may be positioned by an enclosing
     // relative positioned inline.
-    PositionedLayoutConstraints inlineConstraints(*this, downcast<RenderBoxModelObject>(*container()), LogicalBoxAxis::Inline);
-    inlineConstraints.computeInlineStaticDistance(*this);
+    PositionedLayoutConstraints inlineConstraints(*this, LogicalBoxAxis::Inline);
 
     // NOTE: This value of width is final in that the min/max width calculations
     // are dealt with in computeReplacedWidth(). This means that the steps to produce
@@ -4264,8 +4257,7 @@ void RenderBox::computePositionedLogicalWidthReplaced(LogicalExtentComputedValue
 void RenderBox::computePositionedLogicalHeightReplaced(LogicalExtentComputedValues& computedValues) const
 {
     // We don't use containingBlock(), since we may be positioned by an enclosing relpositioned inline.
-    PositionedLayoutConstraints blockConstraints(*this, downcast<RenderBoxModelObject>(*container()), LogicalBoxAxis::Block);
-    blockConstraints.computeBlockStaticDistance(*this);
+    PositionedLayoutConstraints blockConstraints(*this, LogicalBoxAxis::Block);
 
     // NOTE: This value of height is final in that the min/max height calculations
     // are dealt with in computeReplacedHeight(). This means that the steps to produce

--- a/Source/WebCore/rendering/style/PositionTryOrder.cpp
+++ b/Source/WebCore/rendering/style/PositionTryOrder.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PositionTryOrder.h"
+
+namespace WebCore {
+namespace Style {
+
+LogicalBoxAxis boxAxisForPositionTryOrder(PositionTryOrder order, WritingMode writingMode)
+{
+    switch (order) {
+    case PositionTryOrder::MostWidth:
+        return mapAxisPhysicalToLogical(writingMode, BoxAxis::Horizontal);
+    case PositionTryOrder::MostHeight:
+        return mapAxisPhysicalToLogical(writingMode, BoxAxis::Vertical);
+    case PositionTryOrder::MostBlockSize:
+        return LogicalBoxAxis::Block;
+    case PositionTryOrder::MostInlineSize:
+        return LogicalBoxAxis::Inline;
+    case PositionTryOrder::Normal:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return LogicalBoxAxis::Inline;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionTryOrder order)
+{
+    switch (order) {
+    case PositionTryOrder::Normal: ts << "normal"_s; break;
+    case PositionTryOrder::MostWidth: ts << "most-width"_s; break;
+    case PositionTryOrder::MostHeight: ts << "most-height"_s; break;
+    case PositionTryOrder::MostBlockSize: ts << "most-block-size"_s; break;
+    case PositionTryOrder::MostInlineSize: ts << "most-inline-size"_s; break;
+    }
+
+    return ts;
+}
+
+}
+}

--- a/Source/WebCore/rendering/style/PositionTryOrder.h
+++ b/Source/WebCore/rendering/style/PositionTryOrder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BoxSides.h"
+
+namespace WebCore {
+namespace Style {
+
+// https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property
+enum class PositionTryOrder : uint8_t {
+    Normal,
+    MostWidth,
+    MostHeight,
+    MostBlockSize,
+    MostInlineSize
+};
+
+LogicalBoxAxis boxAxisForPositionTryOrder(PositionTryOrder, WritingMode);
+
+WTF::TextStream& operator<<(WTF::TextStream&, PositionTryOrder);
+
+}
+}

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -34,6 +34,7 @@
 #include "HitTestRequest.h"
 #include "ImageOrientation.h"
 #include "PositionArea.h"
+#include "PositionTryOrder.h"
 #include "RenderStyle.h"
 #include "ScrollTypes.h"
 #include "ScrollbarColor.h"

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -27,6 +27,7 @@
 #include "CSSValueKeywords.h"
 #include "EventTarget.h"
 #include "LayoutUnit.h"
+#include "PositionTryOrder.h"
 #include "ScopedName.h"
 #include "WritingMode.h"
 #include <wtf/HashMap.h>
@@ -83,17 +84,6 @@ enum class AnchorSizeDimension : uint8_t {
 
 using AnchorPositionedStates = WeakHashMap<Element, std::unique_ptr<AnchorPositionedState>, WeakPtrImplWithEventTargetData>;
 
-// https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property
-enum class PositionTryOrder : uint8_t {
-    Normal,
-    MostWidth,
-    MostHeight,
-    MostBlockSize,
-    MostInlineSize
-};
-
-WTF::TextStream& operator<<(WTF::TextStream&, PositionTryOrder);
-
 using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<SingleThreadWeakPtr<RenderBoxModelObject>>, WeakPtrImplWithEventTargetData>;
 using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
 
@@ -110,7 +100,7 @@ public:
     static bool propertyAllowsAnchorSizeFunction(CSSPropertyID);
     static std::optional<double> evaluateSize(BuilderState&, std::optional<ScopedName> elementName, std::optional<AnchorSizeDimension>);
 
-    static void updateAnchorPositioningStatesAfterInterleavedLayout(const Document&, AnchorPositionedStates&);
+    static void updateAnchorPositioningStatesAfterInterleavedLayout(Document&, AnchorPositionedStates&);
     static void updateSnapshottedScrollOffsets(Document&);
     static void updateAnchorPositionedStateForLayoutTimePositioned(Element&, const RenderStyle&, AnchorPositionedStates&);
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -151,6 +151,8 @@ private:
 
     void generatePositionOptionsIfNeeded(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);
+    struct PositionOptions;
+    void sortPositionOptionsIfNeeded(PositionOptions&, const Styleable&);
     std::optional<ResolvedStyle> tryChoosePositionOption(const Styleable&, const RenderStyle* existingStyle);
 
     // This returns the style that was in effect (applied to the render tree) before we started the style resolution.
@@ -184,6 +186,7 @@ private:
         std::unique_ptr<RenderStyle> originalStyle;
         Vector<std::unique_ptr<RenderStyle>> optionStyles { };
         size_t index { 0 };
+        bool sorted { false };
         bool chosen { false };
     };
     HashMap<Ref<Element>, PositionOptions> m_positionOptions;


### PR DESCRIPTION
#### 5948edcfa511091cc874eac3558f3b047e251254
<pre>
[css-anchor-position-1] Sort position options based on position-try-order
<a href="https://bugs.webkit.org/show_bug.cgi?id=289701">https://bugs.webkit.org/show_bug.cgi?id=289701</a>
<a href="https://rdar.apple.com/146947787">rdar://146947787</a>

Reviewed by Alan Baradlay.

&quot;For each entry in the position options list, apply that position option to the box, and find
the specified inset-modified containing block size that results from those styles. Stably sort
the position options list according to this size, with the largest coming first.&quot;

<a href="https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property">https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::PositionedLayoutConstraints):

Add a constructor that takes style separely so we can try effects of different styles.
Resolve container locally instead of passing it in.
Resolve static positions locally instead of requiring caller to do it.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):
* Source/WebCore/rendering/style/PositionTryOrder.cpp: Added.
(WebCore::Style::boxAxisForPositionTryOrder):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/rendering/style/PositionTryOrder.h: Added.

Move to a file of its own.

* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):

Update the global anchor map immediately instead of waiting until the end of style resolution.
This way the achor mappings are available during the style resolution already.

(WebCore::Style::operator&lt;&lt;): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Use PositionedLayoutConstraints to figure out the inset modified containing block size for
a given position option style. Sort based on the size on desired axis.

(WebCore::Style::TreeResolver::tryChoosePositionOption):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/292089@main">https://commits.webkit.org/292089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2966b7bf58a8c7f0b5b144bc789658f5ecfb4130

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10745 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/3433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44761 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21963 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81738 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/80810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25363 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21598 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->