### PR TITLE
Make URL host/hostname setters handle @ and : even more correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
@@ -1177,6 +1177,24 @@
                 "host": "test.invalid",
                 "hostname": "test.invalid"
             }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "test/@aaa",
+            "expected": {
+                "href": "https://test/",
+                "host": "test",
+                "hostname": "test"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "test/:aaa",
+            "expected": {
+                "href": "https://test/",
+                "host": "test",
+                "hostname": "test"
+            }
         }
     ],
     "hostname": [
@@ -1623,6 +1641,24 @@
                 "href": "https://test.invalid/",
                 "host": "test.invalid",
                 "hostname": "test.invalid"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "test/@aaa",
+            "expected": {
+                "href": "https://test/",
+                "host": "test",
+                "hostname": "test"
+            }
+        },
+        {
+            "href": "https://test.invalid/",
+            "new_value": "test/:aaa",
+            "expected": {
+                "href": "https://test/",
+                "host": "test",
+                "hostname": "test"
             }
         }
     ],

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
@@ -258,6 +258,10 @@ PASS <area>: Setting <https://test.invalid/>.host = 'foo	\r
 bar'
 PASS <a>: Setting <https://test.invalid/>.host = '><'
 PASS <area>: Setting <https://test.invalid/>.host = '><'
+PASS <a>: Setting <https://test.invalid/>.host = 'test/@aaa'
+PASS <area>: Setting <https://test.invalid/>.host = 'test/@aaa'
+PASS <a>: Setting <https://test.invalid/>.host = 'test/:aaa'
+PASS <area>: Setting <https://test.invalid/>.host = 'test/:aaa'
 PASS <a>: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS <area>: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS <a>: Setting <sc://x/>.hostname = '	'
@@ -354,6 +358,10 @@ PASS <area>: Setting <https://test.invalid/>.hostname = 'foo	\r
 bar'
 PASS <a>: Setting <https://test.invalid/>.hostname = '><'
 PASS <area>: Setting <https://test.invalid/>.hostname = '><'
+PASS <a>: Setting <https://test.invalid/>.hostname = 'test/@aaa'
+PASS <area>: Setting <https://test.invalid/>.hostname = 'test/@aaa'
+PASS <a>: Setting <https://test.invalid/>.hostname = 'test/:aaa'
+PASS <area>: Setting <https://test.invalid/>.hostname = 'test/:aaa'
 PASS <a>: Setting <http://example.net>.port = '8080'
 PASS <area>: Setting <http://example.net>.port = '8080'
 PASS <a>: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -110,6 +110,8 @@ PASS URL: Setting <https://test.invalid/>.host = 'x@x'
 PASS URL: Setting <https://test.invalid/>.host = 'foo	\r
 bar'
 PASS URL: Setting <https://test.invalid/>.host = '><'
+PASS URL: Setting <https://test.invalid/>.host = 'test/@aaa'
+PASS URL: Setting <https://test.invalid/>.host = 'test/:aaa'
 PASS URL: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS URL: Setting <sc://x/>.hostname = '	'
 PASS URL: Setting <sc://x/>.hostname = '
@@ -154,6 +156,8 @@ PASS URL: Setting <https://test.invalid/>.hostname = 'x@x'
 PASS URL: Setting <https://test.invalid/>.hostname = 'foo	\r
 bar'
 PASS URL: Setting <https://test.invalid/>.hostname = '><'
+PASS URL: Setting <https://test.invalid/>.hostname = 'test/@aaa'
+PASS URL: Setting <https://test.invalid/>.hostname = 'test/:aaa'
 PASS URL: Setting <http://example.net>.port = '8080'
 PASS URL: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value
 PASS URL: Setting <http://example.net:8080>.port = '80' Default port number is removed

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
@@ -110,6 +110,8 @@ PASS URL: Setting <https://test.invalid/>.host = 'x@x'
 PASS URL: Setting <https://test.invalid/>.host = 'foo	\r
 bar'
 PASS URL: Setting <https://test.invalid/>.host = '><'
+PASS URL: Setting <https://test.invalid/>.host = 'test/@aaa'
+PASS URL: Setting <https://test.invalid/>.host = 'test/:aaa'
 PASS URL: Setting <sc://x/>.hostname = '\0' Non-special scheme
 PASS URL: Setting <sc://x/>.hostname = '	'
 PASS URL: Setting <sc://x/>.hostname = '
@@ -154,6 +156,8 @@ PASS URL: Setting <https://test.invalid/>.hostname = 'x@x'
 PASS URL: Setting <https://test.invalid/>.hostname = 'foo	\r
 bar'
 PASS URL: Setting <https://test.invalid/>.hostname = '><'
+PASS URL: Setting <https://test.invalid/>.hostname = 'test/@aaa'
+PASS URL: Setting <https://test.invalid/>.hostname = 'test/:aaa'
 PASS URL: Setting <http://example.net>.port = '8080'
 PASS URL: Setting <http://example.net:8080>.port = '' Port number is removed if empty is the new value
 PASS URL: Setting <http://example.net:8080>.port = '80' Default port number is removed

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -494,14 +494,14 @@ void URL::setHost(StringView newHost)
     if (!m_isValid || hasOpaquePath())
         return;
 
+    if (auto index = newHost.find(hasSpecialScheme() ? slashHashOrQuestionMark : forwardSlashHashOrQuestionMark); index != notFound)
+        newHost = newHost.left(index);
+
     if (newHost.contains('@'))
         return;
 
     if (newHost.contains(':') && !newHost.startsWith('['))
         return;
-
-    if (auto index = newHost.find(hasSpecialScheme() ? slashHashOrQuestionMark : forwardSlashHashOrQuestionMark); index != notFound)
-        newHost = newHost.left(index);
 
     Vector<UChar, 512> encodedHostName;
     if (hasSpecialScheme() && !appendEncodedHostname(encodedHostName, newHost))
@@ -549,9 +549,6 @@ void URL::setHostAndPort(StringView hostAndPort)
     if (!m_isValid || hasOpaquePath())
         return;
 
-    if (hostAndPort.contains('@'))
-        return;
-
     if (auto index = hostAndPort.find(hasSpecialScheme() ? slashHashOrQuestionMark : forwardSlashHashOrQuestionMark); index != notFound)
         hostAndPort = hostAndPort.left(index);
 
@@ -567,6 +564,8 @@ void URL::setHostAndPort(StringView hostAndPort)
 
     auto portString = hostAndPort.substring(colonIndex + 1);
     auto hostName = hostAndPort.left(colonIndex);
+    if (hostName.contains('@'))
+        return;
     // Multiple colons are acceptable only in case of IPv6.
     if (hostName.contains(':') && ipv6Separator == notFound)
         return;


### PR DESCRIPTION
#### 7c829d0e1c400a3588c67e61206f3b716fd4bebb
<pre>
Make URL host/hostname setters handle @ and : even more correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=289789">https://bugs.webkit.org/show_bug.cgi?id=289789</a>

Reviewed by Alex Christensen.

While 292041@main eliminated re-parsing issues, it was not doing the
correct thing for inputs where @ follows a separator (a host &quot;EOF&quot;).
This fixes that as well as a similar issue for :.

New tests are upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/51354">https://github.com/web-platform-tests/wpt/pull/51354</a>

* LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::setHost):
(WTF::URL::setHostAndPort):

Canonical link: <a href="https://commits.webkit.org/292290@main">https://commits.webkit.org/292290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f8b869277b96552261cdcb55c581dd1df8f052e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72609 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98154 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11233 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44989 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87822 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102228 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93774 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80970 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20350 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15450 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22169 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27295 "Build is in progress. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Checked out pull request; Running scan-build") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116462 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21828 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->