### PR TITLE
Unreviewed, unskip files that are now passing on the Safer CPP bot

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -368,7 +368,6 @@ wasm/WasmNameSectionParser.h
 wasm/WasmOMGIRGenerator.cpp
 wasm/WasmParser.h
 wasm/WasmStreamingCompiler.h
-wasm/WasmStreamingParser.h
 wasm/WasmTable.h
 wasm/WasmTypeDefinition.h
 wasm/WasmWorklist.cpp

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,11 +1,1 @@
-Storage/StorageTracker.h
-WebCoreSupport/SocketStreamHandle.h
-mac/History/WebHistory.mm
-mac/Misc/WebElementDictionary.h
-mac/Misc/WebSharingServicePickerController.h
-mac/Storage/WebDatabaseManagerClient.mm
 mac/WebCoreSupport/PopupMenuMac.h
-mac/WebCoreSupport/WebInspectorClient.mm
-mac/WebView/WebDynamicScrollBarsView.h
-mac/WebView/WebHTMLView.mm
-mac/WebView/WebPreferences.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,12 +1,2 @@
-Storage/StorageTracker.h
-WebCoreSupport/SocketStreamHandle.h
-mac/History/WebHistory.mm
-mac/Misc/WebElementDictionary.h
-mac/Misc/WebSharingServicePickerController.h
-mac/Storage/WebDatabaseManagerClient.mm
 mac/WebCoreSupport/PopupMenuMac.h
-mac/WebCoreSupport/WebInspectorClient.mm
 mac/WebCoreSupport/WebValidationMessageClient.h
-mac/WebView/WebDynamicScrollBarsView.h
-mac/WebView/WebPreferences.h
-mac/WebView/WebHTMLView.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -138,7 +138,6 @@ mac/WebCoreSupport/WebFrameLoaderClient.mm
 mac/WebCoreSupport/WebFrameNetworkingContext.mm
 mac/WebCoreSupport/WebGeolocationClient.mm
 mac/WebCoreSupport/WebKitFullScreenListener.mm
-mac/WebCoreSupport/WebNotificationClient.mm
 mac/WebCoreSupport/WebOpenPanelResultListener.mm
 mac/WebCoreSupport/WebSecurityOrigin.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm


### PR DESCRIPTION
#### 2b1a30f5d1ac2006cfa034b56fe20ab3abf8a909
<pre>
Unreviewed, unskip files that are now passing on the Safer CPP bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=289796">https://bugs.webkit.org/show_bug.cgi?id=289796</a>

* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/292161@main">https://commits.webkit.org/292161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b63fbaf14cf4697f8253d0a07196e5fa8fa2d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15067 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/23206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/52925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/3663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87850 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/3760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102260 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93802 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22227 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/23206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/22475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/80988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15480 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/15274 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22197 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116490 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/21856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->