### PR TITLE
[JSC] Opportunistically exclude environment variable from stack scanning on Linux

### DIFF
--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -158,7 +158,19 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         void* bound = static_cast<char*>(origin) - size;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        return StackBounds { origin, bound };
+
+        static char** oldestEnviron = environ;
+
+        // In 32bit architecture, it is possible that environment variables are having a characters which looks like a pointer,
+        // and conservative GC will find it as a live pointer. We would like to avoid that to precisely exclude non user stack
+        // data region from this stack bounds. As the article (https://lwn.net/Articles/631631/) and the elf loader implementation
+        // explain how Linux main thread stack is organized, environment variables vector is placed on the stack, so we can exclude
+        // environment variables if we use `environ` global variable as a origin of the stack.
+        // But `setenv` / `putenv` may alter `environ` variable's content. So we record the oldest `environ` variable content, and use it.
+        StackBounds stackBounds { origin, bound };
+        if (stackBounds.contains(oldestEnviron))
+            stackBounds = { oldestEnviron, bound };
+        return stackBounds;
     }
 #endif
     return ret;


### PR DESCRIPTION
#### 5635198a9b0dc2f6cda80c7bffe1389f23b347be
<pre>
[JSC] Opportunistically exclude environment variable from stack scanning on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=289774">https://bugs.webkit.org/show_bug.cgi?id=289774</a>
<a href="https://rdar.apple.com/147017776">rdar://147017776</a>

Reviewed by Justin Michaud.

As it is suggested in
<a href="https://webkit.slack.com/archives/CTV4FGWF4/p1737380355218399">https://webkit.slack.com/archives/CTV4FGWF4/p1737380355218399</a>, we should
leverage Linux&apos;s ELF loader&apos;s stack setup mechanism to exclude
environment variables from the stack.

* Source/WTF/wtf/StackBounds.cpp:
(WTF::StackBounds::currentThreadStackBoundsInternal):

Canonical link: <a href="https://commits.webkit.org/292171@main">https://commits.webkit.org/292171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699427222c69665fc48a435fcd5c31b32bc78c4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95123 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15007 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/23232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72553 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3612 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44961 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87792 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102200 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93744 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22167 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16176 "Exiting early after 60 failures. 74259 tests run. 60 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15407 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27267 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116434 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21797 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->