### PR TITLE
[Screen Time Refactoring] Don't spin up Screen Time in offscreen web views

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -469,11 +469,11 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(SCREEN_TIME)
-- (void)_installScreenTimeWebpageController;
+- (void)_installScreenTimeWebpageControllerIfNeeded;
 - (void)_uninstallScreenTimeWebpageController;
 
 - (void)_updateScreenTimeViewGeometry;
-- (void)_updateScreenTimeShieldVisibilityForWindow;
+- (void)_updateScreenTimeBasedOnWindowVisibility;
 #endif
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -335,17 +335,16 @@ void PageClientImplCocoa::updateScreenTimeWebpageControllerURL(WKWebView *webVie
     if (!PAL::isScreenTimeFrameworkAvailable())
         return;
 
-    if (![webView _screenTimeWebpageController])
-        [webView _installScreenTimeWebpageController];
-
-    RetainPtr screenTimeWebpageController = [webView _screenTimeWebpageController];
-
     RefPtr pageProxy = [webView _page].get();
     if (pageProxy && !pageProxy->preferences().screenTimeEnabled()) {
         [webView _uninstallScreenTimeWebpageController];
         return;
     }
 
+    if ([webView window])
+        [webView _installScreenTimeWebpageControllerIfNeeded];
+
+    RetainPtr screenTimeWebpageController = [webView _screenTimeWebpageController];
     [screenTimeWebpageController setURL:[webView _mainFrameURL]];
 }
 
@@ -372,14 +371,14 @@ void PageClientImplCocoa::setURLIsPlayingVideoForScreenTime(bool value)
 void PageClientImplCocoa::viewIsBecomingVisible()
 {
 #if ENABLE(SCREEN_TIME)
-    [m_webView _updateScreenTimeShieldVisibilityForWindow];
+    [m_webView _updateScreenTimeBasedOnWindowVisibility];
 #endif
 }
 
 void PageClientImplCocoa::viewIsBecomingInvisible()
 {
 #if ENABLE(SCREEN_TIME)
-    [m_webView _updateScreenTimeShieldVisibilityForWindow];
+    [m_webView _updateScreenTimeBasedOnWindowVisibility];
 #endif
 }
 


### PR DESCRIPTION
#### eb2cf5ec637d91ca194ee664da7ccc1127cc6167
<pre>
[Screen Time Refactoring] Don&apos;t spin up Screen Time in offscreen web views
<a href="https://bugs.webkit.org/show_bug.cgi?id=289784">https://bugs.webkit.org/show_bug.cgi?id=289784</a>
<a href="https://rdar.apple.com/146809373">rdar://146809373</a>

Reviewed by Aditya Keerthi.

Check and do not create the ScreenTimeWebpageController if the web view
is never in window. Also, add an API test for this case.

Change the API test (DoNotDonateURLsInOccludedWebView) which used to
remove the webview from window, then add the webview back to window.
Now, instead of removing the webview from the window, we add a new window
to cover the webview, effectively occluding the webview. Then check for
donations again after making the covering window have zero width and height.

Add an API test (CreateControllerAfterOffscreenWebViewBecomesInWindow) for
the case of an offscreen webview that becomes an onscreen webview.

Add an API test (ScreenTimeControllerSetsURLWhenOffscreenWebViewBecomesInWindow)
to check if we set URLs in the case of an offscreen webview that becomes
an onscreen webview.

Update the API test (ScreenTimeControllerInstalledAfterRestoreFromSessionState)
to not be added to test window upon creation and added after verifying the
controller does not exist yet.

Rename function from _updateScreenTimeShieldVisibilityForWindow
to _updateScreenTimeBasedOnWindowVisibility since we are generally setting
Screen Time information based on the window&apos;s visibility. Additionally,
install the controller if the webview is now in window and we have not
installed the controller previously. Also, set the URL on the controller
if we are installing the controller from _updateScreenTimeBasedOnWindowVisibility.

Rename function from _installScreenTimeWebpageController to
_installScreenTimeWebpageControllerIfNeeded since this is
conditional on whether we need to install the controller or not.

Note: The uninstallation of the controller for
the case of a onscreen webview, then offscreen webview will be
in a separate PR to keep things concise and organized.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView _updateScreenTimeBasedOnWindowVisibility]):
(-[WKWebView _installScreenTimeWebpageController]): Deleted.
(-[WKWebView _updateScreenTimeShieldVisibilityForWindow]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::updateScreenTimeWebpageControllerURL):
(WebKit::PageClientImplCocoa::viewIsBecomingVisible):
(WebKit::PageClientImplCocoa::viewIsBecomingInvisible):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, DoNotDonateURLsInOccludedWebView)):
(TEST(ScreenTime, CreateControllerAfterOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerSetsURLWhenOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerInstalledAfterRestoreFromSessionState)):
(TEST(ScreenTime, DoNotDonateURLsInOffscreenWebView)): Deleted.

Canonical link: <a href="https://commits.webkit.org/292400@main">https://commits.webkit.org/292400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a2e3326b0a742df0c908de4da1038e0f538d70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73135 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30356 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4390 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82175 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81538 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16325 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15437 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22951 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->