### PR TITLE
[WPE] WPEPlatform: add API to get/set user data to WPEEvent

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
@@ -77,10 +77,21 @@ struct WPEEventTouch {
 struct _WPEEvent {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
+    ~_WPEEvent()
+    {
+        if (userData.destroyFunction)
+            userData.destroyFunction(userData.data);
+    }
+
     GRefPtr<WPEView> view;
     WPEEventType type { WPE_EVENT_NONE };
     WPEInputSource source { WPE_INPUT_SOURCE_MOUSE };
     guint32 time { 0 };
+
+    struct {
+        gpointer data { nullptr };
+        GDestroyNotify destroyFunction { nullptr };
+    } userData;
 
     std::variant<WPEEventPointerButton, WPEEventPointerMove, WPEEventScroll, WPEEventKeyboard, WPEEventTouch> variant;
 
@@ -148,6 +159,44 @@ WPEView* wpe_event_get_view(WPEEvent* event)
     g_return_val_if_fail(event, nullptr);
 
     return event->view.get();
+}
+
+/**
+ * wpe_event_set_user_data:
+ * @event: a #WPEEvent
+ * @user_data: data to associate with @event
+ * @destroy_func: (nullable): the function to call to release @user_data
+ *
+ * Set @user_data to @event
+ * When @event is destroyed @destroy_func is called with @user_data.
+ */
+void wpe_event_set_user_data(WPEEvent* event, gpointer userData, GDestroyNotify destroyFunction)
+{
+    g_return_if_fail(event);
+
+    if (event->userData.data == userData && event->userData.destroyFunction == destroyFunction)
+        return;
+
+    if (event->userData.destroyFunction)
+        event->userData.destroyFunction(event->userData.data);
+
+    event->userData.data = userData;
+    event->userData.destroyFunction = destroyFunction;
+}
+
+/**
+ * wpe_event_get_user_data:
+ * @event: a #WPEEvent
+ *
+ * Get user data previously set with wpe_event_set_user_data().
+ *
+ * Returns: (nullable): the @event user data, or %NULL
+ */
+gpointer wpe_event_get_user_data(WPEEvent* event)
+{
+    g_return_val_if_fail(event, nullptr);
+
+    return event->userData.data;
 }
 
 /**
@@ -274,7 +323,7 @@ WPEEvent* wpe_event_pointer_button_new(WPEEventType type, WPEView* view, WPEInpu
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
     g_return_val_if_fail(!pressCount || type == WPE_EVENT_POINTER_DOWN, nullptr);
 
-    return new _WPEEvent { view, type, source, time, WPEEventPointerButton { modifiers, button, pressCount, x, y }, 1 };
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventPointerButton { modifiers, button, pressCount, x, y }, 1 };
 }
 
 /**
@@ -332,7 +381,7 @@ WPEEvent* wpe_event_pointer_move_new(WPEEventType type, WPEView* view, WPEInputS
     g_return_val_if_fail(type == WPE_EVENT_POINTER_MOVE || type == WPE_EVENT_POINTER_ENTER || type == WPE_EVENT_POINTER_LEAVE, nullptr);
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    return new _WPEEvent { view, type, source, time, WPEEventPointerMove { modifiers, x, y, deltaX, deltaY }, 1 };
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventPointerMove { modifiers, x, y, deltaX, deltaY }, 1 };
 }
 
 /**
@@ -377,7 +426,7 @@ WPEEvent* wpe_event_scroll_new(WPEView* view, WPEInputSource source, guint32 tim
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    return new _WPEEvent { view, WPE_EVENT_SCROLL, source, time, WPEEventScroll { modifiers, deltaX, deltaY, x, y, !!preciseDeltas, !!isStop }, 1 };
+    return new _WPEEvent { view, WPE_EVENT_SCROLL, source, time, { nullptr, nullptr }, WPEEventScroll { modifiers, deltaX, deltaY, x, y, !!preciseDeltas, !!isStop }, 1 };
 }
 
 /**
@@ -453,7 +502,7 @@ WPEEvent* wpe_event_keyboard_new(WPEEventType type, WPEView* view, WPEInputSourc
     g_return_val_if_fail(type == WPE_EVENT_KEYBOARD_KEY_DOWN || type == WPE_EVENT_KEYBOARD_KEY_UP, nullptr);
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    return new _WPEEvent { view, type, source, time, WPEEventKeyboard { modifiers, keycode, keyval }, 1 };
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventKeyboard { modifiers, keycode, keyval }, 1 };
 }
 
 /**
@@ -510,7 +559,7 @@ WPEEvent* wpe_event_touch_new(WPEEventType type, WPEView* view, WPEInputSource s
     g_return_val_if_fail(type == WPE_EVENT_TOUCH_DOWN || type == WPE_EVENT_TOUCH_UP || type == WPE_EVENT_TOUCH_MOVE || type == WPE_EVENT_TOUCH_CANCEL, nullptr);
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    return new _WPEEvent { view, type, source, time, WPEEventTouch { modifiers, sequenceID, x, y }, 1 };
+    return new _WPEEvent { view, type, source, time, { nullptr, nullptr }, WPEEventTouch { modifiers, sequenceID, x, y }, 1 };
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
@@ -155,6 +155,10 @@ typedef enum {
 WPE_API GType          wpe_event_get_type                       (void);
 WPE_API WPEEvent      *wpe_event_ref                            (WPEEvent      *event);
 WPE_API void           wpe_event_unref                          (WPEEvent      *event);
+WPE_API void           wpe_event_set_user_data                  (WPEEvent      *event,
+                                                                 gpointer       user_data,
+                                                                 GDestroyNotify destroy_func);
+WPE_API gpointer       wpe_event_get_user_data                  (WPEEvent      *event);
 WPE_API WPEEventType   wpe_event_get_event_type                 (WPEEvent      *event);
 WPE_API WPEView       *wpe_event_get_view                       (WPEEvent      *event);
 WPE_API WPEInputSource wpe_event_get_input_source               (WPEEvent      *event);


### PR DESCRIPTION
#### 2d6367fd58b8a413b1033ea9f0a53ff86803c098
<pre>
[WPE] WPEPlatform: add API to get/set user data to WPEEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=289704">https://bugs.webkit.org/show_bug.cgi?id=289704</a>

Reviewed by Patrick Griffis.

This is useful for platform implementations that want to attach its
platform event to the WPEEvent.

* Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp:
(_WPEEvent::~_WPEEvent):
(wpe_event_set_user_data):
(wpe_event_get_user_data):
(wpe_event_pointer_button_new):
(wpe_event_pointer_move_new):
(wpe_event_scroll_new):
(wpe_event_keyboard_new):
(wpe_event_touch_new):
* Source/WebKit/WPEPlatform/wpe/WPEEvent.h:

Canonical link: <a href="https://commits.webkit.org/292144@main">https://commits.webkit.org/292144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/680d5557f2ffded3e55e08e4cba596ead28664d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97938 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11038 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10746 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80803 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15216 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27062 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->