### PR TITLE
Address Safer CPP issues in HTMLOptionElement.cpp & HTMLOptGroupElement.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -702,8 +702,6 @@ html/HTMLMetaElement.cpp
 html/HTMLMeterElement.cpp
 html/HTMLNameCollectionInlines.h
 html/HTMLObjectElement.cpp
-html/HTMLOptGroupElement.cpp
-html/HTMLOptionElement.cpp
 html/HTMLOptionsCollection.cpp
 html/HTMLPlugInElement.cpp
 html/HTMLPlugInImageElement.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -365,8 +365,6 @@ html/HTMLInputElement.cpp
 html/HTMLLabelElement.cpp
 html/HTMLMapElement.cpp
 html/HTMLMediaElement.cpp
-html/HTMLOptGroupElement.cpp
-html/HTMLOptionElement.cpp
 html/HTMLPictureElement.cpp
 html/HTMLSlotElement.cpp
 html/HTMLTableElement.cpp

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -606,9 +606,9 @@ void ScriptElement::deref() const
     element().deref();
 }
 
-bool isScriptElement(Element& element)
+bool isScriptElement(Node& node)
 {
-    return is<HTMLScriptElement>(element) || is<SVGScriptElement>(element);
+    return is<HTMLScriptElement>(node) || is<SVGScriptElement>(node);
 }
 
 ScriptElement* dynamicDowncastScriptElement(Element& element)

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -39,6 +39,7 @@ class CachedScript;
 class ContainerNode;
 class Element;
 class LoadableModuleScript;
+class Node;
 class PendingScript;
 class ScriptSourceCode;
 
@@ -166,7 +167,7 @@ private:
 };
 
 // FIXME: replace with is/downcast<ScriptElement>.
-bool isScriptElement(Element&);
+bool isScriptElement(Node&);
 ScriptElement* dynamicDowncastScriptElement(Element&);
 
 }

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -101,7 +101,7 @@ void HTMLOptGroupElement::attributeChanged(const QualifiedName& name, const Atom
             Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClass::Disabled, newDisabled }, { CSSSelector::PseudoClass::Enabled, !newDisabled } });
 
             Vector<Style::PseudoClassChangeInvalidation> optionInvalidation;
-            for (auto& descendant : descendantsOfType<HTMLOptionElement>(*this))
+            for (Ref descendant : descendantsOfType<HTMLOptionElement>(*this))
                 optionInvalidation.append({ descendant, { { CSSSelector::PseudoClass::Disabled, newDisabled }, { CSSSelector::PseudoClass::Enabled, !newDisabled } } });
 
             m_isDisabled = newDisabled;
@@ -119,7 +119,7 @@ void HTMLOptGroupElement::recalcSelectOptions()
 
 String HTMLOptGroupElement::groupLabelText() const
 {
-    String itemText = document().displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
+    String itemText = protectedDocument()->displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
     
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
     itemText = itemText.trim(deprecatedIsSpaceOrNewline);


### PR DESCRIPTION
#### 7ff967f6476023e5bfebf411780e4a1ef53f2aa6
<pre>
Address Safer CPP issues in HTMLOptionElement.cpp &amp; HTMLOptGroupElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=289799">https://bugs.webkit.org/show_bug.cgi?id=289799</a>
<a href="https://rdar.apple.com/147058720">rdar://147058720</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::isScriptElement):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::attributeChanged):
(WebCore::HTMLOptGroupElement::groupLabelText const):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::text const):
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::setSelectedState):
(WebCore::HTMLOptionElement::childrenChanged):
(WebCore::HTMLOptionElement::willResetComputedStyle):
(WebCore::HTMLOptionElement::collectOptionInnerText const):

Canonical link: <a href="https://commits.webkit.org/292209@main">https://commits.webkit.org/292209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80283daeff25ce20a7e931640319b3e35662a395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72642 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29915 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81036 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15564 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15307 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21940 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->