### PR TITLE
Address more safer CPP failures in WebKit/UIProcess/API/Cocoa

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -60,10 +60,6 @@ UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/WKWebsitePolicies.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
-UIProcess/API/Cocoa/NSAttributedString.mm
-UIProcess/API/Cocoa/WKBackForwardList.mm
-UIProcess/API/Cocoa/WKBackForwardListItem.mm
-UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKContentRuleList.mm
 UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKContentWorld.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -7,8 +7,6 @@ UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKUserScriptRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
-UIProcess/API/Cocoa/WKBackForwardListItem.mm
-UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -495,7 +495,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 
         contentNavigation = loadWebContent(webView.get());
         if (!finished)
-            attributedStringActivity = [webView _page]->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
+            attributedStringActivity = [webView _protectedPage]->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
 
         ASSERT(contentNavigation);
         ASSERT(webView.get().loading);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -37,44 +37,49 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
+- (Ref<WebKit::WebBackForwardList>)_protectedList
+{
+    return *_list;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKBackForwardList.class, self))
         return;
 
-    _list->~WebBackForwardList();
+    self._protectedList->~WebBackForwardList();
 
     [super dealloc];
 }
 
 - (WKBackForwardListItem *)currentItem
 {
-    return WebKit::wrapper(_list->currentItem());
+    return WebKit::wrapper(self._protectedList->protectedCurrentItem().get());
 }
 
 - (WKBackForwardListItem *)backItem
 {
-    return WebKit::wrapper(_list->backItem());
+    return WebKit::wrapper(self._protectedList->protectedBackItem().get());
 }
 
 - (WKBackForwardListItem *)forwardItem
 {
-    return WebKit::wrapper(_list->forwardItem());
+    return WebKit::wrapper(self._protectedList->protectedForwardItem().get());
 }
 
 - (WKBackForwardListItem *)itemAtIndex:(NSInteger)index
 {
-    return WebKit::wrapper(_list->itemAtIndex(index));
+    return WebKit::wrapper(self._protectedList->protectedItemAtIndex(index).get());
 }
 
 - (NSArray *)backList
 {
-    return WebKit::wrapper(_list->backList()).autorelease();
+    return WebKit::wrapper(self._protectedList->backList()).autorelease();
 }
 
 - (NSArray *)forwardList
 {
-    return WebKit::wrapper(_list->forwardList()).autorelease();
+    return WebKit::wrapper(self._protectedList->forwardList()).autorelease();
 }
 
 #pragma mark WKObject protocol implementation
@@ -90,12 +95,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)_removeAllItems
 {
-    _list->removeAllItems();
+    self._protectedList->removeAllItems();
 }
 
 - (void)_clear
 {
-    _list->clear();
+    self._protectedList->clear();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -36,32 +36,38 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
+- (Ref<WebKit::WebBackForwardListItem>)_protectedItem
+{
+    return *_item;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKBackForwardListItem.class, self))
         return;
 
-    _item->~WebBackForwardListItem();
+    self._protectedItem->~WebBackForwardListItem();
 
     [super dealloc];
 }
 
 - (NSURL *)URL
 {
-    return [NSURL _web_URLWithWTFString:_item->url()];
+    return [NSURL _web_URLWithWTFString:self._protectedItem->url()];
 }
 
 - (NSString *)title
 {
-    if (!_item->title())
+    Ref item = *_item;
+    if (!item->title())
         return nil;
 
-    return _item->title();
+    return item->title();
 }
 
 - (NSURL *)initialURL
 {
-    return [NSURL _web_URLWithWTFString:_item->originalURL()];
+    return [NSURL _web_URLWithWTFString:self._protectedItem->originalURL()];
 }
 
 - (WebKit::WebBackForwardListItem&)_item
@@ -71,19 +77,20 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (CGImageRef)_copySnapshotForTesting
 {
-    if (auto snapshot = _item->snapshot())
+    if (RefPtr snapshot = _item->snapshot())
         return snapshot->asImageForTesting().leakRef();
     return nullptr;
 }
 
 - (CGPoint)_scrollPosition
 {
-    return CGPointMake(_item->mainFrameState()->scrollPosition.x(), _item->mainFrameState()->scrollPosition.y());
+    Ref item = *_item;
+    return CGPointMake(item->mainFrameState()->scrollPosition.x(), item->mainFrameState()->scrollPosition.y());
 }
 
 - (BOOL)_wasCreatedByJSWithoutUserInteraction
 {
-    return _item->wasCreatedByJSWithoutUserInteraction();
+    return self._protectedItem->wasCreatedByJSWithoutUserInteraction();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -277,11 +277,21 @@ WebBackForwardListItem* WebBackForwardList::backItem() const
     return m_page && m_currentIndex && *m_currentIndex ? m_entries[*m_currentIndex - 1].ptr() : nullptr;
 }
 
+RefPtr<WebBackForwardListItem> WebBackForwardList::protectedBackItem() const
+{
+    return backItem();
+}
+
 WebBackForwardListItem* WebBackForwardList::forwardItem() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     return m_page && m_currentIndex && m_entries.size() && *m_currentIndex < m_entries.size() - 1 ? m_entries[*m_currentIndex + 1].ptr() : nullptr;
+}
+
+RefPtr<WebBackForwardListItem> WebBackForwardList::protectedForwardItem() const
+{
+    return forwardItem();
 }
 
 WebBackForwardListItem* WebBackForwardList::itemAtIndex(int index) const
@@ -299,6 +309,11 @@ WebBackForwardListItem* WebBackForwardList::itemAtIndex(int index) const
         return nullptr;
 
     return m_entries[index + *m_currentIndex].ptr();
+}
+
+RefPtr<WebBackForwardListItem> WebBackForwardList::protectedItemAtIndex(int index) const
+{
+    return itemAtIndex(index);
 }
 
 unsigned WebBackForwardList::backListCount() const

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -64,8 +64,11 @@ public:
     WebBackForwardListItem* currentItem() const;
     RefPtr<WebBackForwardListItem> protectedCurrentItem() const;
     WebBackForwardListItem* backItem() const;
+    RefPtr<WebBackForwardListItem> protectedBackItem() const;
     WebBackForwardListItem* forwardItem() const;
+    RefPtr<WebBackForwardListItem> protectedForwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;
+    RefPtr<WebBackForwardListItem> protectedItemAtIndex(int) const;
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;


### PR DESCRIPTION
#### 2c9562fcc9d92a65767b33a7c5dca1f1ff45a62b
<pre>
Address more safer CPP failures in WebKit/UIProcess/API/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=289748">https://bugs.webkit.org/show_bug.cgi?id=289748</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList _protectedList]):
(-[WKBackForwardList dealloc]):
(-[WKBackForwardList currentItem]):
(-[WKBackForwardList backItem]):
(-[WKBackForwardList forwardItem]):
(-[WKBackForwardList itemAtIndex:]):
(-[WKBackForwardList backList]):
(-[WKBackForwardList forwardList]):
(-[WKBackForwardList _removeAllItems]):
(-[WKBackForwardList _clear]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _protectedItem]):
(-[WKBackForwardListItem dealloc]):
(-[WKBackForwardListItem URL]):
(-[WKBackForwardListItem title]):
(-[WKBackForwardListItem initialURL]):
(-[WKBackForwardListItem _copySnapshotForTesting]):
(-[WKBackForwardListItem _scrollPosition]):
(-[WKBackForwardListItem _wasCreatedByJSWithoutUserInteraction]):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController dealloc]):
(-[WKBrowsingContextController activeURL]):
(-[WKBrowsingContextController committedURL]):
(didFailProvisionalNavigation):
(didFailNavigation):
(-[WKBrowsingContextController _initWithPageRef:]):

Canonical link: <a href="https://commits.webkit.org/292165@main">https://commits.webkit.org/292165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e7eef484292e922d7ae58323bb07a21b837d063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23198 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29873 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10959 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102253 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22220 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80984 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25548 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15473 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15276 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22190 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27316 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->