### PR TITLE
[visionOS] Import LinearMediaKit symbols from AVKit when available

### DIFF
--- a/Source/WebKit/Configurations/WebKitSwift.xcconfig
+++ b/Source/WebKit/Configurations/WebKitSwift.xcconfig
@@ -54,8 +54,10 @@ SWIFT_VERSION = 5.0;
 CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING = NO; // Disable PGO profile generation
 OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS) $(FRAMEWORK_LDFLAGS_$(WK_PLATFORM_NAME));
 
-FRAMEWORK_LDFLAGS_xros = -framework LinearMediaKit;
-FRAMEWORK_LDFLAGS_xrsimulator = -framework LinearMediaKit;
+FRAMEWORK_LDFLAGS_xros = -framework AVKit;
+FRAMEWORK_LDFLAGS_xrsimulator = -framework AVKit;
+FRAMEWORK_LDFLAGS_xros[sdk=xr*2.*] = -framework LinearMediaKit;
+FRAMEWORK_LDFLAGS_xrsimulator[sdk=xr*2.*] = -framework LinearMediaKit;
 
 // Use handwritten SPI modules on public SDKs.
 SWIFT_INCLUDE_PATHS = $(SWIFT_INCLUDE_PATHS_$(USE_INTERNAL_SDK));

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
@@ -25,7 +25,11 @@
 
 import UIKit
 
+#if canImport(AVKit, _version: 1270)
+@_spi(LinearMediaKit) @_spi(LinearMediaKit_WebKitOnly) import AVKit
+#else
 @_spi(WebKitOnly) import LinearMediaKit
+#endif
 
 @objc extension PlayableViewController {
     var wks_automaticallyDockOnFullScreenPresentation: Bool {

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitSPI.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitSPI.h
@@ -31,9 +31,13 @@
 
 #import <UIKit/UIKit.h>
 
-#if __has_include(<LinearMediaKit/LinearMediaKit.h>)
+#if __has_include(<AVKit/LMPlayableViewController.h>)
 
-#import <LinearMediaKit/LinearMediaKit.h>
+#import <AVKit/LMPlayableViewController.h>
+
+#elif __has_include(<LinearMediaKit/LMPlayableViewController.h>)
+
+#import <LinearMediaKit/LMPlayableViewController.h>
 
 #else
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -25,11 +25,16 @@
 
 import AVFoundation
 import Combine
-import LinearMediaKit
 import RealityFoundation
 import UIKit
 import WebKitSwift
 import os
+
+#if canImport(AVKit, _version: 1270)
+@_spi(LinearMediaKit) import AVKit
+#else
+import LinearMediaKit
+#endif
 
 private extension Logger {
     static let linearMediaPlayer = Logger(subsystem: "com.apple.WebKit", category: "LinearMediaPlayer")
@@ -326,7 +331,7 @@ extension WKSLinearMediaPlayer {
 
 #if canImport(LinearMediaKit, _version: 205)
 
-extension WKSLinearMediaPlayer: @retroactive Playable {
+@_spi(Internal) extension WKSLinearMediaPlayer: @retroactive Playable {
     public var selectedPlaybackRatePublisher: AnyPublisher<Double, Never> {
         publisher(for: \.selectedPlaybackRate).eraseToAnyPublisher()
     }

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -23,8 +23,13 @@
 
 #if os(visionOS)
 
-import LinearMediaKit
 import WebKitSwift
+
+#if canImport(AVKit, _version: 1270)
+@_spi(LinearMediaKit) import AVKit
+#else
+import LinearMediaKit
+#endif
 
 // MARK: Objective-C Implementations
 
@@ -231,7 +236,7 @@ extension WKSLinearMediaTimeRange {
 }
 
 #if canImport(LinearMediaKit, _version: 205)
-extension WKSLinearMediaTrack: @retroactive Track {
+@_spi(Internal) extension WKSLinearMediaTrack: @retroactive Track {
 }
 #endif
 


### PR DESCRIPTION
#### f9e73d0c830138d2c7ee156f96f62388311b7be8
<pre>
[visionOS] Import LinearMediaKit symbols from AVKit when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=289760">https://bugs.webkit.org/show_bug.cgi?id=289760</a>
<a href="https://rdar.apple.com/133022259">rdar://133022259</a>

Reviewed by Elliott Williams.

Imported LinearMediaKit symbols from AVKit on SDKs where such symbols are available.

* Source/WebKit/Configurations/WebKitSwift.xcconfig:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitSPI.h:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:

Canonical link: <a href="https://commits.webkit.org/292511@main">https://commits.webkit.org/292511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30e51b55be200641d1273a0d510f581e341f042

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46784 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24312 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11893 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46111 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103360 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23295 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22954 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->