### PR TITLE
REGRESSION(291521@main): IPC tests which establish a RemoteRenderingBackend should wait for DidInitialize

### DIFF
--- a/LayoutTests/ipc/create-image-buffer-crash.html
+++ b/LayoutTests/ipc/create-image-buffer-crash.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
 <p>This test passes if WebKit does not crash.</p>
-
+<script src="../resources/ipc.js"></script>
 <script>
   if (window.testRunner) {
     testRunner.dumpAsText();
@@ -13,9 +13,13 @@
 
     const { CoreIPC } = await import('./coreipc.js');
 
+    const renderingBackendIdentifier = randomIPCID();
     const connection = CoreIPC.newStreamConnection();
-    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier: 393221, connectionHandle: connection });
-    const remoteBackend = connection.newInterface("RemoteRenderingBackend", 393221);
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier: renderingBackendIdentifier, connectionHandle: connection });
+    const remoteBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = connection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+    connection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
 
     // The pixel formats to test
     const pixelFormats = [
@@ -51,6 +55,8 @@
         });
       } catch {}
     }
+
+    connection.connection.invalidate();
 
     window.testRunner?.notifyDone();
   }, 10);

--- a/LayoutTests/ipc/invalid-path-segments-crash.html
+++ b/LayoutTests/ipc/invalid-path-segments-crash.html
@@ -1,6 +1,6 @@
 <!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
 <p>This test passes if WebKit does not crash.</p>
-
+<script src="../resources/ipc.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
@@ -13,53 +13,60 @@ window.setTimeout(async () => {
 
   const { CoreIPC } = await import('./coreipc.js');
 
-
   const createRepeatedPath = (pathSegments, repeatCount) => Array(repeatCount).fill(pathSegments).flat();
 
+  const renderingBackendIdentifier = randomIPCID();
   const connection = CoreIPC.newStreamConnection();
   CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
-    renderingBackendIdentifier: 393217,
+    renderingBackendIdentifier: renderingBackendIdentifier,
     connectionHandle: connection
   });
 
-  const renderingBackend = connection.newInterface("RemoteRenderingBackend", 393217);
+  const renderingBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+  const didInitializeReply = connection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+  connection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+  const imageBufferIdentifier = randomIPCID();
+  const snapshotIdentifier = randomIPCID();
 
   renderingBackend.CreateImageBuffer({
     logicalSize: { width: 91, height: 119 },
-    renderingMode: 3,
-    renderingPurpose: 1,
+    renderingMode: 3, // DisplayList
+    renderingPurpose: 1, // Canvas
     resolutionScale: 57,
     colorSpace: {
       serializableColorSpace: {
         alias: {
-          m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 19 } }
+          m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 1 } }
         }
       }
     },
     pixelFormat: 1,
-    renderingResourceIdentifier: 393224
+    renderingResourceIdentifier: imageBufferIdentifier
   });
 
-  const imageBufferIdentifier = 393224;
+  const didCreateBackend = connection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
+
   const imageBuffer = connection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
   const displayListRecorder = connection.newInterface("RemoteDisplayListRecorder", imageBufferIdentifier);
   const pageID = IPC.pageID;
+
+  displayListRecorder.BeginPage({
+    pageSize: {
+      width: 100,
+      height: 100,
+    }
+  });
 
   displayListRecorder.DrawFocusRingPath({
     path: {
       segments: createRepeatedPath([
         { data: { alias: { variantType: 'WebCore::PathMoveTo', variant: { point: { x: 43, y: 22 } } } } },
-        { data: { alias: { variantType: 'WebCore::PathQuadCurveTo', variant: { controlPoint: { x: 7, y: 12 }, endPoint: { x: 91, y: 109 } } } } },
-        { data: { alias: { variantType: 'WebCore::PathDataQuadCurve', variant: { start: { x: 122, y: 46 }, controlPoint: { x: 54, y: 69 }, endPoint: { x: 70, y: 506806141048 } } } } },
-        { data: { alias: { variantType: 'WebCore::PathArcTo', variant: { controlPoint1: { x: 62, y: 18 }, controlPoint2: { x: 72, y: 88 }, radius: 37 } } } },
-        { data: { alias: { variantType: 'WebCore::PathRect', variant: { rect: { location: { x: 67, y: 60 }, size: { width: 31, height: 4875397766316111 } } } } } },
-        { data: { alias: { variantType: 'WebCore::PathRoundedRect', variant: { roundedRect: { rect: { location: { x: 55834574893, y: 275066885505103 }, size: { width: 118, height: 91 } }, radiiTopLeft: { width: 50, height: 102 }, radiiTopRight: { width: 20, height: 125 }, radiiBottomLeft: { width: 66, height: 119 }, radiiBottomRight: { width: 322123005958, height: 122 } }, strategy: 0 } } } },
-        { data: { alias: { variantType: 'WebCore::PathArcTo', variant: { controlPoint1: { x: 19, y: 335008760447 }, controlPoint2: { x: 197568495714, y: 124 }, radius: 65 } } } },
-        { data: { alias: { variantType: 'WebCore::PathArc', variant: { center: { x: 1, y: 79 }, radius: 97, startAngle: 83, endAngle: 19, direction: 1 } } } },
-        { data: { alias: { variantType: 'WebCore::PathMoveTo', variant: { point: { x: 106, y: 14 } } } } }
-      ], 1120)
+        { data: { alias: { variantType: 'WebCore::PathQuadCurveTo', variant: { controlPoint: { x: 7, y: 12 }, endPoint: { x: 91, y: 99 } } } } },
+      ], 1)
     },
-    outlineWidth: 240518168607,
+    outlineWidth: 1,
     color: {
       data: {
         optionalValue: {
@@ -71,9 +78,14 @@ window.setTimeout(async () => {
     }
   });
 
-  renderingBackend.DidDrawRemoteToPDF({ pageID, imageBufferIdentifier, snapshotIdentifier: 262145 });
-  imageBuffer.GetShareableBitmap({ preserveResolution: true });
+  renderingBackend.DidDrawRemoteToPDF({ pageID, imageBufferIdentifier, snapshotIdentifier: snapshotIdentifier });
+  imageBuffer.FlushContextSync({}, ()=>{
+      CoreIPC.GPU.GPUConnectionToWebProcess.ReleaseRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier
+      });
+    connection.connection.invalidate();
+    window.testRunner?.notifyDone();
+  });
 
-  window.testRunner?.notifyDone();
 }, 20);
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7725,9 +7725,8 @@ webkit.org/b/289090 imported/w3c/web-platform-tests/dom/nodes/remove-from-shadow
 
 webkit.org/b/289097 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html [ Pass Failure ]
 
-# webkit.org/b/289095 REGRESSION(291032@main): [macOS iOS Debug] ipc/large-vector-allocate-failure-crash.html is constantly crashing ( failure in EWS)
+# webkit.org/b/289620 ipc/large-vector-allocate-failure-crash.html should be a macOS only test
 [ Debug ] ipc/large-vector-allocate-failure-crash.html [ Skip ]
-[ Debug ] ipc/invalid-path-segments-crash.html [ Skip ]
 
 webkit.org/b/289094 imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any.html [ Pass Timeout ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2005,9 +2005,8 @@ webkit.org/b/289090 [ Debug arm64 ] imported/w3c/web-platform-tests/dom/nodes/re
 
 webkit.org/b/289092 http/wpt/background-fetch/background-fetch-abort.window.html [ Pass Failure ]
 
-# webkit.org/b/289095 REGRESSION(291032@main): [macOS iOS Debug] ipc/large-vector-allocate-failure-crash.html is constantly crashing ( failure in EWS)
+# webkit.org/b/289620 ipc/large-vector-allocate-failure-crash.html should be a macOS only test
 [ Debug ] ipc/large-vector-allocate-failure-crash.html [ Skip ]
-[ Debug ] ipc/invalid-path-segments-crash.html [ Skip ]
 
 webkit.org/b/289094 [ Sequoia Debug ] imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any.html [ Pass Timeout ]
 


### PR DESCRIPTION
#### c11e1c64acff2ca2da30067de5fe4e4597adaf33
<pre>
REGRESSION(291521@main): IPC tests which establish a RemoteRenderingBackend should wait for DidInitialize
<a href="https://bugs.webkit.org/show_bug.cgi?id=289095">https://bugs.webkit.org/show_bug.cgi?id=289095</a>
<a href="https://rdar.apple.com/146121871">rdar://146121871</a>

Reviewed by Simon Fraser.

create-image-buffer-crash and invalid-path-segments-crash both established a RemoteRenderingBackend but
did not wait for the DidInitialize message to come back from GPUP. As a result, the message hit the
invalid message handler and would cause a MESSAGE_CHECK to be triggered in debug builds. This change
waits for DidInitialize before we use the connections

* LayoutTests/ipc/create-image-buffer-crash.html:
* LayoutTests/ipc/invalid-path-segments-crash.html:

Canonical link: <a href="https://commits.webkit.org/292379@main">https://commits.webkit.org/292379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4948baaeda1e47642bdc71b1f3d841f60c1a8b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72948 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81344 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16049 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22672 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->