### PR TITLE
[ARMv7] Fix i32 wasm args when useJIT=0

### DIFF
--- a/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
@@ -1,4 +1,4 @@
-
+//@skip if $memoryLimited
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/dataview-byte-length-large-array-oob.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob.js
@@ -1,4 +1,4 @@
-
+//@skip if $memoryLimited
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/dataview-byte-length-large-array.js
+++ b/JSTests/stress/dataview-byte-length-large-array.js
@@ -1,4 +1,4 @@
-
+//@skip if $memoryLimited
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/proxy-revoke.js
+++ b/JSTests/stress/proxy-revoke.js
@@ -1,5 +1,3 @@
-//@ defaultNoNoLLIntRun if $architecture == "arm64"
-
 function assert(b) {
     if (!b)
         throw new Error("bad assertion");

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -87,6 +87,9 @@ void linkMonomorphicCall(VM& vm, JSCell* owner, CallLinkInfo& callLinkInfo, Code
     CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
 
+    if (UNLIKELY(Options::forceICFailure()))
+        return;
+
     ASSERT(!callLinkInfo.isLinked());
     callLinkInfo.setMonomorphicCallee(vm, owner, callee, calleeCodeBlock, codePtr);
     callLinkInfo.setLastSeenCallee(vm, owner, callee);

--- a/Source/JavaScriptCore/interpreter/CalleeBits.h
+++ b/Source/JavaScriptCore/interpreter/CalleeBits.h
@@ -57,9 +57,9 @@ public:
     }
 
 #if USE(JSVALUE32_64)
-    static EncodedJSValue encodeNullCallee()
+    static constexpr EncodedJSValue encodeNullCallee()
     {
-        return JSValue::encode(jsNull());
+        return static_cast<uint64_t>(JSValue::NullTag) << 32;
     }
 
     static EncodedJSValue encodeJSCallee(const JSCell* cell)
@@ -80,9 +80,9 @@ public:
     }
 
 #elif USE(JSVALUE64)
-    static EncodedJSValue encodeNullCallee()
+    static constexpr EncodedJSValue encodeNullCallee()
     {
-        return reinterpret_cast<EncodedJSValue>(nullptr);
+        return 0;
     }
 
     static EncodedJSValue encodeJSCallee(const JSCell* cell)

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -131,6 +131,16 @@ void StackVisitor::readFrame(CallFrame* callFrame)
         return;
     }
 
+#if ASSERT_ENABLED
+    if (!codeBlock->inherits<CodeBlock>()) {
+        dataLogLn("Invalid codeblock type: ", *(JSCell*)codeBlock);
+        dataLogLn("Callee: ", RawPointer(callFrame->unsafeCallee().rawPtr()));
+        ASSERT_NOT_REACHED();
+        readNonInlinedFrame(callFrame);
+        return;
+    }
+#endif
+
     // If the code block does not have any code origins, then there's no
     // inlining. Hence, we're not at an inlined frame.
     if (!codeBlock->hasCodeOrigins()) {

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -912,7 +912,7 @@ public:
 #endif
     }
 
-    void storeWasmCalleeCallee(const uintptr_t* boxedWasmCalleeLoadLocation)
+    void storeWasmCalleeCallee(const EncodedJSValue* boxedWasmCalleeLoadLocation)
     {
         ASSERT(boxedWasmCalleeLoadLocation);
         JIT_COMMENT(*this, "> ", RawHex(*boxedWasmCalleeLoadLocation));

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1046,6 +1046,10 @@ else
     end)
 end
 
+if ASSERT_ENABLED
+    storep cfr, (constexpr (JSWebAssemblyInstance::offsetOfTemporaryCallFrame()))[wasmInstance]
+end
+
     move wasmInstance, a0
     move ws0, a1
     cCall2(_operationGetWasmCalleeStackSize)
@@ -1102,6 +1106,9 @@ end
 .postcall:
     subp RegisterSpaceScratchSize, sp
     storep r0, [sp]
+if not JSVALUE64
+    storep r1, TagOffset[sp]
+end
 
     loadp WasmCallableFunctionScratch[cfr], a0
     call _operationWasmToJSExitNeedToUnpack

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -206,7 +206,7 @@ public:
     WasmToJSCallee(FunctionSpaceIndex, std::pair<const Name*, RefPtr<NameSection>>&&);
     static WasmToJSCallee& singleton();
 
-    uintptr_t* boxedWasmCalleeLoadLocation() { return &m_boxedThis; }
+    EncodedJSValue* boxedWasmCalleeLoadLocation() { return &m_boxedThis; }
 
 private:
     WasmToJSCallee();
@@ -214,7 +214,7 @@ private:
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
     RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 
-    uintptr_t m_boxedThis;
+    EncodedJSValue m_boxedThis;
 };
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -37,7 +37,7 @@
 
 namespace JSC { namespace Wasm {
 
-constexpr uintptr_t NullWasmCallee = 0;
+constexpr EncodedJSValue NullWasmCallee = CalleeBits::encodeNullCallee();
 
 Segment::Ptr Segment::create(std::optional<I32InitExpr> offset, uint32_t sizeInBytes, Kind kind)
 {

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -794,7 +794,7 @@ struct InternalFunction {
     unsigned osrEntryScratchBufferSize { 0 };
 };
 
-extern const uintptr_t NullWasmCallee;
+extern const EncodedJSValue NullWasmCallee;
 
 struct alignas(8) WasmCallableFunction {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -802,7 +802,7 @@ struct alignas(8) WasmCallableFunction {
     static constexpr ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, entrypointLoadLocation); }
     static constexpr ptrdiff_t offsetOfBoxedWasmCalleeLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, boxedWasmCalleeLoadLocation); }
 
-    const uintptr_t* boxedWasmCalleeLoadLocation { &NullWasmCallee };
+    const EncodedJSValue* boxedWasmCalleeLoadLocation { &NullWasmCallee };
     // Target instance and entrypoint are only set for wasm->wasm calls, and are otherwise nullptr. The js-specific logic occurs through import function.
     WriteBarrier<JSWebAssemblyInstance> targetInstance { };
     LoadLocation entrypointLoadLocation { };
@@ -829,7 +829,7 @@ struct WasmOrJSImportableFunction : public WasmToWasmImportableFunction {
 
     CodePtr<WasmEntryPtrTag> importFunctionStub;
     WriteBarrier<JSObject> importFunction { };
-    uintptr_t boxedCallee { 0xBEEF };
+    EncodedJSValue boxedCallee { 0xBEEF };
 };
 
 struct WasmOrJSImportableFunctionCallLinkInfo final : public WasmOrJSImportableFunction {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -348,24 +348,31 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
         case TypeKind::Exn:
         case TypeKind::I32: {
             if (wasmParam.isStackArgument()) {
-                uint64_t raw = *access.operator()<uint64_t>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC));
+                uint64_t raw = *access.operator()<UCPURegister>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC));
 #if USE(JSVALUE64)
                 if (argType.isI32())
                     *access.operator()<uint64_t>(calleeFrame, dst) = static_cast<uint32_t>(raw) | JSValue::NumberTag;
 #else
-                if (false);
+                if (argType.isI32()) {
+                    *access.operator()<uint32_t>(calleeFrame, dst + PayloadOffset) = static_cast<uint32_t>(raw);
+                    *access.operator()<uint32_t>(calleeFrame, dst + TagOffset) = JSValue::Int32Tag;
+                }
 #endif
                 else
                     *access.operator()<uint64_t>(calleeFrame, dst) = raw;
             } else {
-                auto raw = *access.operator()<uint64_t>(argumentRegisters, GPRInfo::toArgumentIndex(wasmParam.jsr().payloadGPR()) * sizeof(UCPURegister));
+                auto raw = *access.operator()<UCPURegister>(argumentRegisters, GPRInfo::toArgumentIndex(wasmParam.jsr().payloadGPR()) * sizeof(UCPURegister));
 #if USE(JSVALUE64)
                 if (argType.isI32())
                     *access.operator()<uint64_t>(calleeFrame, dst) = static_cast<uint32_t>(raw) | JSValue::NumberTag;
                 else
                     *access.operator()<uint64_t>(calleeFrame, dst) = raw;
 #else
-                *access.operator()<uint32_t>(calleeFrame, dst) = raw;
+                if (argType.isI32()) {
+                    *access.operator()<uint32_t>(calleeFrame, dst + PayloadOffset) = static_cast<uint32_t>(raw);
+                    *access.operator()<uint32_t>(calleeFrame, dst + TagOffset) = JSValue::Int32Tag;
+                } else
+                    *access.operator()<uint32_t>(calleeFrame, dst) = raw;
 #endif
             }
             break;
@@ -418,10 +425,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
     *access.operator()<uint64_t>(calleeFrame, CallFrameSlot::thisArgument * static_cast<int>(sizeof(Register))) = JSValue::encode(jsUndefined());
 
     // materializeImportJSCell and store
-    *access.operator()<uintptr_t>(calleeFrame, CallFrameSlot::callee * static_cast<int>(sizeof(Register))) = std::bit_cast<uintptr_t>(importableFunction->importFunction);
-#if USE(JSVALUE32_64)
-    *access.operator()<uintptr_t>(calleeFrame, CallFrameSlot::callee * sizeof(Register) + TagOffset) = JSValue::CellTag;
-#endif
+    *access.operator()<uint64_t>(calleeFrame, CallFrameSlot::callee * sizeof(Register)) = JSValue::encode(importableFunction->importFunction.get());
     *access.operator()<uint32_t>(calleeFrame, CallFrameSlot::argumentCountIncludingThis * static_cast<int>(sizeof(Register)) + PayloadOffset) = argCount + 1; // including this = +1
 
     // set up codeblock
@@ -455,7 +459,6 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
     auto scope = DECLARE_THROW_SCOPE(instance->vm());
 
     constexpr int codeBlockOffset = -0x18;
-
     auto* importableFunction = *access.operator()<WasmOrJSImportableFunctionCallLinkInfo*>(cfr, codeBlockOffset);
     auto typeIndex = importableFunction->typeIndex;
     const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -220,7 +220,7 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
         if (!info->targetInstance) {
             info->importFunctionStub = module().importFunctionStub(functionSpaceIndex);
             importCallees.append(adoptRef(*new WasmToJSCallee(functionSpaceIndex, { nullptr, nullptr })));
-            ASSERT(!*info->boxedWasmCalleeLoadLocation);
+            ASSERT(*info->boxedWasmCalleeLoadLocation == CalleeBits::encodeNullCallee());
             info->boxedCallee = CalleeBits::encodeNativeCallee(importCallees.last().ptr());
             info->boxedWasmCalleeLoadLocation = &info->boxedCallee;
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -37,7 +37,7 @@ namespace JSC {
 
 class JSWebAssemblyInstance;
 
-class JSWebAssemblyStruct final : public WebAssemblyGCObjectBase, private TrailingArray<JSWebAssemblyStruct, uint8_t> {
+class alignas(sizeof(uint64_t)) JSWebAssemblyStruct final : public WebAssemblyGCObjectBase, private TrailingArray<JSWebAssemblyStruct, uint8_t> {
 public:
     using Base = WebAssemblyGCObjectBase;
     using TrailingArrayType = TrailingArray<JSWebAssemblyStruct, uint8_t>;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -96,7 +96,7 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
 
 WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT>&& rtt)
     : Base { vm, executable, globalObject, structure, instance, Wasm::WasmOrJSImportableFunction { { { &m_boxedWasmCallee, { vm, globalObject, instance }, wasmToWasmEntrypointLoadLocation }, typeIndex, rtt.get() }, { }, { } }, nullptr }
-    , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
+    , m_boxedWasmCallee(CalleeBits::encodeNativeCallee(wasmCallee))
     , m_jsToWasmCallee { jsEntrypoint }
 { }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -88,7 +88,7 @@ private:
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
 
     // This is the callee needed by LLInt/IPInt
-    uintptr_t m_boxedWasmCallee;
+    EncodedJSValue m_boxedWasmCallee;
     // This let's the JS->Wasm interpreter find its metadata
     Ref<Wasm::JSEntrypointCallee> m_jsToWasmCallee;
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -50,7 +50,7 @@ public:
     Wasm::TypeIndex typeIndex() const { return m_importableFunction.typeIndex; }
     Wasm::Type type() const { return { Wasm::TypeKind::Ref, typeIndex() }; }
     WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation() const { return m_importableFunction.entrypointLoadLocation; }
-    const uintptr_t* boxedWasmCalleeLoadLocation() const { return m_importableFunction.boxedWasmCalleeLoadLocation; }
+    const EncodedJSValue* boxedWasmCalleeLoadLocation() const { return m_importableFunction.boxedWasmCalleeLoadLocation; }
     const Wasm::WasmOrJSImportableFunction& importableFunction() const { return m_importableFunction; }
     const Wasm::RTT* rtt() const { return m_importableFunction.rtt; }
     const Wasm::FunctionSignature& signature() const;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -205,7 +205,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
             JSWebAssemblyInstance* calleeInstance = nullptr;
             WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = nullptr;
-            const uintptr_t* boxedWasmCalleeLoadLocation = &Wasm::NullWasmCallee;
+            const EncodedJSValue* boxedWasmCalleeLoadLocation = &Wasm::NullWasmCallee;
             JSObject* function = jsCast<JSObject*>(value);
 
             // ii. If v is an Exported Function Exotic Object:


### PR DESCRIPTION
#### 21f5de370a78c239379d70b00dc4fc5b471a477e
<pre>
[ARMv7] Fix i32 wasm args when useJIT=0
<a href="https://bugs.webkit.org/show_bug.cgi?id=289752">https://bugs.webkit.org/show_bug.cgi?id=289752</a>

Reviewed by Yusuke Suzuki.

These remaining changes shoud fix the jitless wasm tests on armv7. We just make
the wasm_to_js thunk more carful about the 32-bit JSValue representation.

First, we make the callee load location be an EncodedJSValue. This
shouldn&apos;t change 64-bit platforms, but lets us easily also write the
tag. We also skip some troublesome tests, and fix forceICFailure for
wasm call sites.

* JSTests/microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js:
* JSTests/stress/dataview-byte-length-large-array-oob-baseline.js:
* JSTests/stress/dataview-byte-length-large-array-oob.js:
* JSTests/stress/dataview-byte-length-large-array.js:
* JSTests/stress/proxy-revoke.js:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkMonomorphicCall):
* Source/JavaScriptCore/interpreter/CalleeBits.h:
(JSC::CalleeBits::encodeNullCallee):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::readFrame):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::storeWasmCalleeCallee):
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::finalizeCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
(JSC::WebAssemblyFunctionBase::boxedWasmCalleeLoadLocation const):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/292645@main">https://commits.webkit.org/292645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96051f1069924dfc821159cadf0398acb79bed77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96618 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47138 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24666 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73635 "Found 74 new test failures: compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html fast/canvas/canvas-bg-multiple-removal.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/empty-generated-content.html fast/inline/list-marker-float-crash.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46466 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89291 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95239 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83416 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82065 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17159 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28803 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118865 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23307 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->