### PR TITLE
[WebGPU] GPURenderPassEncoder.setBindGroup() shows up in CPU trace samples as significant

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -181,7 +181,7 @@ private:
     HashMap<uint64_t, DrawIndexCacheContainer, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_drawIndexedCache;
 
     const Ref<Device> m_device;
-    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable Vector<uint64_t> m_commandEncoders; // NOLINT - https://bugs.webkit.org/show_bug.cgi?id=289718
     mutable HashMap<uint64_t, uint32_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_gpuResourceMap;
     WeakHashSet<CommandEncoder> m_skippedValidationCommandEncoders;
     bool m_mustTakeSlowIndexValidationPath { false };

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -137,10 +137,15 @@ public:
     void setExistingEncoder(id<MTLCommandEncoder>);
     void generateInvalidEncoderStateError();
     bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
+    static void trackEncoder(CommandEncoder&, Vector<uint64_t>&);
     static void trackEncoder(CommandEncoder&, WeakHashSet<CommandEncoder>&);
+    static size_t computeSize(Vector<uint64_t>&, const Device&);
     uint64_t uniqueId() const { return m_uniqueId; }
     NSMutableSet<id<MTLCounterSampleBuffer>> *timestampBuffers() const { return m_retainedTimestampBuffers; };
     void addOnCommitHandler(Function<bool(CommandBuffer&)>&&);
+#if ENABLE(WEBGPU_BY_DEFAULT)
+    bool useResidencySet(id<MTLResidencySet>);
+#endif
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&, uint64_t uniqueId);
@@ -192,6 +197,9 @@ private PUBLIC_IN_WEBGPU_SWIFT:
     uint64_t m_sharedEventSignalValue { 0 };
     const Ref<Device> m_device;
     uint64_t m_uniqueId;
+#if ENABLE(WEBGPU_BY_DEFAULT)
+    uint32_t m_currentResidencySetCount { 0 };
+#endif
 private:
 } SWIFT_SHARED_REFERENCE(refCommandEncoder, derefCommandEncoder);
 

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -80,7 +80,7 @@ private:
     bool m_destroyed { false };
     id<MTLTexture> m_texture0 { nil };
     id<MTLTexture> m_texture1 { nil };
-    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable Vector<uint64_t> m_commandEncoders;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -70,8 +70,10 @@ void ExternalTexture::destroy()
 {
     m_pixelBuffer = nil;
     m_destroyed = true;
-    for (Ref commandEncoder : m_commandEncoders)
-        commandEncoder->makeSubmitInvalid();
+    for (auto commandEncoder : m_commandEncoders) {
+        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
+            ptr->makeSubmitInvalid();
+    }
 
     m_commandEncoders.clear();
 }
@@ -119,7 +121,7 @@ void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 
 size_t ExternalTexture::openCommandEncoderCount() const
 {
-    return m_commandEncoders.computeSize();
+    return CommandEncoder::computeSize(m_commandEncoders, m_device.get());
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -46,6 +46,7 @@ struct HardwareCapabilities {
         // as all hardware can render to this format. It's unclear whether this should
         // apply to _all_ PresentationContexts or just PresentationContextCoreAnimation.
         bool canPresentRGB10A2PixelFormats { false };
+        bool supportsResidencySets { false };
     } baseCapabilities;
 };
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -103,6 +103,7 @@ static HardwareCapabilities::BaseCapabilities baseCapabilities(id<MTLDevice> dev
         .timestampCounterSet = timestampCounterSet,
         .statisticCounterSet = statisticCounterSet,
         .canPresentRGB10A2PixelFormats = false, // To be filled in by the caller.
+        .supportsResidencySets = false,
     };
 }
 
@@ -198,6 +199,7 @@ static HardwareCapabilities apple6(id<MTLDevice> device)
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
     baseCapabilities.canPresentRGB10A2PixelFormats = false;
+    baseCapabilities.supportsResidencySets = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -257,6 +259,7 @@ static HardwareCapabilities apple7(id<MTLDevice> device)
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
     baseCapabilities.canPresentRGB10A2PixelFormats = false;
+    baseCapabilities.supportsResidencySets = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -444,6 +447,7 @@ static HardwareCapabilities::BaseCapabilities mergeBaseCapabilities(const Hardwa
         previous.timestampCounterSet,
         previous.statisticCounterSet,
         previous.canPresentRGB10A2PixelFormats || next.canPresentRGB10A2PixelFormats,
+        previous.supportsResidencySets || next.supportsResidencySets,
     };
 }
 

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -100,7 +100,7 @@ private:
         Ref<QuerySet> other;
         uint32_t otherIndex;
     };
-    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable Vector<uint64_t> m_commandEncoders;
     bool m_destroyed { false };
 } SWIFT_SHARED_REFERENCE(refQuerySet, derefQuerySet);
 

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -116,8 +116,10 @@ void QuerySet::destroy()
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
     m_visibilityBuffer = nil;
     m_timestampBuffer = nil;
-    for (Ref commandEncoder : m_commandEncoders)
-        commandEncoder->makeSubmitInvalid();
+    for (auto commandEncoder : m_commandEncoders) {
+        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
+            ptr->makeSubmitInvalid();
+    }
 
     m_commandEncoders.clear();
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -113,6 +113,7 @@ private:
     void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
 
     NSString* errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
+    std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
 
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };
@@ -133,6 +134,8 @@ private:
     Lock m_committedNotCompletedBuffersLock;
     NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> *m_openCommandEncoders;
     const ThreadSafeWeakPtr<Instance> m_instance;
+    id<MTLBuffer> m_temporaryBuffer;
+    uint64_t m_temporaryBufferOffset;
 } SWIFT_SHARED_REFERENCE(refQueue, derefQueue);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -264,7 +264,7 @@ bool RenderBundleEncoder::addResource(RenderBundle::ResourcesContainer* resource
         if (resource.renderStages && mtlResource)
             [renderPassEncoder->renderCommandEncoder() useResource:mtlResource usage:resource.usage stages:resource.renderStages];
         ASSERT(resource.entryUsage.hasExactlyOneBitSet());
-        renderPassEncoder->addResourceToActiveResources(resource.resource, mtlResource, resource.entryUsage);
+        renderPassEncoder->addResourceToActiveResources(resource.resource, resource.entryUsage);
         renderPassEncoder->setCommandEncoder(resource.resource);
         return renderPassEncoder->renderCommandEncoder();
     }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -102,7 +102,7 @@ public:
     Ref<CommandEncoder> protectedParentEncoder() const { return m_parentEncoder; }
 
     bool setCommandEncoder(const BindGroupEntryUsageData::Resource&);
-    void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, id<MTLResource>, OptionSet<BindGroupEntryUsage>);
+    void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, OptionSet<BindGroupEntryUsage>);
     static double quantizedDepthValue(double, WGPUTextureFormat);
     NSString* errorValidatingPipeline(const RenderPipeline&) const;
 
@@ -124,7 +124,8 @@ private:
     void runVertexBufferValidation(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>, WGPUTextureAspect);
-    void addResourceToActiveResources(const void*, id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel = 0, uint32_t baseArrayLayer = 0, WGPUTextureAspect = WGPUTextureAspect_DepthOnly);
+    void addTextureToActiveResources(const void*, id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect);
+    void addResourceToActiveResources(const void*, OptionSet<BindGroupEntryUsage>);
 
     NSString* errorValidatingAndBindingBuffers();
     NSString* errorValidatingDrawIndexed() const;
@@ -164,7 +165,8 @@ private:
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     using EntryUsage = OptionSet<BindGroupEntryUsage>;
     using EntryMap = HashMap<uint64_t, EntryUsage, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
-    HashMap<const void*, EntryMap> m_usagesForResource;
+    HashMap<const void*, EntryMap> m_usagesForTexture;
+    HashMap<const void*, EntryUsage> m_usagesForBuffer;
     float m_minDepth { 0.f };
     float m_maxDepth { 1.f };
     HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_queryBufferIndicesToClear;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -252,7 +252,7 @@ static void setViewportMinMaxDepthIntoBuffer(auto& fragmentDynamicOffsets, float
     fragmentDynamicOffsets[1] = std::bit_cast<destType>(maxDepth);
 }
 
-void RenderPassEncoder::addResourceToActiveResources(const void* resourceAddress, id<MTLResource> mtlResource, OptionSet<BindGroupEntryUsage> initialUsage, uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect aspect)
+void RenderPassEncoder::addTextureToActiveResources(const void* resourceAddress, id<MTLResource> mtlResource, OptionSet<BindGroupEntryUsage> initialUsage, uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect aspect)
 {
     if (!mtlResource)
         return;
@@ -275,7 +275,7 @@ void RenderPassEncoder::addResourceToActiveResources(const void* resourceAddress
     auto mapKey = BindGroup::makeEntryMapKey(baseMipLevel, baseArrayLayer, aspect);
     EntryUsage resourceUsage = initialUsage;
     EntryMap* entryMap = nullptr;
-    if (auto it = m_usagesForResource.find(resourceAddress); it != m_usagesForResource.end()) {
+    if (auto it = m_usagesForTexture.find(resourceAddress); it != m_usagesForTexture.end()) {
         entryMap = &it->value;
         if (auto innerIt = it->value.find(mapKey); innerIt != it->value.end())
             resourceUsage.add(innerIt->value);
@@ -288,41 +288,57 @@ void RenderPassEncoder::addResourceToActiveResources(const void* resourceAddress
     if (!entryMap) {
         EntryMap entryMap;
         entryMap.set(mapKey, resourceUsage);
-        m_usagesForResource.set(resourceAddress, entryMap);
+        m_usagesForTexture.set(resourceAddress, entryMap);
     } else
         entryMap->set(mapKey, resourceUsage);
 }
 
+void RenderPassEncoder::addResourceToActiveResources(const void* resourceAddress, OptionSet<BindGroupEntryUsage> initialUsage)
+{
+    if (!resourceAddress)
+        return;
+
+    EntryUsage resourceUsage = initialUsage;
+    if (auto it = m_usagesForBuffer.find(resourceAddress); it != m_usagesForBuffer.end())
+        resourceUsage.add(it->value);
+
+    if (!BindGroup::allowedUsage(resourceUsage)) {
+        makeInvalid([NSString stringWithFormat:@"Bind group has incompatible usage list: %@", BindGroup::usageName(resourceUsage)]);
+        return;
+    }
+    m_usagesForBuffer.set(resourceAddress, resourceUsage);
+}
+
 void RenderPassEncoder::addResourceToActiveResources(const TextureView& texture, OptionSet<BindGroupEntryUsage> resourceUsage, WGPUTextureAspect textureAspect)
 {
-    addResourceToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), textureAspect);
+    addTextureToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), textureAspect);
 }
 
 void RenderPassEncoder::addResourceToActiveResources(const TextureView& texture, OptionSet<BindGroupEntryUsage> resourceUsage)
 {
     WGPUTextureAspect textureAspect = texture.aspect();
     if (textureAspect != WGPUTextureAspect_All) {
-        addResourceToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), textureAspect);
+        addTextureToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), textureAspect);
         return;
     }
 
-    addResourceToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), WGPUTextureAspect_DepthOnly);
-    addResourceToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), WGPUTextureAspect_StencilOnly);
+    addTextureToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), WGPUTextureAspect_DepthOnly);
+    addTextureToActiveResources(&texture.apiParentTexture(), texture.parentTexture(), resourceUsage, texture.baseMipLevel(), texture.baseArrayLayer(), WGPUTextureAspect_StencilOnly);
 }
 
-void RenderPassEncoder::addResourceToActiveResources(const BindGroupEntryUsageData::Resource& resource, id<MTLResource> mtlResource, OptionSet<BindGroupEntryUsage> resourceUsage)
+void RenderPassEncoder::addResourceToActiveResources(const BindGroupEntryUsageData::Resource& resource, OptionSet<BindGroupEntryUsage> resourceUsage)
 {
     WTF::switchOn(resource, [&](const RefPtr<Buffer>& buffer) {
         if (buffer.get()) {
             if (resourceUsage.contains(BindGroupEntryUsage::Storage))
                 buffer->indirectBufferInvalidated(protectedParentEncoder());
-            addResourceToActiveResources(buffer.get(), buffer->buffer(), resourceUsage);
+            addResourceToActiveResources(buffer.get(), resourceUsage);
         }
         }, [&](const RefPtr<const TextureView>& textureView) {
             if (textureView.get())
                 addResourceToActiveResources(*textureView.get(), resourceUsage);
         }, [&](const RefPtr<const ExternalTexture>& externalTexture) {
-            addResourceToActiveResources(externalTexture.get(), mtlResource, resourceUsage);
+            addResourceToActiveResources(externalTexture.get(), resourceUsage);
     });
 }
 
@@ -523,7 +539,7 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
     }
 
     if (indirectBuffer)
-        addResourceToActiveResources(indirectBuffer, indirectBuffer->buffer(), BindGroupEntryUsage::Input);
+        addResourceToActiveResources(indirectBuffer, BindGroupEntryUsage::Input);
     if (NSString* error = errorValidatingAndBindingBuffers()) {
         makeInvalid(error);
         return false;
@@ -546,7 +562,7 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
                 ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());
                 for (size_t i = 0, sz = resource.mtlResources.size(); i < sz; ++i) {
                     auto& resourceUsage = resource.resourceUsages[i];
-                    addResourceToActiveResources(resourceUsage.resource, resource.mtlResources[i], resourceUsage.usage);
+                    addResourceToActiveResources(resourceUsage.resource, resourceUsage.usage);
                     setCommandEncoder(resourceUsage.resource);
                 }
             }
@@ -1222,7 +1238,7 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
                 ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());
                 for (size_t i = 0, resourceCount = resource.mtlResources.size(); i < resourceCount; ++i) {
                     auto& resourceUsage = resource.resourceUsages[i];
-                    addResourceToActiveResources(resourceUsage.resource, resource.mtlResources[i], resourceUsage.usage);
+                    addResourceToActiveResources(resourceUsage.resource, resourceUsage.usage);
                     setCommandEncoder(resourceUsage.resource);
                 }
             }
@@ -1350,6 +1366,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
     else
         m_bindGroupDynamicOffsets.remove(groupIndex);
 
+    auto parentEncoder = m_parentEncoder;
     for (const auto& resource : group.resources()) {
         if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())
             [renderCommandEncoder() useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
@@ -1357,10 +1374,10 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
         ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());
         for (size_t i = 0, sz = resource.mtlResources.size(); i < sz; ++i) {
             auto& resourceUsage = resource.resourceUsages[i];
-            addResourceToActiveResources(resourceUsage.resource, resource.mtlResources[i], resourceUsage.usage);
+            addResourceToActiveResources(resourceUsage.resource, resourceUsage.usage);
             setCommandEncoder(resourceUsage.resource);
         }
-        auto parentEncoder = m_parentEncoder;
+
         for (auto& [samplerPtr, _] : group.samplers()) {
             if (RefPtr sampler = samplerPtr.get())
                 parentEncoder->addSampler(*sampler);
@@ -1404,7 +1421,7 @@ void RenderPassEncoder::setIndexBuffer(Buffer& buffer, WGPUIndexFormat format, u
     m_indexBufferSize = size == WGPU_WHOLE_SIZE ? buffer.initialSize() : size;
     m_indexType = format == WGPUIndexFormat_Uint32 ? MTLIndexTypeUInt32 : MTLIndexTypeUInt16;
     m_indexBufferOffset = offset;
-    addResourceToActiveResources(&buffer, buffer.buffer(), BindGroupEntryUsage::Input);
+    addResourceToActiveResources(&buffer, BindGroupEntryUsage::Input);
 }
 
 NSString* RenderPassEncoder::errorValidatingPipeline(const RenderPipeline& pipeline) const
@@ -1504,7 +1521,7 @@ void RenderPassEncoder::setVertexBuffer(uint32_t slot, const Buffer* optionalBuf
         makeInvalid(@"setVertexBuffer: buffer length is invalid");
         return;
     }
-    addResourceToActiveResources(&buffer, mtlBuffer, BindGroupEntryUsage::Input);
+    addResourceToActiveResources(&buffer, BindGroupEntryUsage::Input);
 }
 
 void RenderPassEncoder::setViewport(float x, float y, float width, float height, float minDepth, float maxDepth)

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -161,7 +161,7 @@ private:
     Vector<WeakPtr<TextureView>> m_textureViews;
     bool m_destroyed { false };
     bool m_canvasBacking { false };
-    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable Vector<uint64_t> m_commandEncoders;
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
 } SWIFT_SHARED_REFERENCE(refTexture, derefTexture);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3000,8 +3000,10 @@ void Texture::makeCanvasBacking()
 bool Texture::waitForCommandBufferCompletion()
 {
     bool result = true;
-    for (Ref commandEncoder : m_commandEncoders)
-        result = commandEncoder->waitForCommandBufferCompletion() && result;
+    for (auto commandEncoder : m_commandEncoders) {
+        if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
+            result = ptr->waitForCommandBufferCompletion() && result;
+    }
 
     return result;
 }
@@ -3228,8 +3230,10 @@ void Texture::destroy()
         }
     }
     if (!m_canvasBacking) {
-        for (Ref commandEncoder : m_commandEncoders)
-            commandEncoder->makeSubmitInvalid();
+        for (auto commandEncoder : m_commandEncoders) {
+            if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
+                ptr->makeSubmitInvalid();
+        }
     }
     m_commandEncoders.clear();
 

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -102,7 +102,7 @@ private:
 
     const Ref<Device> m_device;
     Ref<Texture> m_parentTexture;
-    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable Vector<uint64_t> m_commandEncoders;
 } SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -172,8 +172,10 @@ void TextureView::destroy()
 {
     m_texture = Ref { m_device }->placeholderTexture(format());
     if (!m_parentTexture->isCanvasBacking()) {
-        for (Ref commandEncoder : m_commandEncoders)
-            commandEncoder->makeSubmitInvalid();
+        for (auto commandEncoder : m_commandEncoders) {
+            if (RefPtr ptr = m_device->commandEncoderFromIdentifier(commandEncoder))
+                ptr->makeSubmitInvalid();
+        }
     }
 
     m_commandEncoders.clear();


### PR DESCRIPTION
#### 29155572a7c4547529fc876564975662d36d15be
<pre>
[WebGPU] GPURenderPassEncoder.setBindGroup() shows up in CPU trace samples as significant
<a href="https://bugs.webkit.org/show_bug.cgi?id=289433">https://bugs.webkit.org/show_bug.cgi?id=289433</a>
<a href="https://rdar.apple.com/146605221">rdar://146605221</a>

Reviewed by Tadeu Zagallo.

CPU profile showed significant time in setBindGroup calls

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Device::safeCreateBuffer const):
(WebGPU::Buffer::incrementBufferMapCount):
(WebGPU::Buffer::decrementBufferMapCount):
(WebGPU::Buffer::setCommandEncoder const):
(WebGPU::Buffer::destroy):
Creating the WeakPtr was showing up significantly in traces,
we can avoid this by storing identifiers and then performing
lookups in the rare cases it is needed.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
(WebGPU::CommandEncoder::CommandEncoder):
(WebGPU::CommandEncoder::~CommandEncoder):
(WebGPU::CommandEncoder::encoderIsCurrent const):
(WebGPU::CommandEncoder::computeSize):
(WebGPU::CommandEncoder::trackEncoder):
Adapt new container.

(WebGPU::CommandEncoder::useResidencySet):
Allow for residency sets on devices which support them.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::addTextureToActiveResources):
(WebGPU::addResourceToActiveResources):
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
Track textures and buffers seperately as buffers consume less resources.

* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::isShaderValidationEnabled const):
(WebGPU::Device::commandEncoderFromIdentifier const):
(WebGPU::Device::commandEncoderFromIdentifier):
(WebGPU::Device::removeCommandEncoder):
(WebGPU::Device::supportsResidencySets):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::newBufferWithBytes const):
(WebGPU::Device::newBufferWithBytesNoCopy const):
Skip memory attributions for buffers of short lifetime, the attribution
cost is significant and the GPU process already needs headroom available
to allocate the memory initially.

* Source/WebGPU/WebGPU/ExternalTexture.h:
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::destroy):
(WebGPU::ExternalTexture::openCommandEncoderCount const):
Use adopted helper functions.

* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseCapabilities):
(WebGPU::apple6):
(WebGPU::apple7):
(WebGPU::mergeBaseCapabilities):
Apple6 and later support residency sets.

* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::QuerySet::destroy):
Use new container.

* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::span):
(WebGPU::Queue::newTemporaryBufferWithBytes):
(WebGPU::Queue::writeBuffer):
(WebGPU::Queue::writeTexture):
Sub-allocate small writeBuffer calls from a single buffer.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::addResource):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::addTextureToActiveResources):
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setBindGroup):
(WebGPU::RenderPassEncoder::setIndexBuffer):
(WebGPU::RenderPassEncoder::setVertexBuffer):
Use lighter weight mechanism for tracking resources.

* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::waitForCommandBufferCompletion):
(WebGPU::Texture::destroy):
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::destroy):
Adapt new container.

Canonical link: <a href="https://commits.webkit.org/292320@main">https://commits.webkit.org/292320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38a5c667ed9800bf8c4ab128e47288b342cc11b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46045 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30134 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11266 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102624 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22590 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16497 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81908 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15921 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27715 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->