### PR TITLE
Pasting an RTL paragraph starting with LTR text produces a jumbled LTR paragraph

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text-expected.html
+++ b/LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true BidiContentAwarePasteEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            font-family: system-ui;
+            font-size: 16px;
+        }
+
+        div[contenteditable] {
+            padding: 1em;
+            margin: 1em;
+            border: 2px solid darkgray;
+            outline: none;
+        }
+    </style>
+</head>
+<body>
+    <div dir="rtl" contenteditable>Apple Pay هي الطريقة الآمنة للدفع وإجراء عمليات الشراء في المتاجر وداخل التطبيقات وعلى الإنترنت.</div>
+    <div dir="rtl" contenteditable>Apple Pay هي الطريقة الآمنة للدفع وإجراء عمليات الشراء في المتاجر وداخل التطبيقات وعلى الإنترنت.</div>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text.html
+++ b/LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true BidiContentAwarePasteEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            font-family: system-ui;
+            font-size: 16px;
+        }
+
+        div[contenteditable] {
+            padding: 1em;
+            margin: 1em;
+            border: 2px solid darkgray;
+            outline: none;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        window.testRunner?.waitUntilDone();
+
+        addEventListener("load", async () => {
+            const source = document.querySelector(".source");
+            const destination = document.querySelector(".destination");
+
+            source.focus();
+            document.execCommand("SelectAll");
+            document.execCommand("Copy");
+            await UIHelper.ensurePresentationUpdate();
+
+            destination.focus();
+            document.execCommand("Paste");
+
+            destination.blur();
+            await UIHelper.ensurePresentationUpdate();
+
+            window.testRunner?.notifyDone();
+        });
+    </script>
+</head>
+<body>
+    <div dir="rtl" class="source" contenteditable>Apple Pay هي الطريقة الآمنة للدفع وإجراء عمليات الشراء في المتاجر وداخل التطبيقات وعلى الإنترنت.</div>
+    <div class="destination" contenteditable></div>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1739,6 +1739,9 @@ imported/w3c/web-platform-tests/preload/preload-time-to-fetch.https.html [ Failu
 # Failing with skia only with swrast
 webkit.org/b/273396 platform/gtk/fonts/webkit-font-smoothing.html [ ImageOnlyFailure ]
 
+# Bidi content-aware paste not yet supported
+editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text.html [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of non-crashing, non-flaky tests failing
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -127,7 +127,7 @@ private:
     ReplacementFragment* ensureReplacementFragment();
     bool performTrivialReplace(const ReplacementFragment&);
 
-    void updateDirectionForStartOfInsertedContentIfNeeded();
+    void updateDirectionForStartOfInsertedContentIfNeeded(const InsertedNodes&);
 
     RefPtr<DocumentFragment> protectedDocumentFragment() const { return m_documentFragment; }
 


### PR DESCRIPTION
#### b4b476f1502dd436d330bb2a2be01ca5d3c6e723
<pre>
Pasting an RTL paragraph starting with LTR text produces a jumbled LTR paragraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=289753">https://bugs.webkit.org/show_bug.cgi?id=289753</a>
<a href="https://rdar.apple.com/146855030">rdar://146855030</a>

Reviewed by Abrar Rahman Protyasha.

Copying an RTL paragraph that begins with LTR text, such as:

Apple Pay هي الطريقة الآمنة للدفع وإجراء عمليات الشراء في المتاجر وداخل التطبيقات وعلى الإنترنت.

...and pasting into a new line in Mail compose (or another WebKit-based rich text editor) currently
produces an LTR paragraph, where the RTL text is visually jumbled. This happens because the
heuristic to set base writing direction when pasting bases the target writing direction off of the
pasted text; since the pasted text logically starts with an LTR word, this causes us to apply LTR
base writing direction before inserting the paragraph, only if we&apos;re on an empty line.

To fix this, we make a couple of adjustments below:

1.  When copying, preserve the direction of text in the `span` element created to wrap the copied
    text, in the case where the base writing direction of the text does not match the text direction
    of the enclosing block containing the text. In the scenario described above, this would mean
    wrapping the text inside an `&lt;span dir=&quot;rtl&quot; style=&quot;…&quot;&gt; … &lt;/span&gt;`.

2.  When pasting, if a direction is set on the first inserted node, use that direction as the base
    writing direction instead of falling back to checking the pasted text content.

* LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text-expected.html: Added.
* LayoutTests/editing/pasteboard/paste-rtl-paragraph-with-leading-ltr-text.html: Added.

Add a layout test to verify that copying and pasting a selected RTL mixed English/Arabic sentence
that starts with an English word will paste as an RTL paragraph, instead of LTR.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded):

Pass in the list of `InsertedNodes`, so that we can use the first inserted node&apos;s effective text
direction if needed. See (2) above.

* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Source/WebCore/editing/markup.cpp:
(WebCore::directionAttributeAndValue):
(WebCore::StyledMarkupAccumulator::StyledMarkupAccumulator):

Pass the `PreserveDirectionForInlineText` flag down into the markup accumulator.

(WebCore::StyledMarkupAccumulator::appendStyleNodeOpenTag):

Teach this to also append `dir=&quot;ltr&quot;` or `dir=&quot;rtl&quot;` if needed. See (1) above.

(WebCore::StyledMarkupAccumulator::appendText):
(WebCore::serializePreservingVisualAppearanceInternal):

Canonical link: <a href="https://commits.webkit.org/292156@main">https://commits.webkit.org/292156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ff8bbeb6a2d295f283a10317283c4f39225563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95128 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72560 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29841 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52890 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102205 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22172 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80952 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20236 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25513 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2914 "Found 1 new test failure: compositing/repaint/become-overlay-composited-layer.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15412 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22144 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->