### PR TITLE
Avoid scanning for GC roots in environment

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1114,7 +1114,7 @@ void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&
     m_checkpointSideState.append(WTFMove(payload));
 
 #if ASSERT_ENABLED
-    auto bounds = StackBounds::currentThreadStackBounds();
+    auto bounds = Thread::currentSingleton().stack();
     void* previousCallFrame = bounds.end();
     for (size_t i = m_checkpointSideState.size(); i--;) {
         auto* callFrame = m_checkpointSideState[i]->associatedCallFrame;
@@ -1137,7 +1137,7 @@ std::unique_ptr<CheckpointOSRExitSideState> VM::popCheckpointOSRSideState(CallFr
 void VM::popAllCheckpointOSRSideStateUntil(CallFrame* target)
 {
     ASSERT(currentThreadIsHoldingAPILock());
-    auto bounds = StackBounds::currentThreadStackBounds().withSoftOrigin(target);
+    auto bounds = Thread::currentSingleton().stack().withSoftOrigin(target);
     ASSERT(bounds.contains(target));
 
     // We have to worry about migrating from another thread since there may be no checkpoints in our thread but one in the other threads.

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -144,6 +144,8 @@ void RunLoop::performWork()
         }
 
         auto function = m_currentIteration.takeFirst();
+        int stackOrigin;
+        Thread::currentSingleton().lowerStackOriginInThread(&stackOrigin);
         function();
     }
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -215,11 +215,14 @@ const char* Thread::normalizeThreadName(const char* threadName)
 #endif
 }
 
-void Thread::initializeInThread()
+void Thread::initializeInThread(void* softStackOrigin)
 {
     if (m_stack.isEmpty())
         m_stack = StackBounds::currentThreadStackBounds();
     m_savedLastStackTop = stack().origin();
+
+    if (softStackOrigin)
+        lowerStackOriginInThread(softStackOrigin);
 
     m_currentAtomStringTable = &m_defaultAtomStringTable;
 #if USE(WEB_THREAD)
@@ -239,8 +242,17 @@ void Thread::initializeInThread()
 #endif
 }
 
+void Thread::lowerStackOriginInThread(void* origin) {
+    if (origin < m_stack.origin()) {
+        m_stack = m_stack.withSoftOrigin(origin);
+        m_savedLastStackTop = stack().origin();
+    }
+}
+
 void Thread::entryPoint(NewThreadContext* newThreadContext)
 {
+    int softStackOrigin;
+
     Function<void()> function;
     {
         // Ref is already incremented by Thread::create.
@@ -253,7 +265,7 @@ void Thread::entryPoint(NewThreadContext* newThreadContext)
         function = WTFMove(context->entryPoint);
 
         Ref thread = WTFMove(context->thread);
-        thread->initializeInThread();
+        thread->initializeInThread(&softStackOrigin);
 
         Thread::initializeTLS(WTFMove(thread));
 

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -300,10 +300,12 @@ public:
     static Thread* currentMayBeNull();
 #endif
 
+    void lowerStackOriginInThread(void* origin);
+
 protected:
     Thread() = default;
 
-    void initializeInThread();
+    void initializeInThread(void* softStackOrigin = nullptr);
 
     // Internal platform-specific Thread establishment implementation.
     bool establishHandle(NewThreadContext*, std::optional<size_t> stackSize, QOS, SchedulingPolicy);


### PR DESCRIPTION
#### b46d114578ba0717820c60512abf6a25db87f477
<pre>
Avoid scanning for GC roots in environment
<a href="https://bugs.webkit.org/show_bug.cgi?id=285840">https://bugs.webkit.org/show_bug.cgi?id=285840</a>

Reviewed by NOBODY (OOPS!).

On 32-bit armv7/linux we run into an issue where the environment strings
located at the bottom of the stack are interpreted as cells pointing
into the heap, keeping actually dead objects alive.

This opportunistically lowers the stack bounds origin of WTF::Threads
to avoid scanning parts of the stack for roots we know cannot contain
true roots.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::pushCheckpointOSRSideState):
(JSC::VM::popAllCheckpointOSRSideStateUntil):
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::performWork):
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::initializeInThread):
(WTF::Thread::lowerStackOriginInThread):
(WTF::Thread::entryPoint):
* Source/WTF/wtf/Threading.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b46d114578ba0717820c60512abf6a25db87f477

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95018 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23035 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72486 "Failure limit exceed. At least found 346 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/subtle/gc-worker.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html fast/animation/request-animation-frame-during-modal.html fast/dom/no-scroll-when-command-click-fragment-URL.html fast/events/focus-anchor-with-tabindex-hang.html fast/events/platform-wheelevent-with-delta-zero-crash.html fast/events/wheel/wheel-event-outside-body.html fast/events/wheel/wheelevent-mousewheel-interaction.html fast/frames/iframe-window-focus.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29779 "Exiting early after 60 failures. 331 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98019 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11126 "Found 60 new test failures: accessibility/aria-brailleroledescription.html accessibility/aria-description.html accessibility/aria-roles-unignored.html accessibility/dirty-style-and-relations-crash.html accessibility/display-contents/object-ordering.html accessibility/dynamically-changing-iframe-remains-accessible.html accessibility/heading-level.html accessibility/ignore-modals-without-any-content.html accessibility/ios-simulator/accessibility-make-first-responder.html accessibility/ios-simulator/attributed-string-for-element.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85804 "Found 26 new API test failures: TestWebKitAPI.DeviceScaleFactorOnBack.WebKit, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedWebArchive, TestWebKitAPI.ExitFullscreenOnEnterPiP.VideoFullscreen, TestWebKitAPI.WebKitLegacy.WindowlessWebViewWithMedia, TestWebKitAPI.WebKitLegacy.DidCreateJavaScriptContextBackForwardCacheTest, TestWebKitAPI.WebKitLegacy.WebScriptObjectDescription, TestWebKitAPI.WebKit2.GetDisplayMediaWindowAndScreenPrompt, TestWebKitAPI.DynamicDeviceScaleFactor.WebKit, TestWebKitAPI.WebKitLegacy.SelectionAppearanceUpdatesInEditableWebView, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedRTFD ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52813 "Found 51 new API test failures: /WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/window-object-cleared, /WPE/TestWebKitWebView:/webkit/WebKitWebView/cors-allowlist, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-async-js-functions, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebView:/webkit/WebKitWebView/document-focus, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-disallowed, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10837 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.html imported/w3c/web-platform-tests/FileAPI/file/File-constructor.any.worker.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-controls.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-iso-2022-jp.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-punctuation.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-utf-8.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3530 "Found 60 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/subtle/gc-worker.html fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video.html fast/css/first-letter-block-form-controls-crash.html fast/css/view-transitions-update-pseudo-element-crash.html fast/dynamic/content-visibility-crash-with-continuation-and-table.html fast/events/input-events-ime-composition.html fast/forms/input-user-modify.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44855 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87688 "Found 1 new JSC binary failure: testapi, Found 131 new JSC stress test failures: stress/atomic-increment-bigint64.js.dfg-eager, stress/atomic-increment-bigint64.js.dfg-eager-no-cjit-validate, stress/atomic-increment-bigint64.js.ftl-eager, stress/atomic-increment-bigint64.js.ftl-eager-no-cjit, stress/atomic-increment-bigint64.js.no-cjit-collect-continuously, stress/collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js.default, stress/lars-sab-workers.js.dfg-eager, stress/lars-sab-workers.js.dfg-eager-no-cjit-validate, stress/lars-sab-workers.js.ftl-eager, stress/lars-sab-workers.js.ftl-eager-no-cjit ... (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3623 "Found 60 new test failures: accessibility/accessibility-crash-setattribute.html accessibility/button-inside-label-ax-text.html accessibility/color-input-value-changes.html accessibility/custom-elements/heading.html accessibility/custom-elements/table.html accessibility/display-contents/list.html accessibility/dynamically-changing-iframe-remains-accessible.html accessibility/ellipsis-text.html accessibility/focusable-inside-hidden.html accessibility/mac/aria-describedby-fieldset.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102115 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93639 "Found 1 new JSC binary failure: testapi, Found 131 new JSC stress test failures: stress/atomic-increment-bigint64.js.dfg-eager, stress/atomic-increment-bigint64.js.dfg-eager-no-cjit-validate, stress/atomic-increment-bigint64.js.ftl-eager, stress/atomic-increment-bigint64.js.ftl-eager-no-cjit, stress/atomic-increment-bigint64.js.no-cjit-collect-continuously, stress/collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js.default, stress/lars-sab-workers.js.dfg-eager, stress/lars-sab-workers.js.dfg-eager-no-cjit-validate, stress/lars-sab-workers.js.ftl-eager, stress/lars-sab-workers.js.ftl-eager-no-cjit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22060 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16141 "Found 60 new test failures: accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-node-memory-management.html accessibility/active-descendant-changes-result-in-focus-changes.html accessibility/combobox/combobox-active-element-selected-children.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-value.html accessibility/custom-elements/current.html accessibility/custom-elements/describedby.html accessibility/custom-elements/flowto.html accessibility/datetime/input-datetime-local-label-value.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81500 "Failure limit exceed. At least found 331 new test failures: crypto/workers/crypto-gc-worker.html crypto/workers/subtle/gc-worker.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html editing/async-clipboard/clipboard-do-not-read-text-from-platform-if-text-changes.html editing/execCommand/typing-should-not-trigger-scrolling-when-selection-is-visible.html editing/input/delete-text-in-composition.html editing/pasteboard/paste-and-sanitize.html editing/spelling/spellcheck-attribute-toggle.html fast/animation/request-animation-frame-during-modal.html fast/events/focus-anchor-with-tabindex-hang.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81822 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80888 "Found 56 new API test failures: /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/window-object-cleared, /WebKitGTK/TestFrame:/webkit/WebKitFrame/main-frame, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/load-alternate-html-from-page-with-csp, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/isolated-world, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-disallowed, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/default-content-security-policy ... (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25434 "Found 25 new test failures: http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrHandInput_gc.html imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https.html imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https.html imported/w3c/web-platform-tests/webxr/idlharness.https.window.html imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_contextlost.https.html imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https.html imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_immersive_unsupported.https.html imported/w3c/web-platform-tests/webxr/xrFrame_getViewerPose_getPose.https.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2840 "Found 60 new test failures: accessibility/accessibility-node-memory-management.html accessibility/anchor-linked-anonymous-block-crash.html accessibility/aria-checked-mixed-value.html accessibility/combobox/combobox-linked-listbox-destroyed.html accessibility/custom-elements/heading.html accessibility/custom-elements/shadow-element-text.html accessibility/display-contents/dynamically-added-children.html accessibility/display-contents/table-dynamic.html accessibility/mac/alt-for-css-content.html accessibility/mac/aria-expanded-not-exposed-when-undefined.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15302 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27156 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116329 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21690 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->