### PR TITLE
[JSC] Implement `RegExp.prototype.test` in C++

### DIFF
--- a/JSTests/stress/regexp-prototype-test-fastpath-check.js
+++ b/JSTests/stress/regexp-prototype-test-fastpath-check.js
@@ -1,0 +1,76 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(run, errorType, message) {
+    let actual;
+    var hadError = false;
+
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+{
+    // Execute fast path and throw type error
+    shouldThrow(() => {
+        RegExp.prototype.test({});
+    }, TypeError, "Builtin RegExp exec can only be called on a RegExp object");
+}
+
+{
+    // Execute builtin exec
+    const re = /foo/;
+    let called = 0;
+    Object.defineProperty(re, "exec", {
+        get() {
+            called++;
+            return function () { return null };
+        }
+    });
+    shouldBe(re.test("foo"), false);
+    shouldBe(re.test("bar"), false);
+    shouldBe(called, 2);
+}
+
+{
+    // Execute non-builtin exec (native function)
+    const re = /foo/;
+    let called = 0;
+    Object.defineProperty(re, "exec", {
+        get() {
+            called++;
+            return Object.getPrototypeOf;
+        }
+    });
+    shouldBe(re.test("foo"), true);
+    shouldBe(re.test("bar"), true);
+    shouldBe(called, 2);
+}
+
+// Invalidate watchpoint
+Object.defineProperty(RegExp.prototype, "global", { get() { return false }});
+{
+    // Execute builtin exec
+    const re = /foo/;
+    shouldBe(re.test("foo"), true);
+    shouldBe(re.test("bar"), false);
+}
+
+{
+    // Execute builtin exec and throw type error
+    shouldThrow(() => {
+        RegExp.prototype.test({})
+    }, TypeError, "Builtin RegExp exec can only be called on a RegExp object");
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -176,7 +176,6 @@ namespace JSC {
     macro(regExpPrototypeSymbolReplace) \
     macro(regExpSearchFast) \
     macro(regExpSplitFast) \
-    macro(regExpTestFast) \
     macro(stringIncludesInternal) \
     macro(stringIndexOfInternal) \
     macro(stringSplitFast) \

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -629,33 +629,3 @@ function split(string, limit)
     return result;
 }
 
-// ES 21.2.5.13 RegExp.prototype.test(string)
-@intrinsic=RegExpTestIntrinsic
-function test(strArg)
-{
-    "use strict";
-
-    var regexp = this;
-
-    // Check for observable side effects and call the fast path if there aren't any.
-    if (@isRegExpObject(regexp)
-        && @tryGetById(regexp, "exec") === @regExpBuiltinExec
-        && typeof regexp.lastIndex === "number")
-        return @regExpTestFast.@call(regexp, strArg);
-
-    // 1. Let R be the this value.
-    // 2. If Type(R) is not Object, throw a TypeError exception.
-    if (!@isObject(regexp))
-        @throwTypeError("RegExp.prototype.test requires that |this| be an Object");
-
-    // 3. Let string be ? ToString(S).
-    var str = @toString(strArg);
-
-    // 4. Let match be ? RegExpExec(R, string).
-    var match = @regExpExec(regexp, str);
-
-    // 5. If match is not null, return true; else return false.
-    if (match !== null)
-        return true;
-    return false;
-}

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -110,7 +110,6 @@ class JSGlobalObject;
     v(regExpSplitFast, nullptr) \
     v(regExpPrototypeSymbolMatch, nullptr) \
     v(regExpPrototypeSymbolReplace, nullptr) \
-    v(regExpTestFast, nullptr) \
     v(stringIncludesInternal, nullptr) \
     v(stringIndexOfInternal, nullptr) \
     v(stringSplitFast, nullptr) \

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -99,7 +99,6 @@ namespace JSC {
     macro(Log2Intrinsic) \
     macro(RegExpExecIntrinsic) \
     macro(RegExpTestIntrinsic) \
-    macro(RegExpTestFastIntrinsic) \
     macro(RegExpMatchFastIntrinsic) \
     macro(ObjectAssignIntrinsic) \
     macro(ObjectCreateIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1753,9 +1753,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpSplitFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "regExpSplitFast"_s, regExpProtoFuncSplitFast, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpTestFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "regExpTestFast"_s, regExpProtoFuncTestFast, ImplementationVisibility::Private, RegExpTestFastIntrinsic));
-        });
 
     // String.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIncludesInternal)].initLater([] (const Initializer<JSCell>& init) {

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -56,6 +56,5 @@ private:
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncMatchFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSearchFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSplitFast);
-JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncTestFast);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
@@ -20,9 +20,28 @@
 
 #pragma once
 
+#include "JSGlobalObject.h"
 #include "RegExpPrototype.h"
 
 namespace JSC {
+
+ALWAYS_INLINE bool regExpTestWatchpointIsValid(VM& vm, JSObject* thisObject)
+{
+    JSGlobalObject* globalObject = thisObject->globalObject();
+    RegExpPrototype* regExpPrototype = globalObject->regExpPrototype();
+
+    ASSERT(globalObject->regExpPrimordialPropertiesWatchpointSet().state() != ClearWatchpoint);
+    if (regExpPrototype != thisObject->getPrototypeDirect())
+        return false;
+
+    if (globalObject->regExpPrimordialPropertiesWatchpointSet().state() != IsWatched)
+        return false;
+
+    if (!thisObject->hasCustomProperties())
+        return true;
+
+    return thisObject->getDirectOffset(vm, vm.propertyNames->exec) == invalidOffset;
+}
 
 inline Structure* RegExpPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {


### PR DESCRIPTION
#### 02fd5f298eb0726573ffa11ead463140a6cb3f8a
<pre>
[JSC] Implement `RegExp.prototype.test` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=289765">https://bugs.webkit.org/show_bug.cgi?id=289765</a>

Reviewed by Yusuke Suzuki.

This patch implements `RegExp.prototype.test` in C++.

It is already handled by the DFG/FTL, so this patch improves
performance in the LLInt/Baseline JIT. No performance
regressions were found in the DFG/FTL.

Benchmark results without DFG/FTL:
                                                  TipOfTree                  Patched

simple-regexp-test-folding                     54.2258+-2.8848     ^     32.5454+-0.7088        ^ definitely 1.6662x faster
simple-regexp-test-folding-with-hoisted-regexp
                                               37.9803+-0.3388     ^     18.3770+-0.2817        ^ definitely 2.0667x faster
simple-regexp-test-folding-fail-with-hoisted-regexp
                                               36.4906+-0.3061     ^     17.7502+-0.3467        ^ definitely 2.0558x faster
simple-regexp-test-folding-fail                53.1335+-0.5068     ^     31.7124+-0.7364        ^ definitely 1.6755x faster

Benchmark results with DFG/FTL:
                                                  TipOfTree                  Patched

simple-regexp-test-folding                      2.3313+-0.0701     ?      2.3508+-0.1976        ?
simple-regexp-test-folding-with-hoisted-regexp
                                               11.3422+-0.5250           10.9961+-0.2163          might be 1.0315x faster
simple-regexp-test-folding-fail-with-hoisted-regexp
                                               13.4536+-5.4919           12.0053+-5.1104          might be 1.1206x faster
simple-regexp-test-folding-fail                 1.8815+-0.0610            1.7787+-0.1649          might be 1.0578x faster

* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::RegExpPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h:
(JSC::regExpExecWatchpointIsValid):

Canonical link: <a href="https://commits.webkit.org/292161@main">https://commits.webkit.org/292161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b196fef9ccf1074dc73448c02969bb9dfe90971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72576 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3640 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44991 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87820 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102231 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93772 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15447 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22167 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116460 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21826 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->