### PR TITLE
[GLib] Fix heap-uAFs in NetworkProcess::IOChannel

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
@@ -104,7 +104,7 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
                 }
             }
         }
-        queue->dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
+        queue->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] {
             completionHandler(Data { }, -1);
         });
     }, ThreadType::Unknown, m_qos)->detach();
@@ -127,7 +127,7 @@ void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&&
         gsize buffersize;
         const auto* bufferData = g_bytes_get_data(buffer.get(), &buffersize);
         auto success = g_output_stream_write_all(m_outputStream.get(), bufferData, buffersize, nullptr, nullptr, nullptr);
-        queue->dispatch([protectedThis = WTFMove(protectedThis), success, completionHandler = WTFMove(completionHandler)] {
+        queue->dispatch([protectedThis = Ref { *this }, success, completionHandler = WTFMove(completionHandler)] {
             completionHandler(success ? 0 : -1);
         });
     }, ThreadType::Unknown, m_qos)->detach();


### PR DESCRIPTION
#### d718cfa9f30d2c65efa55aa6d4e8dd0cc605f5c0
<pre>
[GLib] Fix heap-uAFs in NetworkProcess::IOChannel
<a href="https://bugs.webkit.org/show_bug.cgi?id=289792">https://bugs.webkit.org/show_bug.cgi?id=289792</a>

Reviewed by Adrian Perez de Castro.

By moving protectedThis to the WorkQueue dispatch function there was no guarantee that this was
still valid, leading to use-after-free when disposing m_lock when going out of scope.

* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp:
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):

Canonical link: <a href="https://commits.webkit.org/292157@main">https://commits.webkit.org/292157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c30ba810d889c8a9653d68e28d4a5a2f6692283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45657 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72579 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98159 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52910 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10943 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44995 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81136 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80974 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15457 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22174 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->