### PR TITLE
StringBuilder::appendQuotedJSONString() should handle OOME more gracefully.

### DIFF
--- a/JSTests/stress/json-stringify-out-of-memory.js
+++ b/JSTests/stress/json-stringify-out-of-memory.js
@@ -1,0 +1,23 @@
+//@ skip if $memoryLimited or $buildType == "debug"
+//@ runDefault
+
+var a = [];
+var str = "a";
+
+for (var i = 0; i < 8; i++) {
+  str += str;
+  str += String.fromCharCode(i, i) + str.trimLeft();
+}
+for (var i = 0; i < 10000; i++)
+  a.push(str);
+
+var exception;
+try {
+    json1 = JSON.stringify(a);
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Out of memory")
+    throw "FAIL";
+

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
  * Copyright (C) 2017 Mozilla Foundation. All rights reserved.
@@ -34,10 +34,25 @@ void StringBuilder::appendQuotedJSONString(const String& string)
         return;
     }
 
-    auto stringLengthValue = stringLength.value();
+    // We need to use saturatedSum<uint32_t>() below instead of saturatedSum<int32_t>
+    // because INT_MAX is a valid capacity value. If stringLengthValue is greater than
+    // INT_MAX, but is saturated to INT_MAX, then we'll end up allocating an INT_MAX
+    // sized buffer and try to write beyond it resulting in a crash due to std:::span.
+    // Ideally, we should fail with an overflow instead.
+    //
+    // Using saturatedSum<uint32_t>(), the sum can be:
+    // 1. less or equal to INT_MAX.
+    // 2. greater than INT_MAX but not be saturated.
+    // 3. be saturated at UINT_MAX.
+    // For (1), things work like normal as expected (limited only by available memory).
+    // For (2), the extendBufferForAppending calls will reject the new capacity because
+    // the underlying buffer is backed by a StringImpl, which is capped at a max length
+    // of INT_MAX.
+    // For (3), the saturated value of UINT_MAX will be rejected just like (2).
+    auto stringLengthValue = static_cast<uint32_t>(stringLength.value());
 
     if (is8Bit() && string.is8Bit()) {
-        if (auto output = extendBufferForAppending<LChar>(saturatedSum<int32_t>(m_length, stringLengthValue)); output.data()) {
+        if (auto output = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, stringLengthValue)); output.data()) {
             output = output.first(stringLengthValue);
             consume(output) = '"';
             appendEscapedJSONStringContent(output, string.span8());
@@ -46,7 +61,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
                 shrink(m_length - output.size());
         }
     } else {
-        if (auto output = extendBufferForAppendingWithUpconvert(saturatedSum<int32_t>(m_length, stringLengthValue)); output.data()) {
+        if (auto output = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, stringLengthValue)); output.data()) {
             output = output.first(stringLengthValue);
             consume(output) = '"';
             if (string.is8Bit())


### PR DESCRIPTION
#### 5deaf3ecdf97cf9e9e8c4b3c649c6acb4264030c
<pre>
StringBuilder::appendQuotedJSONString() should handle OOME more gracefully.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289232">https://bugs.webkit.org/show_bug.cgi?id=289232</a>
<a href="https://rdar.apple.com/146943330">rdar://146943330</a>

Reviewed by Yusuke Suzuki.

The saturatedSum in StringBuilder::appendQuotedJSONString() should use uint32_t instead of int32_t.
This is because INT_MAX is a valid capacity.  If the requested stringLengthValue gets saturated to
INT_MAX, we&apos;ll mistakenly think that there&apos;s enough buffer space to handle appending the string
when we actually need more memory.

The fix is simply to use saturatedSum&lt;uint32_t&gt; instead.  As a result, a stringLengthValue that is
greater than INT_MAX won&apos;t saturate it, but will still be rejected when by the underlying buffer
allocator, which is the StringImpl allocator, which will reject allocations above INT_MAX.  In the
event that saturatedSum&lt;uint32_t&gt; does saturate, it will saturate to UINT_MAX, and will still be
rejected by the underlying buffer allocator.

* JSTests/stress/json-stringify-out-of-memory.js: Added.
(catch):
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::StringBuilder::appendQuotedJSONString):

Canonical link: <a href="https://commits.webkit.org/292170@main">https://commits.webkit.org/292170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53c0f7e3599d406f829633e2d1992d9edccad05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45611 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72546 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29830 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44949 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102188 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93732 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22154 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81544 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80936 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15396 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15280 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27255 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116422 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21784 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->