### PR TITLE
Address Safer CPP warnings in MediaStream

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011, 2012, 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -123,13 +123,17 @@ RefPtr<MediaStream> MediaStream::clone()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    RefPtr document = this->document();
+    if (!document)
+        return nullptr;
+
     Vector<Ref<MediaStreamTrack>> clonedTracks;
     clonedTracks.reserveInitialCapacity(m_trackMap.size());
     for (auto& track : m_trackMap.values()) {
         if (auto clone = track->clone())
             clonedTracks.append(clone.releaseNonNull());
     }
-    return MediaStream::create(*document(), WTFMove(clonedTracks));
+    return MediaStream::create(*document, WTFMove(clonedTracks));
 }
 
 void MediaStream::addTrack(MediaStreamTrack& track)
@@ -204,7 +208,7 @@ void MediaStream::activeStatusChanged()
 
 void MediaStream::didAddTrack(MediaStreamTrackPrivate& trackPrivate)
 {
-    ScriptExecutionContext* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -277,7 +281,7 @@ void MediaStream::mediaCanStart(Document& document)
 
 void MediaStream::startProducingData()
 {
-    Document* document = this->document();
+    RefPtr document = this->document();
     if (!document || !document->page())
         return;
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011, 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -151,7 +151,7 @@ private:
 
     Document* document() const;
 
-    Ref<MediaStreamPrivate> m_private;
+    const Ref<MediaStreamPrivate> m_private;
 
     MemoryCompactRobinHoodHashMap<String, Ref<MediaStreamTrack>> m_trackMap;
 

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -73,7 +73,6 @@ platform/graphics/coretext/DrawGlyphsRecorder.h
 platform/graphics/cv/GraphicsContextGLCVCocoa.h
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
-platform/mediastream/MediaStreamPrivate.h
 platform/mediastream/mac/CoreAudioCaptureSource.h
 platform/mock/ScrollbarsControllerMock.h
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -93,8 +93,6 @@ Modules/indexeddb/client/IDBConnectionProxy.cpp
 Modules/indexeddb/client/IDBConnectionToServer.cpp
 Modules/indexeddb/client/TransactionOperation.h
 Modules/mediacontrols/MediaControlsHost.cpp
-Modules/mediarecorder/MediaRecorder.cpp
-Modules/mediarecorder/MediaRecorder.h
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
 Modules/mediasession/MediaSessionCoordinator.cpp
@@ -106,8 +104,6 @@ Modules/mediasource/MediaSourceInterfaceMainThread.cpp
 Modules/mediasource/MediaSourceInterfaceWorker.cpp
 Modules/mediasource/SampleMap.cpp
 Modules/mediasource/SourceBuffer.cpp
-Modules/mediastream/MediaStream.cpp
-Modules/mediastream/MediaStream.h
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
@@ -1053,7 +1049,6 @@ platform/mac/ScrollbarsControllerMac.mm
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp
-platform/mediastream/MediaStreamPrivate.cpp
 platform/mediastream/MediaStreamTrackDataHolder.cpp
 platform/mediastream/MediaStreamTrackPrivate.cpp
 platform/mediastream/RealtimeMediaSourceCenter.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -30,7 +30,6 @@ Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediasession/MediaSession.cpp
 Modules/mediasource/SourceBuffer.cpp
-Modules/mediastream/MediaStream.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2011, 2015 Ericsson AB. All rights reserved.
  * Copyright (C) 2013 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -75,7 +75,7 @@ MediaStreamPrivate::MediaStreamPrivate(Ref<const Logger>&& logger, const MediaSt
     UNUSED_PARAM(logger);
     ASSERT(!m_id.isEmpty());
 
-    for (auto& track : tracks) {
+    for (Ref track : tracks) {
         track->addObserver(*this);
         m_trackSet.add(track->id(), track);
     }
@@ -85,7 +85,7 @@ MediaStreamPrivate::MediaStreamPrivate(Ref<const Logger>&& logger, const MediaSt
 
 MediaStreamPrivate::~MediaStreamPrivate()
 {
-    for (auto& track : m_trackSet.values())
+    for (Ref track : m_trackSet.values())
         track->removeObserver(*this);
 }
 
@@ -115,13 +115,13 @@ MediaStreamTrackPrivateVector MediaStreamPrivate::tracks() const
 
 void MediaStreamPrivate::forEachTrack(NOESCAPE const Function<void(const MediaStreamTrackPrivate&)>& callback) const
 {
-    for (auto& track : m_trackSet.values())
+    for (Ref track : m_trackSet.values())
         callback(track.get());
 }
 
 void MediaStreamPrivate::forEachTrack(NOESCAPE const Function<void(MediaStreamTrackPrivate&)>& callback)
 {
-    for (auto& track : m_trackSet.values())
+    for (Ref track : m_trackSet.values())
         callback(track.get());
 }
 
@@ -154,7 +154,7 @@ void MediaStreamPrivate::addTrack(Ref<MediaStreamTrackPrivate>&& track)
 
     ALWAYS_LOG(LOGIDENTIFIER, track->logIdentifier());
 
-    auto& trackRef = track.get();
+    Ref trackRef = track.get();
     track->addObserver(*this);
     m_trackSet.add(track->id(), WTFMove(track));
 
@@ -185,20 +185,20 @@ void MediaStreamPrivate::removeTrack(MediaStreamTrackPrivate& track)
 void MediaStreamPrivate::startProducingData()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (auto& track : m_trackSet.values())
+    for (Ref track : m_trackSet.values())
         track->startProducingData();
 }
 
 void MediaStreamPrivate::stopProducingData()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (auto& track : m_trackSet.values())
+    for (Ref track : m_trackSet.values())
         track->stopProducingData();
 }
 
 bool MediaStreamPrivate::isProducingData() const
 {
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (track->isProducingData())
             return true;
     }
@@ -207,7 +207,7 @@ bool MediaStreamPrivate::isProducingData() const
 
 bool MediaStreamPrivate::hasVideo() const
 {
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (track->isVideo() && track->isActive())
             return true;
     }
@@ -216,7 +216,7 @@ bool MediaStreamPrivate::hasVideo() const
 
 bool MediaStreamPrivate::hasAudio() const
 {
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (track->isAudio() && track->isActive())
             return true;
     }
@@ -225,7 +225,7 @@ bool MediaStreamPrivate::hasAudio() const
 
 bool MediaStreamPrivate::muted() const
 {
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (!track->muted() && !track->ended())
             return false;
     }
@@ -235,8 +235,8 @@ bool MediaStreamPrivate::muted() const
 IntSize MediaStreamPrivate::intrinsicSize() const
 {
     IntSize size;
-    if (m_activeVideoTrack) {
-        const RealtimeMediaSourceSettings& setting = m_activeVideoTrack->settings();
+    if (RefPtr videoTrack = m_activeVideoTrack.get()) {
+        const RealtimeMediaSourceSettings& setting = videoTrack->settings();
         size.setWidth(setting.width());
         size.setHeight(setting.height());
     }
@@ -247,7 +247,7 @@ IntSize MediaStreamPrivate::intrinsicSize() const
 void MediaStreamPrivate::updateActiveVideoTrack()
 {
     m_activeVideoTrack = nullptr;
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (!track->ended() && track->isVideo()) {
             m_activeVideoTrack = track.ptr();
             break;
@@ -312,9 +312,9 @@ void MediaStreamPrivate::trackEnded(MediaStreamTrackPrivate& track)
 
 void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 {
-    for (auto& track : m_trackSet.values()) {
+    for (Ref track : m_trackSet.values()) {
         if (track->isCaptureTrack() && track->deviceType() == CaptureDevice::DeviceType::Camera)
-            track->source().monitorOrientation(notifier);
+            track->protectedSource()->monitorOrientation(notifier);
     }
 }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2011, 2015 Ericsson AB. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,7 +93,7 @@ public:
     bool hasTracks() const { return !m_trackSet.isEmpty(); }
     void forEachTrack(NOESCAPE const Function<void(const MediaStreamTrackPrivate&)>&) const;
     void forEachTrack(NOESCAPE const Function<void(MediaStreamTrackPrivate&)>&);
-    MediaStreamTrackPrivate* activeVideoTrack() { return m_activeVideoTrack; }
+    MediaStreamTrackPrivate* activeVideoTrack() { return m_activeVideoTrack.get(); }
 
     bool active() const { return m_isActive; }
     void updateActiveState();
@@ -141,7 +141,7 @@ private:
 
     WeakHashSet<MediaStreamPrivateObserver> m_observers;
     String m_id;
-    MediaStreamTrackPrivate* m_activeVideoTrack { nullptr };
+    WeakPtr<MediaStreamTrackPrivate> m_activeVideoTrack;
     MemoryCompactRobinHoodHashMap<String, Ref<MediaStreamTrackPrivate>> m_trackSet;
     bool m_isActive { false };
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### 8368791c63c9b7951c406ce9f820b11d99ff5d25
<pre>
Address Safer CPP warnings in MediaStream
<a href="https://bugs.webkit.org/show_bug.cgi?id=289720">https://bugs.webkit.org/show_bug.cgi?id=289720</a>
<a href="https://rdar.apple.com/146969452">rdar://146969452</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::clone):
(WebCore::MediaStream::didAddTrack):
(WebCore::MediaStream::startProducingData):
* Source/WebCore/Modules/mediastream/MediaStream.h:

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::MediaStreamPrivate):
(WebCore::MediaStreamPrivate::~MediaStreamPrivate):
(WebCore::MediaStreamPrivate::forEachTrack const):
(WebCore::MediaStreamPrivate::forEachTrack):
(WebCore::MediaStreamPrivate::addTrack):
(WebCore::MediaStreamPrivate::startProducingData):
(WebCore::MediaStreamPrivate::stopProducingData):
(WebCore::MediaStreamPrivate::isProducingData const):
(WebCore::MediaStreamPrivate::hasVideo const):
(WebCore::MediaStreamPrivate::hasAudio const):
(WebCore::MediaStreamPrivate::muted const):
(WebCore::MediaStreamPrivate::intrinsicSize const):
(WebCore::MediaStreamPrivate::updateActiveVideoTrack):
(WebCore::MediaStreamPrivate::monitorOrientation):
* Source/WebCore/platform/mediastream/MediaStreamPrivate.h:

Canonical link: <a href="https://commits.webkit.org/293155@main">https://commits.webkit.org/293155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1609b5116900cfe0634cd6c2638173a3dba7311

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74573 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100938 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13528 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88503 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54930 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47907 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18639 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30145 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24798 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->