### PR TITLE
[JSC] Hoist ConstantStoragePointer

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1862,6 +1862,7 @@ private:
             case JSConstant:
             case DoubleConstant:
             case Int52Constant:
+            case ConstantStoragePointer:
                 node->remove(m_graph);
                 break;
             default:

--- a/Source/JavaScriptCore/dfg/DFGConstantHoistingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantHoistingPhase.cpp
@@ -53,6 +53,7 @@ public:
         UncheckedKeyHashMap<FrozenValue*, Node*> jsValues;
         UncheckedKeyHashMap<FrozenValue*, Node*> doubleValues;
         UncheckedKeyHashMap<FrozenValue*, Node*> int52Values;
+        UncheckedKeyHashMap<void*, Node*> storagePointerValues;
         
         auto valuesFor = [&] (NodeType op) -> UncheckedKeyHashMap<FrozenValue*, Node*>& {
             // Use a roundabout approach because clang thinks that this closure returning a
@@ -99,6 +100,16 @@ public:
                     }
                     break;
                 }
+                case ConstantStoragePointer: {
+                    auto result = storagePointerValues.add(node->constant(), node);
+                    if (result.isNewEntry)
+                        node->origin = m_graph.block(0)->at(0)->origin;
+                    else {
+                        node->setReplacement(result.iterator->value);
+                        toFree.append(node);
+                    }
+                    break;
+                }
                 default:
                     block->at(targetIndex++) = node;
                     break;
@@ -109,13 +120,14 @@ public:
         
         // Insert the constants into the root block.
         InsertionSet insertionSet(m_graph);
-        auto insertConstants = [&] (const UncheckedKeyHashMap<FrozenValue*, Node*>& values) {
-            for (auto& entry : values)
-                insertionSet.insert(0, entry.value);
+        auto insertConstants = [&] (const auto& map) {
+            for (auto& value : map.values())
+                insertionSet.insert(0, value);
         };
         insertConstants(jsValues);
         insertConstants(doubleValues);
         insertConstants(int52Values);
+        insertConstants(storagePointerValues);
         insertionSet.execute(m_graph.block(0));
         
         // Perform all of the substitutions. We want all instances of the removed constants to


### PR DESCRIPTION
#### 1baafd6f56d4ef3801a3da81d63a6d8ef9fef61f
<pre>
[JSC] Hoist ConstantStoragePointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=289746">https://bugs.webkit.org/show_bug.cgi?id=289746</a>
<a href="https://rdar.apple.com/146996893">rdar://146996893</a>

Reviewed by Keith Miller.

As the same to the other constant DFG nodes, we should hoist
ConstantStoragePointer nodes too in constant hoisting phase.

* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::fixUpsilons):
* Source/JavaScriptCore/dfg/DFGConstantHoistingPhase.cpp:

Canonical link: <a href="https://commits.webkit.org/292135@main">https://commits.webkit.org/292135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89acd81d925ca6eae9ac59da83ce0be5b9e34f5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23088 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44909 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87741 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102147 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93692 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80907 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25471 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15355 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22086 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116382 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21743 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->