### PR TITLE
REGRESSION (286448@main): WKWebView content inset causes content touches to be off inside the web view

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset-expected.txt
@@ -1,0 +1,11 @@
+Tap here
+This test requires WebKitTestRunner. Verifies that adding a top content inset to the web view's scroll view does not offset touches.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS observedTouchStart became true
+PASS observedTouchEnd became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset.html
+++ b/LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true contentInset.top=200 ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+    margin: 0;
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+.target {
+    width: 100%;
+    height: 100px;
+    background: tomato;
+    color: white;
+    text-align: center;
+    line-height: 100px;
+}
+</style>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+observedTouchStart = false;
+observedTouchEnd = false;
+
+addEventListener("load", async () => {
+    description("This test requires WebKitTestRunner. Verifies that adding a top content inset to the web view's scroll view does not offset touches.");
+    const target = document.querySelector(".target");
+    target.addEventListener("touchstart", () => observedTouchStart = true);
+    target.addEventListener("touchend", () => observedTouchEnd = true);
+
+    await UIHelper.activateElement(target);
+    await shouldBecomeEqual("observedTouchStart", "true");
+    await shouldBecomeEqual("observedTouchEnd", "true");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="target">Tap here</div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -232,6 +232,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView;
 #endif
 
+- (UIEdgeInsets)currentlyVisibleContentInsetsWithScale:(CGFloat)scaleFactor obscuredInsets:(UIEdgeInsets)obscuredInsets;
+
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -228,8 +228,14 @@ static CGPoint mapRootViewToViewport(CGPoint pointInRootView, WKContentView *con
 {
     RetainPtr webView = [contentView webView];
     CGPoint origin = [webView bounds].origin;
-    auto inset = [webView _computedObscuredInset];
-    auto offsetInRootView = [webView convertPoint:CGPointMake(origin.x + inset.left, origin.y + inset.top) toView:contentView];
+    auto obscuredInsets = [webView _computedObscuredInset];
+    auto contentZoomScale = static_cast<CGFloat>([webView _contentZoomScale]);
+    auto visibleContentInsets = [webView currentlyVisibleContentInsetsWithScale:contentZoomScale obscuredInsets:obscuredInsets];
+    CGPoint offsetInWebView {
+        origin.x + obscuredInsets.left + (visibleContentInsets.left * contentZoomScale),
+        origin.y + obscuredInsets.top + (visibleContentInsets.top * contentZoomScale)
+    };
+    auto offsetInRootView = [webView convertPoint:offsetInWebView toView:contentView];
     return CGPointMake(pointInRootView.x - offsetInRootView.x, pointInRootView.y - offsetInRootView.y);
 }
 


### PR DESCRIPTION
#### ca94e292f23120175bec2d7c01d1772ec5aee997
<pre>
REGRESSION (286448@main): WKWebView content inset causes content touches to be off inside the web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=289715">https://bugs.webkit.org/show_bug.cgi?id=289715</a>
<a href="https://rdar.apple.com/147075945">rdar://147075945</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 286448@main, when the web view&apos;s scroll view is scrolled to the top with a
nonzero top content inset, touch events end up being offset by exactly the height of the content
inset area that&apos;s visible. This happens because the logic in `mapRootViewToViewport` attempts to
map the touch location in root view coordinates into unscrolled root view coordinates by subtracting
the web view origin in root view coordinates from the touch location in the root view. The web
process then translates these unscrolled root view coordinates back into root view coordinates by
adding the main frame scroll position.

The problem with this approach is that, when the user scrolls to the top of the web view with a
content inset, the main frame scroll position reports an offset of `0`, but the web view origin in
root view coordinates accounts for the top content inset (i.e., it will be equal to the visible
height of the top content inset area). This discrepancy between main frame scroll position and web
view origin subsequently breaks the translation logic.

To fix this, we leverage existing logic in `-currentlyVisibleContentInsetsWithScale:obscuredInsets:`
which was added to fix a similar issue (<a href="https://webkit.org/b/193494)">https://webkit.org/b/193494)</a>, and adjust for this visible
content inset amount when computing `offsetInRootView`.

* LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-events-with-top-content-inset.html: Added.

Add a layout test to exercise this fix, by adding a 200px top content inset to the web view, and
then attempting to observe `touchstart` and `touchend` events over a 100px-tall container at the
top of the viewport. Without this fix, we&apos;d be unable to hit-test to this container at all, since
touches are offset by more than the height of the container.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
(-[WKWebView _currentlyVisibleContentInsetsWithObscuredInsets:]):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(mapRootViewToViewport):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/292199@main">https://commits.webkit.org/292199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cb5f039dcaa87311e46c048edcda2e591ac0390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45763 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72641 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29917 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85986 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52973 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; Running re-run-api-tests; Compiled WebKit; run-api-tests-without-change (failure); Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45102 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81637 "Passed tests") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15563 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22280 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116573 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21939 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/116573 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->