### PR TITLE
Use CoreIPCAVOutputContext instead of WKKeyedCoder for MediaPlaybackTargetContextSerialized where supported

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -448,5 +448,6 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVContentKeyRequestRan
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferAudioRenderer, PAL::getAVSampleBufferAudioRendererClass())
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferDisplayLayer, PAL::getAVSampleBufferDisplayLayerClass())
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferVideoRendererClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVOutputContext, PAL::getAVOutputContextClass())
 
 #endif // USE(AVFOUNDATION)

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
+#include "CoreIPCAVOutputContext.h"
 #include <WebCore/MediaPlaybackTargetCocoa.h>
 #include <WebCore/MediaPlaybackTargetMock.h>
 #include <variant>
@@ -46,9 +47,14 @@ public:
     // Used by IPC serializer.
     WebCore::MediaPlaybackTargetContextType targetType() const { return m_targetType; }
     WebCore::MediaPlaybackTargetContextMockState mockState() const { return m_state; }
+#if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+    CoreIPCAVOutputContext context() const { return m_context; }
+    MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetContextType, WebCore::MediaPlaybackTargetContextMockState, CoreIPCAVOutputContext&&);
+#else
     String contextID() const { return m_contextID; }
     String contextType() const { return m_contextType; }
     MediaPlaybackTargetContextSerialized(String&&, bool, bool, WebCore::MediaPlaybackTargetContextType, WebCore::MediaPlaybackTargetContextMockState, String&&, String&&);
+#endif
 
 private:
     String m_deviceName;
@@ -57,8 +63,12 @@ private:
     // This should be const, however IPC's Decoder's handling doesn't allow for const member.
     WebCore::MediaPlaybackTargetContextType m_targetType;
     WebCore::MediaPlaybackTargetContextMockState m_state { WebCore::MediaPlaybackTargetContextMockState::Unknown };
+#if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+    CoreIPCAVOutputContext m_context;
+#else
     String m_contextID;
     String m_contextType;
+#endif
 };
 
 class MediaPlaybackTargetSerialized final : public WebCore::MediaPlaybackTarget {

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in
@@ -43,8 +43,12 @@ header: "MediaPlaybackTargetContextSerialized.h"
     bool supportsRemoteVideoPlayback();
     WebCore::MediaPlaybackTargetContextType targetType();
     WebCore::MediaPlaybackTargetContextMockState mockState();
+#if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+    WebKit::CoreIPCAVOutputContext context();
+#else
     String contextID();
     String contextType();
+#endif
 };
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
@@ -44,9 +44,10 @@ struct CoreIPCAVOutputContextData {
 class CoreIPCAVOutputContext {
     WTF_MAKE_TZONE_ALLOCATED(CoreIPCAVOutputContext);
 public:
-    CoreIPCAVOutputContext(AVOutputContext *);
+    CoreIPCAVOutputContext() = default;
+    explicit CoreIPCAVOutputContext(AVOutputContext *);
 
-    CoreIPCAVOutputContext(CoreIPCAVOutputContextData&& data)
+    explicit CoreIPCAVOutputContext(CoreIPCAVOutputContextData&& data)
         : m_data(WTFMove(data))
     {
     }

--- a/Source/WebKit/Shared/Cocoa/WKKeyedCoder.h
+++ b/Source/WebKit/Shared/Cocoa/WKKeyedCoder.h
@@ -38,6 +38,9 @@
 // actually needed by the target classes.
 // As we add more specific types that rely on it, we'll expand its feature-set.
 
+// This is an implementation detail of IPC that should only be used for the SupportWKKeyedCoder
+// keyword in a *.serialization.in file, and its use should only be declining.
+
 @interface WKKeyedCoder : NSCoder
 - (instancetype)init;
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary;


### PR DESCRIPTION
#### f0046dd9c2f95fee8dae6e8eb88508b40caa728f
<pre>
Use CoreIPCAVOutputContext instead of WKKeyedCoder for MediaPlaybackTargetContextSerialized where supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=289713">https://bugs.webkit.org/show_bug.cgi?id=289713</a>
<a href="https://rdar.apple.com/147038389">rdar://147038389</a>

Reviewed by Brady Eidson.

No change in observable behaviour.

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h: Adding SPECIALIZE_OBJC_TYPE_TRAITS so that `dynamic_objc_cast&lt;AVOutputContext&gt;` is usable.
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.h:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized):
(WebKit::MediaPlaybackTargetContextSerialized::platformContext const):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.serialization.in:
* Source/WebKit/Shared/Cocoa/WKKeyedCoder.h: Add comment to ensure it should no longer be used.

Canonical link: <a href="https://commits.webkit.org/292187@main">https://commits.webkit.org/292187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e9e80fcc4ab80ece67f044e6a57ed01a270c19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72587 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3658 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45007 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22216 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80982 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15469 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22186 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->