### PR TITLE
[visionOS] Allow WKWebView clients to customize the file upload flow for file inputs

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! WKOpenPanelParameters contains parameters that a file upload control has specified.
  */
 WK_SWIFT_UI_ACTOR
-WK_CLASS_AVAILABLE(macos(10.12), ios(WK_IOS_TBA))
+WK_CLASS_AVAILABLE(macos(10.12), ios(18.4), visionos(2.4))
 @interface WKOpenPanelParameters : NSObject
 
 /*! @abstract Whether the file upload control supports multiple files.
@@ -40,7 +40,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(WK_IOS_TBA))
 
 /*! @abstract Whether the file upload control supports selecting directories.
  */
-@property (nonatomic, readonly) BOOL allowsDirectories WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL allowsDirectories WK_API_AVAILABLE(macos(10.13.4), ios(18.4), visionos(2.4));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h
@@ -27,8 +27,8 @@
 
 @interface WKOpenPanelParameters (WKPrivate)
 
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedMIMETypes WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedFileExtensions WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA));
-@property (nonatomic, readonly, copy) NSArray<NSString *> *_allowedFileExtensions WK_API_AVAILABLE(macos(11.0), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedMIMETypes WK_API_AVAILABLE(macos(10.13.4), ios(18.4), visionos(2.4));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_acceptedFileExtensions WK_API_AVAILABLE(macos(10.13.4), ios(18.4), visionos(2.4));
+@property (nonatomic, readonly, copy) NSArray<NSString *> *_allowedFileExtensions WK_API_AVAILABLE(macos(11.0), ios(18.4), visionos(2.4));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -285,10 +285,10 @@ WK_SWIFT_UI_ACTOR
  @param completionHandler The completion handler to call after open panel has been dismissed. Pass the selected URLs if the user chose OK, otherwise nil.
 
  If you do not implement this method on macOS, the web view will behave as if the user selected the Cancel button.
- If you do not implement this method on iOS, the web view will match the file upload behavior of Safari. If you desire
- the web view to act as if the user selected the Cancel button on iOS, immediately call the completion handler with nil.
+ If you do not implement this method on iOS or visionOS, the web view will match the file upload behavior of Safari. If you desire
+ the web view to act as if the user selected the Cancel button on iOS or visionOS, immediately call the completion handler with nil.
  */
-- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12), ios(WK_IOS_TBA));
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12), ios(18.4), visionos(2.4));
 
 @end
 


### PR DESCRIPTION
#### 0c0fedc14f04e89d2ed7fb0d05d391ca6974fbef
<pre>
[visionOS] Allow WKWebView clients to customize the file upload flow for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=289736">https://bugs.webkit.org/show_bug.cgi?id=289736</a>
<a href="https://rdar.apple.com/130219174">rdar://130219174</a>

Reviewed by Aditya Keerthi.

Expand availability of `runOpenPanelWithParameters:initiatedByFrame:completionHandler:`
to include visionOS.

* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h:
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:

Canonical link: <a href="https://commits.webkit.org/292125@main">https://commits.webkit.org/292125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e57bd1dde98b4abba68884b9fc60ff6a17fa3cd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100075 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52825 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/44884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22088 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25450 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15257 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22061 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25193 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->