### PR TITLE
Implement browser.test.runTests so that it can be used in the web platform tests

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -71,6 +71,7 @@ public:
     JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
 
     JSValue *addTest(JSContextRef, JSValue *testFunction);
+    JSValue *runTests(JSContextRef, NSArray *testFunctions);
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onMessage;
@@ -88,6 +89,7 @@ private:
     bool m_runningTest { false };
     bool m_hitAssertion { false };
 
+    JSValue *addTest(JSContextRef, JSValue *testFunction, String callingAPIName);
     void assertEquals(JSContextRef, bool result, NSString *expectedString, NSString *actualString, NSString *message);
     void startNextTest();
     void recordAssertionIfNeeded(bool result)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -85,4 +85,7 @@
     // Adds a test represented by a promise. If the promise is resolved, the test passes; if the promise is rejected, the test fails.
     [NeedsScriptContext] any addTest(any function);
 
+    // Adds multiple tests to the queue to be ran and returns a promise. If all tests pass, the promise is resolved; if any test fails, the promise is rejected.
+    [NeedsScriptContext] any runTests([NSArray=JSValue] array tests);
+
 };


### PR DESCRIPTION
#### 185980ffc4448a148b4cfb6644cb32a6e659f03e
<pre>
Implement browser.test.runTests so that it can be used in the web platform tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=289747">https://bugs.webkit.org/show_bug.cgi?id=289747</a>
<a href="https://rdar.apple.com/146997451">rdar://146997451</a>

Reviewed by Timothy Hatcher.

This patch implements runTests() on the test namespace, which is intented to be
used in the web platform tests for web extensions.

runTests() takes in an array of functions and returns a promise. All of the
functions are executed in order, and if any of them fail, the promise that was
returned is rejected; otherwise, the promise is resolved.

To actually implement this was more or less a light wrapper around addTest(),
which was previously added in 5ca13e0.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::addTest):
(WebKit::WebExtensionAPITest::runTests):
Abstract out common logic of add test into a helper method, and have the
original add test method and the new run test method call it.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
Add the run test method to the header, and add the private helper add test
method.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
Define the run rest method in the .idl file.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITest, RunAnonymousTests)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, RunTestsThatPass)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, RunTestsWithTestThatFails)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, RunTestsWithAsyncTestThatFails)):
Write new tests to validate the API.

Canonical link: <a href="https://commits.webkit.org/292164@main">https://commits.webkit.org/292164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afe4054227a4c3edfc0f9984da7141fc9d54710b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100221 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/45683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23209 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/45683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98185 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/52928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/3671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3767 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102263 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22478 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/80990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/25558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22200 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27326 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/21859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->