### PR TITLE
WebKit apps occasionally crash during context retrieval under `createElementContent`

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -87,7 +87,12 @@ inline static RetainPtr<WKTextExtractionTextItem> createWKTextItem(const TextExt
         auto& [url, range] = linkAndRange;
         if (UNLIKELY(range.location + range.length > data.content.length()))
             return { };
-        return adoptNS([allocWKTextExtractionLinkInstance() initWithURL:url range:NSMakeRange(range.location, range.length)]);
+
+        RetainPtr nsURL = static_cast<NSURL *>(url);
+        if (!nsURL)
+            return { };
+
+        return adoptNS([allocWKTextExtractionLinkInstance() initWithURL:nsURL.get() range:NSMakeRange(range.location, range.length)]);
     });
 
     return adoptNS([allocWKTextExtractionTextItemInstance()


### PR DESCRIPTION
#### 2c63423daccbd8499fbe0b9503a5a2a1eafa07af
<pre>
WebKit apps occasionally crash during context retrieval under `createElementContent`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289777">https://bugs.webkit.org/show_bug.cgi?id=289777</a>
<a href="https://rdar.apple.com/146796512">rdar://146796512</a>

Reviewed by Richard Robinson.

It&apos;s possible for the conversion from `WTF::URL` to `NSURL` to result in `nil`, if the URL is
`null`. In this case, we end up crashing under WebKitSwift code, since `link.url` below fails to
convert to a Swift URL:

```
private func createElementContent(for item: WKTextExtractionItem) -&gt; IntelligenceElement.Content {
…
        for link in text.links {
            if let range = Range(link.range, in: content) {
                content[range].intelligenceLink = link.url as URL // &lt;---
            }
        }
```

Fix this by returning early, to avoid the crash.

* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::createWKTextItem):

Canonical link: <a href="https://commits.webkit.org/292153@main">https://commits.webkit.org/292153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1279ea28d91dd6e9624d14c3982bfeb6c42c8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45631 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29842 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10923 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44968 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102207 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22174 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80954 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15415 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22146 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->