### PR TITLE
[WebGPU] Add support for core-features-and-limits so CTS continues to pass

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -70,6 +70,7 @@ static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
     static constexpr std::pair<ComparableASCIILiteral, GPUFeatureName> mappings[] = {
         { "bgra8unorm-storage"_s, GPUFeatureName::Bgra8unormStorage },
         { "clip-distances"_s, GPUFeatureName::ClipDistances },
+        { "core-features-and-limits"_s, GPUFeatureName::CoreFeaturesAndLimits },
         { "depth-clip-control"_s, GPUFeatureName::DepthClipControl },
         { "depth32float-stencil8"_s, GPUFeatureName::Depth32floatStencil8 },
         { "dual-source-blending"_s, GPUFeatureName::DualSourceBlending },

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
@@ -49,6 +49,7 @@ enum class GPUFeatureName : uint8_t {
     DualSourceBlending,
     Float16Renderable,
     Float32Renderable,
+    CoreFeaturesAndLimits,
 };
 
 inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
@@ -90,6 +91,8 @@ inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
         return WebGPU::FeatureName::DualSourceBlending;
     case GPUFeatureName::ClipDistances:
         return WebGPU::FeatureName::ClipDistances;
+    case GPUFeatureName::CoreFeaturesAndLimits:
+        return WebGPU::FeatureName::CoreFeaturesAndLimits;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -46,4 +46,5 @@
     "dual-source-blending",
     "float16-renderable",
     "float32-renderable",
+    "core-features-and-limits",
 };

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.cpp
@@ -198,4 +198,14 @@ uint32_t GPUSupportedLimits::maxStorageTexturesInFragmentStage() const
     return m_backing->maxStorageTexturesInFragmentStage();
 }
 
+uint32_t GPUSupportedLimits::maxStorageBuffersInVertexStage() const
+{
+    return m_backing->maxStorageBuffersInVertexStage();
+}
+
+uint32_t GPUSupportedLimits::maxStorageTexturesInVertexStage() const
+{
+    return m_backing->maxStorageTexturesInVertexStage();
+}
+
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.h
@@ -70,6 +70,8 @@ public:
     uint32_t maxComputeWorkgroupsPerDimension() const;
     uint32_t maxStorageBuffersInFragmentStage() const;
     uint32_t maxStorageTexturesInFragmentStage() const;
+    uint32_t maxStorageBuffersInVertexStage() const;
+    uint32_t maxStorageTexturesInVertexStage() const;
 
     WebGPU::SupportedLimits& backing() { return m_backing; }
     const WebGPU::SupportedLimits& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
@@ -65,4 +65,6 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxComputeWorkgroupsPerDimension;
     readonly attribute unsigned long maxStorageBuffersInFragmentStage;
     readonly attribute unsigned long maxStorageTexturesInFragmentStage;
+    readonly attribute unsigned long maxStorageBuffersInVertexStage;
+    readonly attribute unsigned long maxStorageTexturesInVertexStage;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -101,7 +101,9 @@ static Ref<SupportedLimits> supportedLimits(WGPUAdapter adapter)
         limits.limits.maxComputeWorkgroupSizeZ,
         limits.limits.maxComputeWorkgroupsPerDimension,
         limits.limits.maxStorageBuffersInFragmentStage,
-        limits.limits.maxStorageTexturesInFragmentStage);
+        limits.limits.maxStorageTexturesInFragmentStage,
+        limits.limits.maxStorageBuffersInVertexStage,
+        limits.limits.maxStorageTexturesInVertexStage);
 }
 
 static bool isFallbackAdapter(WGPUAdapter adapter)
@@ -229,6 +231,8 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         SET_MAX_VALUE(maxComputeWorkgroupsPerDimension)
         SET_MAX_VALUE(maxStorageBuffersInFragmentStage)
         SET_MAX_VALUE(maxStorageTexturesInFragmentStage)
+        SET_MAX_VALUE(maxStorageBuffersInVertexStage)
+        SET_MAX_VALUE(maxStorageTexturesInVertexStage)
         else {
             callback(nullptr);
             return;
@@ -287,7 +291,9 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         limits.maxComputeWorkgroupSizeZ,
         limits.maxComputeWorkgroupsPerDimension,
         limits.maxStorageBuffersInFragmentStage,
-        limits.maxStorageTexturesInFragmentStage);
+        limits.maxStorageTexturesInFragmentStage,
+        limits.maxStorageBuffersInVertexStage,
+        limits.maxStorageTexturesInVertexStage);
 
     auto requestedFeatures = supportedFeatures(features);
     auto blockPtr = makeBlockPtr([protectedThis = Ref { *this }, convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTFMove(callback), requestedLimits, requestedFeatures](WGPURequestDeviceStatus status, WGPUDevice device, const char*) mutable {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -232,6 +232,8 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
         return WGPUFeatureName_ClipDistances;
     case FeatureName::DualSourceBlending:
         return WGPUFeatureName_DualSourceBlending;
+    case FeatureName::CoreFeaturesAndLimits:
+        return WGPUFeatureName_CoreFeaturesAndLimits;
     }
 }
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
@@ -48,6 +48,7 @@ enum class FeatureName : uint8_t {
     DualSourceBlending,
     Float16Renderable,
     Float32Renderable,
+    CoreFeaturesAndLimits,
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSupportedLimits.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSupportedLimits.h
@@ -67,7 +67,9 @@ public:
         uint32_t maxComputeWorkgroupSizeZ,
         uint32_t maxComputeWorkgroupsPerDimension,
         uint32_t maxStorageBuffersInFragmentStage,
-        uint32_t maxStorageTexturesInFragmentStage)
+        uint32_t maxStorageTexturesInFragmentStage,
+        uint32_t maxStorageBuffersInVertexStage,
+        uint32_t maxStorageTexturesInVertexStage)
     {
         return adoptRef(*new SupportedLimits(
             maxTextureDimension1D,
@@ -103,7 +105,9 @@ public:
             maxComputeWorkgroupSizeZ,
             maxComputeWorkgroupsPerDimension,
             maxStorageBuffersInFragmentStage,
-            maxStorageTexturesInFragmentStage));
+            maxStorageTexturesInFragmentStage,
+            maxStorageBuffersInVertexStage,
+            maxStorageTexturesInVertexStage));
     }
 
     static Ref<SupportedLimits> clone(const SupportedLimits& limits)
@@ -142,7 +146,9 @@ public:
             limits.maxComputeWorkgroupSizeZ(),
             limits.maxComputeWorkgroupsPerDimension(),
             limits.maxStorageBuffersInFragmentStage(),
-            limits.maxStorageTexturesInFragmentStage()));
+            limits.maxStorageTexturesInFragmentStage(),
+            limits.maxStorageBuffersInVertexStage(),
+            limits.maxStorageTexturesInVertexStage()));
     }
 
     uint32_t maxTextureDimension1D() const { return m_maxTextureDimension1D; }
@@ -179,6 +185,8 @@ public:
     uint32_t maxComputeWorkgroupsPerDimension() const { return m_maxComputeWorkgroupsPerDimension; }
     uint32_t maxStorageBuffersInFragmentStage() const { return m_maxStorageBuffersInFragmentStage; }
     uint32_t maxStorageTexturesInFragmentStage() const { return m_maxStorageTexturesInFragmentStage; }
+    uint32_t maxStorageBuffersInVertexStage() const { return m_maxStorageBuffersInVertexStage; }
+    uint32_t maxStorageTexturesInVertexStage() const { return m_maxStorageTexturesInVertexStage; }
 
 private:
     SupportedLimits(
@@ -215,7 +223,9 @@ private:
         uint32_t maxComputeWorkgroupSizeZ,
         uint32_t maxComputeWorkgroupsPerDimension,
         uint32_t maxStorageBuffersInFragmentStage,
-        uint32_t maxStorageTexturesInFragmentStage)
+        uint32_t maxStorageTexturesInFragmentStage,
+        uint32_t maxStorageBuffersInVertexStage,
+        uint32_t maxStorageTexturesInVertexStage)
             : m_maxTextureDimension1D(maxTextureDimension1D)
             , m_maxTextureDimension2D(maxTextureDimension2D)
             , m_maxTextureDimension3D(maxTextureDimension3D)
@@ -250,6 +260,8 @@ private:
             , m_maxComputeWorkgroupsPerDimension(maxComputeWorkgroupsPerDimension)
             , m_maxStorageBuffersInFragmentStage(maxStorageBuffersInFragmentStage)
             , m_maxStorageTexturesInFragmentStage(maxStorageTexturesInFragmentStage)
+            , m_maxStorageBuffersInVertexStage(maxStorageBuffersInVertexStage)
+            , m_maxStorageTexturesInVertexStage(maxStorageTexturesInVertexStage)
     {
     }
 
@@ -292,6 +304,8 @@ private:
     uint32_t m_maxComputeWorkgroupsPerDimension { 0 };
     uint32_t m_maxStorageBuffersInFragmentStage { 0 };
     uint32_t m_maxStorageTexturesInFragmentStage { 0 };
+    uint32_t m_maxStorageBuffersInVertexStage { 0 };
+    uint32_t m_maxStorageTexturesInVertexStage { 0 };
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -110,6 +110,7 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
 {
     Vector<WGPUFeatureName> features;
 
+    features.append(WGPUFeatureName_CoreFeaturesAndLimits);
     features.append(WGPUFeatureName_Float16Renderable);
     features.append(WGPUFeatureName_Float32Renderable);
     features.append(WGPUFeatureName_Float32Blendable);
@@ -242,6 +243,8 @@ static HardwareCapabilities apple6(id<MTLDevice> device)
             .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
             .maxStorageBuffersInFragmentStage = UINT32_MAX,
             .maxStorageTexturesInFragmentStage = UINT32_MAX,
+            .maxStorageBuffersInVertexStage = UINT32_MAX,
+            .maxStorageTexturesInVertexStage = UINT32_MAX,
         },
         WTFMove(features),
         baseCapabilities,
@@ -299,6 +302,8 @@ static HardwareCapabilities apple7(id<MTLDevice> device)
             .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
             .maxStorageBuffersInFragmentStage = UINT32_MAX,
             .maxStorageTexturesInFragmentStage = UINT32_MAX,
+            .maxStorageBuffersInVertexStage = UINT32_MAX,
+            .maxStorageTexturesInVertexStage = UINT32_MAX,
         },
         WTFMove(features),
         baseCapabilities,
@@ -353,6 +358,8 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
             .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
             .maxStorageBuffersInFragmentStage = UINT32_MAX,
             .maxStorageTexturesInFragmentStage = UINT32_MAX,
+            .maxStorageBuffersInVertexStage = UINT32_MAX,
+            .maxStorageTexturesInVertexStage = UINT32_MAX,
         },
         WTFMove(features),
         baseCapabilities,
@@ -410,6 +417,8 @@ static WGPULimits mergeLimits(const WGPULimits& previous, const WGPULimits& next
         .maxComputeWorkgroupsPerDimension = mergeMaximum(previous.maxComputeWorkgroupsPerDimension, next.maxComputeWorkgroupsPerDimension),
         .maxStorageBuffersInFragmentStage = mergeMaximum(previous.maxStorageBuffersInFragmentStage, next.maxStorageBuffersInFragmentStage),
         .maxStorageTexturesInFragmentStage = mergeMaximum(previous.maxStorageTexturesInFragmentStage, next.maxStorageTexturesInFragmentStage),
+        .maxStorageBuffersInVertexStage = mergeMaximum(previous.maxStorageBuffersInVertexStage, next.maxStorageBuffersInVertexStage),
+        .maxStorageTexturesInVertexStage = mergeMaximum(previous.maxStorageTexturesInVertexStage, next.maxStorageTexturesInVertexStage),
     };
 };
 
@@ -564,6 +573,10 @@ bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference)
         return true;
     if (target.maxStorageTexturesInFragmentStage > reference.maxStorageTexturesInFragmentStage)
         return true;
+    if (target.maxStorageBuffersInVertexStage > reference.maxStorageBuffersInVertexStage)
+        return true;
+    if (target.maxStorageTexturesInVertexStage > reference.maxStorageTexturesInVertexStage)
+        return true;
 
     return false;
 }
@@ -615,8 +628,10 @@ WGPULimits defaultLimits()
         .maxComputeWorkgroupSizeY =    256,
         .maxComputeWorkgroupSizeZ =    64,
         .maxComputeWorkgroupsPerDimension =    65535,
-        .maxStorageBuffersInFragmentStage = UINT32_MAX,
-        .maxStorageTexturesInFragmentStage = UINT32_MAX,
+        .maxStorageBuffersInFragmentStage = 8,
+        .maxStorageTexturesInFragmentStage = 4,
+        .maxStorageBuffersInVertexStage = 8,
+        .maxStorageTexturesInVertexStage = 4,
     };
 }
 

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -1111,6 +1111,8 @@ String wgpuAdapterFeatureName(WGPUFeatureName feature)
         return "float16-renderable"_s;
     case WGPUFeatureName_Float32Renderable:
         return "float32-renderable"_s;
+    case WGPUFeatureName_CoreFeaturesAndLimits:
+        return "core-features-and-limits"_s;
     case WGPUFeatureName_Force32:
         return emptyString();
     }

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -374,6 +374,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_DualSourceBlending = 0x00000010,
     WGPUFeatureName_Float16Renderable = 0x00000011,
     WGPUFeatureName_Float32Renderable = 0x00000012,
+    WGPUFeatureName_CoreFeaturesAndLimits = 0x00000013,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 
@@ -898,6 +899,8 @@ typedef struct WGPULimits {
     uint32_t maxComputeWorkgroupsPerDimension;
     uint32_t maxStorageBuffersInFragmentStage;
     uint32_t maxStorageTexturesInFragmentStage;
+    uint32_t maxStorageBuffersInVertexStage;
+    uint32_t maxStorageTexturesInVertexStage;
 } WGPULimits WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUMultisampleState {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -123,6 +123,8 @@ void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, We
             limits->maxComputeWorkgroupsPerDimension(),
             limits->maxStorageBuffersInFragmentStage(),
             limits->maxStorageTexturesInFragmentStage(),
+            limits->maxStorageBuffersInVertexStage(),
+            limits->maxStorageTexturesInVertexStage(),
         });
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -197,6 +197,8 @@ void RemoteGPU::requestAdapter(const WebGPU::RequestAdapterOptions& options, Web
             limits->maxComputeWorkgroupsPerDimension(),
             limits->maxStorageBuffersInFragmentStage(),
             limits->maxStorageTexturesInFragmentStage(),
+            limits->maxStorageBuffersInVertexStage(),
+            limits->maxStorageTexturesInVertexStage(),
         }, adapter->isFallbackAdapter() } });
     });
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
@@ -40,5 +40,6 @@ enum class WebCore::WebGPU::FeatureName : uint8_t {
     DualSourceBlending,
     Float16Renderable,
     Float32Renderable,
+    CoreFeaturesAndLimits,
 };
 #endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.cpp
@@ -71,6 +71,8 @@ std::optional<SupportedLimits> ConvertToBackingContext::convertToBacking(const W
         supportedLimits.maxComputeWorkgroupsPerDimension(),
         supportedLimits.maxStorageBuffersInFragmentStage(),
         supportedLimits.maxStorageTexturesInFragmentStage(),
+        supportedLimits.maxStorageBuffersInVertexStage(),
+        supportedLimits.maxStorageTexturesInVertexStage(),
     } };
 }
 
@@ -110,7 +112,9 @@ RefPtr<WebCore::WebGPU::SupportedLimits> ConvertFromBackingContext::convertFromB
         supportedLimits.maxComputeWorkgroupSizeZ,
         supportedLimits.maxComputeWorkgroupsPerDimension,
         supportedLimits.maxStorageBuffersInFragmentStage,
-        supportedLimits.maxStorageTexturesInFragmentStage
+        supportedLimits.maxStorageTexturesInFragmentStage,
+        supportedLimits.maxStorageBuffersInVertexStage,
+        supportedLimits.maxStorageTexturesInVertexStage
     ) };
 }
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.h
@@ -67,6 +67,8 @@ struct SupportedLimits {
     uint32_t maxComputeWorkgroupsPerDimension { 0 };
     uint32_t maxStorageBuffersInFragmentStage { 0 };
     uint32_t maxStorageTexturesInFragmentStage { 0 };
+    uint32_t maxStorageBuffersInVertexStage { 0 };
+    uint32_t maxStorageTexturesInVertexStage { 0 };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.serialization.in
@@ -56,4 +56,6 @@
     uint32_t maxComputeWorkgroupsPerDimension
     uint32_t maxStorageBuffersInFragmentStage
     uint32_t maxStorageTexturesInFragmentStage
+    uint32_t maxStorageBuffersInVertexStage
+    uint32_t maxStorageTexturesInVertexStage
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -107,7 +107,9 @@ void RemoteAdapterProxy::requestDevice(const WebCore::WebGPU::DeviceDescriptor& 
         supportedLimits.maxComputeWorkgroupSizeZ,
         supportedLimits.maxComputeWorkgroupsPerDimension,
         supportedLimits.maxStorageBuffersInFragmentStage,
-        supportedLimits.maxStorageTexturesInFragmentStage
+        supportedLimits.maxStorageTexturesInFragmentStage,
+        supportedLimits.maxStorageBuffersInVertexStage,
+        supportedLimits.maxStorageTexturesInVertexStage
     );
     auto result = RemoteDeviceProxy::create(WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), *this, convertToBackingContext, identifier, queueIdentifier);
     result->setLabel(WTFMove(convertedDescriptor->label));

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -212,7 +212,9 @@ void RemoteGPUProxy::requestAdapter(const WebCore::WebGPU::RequestAdapterOptions
         response->limits.maxComputeWorkgroupSizeZ,
         response->limits.maxComputeWorkgroupsPerDimension,
         response->limits.maxStorageBuffersInFragmentStage,
-        response->limits.maxStorageTexturesInFragmentStage
+        response->limits.maxStorageTexturesInFragmentStage,
+        response->limits.maxStorageBuffersInVertexStage,
+        response->limits.maxStorageTexturesInVertexStage
     );
     callback(WebGPU::RemoteAdapterProxy::create(WTFMove(response->name), WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), response->isFallbackAdapter, options.xrCompatible, *this, convertToBackingContext, identifier));
 }


### PR DESCRIPTION
#### 19d47219212a6ec7802b200bd9ae7a896000e179
<pre>
[WebGPU] Add support for core-features-and-limits so CTS continues to pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=289714">https://bugs.webkit.org/show_bug.cgi?id=289714</a>
<a href="https://rdar.apple.com/146962830">rdar://146962830</a>

Reviewed by Tadeu Zagallo.

The CTS has adapted two new limits + &apos;core-features-and-limits&apos; feature,
these are needed otherwise CTS thinks it is running on a compat device.

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::convertFeatureNameToEnum):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.cpp:
(WebCore::GPUSupportedLimits::maxStorageBuffersInVertexStage const):
(WebCore::GPUSupportedLimits::maxStorageTexturesInVertexStage const):
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.h:
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::supportedLimits):
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSupportedLimits.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
(WebGPU::apple6):
(WebGPU::apple7):
(WebGPU::mac2):
(WebGPU::mergeLimits):
(WebGPU::anyLimitIsBetterThan):
(WebGPU::defaultLimits):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(wgpuAdapterFeatureName):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::requestDevice):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::requestAdapter):
* Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.h:
* Source/WebKit/Shared/WebGPU/WebGPUSupportedLimits.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::requestAdapter):

Canonical link: <a href="https://commits.webkit.org/292284@main">https://commits.webkit.org/292284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b42a661c4a6546206ef2008552748dc9db40f45f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72495 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85810 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52822 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80882 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27190 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->