### PR TITLE
Bugfix: about scheme handler did not work as expected.

### DIFF
--- a/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
@@ -76,6 +76,8 @@ bool AboutSchemeHandler::canHandleURL(const URL& url) const
 
 void AboutSchemeHandler::platformInitialize()
 {
+    registerHandler(blank, makeUnique<EmptyPathHandler>());
+
 #if PLATFORM(COCOA) && HAVE(CUSTOM_ABOUT_SCHEME_HANDLER)
     registerCocoaAboutHandlers(*this);
 #endif

--- a/Source/WebKit/UIProcess/AboutSchemeHandler.h
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.h
@@ -46,9 +46,20 @@ public:
     bool canHandleURL(const URL&) const;
 
     static constexpr auto scheme = "about"_s;
+    static constexpr auto blank = "blank"_s;
 
 private:
     friend MainThreadNeverDestroyed<AboutSchemeHandler>;
+
+    class EmptyPathHandler final : public OpaquePathHandler {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        void loadContent(URL url, CompletionHandler<void(WebCore::ResourceResponse&&, Ref<WebCore::SharedBuffer>&&)>&& handler)
+        {
+            WebCore::ResourceResponse response(url, "text/html"_s, 0, "UTF-8"_s);
+            handler(WTFMove(response), WebCore::SharedBuffer::create());
+        }
+    };
 
     AboutSchemeHandler();
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -292,7 +292,7 @@ bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resource
     if (!webPage || !webFrame)
         return false;
 
-    if (resourceLoader.request().url().protocolIsAbout() && is<SubresourceLoader>(resourceLoader))
+    if (resourceLoader.request().url().protocolIsAbout() && !resourceLoader.documentLoader()->isLoadingMainResource())
         return false;
 
     auto* handler = webPage->urlSchemeHandlerForScheme(resourceLoader.request().url().protocol());


### PR DESCRIPTION
#### ff246a18ed0e2423d7935a279eaa76689f7c9e47
<pre>
Bugfix: about scheme handler did not work as expected.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289716">https://bugs.webkit.org/show_bug.cgi?id=289716</a>
<a href="https://rdar.apple.com/146966248">rdar://146966248</a>

Reviewed by Brady Eidson.

Generic about scheme handler was landed on <a href="https://bugs.webkit.org/show_bug.cgi?id=288910">https://bugs.webkit.org/show_bug.cgi?id=288910</a>,
but it didn&apos;t work as expected. During the PR, many changes were made onto the original code
to attack Layout Tests failures and during that phase, it seems a bug was introduced.

`WebLoaderStrategy::tryLoadingUsingURLSchemeHandler()` blocks all request to the handler by
checking ResourceLoader is not SubresourceLoader, but that seems wrong.

Changed the check with not loading main resource via documentLoader. Also added about:blank
handler in the scheme handler because still some request is sent to scheme handler.

* Source/WebKit/UIProcess/AboutSchemeHandler.cpp:
(WebKit::AboutSchemeHandler::platformInitialize):
* Source/WebKit/UIProcess/AboutSchemeHandler.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::tryLoadingUsingURLSchemeHandler):

Canonical link: <a href="https://commits.webkit.org/292206@main">https://commits.webkit.org/292206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d57b5754289a6a48a65854d854ea7bf69aac88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45776 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97323 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29924 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98278 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11325 "Found 1 new test failure: quicklook/invalid-ql-id-url.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52985 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11038 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3739 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45115 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102357 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93898 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22323 "Build is in progress. Recent messages:Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22571 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82021 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Skipped layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15576 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22293 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25426 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23691 "Build is in progress. Recent messages:Running apply-patch; Running checkout-pull-request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->