### PR TITLE
Crash under DocumentLoader::removePlugInStreamLoader(WebCore::ResourceLoader&)

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -153,13 +153,13 @@ static bool& contentFilterInDocumentLoader()
 
 static void cancelAll(const ResourceLoaderMap& loaders)
 {
-    for (auto& loader : copyToVector(loaders.values()))
+    for (auto& loader : copyToVector(loaders))
         loader->cancel();
 }
 
 static void setAllDefersLoading(const ResourceLoaderMap& loaders, bool defers)
 {
-    for (auto& loader : copyToVector(loaders.values()))
+    for (auto& loader : copyToVector(loaders))
         loader->setDefersLoading(defers);
 }
 
@@ -2023,7 +2023,7 @@ void DocumentLoader::addSubresourceLoader(SubresourceLoader& loader)
     if (!m_gotFirstByte)
         return;
 
-    ASSERT(!m_subresourceLoaders.contains(*loader.identifier()));
+    ASSERT(!m_subresourceLoaders.contains(&loader));
     ASSERT(!mainResourceLoader() || mainResourceLoader() != &loader);
 
     // Application Cache loaders are handled by their ApplicationCacheGroup directly.
@@ -2049,12 +2049,12 @@ void DocumentLoader::addSubresourceLoader(SubresourceLoader& loader)
     }
 #endif
 
-    m_subresourceLoaders.add(*loader.identifier(), &loader);
+    m_subresourceLoaders.add(&loader);
 }
 
 void DocumentLoader::removeSubresourceLoader(LoadCompletionType type, SubresourceLoader& loader)
 {
-    if (!m_subresourceLoaders.remove(*loader.identifier()))
+    if (!m_subresourceLoaders.remove(&loader))
         return;
     checkLoadComplete();
     if (RefPtr frame = m_frame.get())
@@ -2063,16 +2063,16 @@ void DocumentLoader::removeSubresourceLoader(LoadCompletionType type, Subresourc
 
 void DocumentLoader::addPlugInStreamLoader(ResourceLoader& loader)
 {
-    ASSERT(!m_plugInStreamLoaders.contains(*loader.identifier()));
+    ASSERT(!m_plugInStreamLoaders.contains(&loader));
 
-    m_plugInStreamLoaders.add(*loader.identifier(), &loader);
+    m_plugInStreamLoaders.add(&loader);
 }
 
 void DocumentLoader::removePlugInStreamLoader(ResourceLoader& loader)
 {
-    ASSERT(&loader == m_plugInStreamLoaders.get(*loader.identifier()));
+    ASSERT(m_plugInStreamLoaders.contains(&loader));
 
-    m_plugInStreamLoaders.remove(*loader.identifier());
+    m_plugInStreamLoaders.remove(&loader);
     checkLoadComplete();
 }
 
@@ -2431,14 +2431,11 @@ void DocumentLoader::clearMainResource()
 
 void DocumentLoader::subresourceLoaderFinishedLoadingOnePart(ResourceLoader& loader)
 {
-    auto identifier = *loader.identifier();
-
-    if (!m_multipartSubresourceLoaders.add(identifier, &loader).isNewEntry) {
-        ASSERT(m_multipartSubresourceLoaders.get(identifier) == &loader);
-        ASSERT(!m_subresourceLoaders.contains(identifier));
-    } else {
-        ASSERT(m_subresourceLoaders.contains(identifier));
-        m_subresourceLoaders.remove(identifier);
+    if (!m_multipartSubresourceLoaders.add(&loader).isNewEntry)
+        ASSERT(!m_subresourceLoaders.contains(&loader));
+    else {
+        ASSERT(m_subresourceLoaders.contains(&loader));
+        m_subresourceLoaders.remove(&loader);
     }
 
     checkLoadComplete();

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -111,7 +111,7 @@ enum class ClearSiteDataValue : uint8_t;
 enum class LoadWillContinueInAnotherProcess : bool;
 enum class ShouldContinue;
 
-using ResourceLoaderMap = HashMap<ResourceLoaderIdentifier, RefPtr<ResourceLoader>>;
+using ResourceLoaderMap = HashSet<RefPtr<ResourceLoader>>;
 
 enum class AutoplayPolicy : uint8_t {
     Default, // Uses policies specified in document settings.

--- a/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
+++ b/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 
 static void scheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (RefPtr loader : copyToVector(loaders.values()))
+    for (RefPtr loader : copyToVector(loaders))
         loader->schedule(pair);
 }
 
 static void unscheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (RefPtr loader : copyToVector(loaders.values()))
+    for (RefPtr loader : copyToVector(loaders))
         loader->unschedule(pair);
 }
 


### PR DESCRIPTION
#### 058d1da0540851ab8eb186817ce9b74c833d7219
<pre>
Crash under DocumentLoader::removePlugInStreamLoader(WebCore::ResourceLoader&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=289709">https://bugs.webkit.org/show_bug.cgi?id=289709</a>
<a href="https://rdar.apple.com/146732733">rdar://146732733</a>

Reviewed by Per Arne Vollan.

It looks like it was crashing when dereferencing `loader.identifier()`, which
is a std::optional and thus can be std::nullopt. To address the issue, I have
refactored the code so that we use a HashSet instead of a HashMap whose key
is a ResourceLoadIdentifier. Using a ResourceLoadIdentifier is risky and may
cause leaks since the ResourceLoader&apos;s ResourceLoadIdentifier gets can get
nulled out.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::cancelAll):
(WebCore::setAllDefersLoading):
(WebCore::DocumentLoader::addSubresourceLoader):
(WebCore::DocumentLoader::removeSubresourceLoader):
(WebCore::DocumentLoader::addPlugInStreamLoader):
(WebCore::DocumentLoader::removePlugInStreamLoader):
(WebCore::DocumentLoader::subresourceLoaderFinishedLoadingOnePart):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/mac/DocumentLoaderMac.cpp:
(WebCore::scheduleAll):
(WebCore::unscheduleAll):

Canonical link: <a href="https://commits.webkit.org/292111@main">https://commits.webkit.org/292111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e932c9be6fd844ab45cc26f686238aeb2478cc39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72443 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44794 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102030 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16066 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20200 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21967 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27096 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->