### PR TITLE
Simplify WebCryptoClient::serializeAndWrapCryptoKey

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -122,7 +122,7 @@ public:
     // API implementation helpers. These don't expose special behavior for ArrayBuffers or MessagePorts.
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSContextRef, JSValueRef, JSValueRef* exception);
     WEBCORE_EXPORT JSValueRef deserialize(JSContextRef, JSValueRef* exception);
-    WEBCORE_EXPORT static Vector<uint8_t> serializeCryptoKey(JSContextRef, const WebCore::CryptoKey&);
+    WEBCORE_EXPORT static Vector<uint8_t> serializeCryptoKey(const WebCore::CryptoKey&);
 
     bool hasBlobURLs() const { return !m_internals.blobHandles.isEmpty(); }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9567,14 +9567,6 @@ void Document::didLoadResourceSynchronously(const URL& url)
         page->cookieJar().clearCacheForHost(url.host().toString());
 }
 
-std::optional<Vector<uint8_t>> Document::wrapCryptoKey(const Vector<uint8_t>& key)
-{
-    RefPtr page = this->page();
-    if (!page)
-        return std::nullopt;
-    return page->cryptoClient().wrapCryptoKey(key);
-}
-
 std::optional<Vector<uint8_t>> Document::serializeAndWrapCryptoKey(CryptoKeyData&& keyData)
 {
     RefPtr page = this->page();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1619,7 +1619,6 @@ public:
 
     void setVisualUpdatesAllowedByClient(bool);
 
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final;
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final;
 

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -79,7 +79,6 @@ public:
     void postTask(Task&&) final { ASSERT_NOT_REACHED(); }
     EventTarget* errorEventTarget() final { return nullptr; };
 
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final { return std::nullopt; }
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final { return std::nullopt; }
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { return std::nullopt; }
 

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -290,7 +290,6 @@ public:
     // These two methods are used when CryptoKeys are serialized into IndexedDB. As a side effect, it is also
     // used for things that utilize the same structure clone algorithm, for example, message passing between
     // worker and document.
-    virtual std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>& key) = 0;
     virtual std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) = 0;
     virtual std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) = 0;
 

--- a/Source/WebCore/page/CryptoClient.h
+++ b/Source/WebCore/page/CryptoClient.h
@@ -38,7 +38,6 @@ protected:
     CryptoClient() = default;
 public:
     virtual ~CryptoClient() = default;
-    virtual std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const { return std::nullopt; };
     virtual std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const { return std::nullopt; };
     virtual std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const { return std::nullopt; };
 };

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -501,23 +501,6 @@ void WorkerGlobalScope::addMessage(MessageSource source, MessageLevel level, con
     InspectorInstrumentation::addMessageToConsole(*this, WTFMove(message));
 }
 
-std::optional<Vector<uint8_t>> WorkerGlobalScope::wrapCryptoKey(const Vector<uint8_t>& key)
-{
-    Ref protectedThis { *this };
-    auto* workerLoaderProxy = thread().workerLoaderProxy();
-    if (!workerLoaderProxy)
-        return std::nullopt;
-
-    BinarySemaphore semaphore;
-    std::optional<Vector<uint8_t>> wrappedKey;
-    workerLoaderProxy->postTaskToLoader([&semaphore, &key, &wrappedKey](auto& context) {
-        wrappedKey = context.wrapCryptoKey(key);
-        semaphore.signal();
-    });
-    semaphore.wait();
-    return wrappedKey;
-}
-
 std::optional<Vector<uint8_t>> WorkerGlobalScope::serializeAndWrapCryptoKey(CryptoKeyData&& keyData)
 {
     Ref protectedThis { *this };

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -208,7 +208,6 @@ private:
 
     bool shouldBypassMainWorldContentSecurityPolicy() const final { return m_shouldBypassMainWorldContentSecurityPolicy; }
 
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>& key) final;
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) final;
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -105,7 +105,6 @@ private:
 
     EventTarget* errorEventTarget() final { return this; }
 
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
@@ -35,6 +35,8 @@
 
 namespace API {
 
+#if !PLATFORM(COCOA)
+
 static constexpr auto SharedJSContextWKMaxIdleTime = 10_s;
 
 class SharedJSContextWK {
@@ -96,8 +98,6 @@ private:
     RunLoop::Timer m_timer;
     MonotonicTime m_lastUseTime;
 };
-
-#if !PLATFORM(COCOA)
 
 static WKRetainPtr<WKTypeRef> valueToWKObject(JSContextRef context, JSValueRef value)
 {
@@ -168,14 +168,5 @@ WKRetainPtr<WKTypeRef> SerializedScriptValue::deserializeWK(WebCore::SerializedS
 }
 
 #endif // !PLATFORM(COCOA)
-
-Vector<uint8_t> SerializedScriptValue::serializeCryptoKey(const WebCore::CryptoKey& key)
-{
-    ASSERT(RunLoop::isMain());
-    JSRetainPtr context = SharedJSContextWK::singleton().ensureContext();
-    ASSERT(context);
-
-    return WebCore::SerializedScriptValue::serializeCryptoKey(context.get(), key);
-}
 
 } // API

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -28,7 +28,6 @@
 #include "APIObject.h"
 #include "WKRetainPtr.h"
 #include <JavaScriptCore/JSRetainPtr.h>
-#include <WebCore/CryptoKey.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RefPtr.h>
 
@@ -72,8 +71,6 @@ public:
 
     static WKRetainPtr<WKTypeRef> deserializeWK(WebCore::SerializedScriptValue&);
 #endif
-
-    static Vector<uint8_t> serializeCryptoKey(const WebCore::CryptoKey&);
 
 #if PLATFORM(COCOA)
     static JSRetainPtr<JSGlobalContextRef> deserializationContext();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -54,7 +54,6 @@
 #include "APIPolicyClient.h"
 #include "APIResourceLoadClient.h"
 #include "APISecurityOrigin.h"
-#include "APISerializedScriptValue.h"
 #include "APITargetedElementInfo.h"
 #include "APITargetedElementRequest.h"
 #include "APITextRun.h"
@@ -203,6 +202,7 @@
 #include <WebCore/CaptureDeviceManager.h>
 #include <WebCore/CompositionHighlight.h>
 #include <WebCore/CrossSiteNavigationDataTransfer.h>
+#include <WebCore/CryptoKey.h>
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DiagnosticLoggingClient.h>
@@ -13288,9 +13288,10 @@ void WebPageProxy::wrapCryptoKey(Vector<uint8_t>&& key, CompletionHandler<void(s
 void WebPageProxy::serializeAndWrapCryptoKey(IPC::Connection& connection, WebCore::CryptoKeyData&& keyData, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)
 {
     auto key = WebCore::CryptoKey::create(WTFMove(keyData));
+    MESSAGE_CHECK_COMPLETION_BASE(key, connection, completionHandler(std::nullopt));
     MESSAGE_CHECK_COMPLETION_BASE(key->isValid(), connection, completionHandler(std::nullopt));
 
-    auto serializedKey = API::SerializedScriptValue::serializeCryptoKey(*key);
+    auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(*key);
     wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1911,7 +1911,6 @@ public:
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot);
 #endif
 
-    void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void serializeAndWrapCryptoKey(IPC::Connection&, WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
@@ -2720,9 +2719,11 @@ public:
 #endif
 
 private:
-    void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
+
+    void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+    void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
     void addAllMessageReceivers();
     void removeAllMessageReceivers();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -443,10 +443,8 @@ messages -> WebPageProxy {
 
     DidUpdateActivityState() CanDispatchOutOfOrder
 
-    WrapCryptoKey(Vector<uint8_t> key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     SerializeAndWrapCryptoKey(struct WebCore::CryptoKeyData key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     UnwrapCryptoKey(struct WebCore::WrappedCryptoKey wrappedKey) -> (std::optional<Vector<uint8_t>> key) Synchronous
-
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -29,7 +29,6 @@
 #include "APIFrameHandle.h"
 #include "APIPageConfiguration.h"
 #include "APIPageHandle.h"
-#include "APISerializedScriptValue.h"
 #include "APIUIClient.h"
 #include "AuthenticatorManager.h"
 #include "DownloadProxyMap.h"
@@ -87,6 +86,7 @@
 #include "WebsiteData.h"
 #include "WebsiteDataFetchOption.h"
 #include <WebCore/AudioSession.h>
+#include <WebCore/CryptoKey.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
 #include <WebCore/MediaProducer.h>
 #include <WebCore/PermissionName.h>
@@ -97,6 +97,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SerializedCryptoKeyWrap.h>
+#include <WebCore/SerializedScriptValue.h>
 #include <WebCore/SharedMemory.h>
 #include <WebCore/SuddenTermination.h>
 #include <WebCore/WrappedCryptoKey.h>
@@ -2840,8 +2841,9 @@ void WebProcessProxy::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData
 {
     auto key = WebCore::CryptoKey::create(WTFMove(keyData));
     MESSAGE_CHECK_COMPLETION(key, completionHandler(std::nullopt));
+    MESSAGE_CHECK_COMPLETION(key->isValid(), completionHandler(std::nullopt));
 
-    auto serializedKey = API::SerializedScriptValue::serializeCryptoKey(*key);
+    auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(*key);
     wrapCryptoKey(WTFMove(serializedKey), WTFMove(completionHandler));
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -498,7 +498,6 @@ public:
     void setCaptionLanguage(const String&);
 #endif
     void getNotifications(const URL&, const String&, CompletionHandler<void(Vector<WebCore::NotificationData>&&)>&&);
-    void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unwrapCryptoKey(WebCore::WrappedCryptoKey&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
@@ -583,6 +582,8 @@ private:
     void validateFreezerStatus();
 
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+    void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+
     using WebProcessProxyMap = HashMap<WebCore::ProcessIdentifier, CheckedRef<WebProcessProxy>>;
     static WebProcessProxyMap& allProcessMap();
     static Vector<Ref<WebProcessProxy>> allProcesses();

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -93,7 +93,6 @@ messages -> WebProcessProxy WantsDispatchMessage {
     [EnabledBy=AppBadgeEnabled] SetAppBadge(std::optional<WebKit::WebPageProxyIdentifier> pageIdentifier, WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
     [EnabledBy=AppBadgeEnabled] SetClientBadge(WebKit::WebPageProxyIdentifier pageIdentifier, WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
 
-    WrapCryptoKey(Vector<uint8_t> key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     SerializeAndWrapCryptoKey(struct WebCore::CryptoKeyData key) -> (std::optional<Vector<uint8_t>> wrappedKey) Synchronous
     UnwrapCryptoKey(struct WebCore::WrappedCryptoKey wrappedKey) -> (std::optional<Vector<uint8_t>> key) Synchronous
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "WebCryptoClient.h"
 
-#include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
@@ -37,19 +36,6 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCryptoClient);
-
-std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8_t>& key) const
-{
-    if (m_pageIdentifier) {
-        auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::WrapCryptoKey(key), *m_pageIdentifier);
-        auto [wrappedKey] = sendResult.takeReplyOr(std::nullopt);
-        return wrappedKey;
-    }
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebProcessProxy::WrapCryptoKey(key), 0);
-
-    auto [wrappedKey] = sendResult.takeReplyOr(std::nullopt);
-    return wrappedKey;
-}
 
 std::optional<Vector<uint8_t>> WebCryptoClient::serializeAndWrapCryptoKey(WebCore::CryptoKeyData&& keyData) const
 {
@@ -85,4 +71,5 @@ WebCryptoClient::WebCryptoClient(WebCore::PageIdentifier pageIdentifier)
     : m_pageIdentifier(pageIdentifier)
 {
 }
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
@@ -28,11 +28,8 @@
 #include <WebCore/CryptoClient.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
 
 namespace WebKit {
-
-class WebPage;
 
 class WebCryptoClient:  public WebCore::CryptoClient {
     WTF_MAKE_TZONE_ALLOCATED(WebCryptoClient);
@@ -40,10 +37,10 @@ public:
     WebCryptoClient(WebCore::PageIdentifier);
     WebCryptoClient() = default;
     ~WebCryptoClient() = default;
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const override;
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const override;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const override;
 private:
     std::optional<WebCore::PageIdentifier> m_pageIdentifier;
 };
+
 } // namespace WebKit

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
@@ -39,7 +39,7 @@ public:
     WebCryptoClient() = default;
     ~WebCryptoClient() = default;
     WebCryptoClient(WebView *);
-    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const override;
+    std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>&) const;
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(WebCore::CryptoKeyData&&) const override;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) const override;
 private:

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
@@ -63,8 +63,7 @@ std::optional<Vector<uint8_t>> WebCryptoClient::serializeAndWrapCryptoKey(WebCor
     if (!key)
         return std::nullopt;
 
-    JSContextRef context = [[m_webView mainFrame] globalContext];
-    auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(context, *key);
+    auto serializedKey = WebCore::SerializedScriptValue::serializeCryptoKey(*key);
     return wrapCryptoKey(serializedKey);
 }
 


### PR DESCRIPTION
#### 7aaf7bfc803e868d48991be1cd56099b993d3e80
<pre>
Simplify WebCryptoClient::serializeAndWrapCryptoKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=289733">https://bugs.webkit.org/show_bug.cgi?id=289733</a>
<a href="https://rdar.apple.com/146980182">rdar://146980182</a>

Reviewed by Sihui Liu.

CryptoClient::wrapCryptoKey was unreachable code.  Remove it.
SerializedScriptValue::serializeCryptoKey doesn&apos;t need a JS context.
WebPageProxy::serializeAndWrapCryptoKey and WebProcessProxy::serializeAndWrapCryptoKey
should have consistent and thorough message checks.
SharedJSContextWK is no longer needed on Cocoa platforms.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serializeCryptoKey):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::write):
(WebCore::SerializedScriptValue::serializeCryptoKey):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::wrapCryptoKey): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/CryptoClient.h:
(WebCore::CryptoClient::wrapCryptoKey const): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::wrapCryptoKey): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/Shared/API/APISerializedScriptValue.cpp:
(API::SerializedScriptValue::serializeCryptoKey): Deleted.
* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::serializeAndWrapCryptoKey):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::serializeAndWrapCryptoKey):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp:
(WebKit::WebCryptoClient::wrapCryptoKey const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm:
(WebCryptoClient::serializeAndWrapCryptoKey const):

Canonical link: <a href="https://commits.webkit.org/292195@main">https://commits.webkit.org/292195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/901d7b777e634aa3de0da27ae7c5d5990bf9e9dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97295 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15135 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72635 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98250 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11298 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Skipped layout-tests; 13 new passes 2 flakes 1 failures; Uploaded test results; 13 new passes 10 flakes 1 failures; Compiled WebKit (warnings); Running run-layout-tests-without-change; Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102329 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93870 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-Build-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81037 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15548 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15294 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22265 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21924 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->