### PR TITLE
Make entityTransform read-only always on StageMode Orbit

### DIFF
--- a/LayoutTests/model-element/model-element-entity-transform-expected.txt
+++ b/LayoutTests/model-element/model-element-entity-transform-expected.txt
@@ -3,4 +3,5 @@ PASS <model> with empty source has entityTransform = identity
 PASS <model> gets the updated entityTransform after change
 PASS <model> gets the updated entityTransform after model source change
 PASS <model> gets the identity entityTransform after model source removal
+PASS <model> ignores entityTransform when stagemode is set
 

--- a/LayoutTests/model-element/model-element-entity-transform.html
+++ b/LayoutTests/model-element/model-element-entity-transform.html
@@ -49,5 +49,20 @@ promise_test(async t => {
     });
 }, `<model> gets the identity entityTransform after model source removal`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/2x2x2-positive.usdz");
+    await model.ready;
+    let originalTransform = model.entityTransform;
+    assert_equals(model.stageMode, "");
+    assert_3d_matrix_is_identity(originalTransform, false);
+
+    model.stageMode = "orbit";
+    assert_equals(model.stageMode, "orbit");
+
+    let scaledTransform = originalTransform.scale(2, 2, 2);
+    model.entityTransform = scaledTransform;
+    assert_3d_matrix_equals(model.entityTransform, originalTransform);
+}, `<model> ignores entityTransform when stagemode is set`);
+
 </script>
 </body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -439,6 +439,9 @@ const DOMMatrixReadOnly& HTMLModelElement::entityTransform() const
 
 ExceptionOr<void> HTMLModelElement::setEntityTransform(const DOMMatrixReadOnly& transform)
 {
+    if (supportsStageModeInteraction())
+        return { };
+
     auto player = m_modelPlayer;
     if (!player) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -366,7 +366,7 @@ static CGFloat effectivePointsPerMeter(CALayer *caLayer)
 
 void ModelProcessModelPlayerProxy::computeTransform()
 {
-    if (!m_model || !m_layer || stageModeInteractionInProgress())
+    if (!m_model || !m_layer)
         return;
 
     // FIXME: Use the value of the 'object-fit' property here to compute an appropriate SRT.
@@ -380,7 +380,7 @@ void ModelProcessModelPlayerProxy::computeTransform()
 
 void ModelProcessModelPlayerProxy::updateTransform()
 {
-    if (!m_model || !m_layer || stageModeInteractionInProgress())
+    if (!m_model || !m_layer)
         return;
 
     [m_modelRKEntity setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];


### PR DESCRIPTION
#### 3c9b47c5342932c13eb099767d1c2bcd16394d4f
<pre>
Make entityTransform read-only always on StageMode Orbit
<a href="https://bugs.webkit.org/show_bug.cgi?id=289727">https://bugs.webkit.org/show_bug.cgi?id=289727</a>
<a href="https://rdar.apple.com/146901614">rdar://146901614</a>

Reviewed by Ada Chan.

This PR updates the behavior of how the entityTransform is updated via JS. Because we do not want
the entityTransform to update whenever the stagemode attribute is not set to none, this means that
any calls to update and compute transform while the stagemode attribute is orbit should do an early
return. The exception is when we are computing the initial placement/fit of the model, and when
we toggle the portal for the model.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setEntityTransform):
- Perform an early return if we are setting the entityTransform via JS

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
- Remove our previous checks for computing and updating the transform since
the check has now moved to the HTMLModelElement level and therefore does not
call the said functions while stagemode is set.

* LayoutTests/model-element/model-element-entity-transform-expected.txt:
* LayoutTests/model-element/model-element-entity-transform.html:
- Added layout test to verify expected behavior

Canonical link: <a href="https://commits.webkit.org/292182@main">https://commits.webkit.org/292182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f695250af48236f4fc8852f7aa4dcab7cc3b92fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72500 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52828 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3539 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102123 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2850 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15331 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27193 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->