### PR TITLE
Address Safer CPP issues in HTMLMeterElement.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -698,7 +698,6 @@ html/HTMLMapElement.cpp
 html/HTMLMaybeFormAssociatedCustomElement.cpp
 html/HTMLMediaElement.cpp
 html/HTMLMetaElement.cpp
-html/HTMLMeterElement.cpp
 html/HTMLNameCollectionInlines.h
 html/HTMLObjectElement.cpp
 html/HTMLOptionsCollection.cpp

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -54,7 +54,7 @@ HTMLMeterElement::~HTMLMeterElement() = default;
 
 Ref<HTMLMeterElement> HTMLMeterElement::create(const QualifiedName& tagName, Document& document)
 {
-    Ref<HTMLMeterElement> meter = adoptRef(*new HTMLMeterElement(tagName, document));
+    Ref meter = adoptRef(*new HTMLMeterElement(tagName, document));
     meter->ensureUserAgentShadowRoot();
     return meter;
 }
@@ -219,11 +219,12 @@ static void setValueClass(HTMLElement& element, HTMLMeterElement::GaugeRegion ga
 
 void HTMLMeterElement::didElementStateChange()
 {
-    m_value->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio()*100, CSSUnitType::CSS_PERCENTAGE);
-    setValueClass(*m_value, gaugeRegion());
+    Ref valueElement = *m_valueElement;
+    valueElement->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio() * 100, CSSUnitType::CSS_PERCENTAGE);
+    setValueClass(valueElement, gaugeRegion());
 
-    if (RenderMeter* render = renderMeter())
-        render->updateFromElement();
+    if (CheckedPtr renderer = renderMeter())
+        renderer->updateFromElement();
 }
 
 RenderMeter* HTMLMeterElement::renderMeter() const
@@ -233,28 +234,30 @@ RenderMeter* HTMLMeterElement::renderMeter() const
 
 void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
-    ASSERT(!m_value);
+    ASSERT(!m_valueElement);
 
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(meterElementShadowUserAgentStyleSheet));
 
-    auto style = HTMLStyleElement::create(HTMLNames::styleTag, document(), false);
+    Ref document = this->document();
+    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document, false);
     style->setTextContent(String { shadowStyle });
     root.appendChild(WTFMove(style));
 
     // Pseudos are set to allow author styling.
-    auto inner = HTMLDivElement::create(document());
+    Ref inner = HTMLDivElement::create(document);
     inner->setIdAttribute("inner"_s);
     inner->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
     root.appendChild(inner);
 
-    auto bar = HTMLDivElement::create(document());
+    Ref bar = HTMLDivElement::create(document);
     bar->setIdAttribute("bar"_s);
     bar->setUserAgentPart(UserAgentParts::webkitMeterBar());
     inner->appendChild(bar);
 
-    m_value = HTMLDivElement::create(document());
-    m_value->setIdAttribute("value"_s);
-    bar->appendChild(*m_value);
+    Ref valueElement = HTMLDivElement::create(document);
+    valueElement->setIdAttribute("value"_s);
+    bar->appendChild(valueElement);
+    m_valueElement = WTFMove(valueElement);
 
     didElementStateChange();
 }

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -79,7 +79,7 @@ private:
     void didElementStateChange();
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
-    RefPtr<HTMLElement> m_value;
+    RefPtr<HTMLElement> m_valueElement;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0122615c79925253b698f82c80c1ef961b2a27be
<pre>
Address Safer CPP issues in HTMLMeterElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=289802">https://bugs.webkit.org/show_bug.cgi?id=289802</a>
<a href="https://rdar.apple.com/147060738">rdar://147060738</a>

Reviewed by Aditya Keerthi.

Also rename m_value to m_valueElement to avoid ambiguity with the numeric value.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::create):
(WebCore::HTMLMeterElement::didElementStateChange):
(WebCore::HTMLMeterElement::didAddUserAgentShadowRoot):
* Source/WebCore/html/HTMLMeterElement.h:

Canonical link: <a href="https://commits.webkit.org/292211@main">https://commits.webkit.org/292211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f3d55d33bb75cfab438e4e6e3cf3f02e5f9261

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95255 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14855 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Running compile-webkit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45756 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97303 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Running apply-patch; Running checkout-pull-request") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15143 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23286 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29913 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98258 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45095 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22303 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16252 "Found 1 new test failure: html5lib/generated/run-entities01-data.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81634 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81031 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15556 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27399 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->