### PR TITLE
[results.webkit.org] Timeline.CanvasSeriesComponent doesn't resize width for Chrome for Windows

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js
@@ -801,7 +801,7 @@ Timeline.CanvasSeriesComponent = (dots, scales, option = {}) => {
                     element.addEventListener('mouseleave', (e) => onDotLeave(e, element.getBoundingClientRect()));
 
                 createInsertionObservers(element, (entries) => {
-                    canvasRef.setState({onScreen: entries[0].isIntersecting});
+                    canvasRef.setState({onScreen: entries[entries.length - 1].isIntersecting});
                 }, 0, 0.01, 0.01);
             },
             onElementUnmount: (element) => {


### PR DESCRIPTION
#### fc8fa8fc872382e975ea0e76a01fd51953fa6cb7
<pre>
[results.webkit.org] Timeline.CanvasSeriesComponent doesn&apos;t resize width for Chrome for Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=289734">https://bugs.webkit.org/show_bug.cgi?id=289734</a>

Reviewed by Jonathan Bedard.

IntersectionObserver callback can receive multiple
IntersectionObserverEntry entries at a time.
&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#intersection_change_callbacks">https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#intersection_change_callbacks</a>&gt;

The last IntersectionObserverEntry entry is the latest. However, only
the first one was checked. Check the last entry instead of the first
one.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js:
(Timeline.CanvasSeriesComponent):

Canonical link: <a href="https://commits.webkit.org/292278@main">https://commits.webkit.org/292278@main</a>
</pre>
