### PR TITLE
[iOS] Fix expectation for fast/writing-mode/inline-block-baseline.html

### DIFF
--- a/LayoutTests/fast/writing-mode/inline-block-baseline-expected.html
+++ b/LayoutTests/fast/writing-mode/inline-block-baseline-expected.html
@@ -7,11 +7,11 @@
 Left side of a japanese character "国" should vertically align with baseline of "a".
 <div style="writing-mode: vertical-rl; font-size: 4em">
 <span>a
-<div style="background-color: green; display: inline-block">a<br>国</div><span style="visibility: hidden">あ</span>
+<div style="background-color: green; display: inline-block">a<br>国</div><span style="visibility: hidden">国</span>
 </span>
 <br>
 <span>a
-<ruby style="background-color: green;">国<rt style="background-color: red; opacity: 0.5">くに</rt></ruby><span style="visibility: hidden">あ</span>
+<ruby style="background-color: green;">国<rt style="background-color: red; opacity: 0.5">くに</rt></ruby><span style="visibility: hidden">国</span>
 </span>
 </div>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7662,7 +7662,6 @@ imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigati
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html [ Skip ]
 
 # webkit.org/b/284886 [iOS] 2 tests in fast/writing-mode are constantly failing (flaky in EWS)
-fast/writing-mode/inline-block-baseline.html [ ImageOnlyFailure ]
 fast/writing-mode/vertical-subst-font-vert-no-dflt.html [ ImageOnlyFailure ]
 
 # webkit.org/b/288409 [ MacOS iOS ] 3x imported/w3c/web-platform-tests/navigation-api/navigation are consistent failures 


### PR DESCRIPTION
#### eee2a0dd99d00c96f19dd10a771f9578ccd4c177
<pre>
[iOS] Fix expectation for fast/writing-mode/inline-block-baseline.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=289735">https://bugs.webkit.org/show_bug.cgi?id=289735</a>
<a href="https://rdar.apple.com/141690615">rdar://141690615</a>

Reviewed by Vitor Roriz.

fast/writing-mode/inline-block-baseline.html was added in 275942@main
which was purely a test addition patch (i.e. no code change involved).
According to the bugzilla and commit message the purpose of this test is
to make sure that a Japanese character inside a ruby without any sort of
other Japanese character on the same line does not result in the
character overflowing the ruby.

In order to construct the correct behavior, the test expectation seems
to have another Japanese character within an invisible span on the same
line. However the glyph in this span, あ, is different from the
character inside the ruby, 国. It seems like at some point some metrics
for the glyph inside the span changed which resulted in a slightly
different rendering. The differences in the rendering, a shift in the
content and a small gap between the lines, was due to a change in the
sizes of the lines.

To fix up this test in order to get it passing again while still
honoring the intention behind the test we can change the glyph in the
span to be the same as the one in the ruby. As far as I can tell, there
is no reason why these two need to be different nor why the one in the
span needs to be this specific one. By making them the same we should
still be able to get the same desired behavior while hopefully making
the test case more resilient to differences in font changes.

* LayoutTests/fast/writing-mode/inline-block-baseline-expected.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/292184@main">https://commits.webkit.org/292184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6df2b9ffd3b02b2e4eed4ab16a95aa0354526ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72504 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3556 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81509 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22071 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->