### PR TITLE
[css-anchor-position-1] Use inset-modified containing block size for sorting position options

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block-expected.txt
@@ -1,0 +1,6 @@
+
+PASS most-width --margin, --no-margin | --margin
+PASS most-width --no-margin, --margin | --no-margin
+PASS most-height --margin, --no-margin | --margin
+PASS most-height --no-margin, --margin | --no-margin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: position-try-order behavior with margins</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #cb {
+    position: absolute;
+    width: 400px;
+    height: 400px;
+    border: 1px solid black;
+  }
+  #target, #ref {
+    position: absolute;
+    left: 450px; /* force fallback */
+    height: 40px;
+    background-color: skyblue;
+  }
+  #ref {
+    background-color: seagreen;
+  }
+
+  @position-try --margin {
+    left:0px;
+    right:0px;
+    margin: 100px;
+  }
+  @position-try --no-margin {
+    left:0px;
+    right:0px;
+  }
+
+</style>
+<style id=style>
+</style>
+<div id=cb>
+  <div id=target></div>
+  <div id=ref></div>
+</div>
+<script>
+
+// Test that an element with the specified `position_try` gets the same
+// position as a reference element with `position_try_expected`.
+function test_position_try_order(position_try, position_try_expected) {
+  test((t) => {
+    style.textContent = `
+      #target {
+        position-try: ${position_try};
+      }
+      #ref {
+        position-try: ${position_try_expected};
+      }
+    `;
+    assert_true(CSS.supports('position-try', 'normal --x'));
+    assert_equals(target.offsetLeft, ref.offsetLeft, 'offsetLeft');
+    assert_equals(getComputedStyle(target).marginLeft, getComputedStyle(ref).marginLeft, 'marginLeft');
+  }, `${position_try} | ${position_try_expected}`);
+}
+
+// Margin does not affect the inset-modified containing block size so the first option should get picked.
+test_position_try_order('most-width --margin, --no-margin', '--margin');
+test_position_try_order('most-width --no-margin, --margin', '--no-margin');
+test_position_try_order('most-height --margin, --no-margin', '--margin');
+test_position_try_order('most-height --no-margin, --margin', '--no-margin');
+
+</script>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -52,7 +52,7 @@ static bool shouldFlipStaticPositionInParent(const RenderBox& outOfFlowBox, cons
 }
 
 PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& renderer, const RenderStyle& style, LogicalBoxAxis logicalAxis)
-    : m_container(downcast<RenderBoxModelObject>(*renderer.container()))
+    : m_container(downcast<RenderBoxModelObject>(*renderer.container())) // Using containingBlock() would be wrong for relpositioned inlines.
     , m_containingWritingMode(m_container->writingMode())
     , m_writingMode(style.writingMode())
     , m_physicalAxis(logicalAxis == LogicalBoxAxis::Inline ? m_writingMode.inlineAxis() : m_writingMode.blockAxis())

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -101,6 +101,7 @@ public:
     LayoutUnit insetBeforeValue() const { return minimumValueForLength(m_insetBefore, containingSize()); }
     LayoutUnit insetAfterValue() const { return minimumValueForLength(m_insetAfter, containingSize()); }
     LayoutUnit availableContentSpace() const { return containingSize() - insetBeforeValue() - marginBeforeValue() - bordersPlusPadding() - marginAfterValue() - insetAfterValue(); } // This may be negative.
+    LayoutUnit insetModifiedContainingBlockSize() const { return containingSize() - insetBeforeValue() - insetAfterValue(); }
 
     void convertLogicalLeftValue(LayoutUnit&) const;
     void convertLogicalTopValue(LayoutUnit&, const RenderBox&, const LayoutUnit logicalHeightValue) const;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4006,8 +4006,6 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
     // (block-style-comments in this function and in computePositionedLogicalWidthUsing()
     // correspond to text from the spec)
 
-    // We don't use containingBlock(), since we may be positioned by an enclosing
-    // relative positioned inline.
     PositionedLayoutConstraints inlineConstraints(*this, LogicalBoxAxis::Inline);
 
     // Calculate the used width. See CSS2 § 10.3.7.
@@ -4134,7 +4132,6 @@ void RenderBox::computePositionedLogicalHeight(LogicalExtentComputedValues& comp
         return;
     }
 
-    // We don't use containingBlock(), since we may be positioned by an enclosing relpositioned inline.
     PositionedLayoutConstraints blockConstraints(*this, LogicalBoxAxis::Block);
 
     // Calculate the used height. See CSS2 § 10.6.4.
@@ -4231,8 +4228,6 @@ LayoutUnit RenderBox::computePositionedLogicalHeightUsing(SizeType heightType, L
 
 void RenderBox::computePositionedLogicalWidthReplaced(LogicalExtentComputedValues& computedValues) const
 {
-    // We don't use containingBlock(), since we may be positioned by an enclosing
-    // relative positioned inline.
     PositionedLayoutConstraints inlineConstraints(*this, LogicalBoxAxis::Inline);
 
     // NOTE: This value of width is final in that the min/max width calculations
@@ -4256,7 +4251,6 @@ void RenderBox::computePositionedLogicalWidthReplaced(LogicalExtentComputedValue
 
 void RenderBox::computePositionedLogicalHeightReplaced(LogicalExtentComputedValues& computedValues) const
 {
-    // We don't use containingBlock(), since we may be positioned by an enclosing relpositioned inline.
     PositionedLayoutConstraints blockConstraints(*this, LogicalBoxAxis::Block);
 
     // NOTE: This value of height is final in that the min/max height calculations

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1409,7 +1409,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
     options.sorted = true;
 
     auto order = options.originalStyle->positionTryOrder();
-    if (order == PositionTryOrder::Normal)
+    if (order == PositionTryOrder::Normal || options.optionStyles.size() < 2)
         return;
 
     CheckedPtr box = dynamicDowncast<RenderBox>(styleable.renderer());
@@ -1430,7 +1430,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
 
     for (auto& optionStyle : options.optionStyles) {
         auto constraints = PositionedLayoutConstraints { *box, *optionStyle, boxAxis };
-        optionsForSorting.append({ WTFMove(optionStyle), constraints.availableContentSpace() });
+        optionsForSorting.append({ WTFMove(optionStyle), constraints.insetModifiedContainingBlockSize() });
     }
 
     // "Stably sort the position options list according to this size, with the largest coming first."


### PR DESCRIPTION
#### b0788b3af9c739ecd37d5925330d9e3bc59c2f42
<pre>
[css-anchor-position-1] Use inset-modified containing block size for sorting position options
<a href="https://bugs.webkit.org/show_bug.cgi?id=289785">https://bugs.webkit.org/show_bug.cgi?id=289785</a>
<a href="https://rdar.apple.com/problem/147033919">rdar://problem/147033919</a>

Reviewed by Sam Weinig.

We currently use PositionedLayoutConstraints::availableContentSpace() which also substracts margin, border and padding.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-inset-modified-containing-block.html: Added.

Add a test.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::insetModifiedContainingBlockSize const):

Add a helper.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):

Also get rid of some obsolete comments.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Use insetModifiedContainingBlockSize instead of availableContentSpace.

Canonical link: <a href="https://commits.webkit.org/292162@main">https://commits.webkit.org/292162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e80c0f4d179b0b3e0cab346f5c493d4d59e3b31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45006 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/3756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102248 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22215 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80980 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20240 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25544 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15468 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22185 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->