### PR TITLE
Add API tests for skipping ads in PIP

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		1CFD5D3F2851B62100A0E30B /* EnumeratedArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CFD5D3E2851B62100A0E30B /* EnumeratedArray.cpp */; };
 		1D67BFDC2433E0A7006B5047 /* PreemptVideoFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1D67BFDB2433E0A7006B5047 /* PreemptVideoFullscreen.mm */; };
 		23CB493B2DFEAD81006E424B /* PreciseSum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */; };
+		1FEF15102D7A2AA900D29B57 /* SkipAdInPictureInPicture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */; };
+		1FEF15112D7B69DB00D29B57 /* SkipAdInPictureInPicture.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */; };
 		272A691022F012DA000FDABB /* PageLoadState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 272A690F22F012C7000FDABB /* PageLoadState.cpp */; };
 		278E3E1923CD842F005A6B80 /* KeyedCoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */; };
 		297234B7173AFAC700983601 /* CustomProtocolsInvalidScheme_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 297234B5173AFAC700983601 /* CustomProtocolsInvalidScheme_Bundle.cpp */; };
@@ -2249,6 +2251,7 @@
 				A17C46F02C98E54B0023F3C7 /* simple2.html in Copy Resources */,
 				A17C46F12C98E54B0023F3C7 /* simple3.html in Copy Resources */,
 				A17C47FB2C98E5C20023F3C7 /* skinny-autoplaying-video-with-audio.html in Copy Resources */,
+				1FEF15102D7A2AA900D29B57 /* SkipAdInPictureInPicture.html in Copy Resources */,
 				A17C46F22C98E54B0023F3C7 /* spacebar-scrolling.html in Copy Resources */,
 				A17C47FC2C98E5C20023F3C7 /* SpaceOnly.otf in Copy Resources */,
 				CDDFA89E2DBD6BFF00312417 /* spatial-audio-experience-with-audio.html in Copy Resources */,
@@ -2603,6 +2606,8 @@
 		1F0559E42890A09D002E279C /* image-with-text.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "image-with-text.html"; sourceTree = "<group>"; };
 		1F83571A1D3FFB0E00E3967B /* WKBackForwardListTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKBackForwardListTests.mm; path = Tests/WebKit/WKBackForwardListTests.mm; sourceTree = SOURCE_ROOT; };
 		23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PreciseSum.cpp; sourceTree = "<group>"; };
+		1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SkipAdInPictureInPicture.mm; sourceTree = "<group>"; };
+		1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = SkipAdInPictureInPicture.html; sourceTree = "<group>"; };
 		260BA5781B1D2E7B004FA07C /* DFACombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DFACombiner.cpp; sourceTree = "<group>"; };
 		260BA57A1B1D2EE2004FA07C /* DFAHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DFAHelpers.h; sourceTree = "<group>"; };
 		261516D515B0E60500A2C201 /* SetAndUpdateCacheModel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SetAndUpdateCacheModel.mm; sourceTree = "<group>"; };
@@ -6714,6 +6719,7 @@
 				261516D515B0E60500A2C201 /* SetAndUpdateCacheModel.mm */,
 				52B8CF9515868CF000281053 /* SetDocumentURI.mm */,
 				C540F775152E4DA000A40C8C /* SimplifyMarkup.mm */,
+				1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */,
 				F4CDF3D127E97C7E00191928 /* SpellCheckerDocumentTag.mm */,
 				83BC5ABF20E6C0D300F5879F /* StartLoadInDidFailProvisionalLoad.mm */,
 				291861FD17BD4DC700D4E41E /* StopLoadingFromDidFinishLoading.mm */,
@@ -6778,6 +6784,7 @@
 				290A9BB81735F42300D71BBC /* OpenNewWindow.html */,
 				A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */,
 				52B8CF9415868CF000281053 /* SetDocumentURI.html */,
+				1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */,
 				E194E1BC177E534A009C4D4E /* StopLoadingFromDidReceiveResponse.html */,
 				C540F783152E5A7800A40C8C /* verboseMarkup.html */,
 				536770351CC812F900D425B1 /* WebScriptObjectDescription.html */,
@@ -7985,6 +7992,7 @@
 				51EB126324CA6B66000CB030 /* ShenzhenLongshengweiTechnologyGamepad.mm in Sources */,
 				7CCE7F141A411AE600447C4C /* ShouldKeepCurrentBackForwardListItemInList.cpp in Sources */,
 				7CCE7ECD1A411A7E00447C4C /* SimplifyMarkup.mm in Sources */,
+				1FEF15112D7B69DB00D29B57 /* SkipAdInPictureInPicture.mm in Sources */,
 				C149D550242E98DF003EBB12 /* SleepDisabler.mm in Sources */,
 				073310B52E6E4EFC0048CF1E /* SmartLists.mm in Sources */,
 				07DEB43E2E7900B100066C32 /* SmartListsSupport.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.html
+++ b/Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<video id="video">
+    <source src="video-with-audio.mp4">
+</video>
+<button id="enter-pip" onclick="document.querySelector('video').webkitSetPresentationMode('picture-in-picture')">enter pip</button>
+<script>
+    if ("mediaSession" in navigator) {
+        navigator.mediaSession.setActionHandler("skipad", () => {
+        });
+    }
+</script>
+</html>

--- a/Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.mm
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if HAVE(PIP_SKIP_PREROLL)
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <pal/spi/mac/PIPSPI.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+SOFT_LINK_PRIVATE_FRAMEWORK(PIP)
+SOFT_LINK_CLASS(PIP, PIPPanel)
+SOFT_LINK_CLASS(PIP, PIPPrerollAttributes)
+SOFT_LINK_CLASS(PIP, PIPViewController)
+
+static bool didEnterPiP = false;
+
+@interface SkipAdInPiPFullscreenDelegate : NSObject <WKUIDelegate>
+@end
+
+@implementation SkipAdInPiPFullscreenDelegate
+
+- (void)_webView:(WKWebView *)webView hasVideoInPictureInPictureDidChange:(BOOL)value
+{
+    if (value)
+        didEnterPiP = true;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+static RetainPtr<TestWKWebView> createWebView()
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeAudio];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    return webView;
+}
+
+TEST(SkipAdInPictureInPicture, VideoHasAd)
+{
+    RetainPtr webView = createWebView();
+    RetainPtr<SkipAdInPiPFullscreenDelegate> handler = adoptNS([[SkipAdInPiPFullscreenDelegate alloc] init]);
+    [webView setUIDelegate:handler.get()];
+
+    [webView synchronouslyLoadTestPageNamed:@"SkipAdInPictureInPicture"];
+
+    didEnterPiP = false;
+    [webView evaluateJavaScript:@"document.getElementById('enter-pip').click()" completionHandler:nil];
+    TestWebKitAPI::Util::waitFor([&] {
+        return didEnterPiP;
+    });
+    EXPECT_TRUE(didEnterPiP);
+
+    __block NSWindow *pipPanel = nil;
+    [[NSApplication sharedApplication] enumerateWindowsWithOptions:0 usingBlock:^(NSWindow *window, BOOL *stop) {
+        if ([window isKindOfClass:getPIPPanelClassSingleton()]) {
+            pipPanel = window;
+            *stop = YES;
+        }
+    }];
+    ASSERT_TRUE(pipPanel);
+    RetainPtr contentViewController = [pipPanel contentViewController];
+    ASSERT_TRUE([contentViewController isKindOfClass:getPIPViewControllerClassSingleton()]);
+    RetainPtr pipViewController = (PIPViewController *)contentViewController;
+    ASSERT_TRUE(pipViewController);
+
+    RetainPtr pipPlaybackState = [pipViewController playbackState];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return ([pipPlaybackState prerollAttributes] != nil);
+    });
+    EXPECT_NOT_NULL([pipPlaybackState prerollAttributes]);
+}
+
+TEST(SkipAdInPictureInPicture, VideoHasNoAd)
+{
+    RetainPtr webView = createWebView();
+    RetainPtr<SkipAdInPiPFullscreenDelegate> handler = adoptNS([[SkipAdInPiPFullscreenDelegate alloc] init]);
+    [webView setUIDelegate:handler.get()];
+
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+
+    didEnterPiP = false;
+    [webView evaluateJavaScript:@"document.getElementsByTagName('video')[0].webkitSetPresentationMode('picture-in-picture')" completionHandler:nil];
+    TestWebKitAPI::Util::waitFor([&] {
+        return didEnterPiP;
+    });
+    EXPECT_TRUE(didEnterPiP);
+
+    __block NSWindow *pipPanel = nil;
+    [[NSApplication sharedApplication] enumerateWindowsWithOptions:0 usingBlock:^(NSWindow *window, BOOL *stop) {
+        if ([window isKindOfClass:getPIPPanelClassSingleton()]) {
+            pipPanel = window;
+            *stop = YES;
+        }
+    }];
+    ASSERT_TRUE(pipPanel);
+    RetainPtr contentViewController = [pipPanel contentViewController];
+    ASSERT_TRUE([contentViewController isKindOfClass:getPIPViewControllerClassSingleton()]);
+    RetainPtr pipViewController = (PIPViewController*)contentViewController;
+    ASSERT_TRUE(pipViewController);
+
+    RetainPtr pipPlaybackState = [pipViewController playbackState];
+
+    TestWebKitAPI::Util::runFor(1_s);
+    EXPECT_NULL([pipPlaybackState prerollAttributes]);
+}
+
+}
+#endif


### PR DESCRIPTION
#### 5b4ed0533cea60126d97815660295db151ae86f0
<pre>
Add API tests for skipping ads in PIP
<a href="https://bugs.webkit.org/show_bug.cgi?id=289744">https://bugs.webkit.org/show_bug.cgi?id=289744</a>
<a href="https://rdar.apple.com/146994962">rdar://146994962</a>

Reviewed by Jer Noble.

This patch adds two API tests for ad skipping in PIP. The first
test checks that we set the PIP playbackstate&apos;s PrerollAttributes
property to a nonnull  value when the webpage has set the media session
skipad action handler and a video is in pip.

The second test checks the prerollAttributes stays null when a video
goes into pip and the webpage has not set the skipAd action handler.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.html: Added.
* Tools/TestWebKitAPI/Tests/mac/SkipAdInPictureInPicture.mm: Added.
(-[SkipAdInPiPFullscreenDelegate _webView:hasVideoInPictureInPictureDidChange:]):
(TestWebKitAPI::createWebView):
(TestWebKitAPI::TEST(SkipAdInPictureInPicture, VideoHasAd)):
(TestWebKitAPI::TEST(SkipAdInPictureInPicture, VideoHasNoAd)):

Canonical link: <a href="https://commits.webkit.org/302095@main">https://commits.webkit.org/302095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36d592edc916523e3f3b1bc0842826bfb26a61ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79528 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6e655749-22c7-48ff-a889-3257d18b8e44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/65345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11157530-e69b-4e88-aa29-7d7213801a78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130964 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/18ee910d-2015-4e19-998c-b4cf91380d42) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78696 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137870 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/145 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/105979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105716 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52323 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20001 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/201 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->