### PR TITLE
Address Safer CPP warnings in screen capture

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1062,16 +1062,12 @@ platform/mediastream/RealtimeOutgoingAudioSource.cpp
 platform/mediastream/RealtimeOutgoingVideoSource.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
-platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
-platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
 platform/mediastream/mac/AVCaptureDeviceManager.mm
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/MockAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
-platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
-platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
 platform/mock/GeolocationClientMock.cpp
 platform/mock/MockAudioDestinationCocoa.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -116,7 +116,6 @@ platform/mediastream/RealtimeMediaSourceCenter.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
 rendering/MotionPath.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -201,13 +201,10 @@ platform/mac/WebCoreView.m
 platform/mac/WebPlaybackControlsManager.mm
 platform/mac/WidgetMac.mm
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
-platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
 platform/mediastream/mac/AVCaptureDeviceManager.mm
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/CoreAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
-platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/CertificateInfoCFNet.cpp
 platform/network/mac/CredentialStorageMac.mm
 platform/network/mac/NetworkStateNotifierMac.cpp

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -270,27 +270,27 @@ void DisplayCaptureSourceCocoa::emitFrame()
 
     auto frame = m_capturer->generateFrame();
     auto imageSize = WTF::switchOn(frame,
-        [](RetainPtr<IOSurfaceRef>& surface) -> IntSize {
+        [](RetainPtr<IOSurfaceRef> surface) -> IntSize {
             if (!surface)
                 return { };
 
             return IntSize(IOSurfaceGetWidth(surface.get()), IOSurfaceGetHeight(surface.get()));
         },
-        [](RefPtr<NativeImage>& image) -> IntSize {
+        [](RefPtr<NativeImage> image) -> IntSize {
             if (!image)
                 return { };
 
             return image->size();
         },
-        [](RetainPtr<CMSampleBufferRef>& sample) -> IntSize {
+        [](RetainPtr<CMSampleBufferRef> sample) -> IntSize {
             if (!sample)
                 return { };
 
-            CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(sample.get());
-            if (PAL::CMFormatDescriptionGetMediaType(formatDescription) != kCMMediaType_Video)
+            RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(sample.get());
+            if (PAL::CMFormatDescriptionGetMediaType(formatDescription.get()) != kCMMediaType_Video)
                 return IntSize();
 
-            return IntSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(formatDescription, true, true));
+            return IntSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(formatDescription.get(), true, true));
         }
     );
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -108,18 +108,18 @@ public:
 
         void isRunningChanged(bool running)
         {
-            if (m_observer)
-                m_observer->capturerIsRunningChanged(running);
+            if (RefPtr observer = m_observer.get())
+                observer->capturerIsRunningChanged(running);
         }
         void captureFailed()
         {
-            if (m_observer)
-                m_observer->capturerFailed();
+            if (RefPtr observer = m_observer.get())
+                observer->capturerFailed();
         }
         void configurationChanged()
         {
-            if (m_observer)
-                m_observer->capturerConfigurationChanged();
+            if (RefPtr observer = m_observer.get())
+                observer->capturerConfigurationChanged();
         }
 
     private:
@@ -165,7 +165,7 @@ private:
     void commitConfiguration() { m_capturer->commitConfiguration(settings()); }
     void emitFrame();
 
-    UniqueRef<Capturer> m_capturer;
+    const UniqueRef<Capturer> m_capturer;
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -28,9 +28,9 @@
 
 #include "DisplayCapturePromptType.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSError;
 OBJC_CLASS SCContentFilter;
@@ -94,13 +94,12 @@ private:
     CleanupFunction m_cleanupFunction;
 };
 
-class ScreenCaptureKitSharingSessionManager : public CanMakeWeakPtr<ScreenCaptureKitSharingSessionManager> {
+class ScreenCaptureKitSharingSessionManager : public RefCountedAndCanMakeWeakPtr<ScreenCaptureKitSharingSessionManager> {
 public:
     WEBCORE_EXPORT static ScreenCaptureKitSharingSessionManager& singleton();
     WEBCORE_EXPORT static bool isAvailable();
     WEBCORE_EXPORT static bool useSCContentSharingPicker();
 
-    ScreenCaptureKitSharingSessionManager();
     ~ScreenCaptureKitSharingSessionManager();
 
     void sharingSessionDidChangeContent(SCContentSharingSession*);
@@ -121,6 +120,8 @@ public:
     void cleanupSharingSession(SCContentSharingSession*);
 
 private:
+    ScreenCaptureKitSharingSessionManager();
+
     void cleanupAllSessions();
     void completeDeviceSelection(SCContentFilter*, SCContentSharingSession* = nullptr);
 


### PR DESCRIPTION
#### 0061fc5ad496686a974216d95f4c27cc173c85a2
<pre>
Address Safer CPP warnings in screen capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=289725">https://bugs.webkit.org/show_bug.cgi?id=289725</a>
<a href="https://rdar.apple.com/146976092">rdar://146976092</a>

Reviewed by Youenn Fablet.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::emitFrame):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(-[WebCoreScreenCaptureKitHelper stream:didStopWithError:]):
(-[WebCoreScreenCaptureKitHelper stream:didOutputSampleBuffer:ofType:]):
(-[WebCoreScreenCaptureKitHelper outputVideoEffectDidStartForStream:]):
(-[WebCoreScreenCaptureKitHelper outputVideoEffectDidStopForStream:]):
(WebCore::ScreenCaptureKitCaptureSource::sessionFilterDidChange):
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper sessionDidEnd:]):
(-[WebDisplayMediaPromptHelper sessionDidChangeContent:]):
(-[WebDisplayMediaPromptHelper pickerCanceledForSession:]):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didCancelForStream:]):
(-[WebDisplayMediaPromptHelper contentSharingPickerStartDidFailWithError:]):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didUpdateWithFilter:forStream:]):
(WebCore::ScreenCaptureKitSharingSessionManager::singleton):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::completeDeviceSelection):
(WebCore::ScreenCaptureKitSharingSessionManager::promptForGetDisplayMedia):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(WebCore::ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice):

Canonical link: <a href="https://commits.webkit.org/293012@main">https://commits.webkit.org/293012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea307388d4c72d54be8fb73c0341cff57f667b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74419 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100710 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13355 "Found 1 new test failure: fast/mediacapturefromelement/CanvasCaptureMediaStream-exceptions.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47679 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104815 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24787 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82901 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18388 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24748 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29917 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->