### PR TITLE
[Wasm] GC objects should not require destructors

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -770,6 +770,7 @@
 		14CA958D16AB50FA00938A06 /* ObjectAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 14CA958C16AB50FA00938A06 /* ObjectAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14D01A7721FB351F00BC54E9 /* JSScriptSourceProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01A7621FB350300BC54E9 /* JSScriptSourceProvider.h */; };
 		14D01A7721FBEF3800CAE0D0 /* JSWebAssemblyStruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01BE026DEEF3800CAE0D0 /* JSWebAssemblyStruct.h */; };
+		14D01A7721FBEF3800CAE0D1 /* WebAssemblyGCStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01BE026DEEF3800CAE0D1 /* WebAssemblyGCStructure.h */; };
 		14D01BE626DEEF3800CAE0D0 /* WebAssemblyTagConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01BDA26DEEF3700CAE0D0 /* WebAssemblyTagConstructor.h */; };
 		14D01BE726DEEF3800CAE0D0 /* WebAssemblyTagPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01BDB26DEEF3700CAE0D0 /* WebAssemblyTagPrototype.h */; };
 		14D01BE926DECC3800CAE0D0 /* WebAssemblyStructPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D01BDD26DEEF378CCAE0D0 /* WebAssemblyStructPrototype.h */; };
@@ -3799,6 +3800,7 @@
 		14CC3BA12138A238002D58B6 /* InstructionStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InstructionStream.cpp; sourceTree = "<group>"; };
 		14CC3BA22138A238002D58B6 /* InstructionStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstructionStream.h; sourceTree = "<group>"; };
 		14CC3BA22138F3700CAE0D0D /* JSWebAssemblyStruct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JSWebAssemblyStruct.cpp; path = js/JSWebAssemblyStruct.cpp; sourceTree = "<group>"; };
+		14CC3BA22138F3700CAE0D0E /* WebAssemblyGCStructure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyGCStructure.cpp; path = js/WebAssemblyGCStructure.cpp; sourceTree = "<group>"; };
 		14D01A7521FB350300BC54E9 /* JSScriptSourceProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSScriptSourceProvider.mm; sourceTree = "<group>"; };
 		14D01A7621FB350300BC54E9 /* JSScriptSourceProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSScriptSourceProvider.h; sourceTree = "<group>"; };
 		14D01BDA26DEEF3700CAE0D0 /* WebAssemblyTagConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyTagConstructor.h; path = js/WebAssemblyTagConstructor.h; sourceTree = "<group>"; };
@@ -3810,6 +3812,7 @@
 		14D01BDF26DEEF3700CAE0D0 /* WebAssemblyTagPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyTagPrototype.cpp; path = js/WebAssemblyTagPrototype.cpp; sourceTree = "<group>"; };
 		14D01BE026DEEF3700CAE0D0 /* JSWebAssemblyTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblyTag.h; path = js/JSWebAssemblyTag.h; sourceTree = "<group>"; };
 		14D01BE026DEEF3800CAE0D0 /* JSWebAssemblyStruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblyStruct.h; path = js/JSWebAssemblyStruct.h; sourceTree = "<group>"; };
+		14D01BE026DEEF3800CAE0D1 /* WebAssemblyGCStructure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyGCStructure.h; path = js/WebAssemblyGCStructure.h; sourceTree = "<group>"; };
 		14D01BE126DEEF3800CAE0D0 /* JSWebAssemblyException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblyException.h; path = js/JSWebAssemblyException.h; sourceTree = "<group>"; };
 		14D01BE226DEEF3800CAE0D0 /* WebAssemblyExceptionPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyExceptionPrototype.cpp; path = js/WebAssemblyExceptionPrototype.cpp; sourceTree = "<group>"; };
 		14D01BE226DEEF3CFECAE0D0 /* WebAssemblyStructPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyStructPrototype.cpp; path = js/WebAssemblyStructPrototype.cpp; sourceTree = "<group>"; };
@@ -10101,6 +10104,8 @@
 				521322441ECBCE8200F65615 /* WebAssemblyFunctionBase.h */,
 				554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */,
 				554C418629B14CA5003C9F71 /* WebAssemblyGCObjectBase.h */,
+				14CC3BA22138F3700CAE0D0E /* WebAssemblyGCStructure.cpp */,
+				14D01BE026DEEF3800CAE0D1 /* WebAssemblyGCStructure.h */,
 				E3BF3C4E2390D1FC008BC752 /* WebAssemblyGlobalConstructor.cpp */,
 				E3BF3C512390D1FC008BC752 /* WebAssemblyGlobalConstructor.h */,
 				E3BF3C4F2390D1FC008BC752 /* WebAssemblyGlobalPrototype.cpp */,
@@ -12134,6 +12139,7 @@
 				AD4937D41DDD27DE0077C807 /* WebAssemblyFunction.h in Headers */,
 				521322461ECBCE8200F65615 /* WebAssemblyFunctionBase.h in Headers */,
 				554C418829B14CA5003C9F71 /* WebAssemblyGCObjectBase.h in Headers */,
+				14D01A7721FBEF3800CAE0D1 /* WebAssemblyGCStructure.h in Headers */,
 				E3BF3C532390D205008BC752 /* WebAssemblyGlobalConstructor.h in Headers */,
 				E3BF3C522390D202008BC752 /* WebAssemblyGlobalPrototype.h in Headers */,
 				AD2FCBF11DB58DAD00B3E736 /* WebAssemblyInstanceConstructor.h in Headers */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -149,14 +149,12 @@ wasm/WasmOSREntryPlan.cpp
 wasm/WasmOperations.cpp
 wasm/WasmSlowPaths.cpp
 wasm/WasmStreamingCompiler.cpp
-wasm/js/JSWebAssemblyArray.cpp
 wasm/js/JSWebAssemblyException.cpp
 wasm/js/JSWebAssemblyGlobal.cpp
 wasm/js/JSWebAssemblyHelpers.h
 wasm/js/JSWebAssemblyInstance.cpp
 wasm/js/JSWebAssemblyMemory.cpp
 wasm/js/JSWebAssemblyModule.cpp
-wasm/js/JSWebAssemblyStruct.cpp
 wasm/js/JSWebAssemblyTable.cpp
 wasm/js/JSWebAssemblyTag.cpp
 wasm/js/WebAssemblyFunction.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -211,7 +211,6 @@ wasm/js/JSWebAssemblyInstance.h
 wasm/js/JSWebAssemblyMemory.cpp
 wasm/js/JSWebAssemblyMemory.h
 wasm/js/JSWebAssemblyModule.cpp
-wasm/js/JSWebAssemblyStruct.cpp
 wasm/js/JSWebAssemblyTable.cpp
 wasm/js/WasmToJS.cpp
 wasm/js/WebAssemblyFunction.h

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1211,6 +1211,7 @@ wasm/js/WebAssemblyExceptionPrototype.cpp
 wasm/js/WebAssemblyFunction.cpp
 wasm/js/WebAssemblyFunctionBase.cpp
 wasm/js/WebAssemblyGCObjectBase.cpp
+wasm/js/WebAssemblyGCStructure.cpp
 wasm/js/WebAssemblyGlobalConstructor.cpp
 wasm/js/WebAssemblyGlobalPrototype.cpp
 wasm/js/WebAssemblyInstanceConstructor.cpp

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -150,9 +150,18 @@ class Heap;
     v(structureRareDataSpace, destructibleCellHeapCellType, StructureRareData) \
     v(symbolTableSpace, destructibleCellHeapCellType, SymbolTable)
     
+
+#if ENABLE(WEBASSEMBLY)
+#define FOR_EACH_JSC_WEBASSEMBLY_STRUCTURE_ISO_SUBSPACE(v) \
+    v(webAssemblyGCStructureSpace, destructibleCellHeapCellType, WebAssemblyGCStructure)
+#else
+#define FOR_EACH_JSC_WEBASSEMBLY_STRUCTURE_ISO_SUBSPACE(v)
+#endif
+
 #define FOR_EACH_JSC_STRUCTURE_ISO_SUBSPACE(v) \
     v(structureSpace, destructibleCellHeapCellType, Structure) \
     v(brandedStructureSpace, destructibleCellHeapCellType, BrandedStructure) \
+    FOR_EACH_JSC_WEBASSEMBLY_STRUCTURE_ISO_SUBSPACE(v)
 
 #define FOR_EACH_JSC_ISO_SUBSPACE(v) \
     FOR_EACH_JSC_COMMON_ISO_SUBSPACE(v) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -183,7 +183,6 @@ constexpr bool typeExposedByDefault = true;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(macro) \
-    macro(WebAssemblyArray,        webAssemblyArray,        webAssemblyArray,        JSWebAssemblyArray,        Array,        null,   typeExposedByDefault) \
     macro(WebAssemblyCompileError, webAssemblyCompileError, webAssemblyCompileError, ErrorInstance,             CompileError, error,  typeExposedByDefault) \
     macro(WebAssemblyException,    webAssemblyException,    webAssemblyException,    JSWebAssemblyException,    Exception,    object, typeExposedByDefault) \
     macro(WebAssemblyGlobal,       webAssemblyGlobal,       webAssemblyGlobal,       JSWebAssemblyGlobal,       Global,       object, typeExposedByDefault) \
@@ -192,7 +191,6 @@ constexpr bool typeExposedByDefault = true;
     macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,       Memory,       object, typeExposedByDefault) \
     macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,       Module,       object, typeExposedByDefault) \
     macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,             RuntimeError, error,  typeExposedByDefault) \
-    macro(WebAssemblyStruct,       webAssemblyStruct,       webAssemblyStruct,       JSWebAssemblyStruct,       Struct,       null,   typeExposedByDefault) \
     macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,        Table,        object, typeExposedByDefault) \
     macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,          Tag,          object, typeExposedByDefault) 
 #else

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -75,7 +75,7 @@ inline Structure* Structure::create(VM& vm, Structure* previous, DeferredStructu
     if (previous->isBrandedStructure())
         newStructure = new (NotNull, allocateCell<BrandedStructure>(vm)) BrandedStructure(vm, jsCast<BrandedStructure*>(previous));
     else
-        newStructure = new (NotNull, allocateCell<Structure>(vm)) Structure(vm, previous);
+        newStructure = new (NotNull, allocateCell<Structure>(vm)) Structure(vm, previous->variant(), previous);
     newStructure->finishCreation(vm, previous, deferred);
     return newStructure;
 }

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -93,7 +93,7 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
                 return;
             }
             auto objectPtr = jsCast<WebAssemblyGCObjectBase*>(value);
-            RefPtr<const RTT> objectRTT = objectPtr->rtt();
+            auto objectRTT = objectPtr->rtt();
             ASSERT(objectRTT->isSubRTT(*expectedRTT.get()));
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -150,6 +150,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
 
     uint32_t typeCount() const { return typeSignatures.size(); }
 
+    bool hasGCObjectTypes() const { return m_hasGCObjectTypes; }
     bool hasMemoryImport() const { return memory.isImport(); }
 
     BranchHint getBranchHint(uint32_t functionOffset, uint32_t branchOffset) const
@@ -181,6 +182,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     Vector<Ref<TypeDefinition>> recursionGroups;
 
     MemoryInformation memory;
+    bool m_hasGCObjectTypes { false };
 
     Vector<FunctionData> functions;
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -3565,8 +3565,8 @@ Value* OMGIRGenerator::emitGetArrayPayloadBase(Wasm::StorageType fieldType, Valu
     if (JSWebAssemblyArray::needsAlignmentCheck(fieldType)) {
         auto isPreciseAllocation = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), arrayref, constant(pointerType(), PreciseAllocation::halfAlignment));
         return m_currentBlock->appendNew<Value>(m_proc, B3::Select, origin(), isPreciseAllocation,
-            m_currentBlock->appendNew<Value>(m_proc, Add, origin(), payloadBase, constant(pointerType(), PreciseAllocation::halfAlignment)),
-            payloadBase);
+            payloadBase,
+            m_currentBlock->appendNew<Value>(m_proc, Add, origin(), payloadBase, constant(pointerType(), JSWebAssemblyArray::v128AlignmentShift)));
     }
     return payloadBase;
 }

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -124,6 +124,8 @@ auto SectionParser::parseType() -> PartialResult
             m_info->typeSignatures.append(signature.releaseNonNull());
         }
     }
+
+    RELEASE_ASSERT(m_info->typeSignatures.size() == m_info->rtts.size());
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1149,7 +1149,7 @@ bool TypeInformation::castReference(JSValue refValue, bool allowNull, TypeIndex 
             if (!arrayRef)
                 return false;
             auto arrayRTT = arrayRef->rtt();
-            if (arrayRTT.get() == signatureRTT.get())
+            if (arrayRTT.ptr() == signatureRTT.get())
                 return true;
             return arrayRTT->isStrictSubRTT(*signatureRTT);
         }
@@ -1158,7 +1158,7 @@ bool TypeInformation::castReference(JSValue refValue, bool allowNull, TypeIndex 
         if (!structRef)
             return false;
         auto structRTT = structRef->rtt();
-        if (structRTT.get() == signatureRTT.get())
+        if (structRTT.ptr() == signatureRTT.get())
             return true;
         return structRTT->isStrictSubRTT(*signatureRTT);
     }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -33,6 +33,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "JSCInlines.h"
 #include "JSWebAssemblyArrayInlines.h"
+#include "JSWebAssemblyInstance.h"
 #include "TypeError.h"
 #include "WasmFormat.h"
 #include "WasmTypeDefinition.h"
@@ -42,21 +43,14 @@ namespace JSC {
 
 const ClassInfo JSWebAssemblyArray::s_info = { "WebAssembly.Array"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyArray) };
 
-Structure* JSWebAssemblyArray::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
-{
-    return Structure::create(vm, globalObject, prototype, TypeInfo(WebAssemblyGCObjectType, StructureFlags), info());
-}
-
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, unsigned size, RefPtr<const Wasm::RTT>&& rtt)
-    : Base(vm, structure, WTFMove(rtt))
-    , m_elementType(elementType)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, WebAssemblyGCStructure* structure, unsigned size)
+    : Base(vm, structure)
     , m_size(size)
 {
     if (elementsAreRefTypes())
         std::fill(span<uint64_t>().begin(), span<uint64_t>().end(), JSValue::encode(jsNull()));
-    else {
+    else
         zeroSpan(bytes());
-    }
 }
 
 void JSWebAssemblyArray::fill(VM& vm, uint32_t offset, uint64_t value, uint32_t size)
@@ -77,7 +71,7 @@ void JSWebAssemblyArray::fill(VM& vm, uint32_t offset, uint64_t value, uint32_t 
 
 void JSWebAssemblyArray::fill(VM&, uint32_t offset, v128_t value, uint32_t size)
 {
-    ASSERT(m_elementType.type.unpacked().isV128());
+    ASSERT(elementType().type.unpacked().isV128());
     auto payload = span<v128_t>().subspan(offset, size);
     std::fill(payload.begin(), payload.end(), value);
 }
@@ -96,11 +90,6 @@ void JSWebAssemblyArray::copy(VM& vm, JSWebAssemblyArray& dst, uint32_t dstOffse
         auto dstSpan = dst.span<T>().subspan(dstOffset, size);
         memmoveSpan(dstSpan, srcSpan);
     });
-}
-
-void JSWebAssemblyArray::destroy(JSCell* cell)
-{
-    static_cast<JSWebAssemblyArray*>(cell)->JSWebAssemblyArray::~JSWebAssemblyArray();
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -42,9 +42,6 @@ namespace JSC {
 class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
 public:
     using Base = WebAssemblyGCObjectBase;
-    static constexpr DestructionMode needsDestruction = NeedsDestruction;
-
-    static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>
     static CompleteSubspace* subspaceFor(VM& vm)
@@ -52,20 +49,21 @@ public:
         return vm.heap.webAssemblyArraySpace<mode>();
     }
 
-    DECLARE_EXPORT_INFO;
+    DECLARE_INFO;
 
-    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+    static inline WebAssemblyGCStructure* createStructure(VM&, JSGlobalObject*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
 
-    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, unsigned size, RefPtr<const Wasm::RTT>&& rtt)
+    static JSWebAssemblyArray* create(VM& vm, WebAssemblyGCStructure* structure, unsigned size)
     {
-        auto* object = new (NotNull, allocateCell<JSWebAssemblyArray>(vm, allocationSizeInBytes(elementType, size))) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(rtt));
+        auto* object = new (NotNull, allocateCell<JSWebAssemblyArray>(vm, allocationSizeInBytes(elementType(structure), size))) JSWebAssemblyArray(vm, structure, size);
         object->finishCreation(vm);
         return object;
     }
 
     DECLARE_VISIT_CHILDREN;
 
-    Wasm::FieldType elementType() const { return m_elementType; }
+    static Wasm::FieldType elementType(const WebAssemblyGCStructure* structure) { return structure->typeDefinition().as<Wasm::ArrayType>()->elementType(); }
+    Wasm::FieldType elementType() const { return elementType(gcStructure()); }
     static bool needsAlignmentCheck(Wasm::StorageType type) { return type.unpacked().isV128(); }
     size_t size() const { return m_size; }
     size_t sizeInBytes() const { return size() * elementType().type.elementSize(); }
@@ -77,35 +75,12 @@ public:
 
     bool elementsAreRefTypes() const
     {
-        return Wasm::isRefType(m_elementType.type.unpacked());
+        return Wasm::isRefType(elementType().type.unpacked());
     }
 
     inline std::span<uint64_t> refTypeSpan() LIFETIME_BOUND;
 
-    ALWAYS_INLINE auto visitSpan(auto functor)
-    {
-        if (m_elementType.type.is<Wasm::PackedType>()) {
-            switch (m_elementType.type.as<Wasm::PackedType>()) {
-            case Wasm::PackedType::I8:
-                return functor(span<uint8_t>());
-            case Wasm::PackedType::I16:
-                return functor(span<uint16_t>());
-            }
-        }
-
-        // m_element_type must be a type, so we can get its kind
-        ASSERT(m_elementType.type.is<Wasm::Type>());
-        switch (m_elementType.type.as<Wasm::Type>().kind) {
-        case Wasm::TypeKind::I32:
-        case Wasm::TypeKind::F32:
-            return functor(span<uint32_t>());
-        case Wasm::TypeKind::V128:
-            return functor(span<v128_t>());
-        default:
-            return functor(span<uint64_t>());
-        }
-    }
-
+    ALWAYS_INLINE auto visitSpan(auto functor);
     ALWAYS_INLINE auto visitSpanNonVector(auto functor);
 
     inline uint64_t get(uint32_t index);
@@ -116,30 +91,38 @@ public:
     void fill(VM&, uint32_t, v128_t, uint32_t);
     void copy(VM&, JSWebAssemblyArray&, uint32_t, uint32_t, uint32_t);
 
-    // We add 8 bytes for v128 arrays since a PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
-    // Note: Technically this isn't needed since the GC/malloc always allocates 16 byte chunks so for precise allocations
+    // We add 8 bytes for v128 arrays since a non-PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
+    // Note: Technically this isn't needed since the GC/malloc always allocates 16 byte chunks so for non-precise v128 allocations
     // there will be a 8 spare bytes at the end. This is just a bit more explicit and shouldn't make a difference.
-    static size_t allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size) { return sizeof(JSWebAssemblyArray) + size * fieldType.type.elementSize() + (needsAlignmentCheck(fieldType.type) * 8); }
+    static constexpr ptrdiff_t v128AlignmentShift = 8;
+    static size_t allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size) { return sizeof(JSWebAssemblyArray) + size * fieldType.type.elementSize() + (needsAlignmentCheck(fieldType.type) * v128AlignmentShift); }
     static constexpr ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_size); }
     static constexpr ptrdiff_t offsetOfData() { return sizeof(JSWebAssemblyArray); }
 
 private:
     friend class LLIntOffsetsExtractor;
     inline std::span<uint8_t> bytes();
+
+    // NB: It's *HIGHLY* recommended that you don't use these directly since you'll have to remember to clean up the alignment for v128.
     uint8_t* data() { return reinterpret_cast<uint8_t*>(this) + offsetOfData(); }
     const uint8_t* data() const { return const_cast<JSWebAssemblyArray*>(this)->data(); }
 
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, unsigned, RefPtr<const Wasm::RTT>&&);
+    JSWebAssemblyArray(VM&, WebAssemblyGCStructure*, unsigned);
 
     DECLARE_DEFAULT_FINISH_CREATION;
 
-    Wasm::FieldType m_elementType;
     unsigned m_size;
+
+    // FIXME: We shouldn't need this padding but otherwise all the calculations about v128AlignmentShifts are wrong.
+#if USE(JSVALUE32_64)
+    unsigned m_padding;
+#endif
 };
 
 static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
-// We still have to check for PreciseAllocations since those are shifted by 8 bytes for v128 but this asserts our shifted offset will be correct.
-static_assert(!(JSWebAssemblyArray::offsetOfData() % alignof(v128_t)), "JSWebAssemblyArray storage needs to be aligned for v128_t");
+// We still have to check for PreciseAllocations since those are correctly aligned for v128 but this asserts our shifted offset will be correct.
+// FIXME: Fix this check for 32-bit.
+static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -40,25 +40,18 @@ namespace JSC {
 
 const ClassInfo JSWebAssemblyStruct::s_info = { "WebAssembly.Struct"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyStruct) };
 
-Structure* JSWebAssemblyStruct::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
-{
-    return Structure::create(vm, globalObject, prototype, TypeInfo(WebAssemblyGCObjectType, StructureFlags), info());
-}
-
-JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const Wasm::TypeDefinition>&& type, RefPtr<const Wasm::RTT>&& rtt)
-    : Base(vm, structure, WTFMove(rtt))
-    , TrailingArrayType(type->as<Wasm::StructType>()->instancePayloadSize())
-    , m_type(WTFMove(type))
+JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, WebAssemblyGCStructure* structure)
+    : Base(vm, structure)
+    , TrailingArrayType(structure->typeDefinition().as<Wasm::StructType>()->instancePayloadSize())
 {
     // FIXME: It would be nice to not do this but we need to zero the memory otherwise we would have to be extremely careful to avoid visiting this object before the mutator initializes all the fields.
     memsetSpan(span(), 0);
 }
 
-JSWebAssemblyStruct* JSWebAssemblyStruct::create(VM& vm, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex, RefPtr<const Wasm::RTT>&& rtt)
+JSWebAssemblyStruct* JSWebAssemblyStruct::create(VM& vm, WebAssemblyGCStructure* structure)
 {
-    Ref type = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
-    auto* structType = type->as<Wasm::StructType>();
-    auto* structValue = new (NotNull, allocateCell<JSWebAssemblyStruct>(vm, TrailingArrayType::allocationSize(structType->instancePayloadSize()))) JSWebAssemblyStruct(vm, structure, WTFMove(type), WTFMove(rtt));
+    auto* structType = structure->typeDefinition().as<Wasm::StructType>();
+    auto* structValue = new (NotNull, allocateCell<JSWebAssemblyStruct>(vm, TrailingArrayType::allocationSize(structType->instancePayloadSize()))) JSWebAssemblyStruct(vm, structure);
     structValue->finishCreation(vm);
     return structValue;
 }
@@ -194,11 +187,6 @@ void JSWebAssemblyStruct::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyStruct);
-
-void JSWebAssemblyStruct::destroy(JSCell* cell)
-{
-    static_cast<JSWebAssemblyStruct*>(cell)->JSWebAssemblyStruct::~JSWebAssemblyStruct();
-}
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -36,11 +36,9 @@ namespace JSC {
 
 const ClassInfo WebAssemblyGCObjectBase::s_info = { "WebAssemblyGCObjectBase"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyGCObjectBase) };
 
-WebAssemblyGCObjectBase::WebAssemblyGCObjectBase(VM& vm, Structure* structure, RefPtr<const Wasm::RTT>&& rtt)
+WebAssemblyGCObjectBase::WebAssemblyGCObjectBase(VM& vm, WebAssemblyGCStructure* structure)
     : Base(vm, structure)
-    , m_rtt(WTFMove(rtt))
-{
-}
+{ }
 
 template<typename Visitor>
 void WebAssemblyGCObjectBase::visitChildrenImpl(JSCell* cell, Visitor& visitor)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -30,6 +30,7 @@
 
 #include "JSObject.h"
 #include "WasmTypeDefinition.h"
+#include "WebAssemblyGCStructure.h"
 
 namespace JSC {
 
@@ -38,16 +39,15 @@ public:
     using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesPut | OverridesIsExtensible | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
-    DECLARE_EXPORT_INFO;
+    DECLARE_INFO;
 
-    RefPtr<const Wasm::RTT> rtt() { return m_rtt; }
-
-    static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCObjectBase, m_rtt); };
+    const WebAssemblyGCStructure* gcStructure() const { return uncheckedDowncast<WebAssemblyGCStructure>(structure()); }
+    Ref<const Wasm::RTT> rtt() const { return gcStructure()->rtt(); }
 
 protected:
     DECLARE_VISIT_CHILDREN;
 
-    WebAssemblyGCObjectBase(VM&, Structure*, RefPtr<const Wasm::RTT>&&);
+    WebAssemblyGCObjectBase(VM&, WebAssemblyGCStructure*);
 
     DECLARE_DEFAULT_FINISH_CREATION;
 
@@ -63,8 +63,6 @@ protected:
     JS_EXPORT_PRIVATE static bool setPrototype(JSObject*, JSGlobalObject*, JSValue, bool shouldThrowIfCantSet);
     JS_EXPORT_PRIVATE static bool isExtensible(JSObject*, JSGlobalObject*);
     JS_EXPORT_PRIVATE static bool preventExtensions(JSObject*, JSGlobalObject*);
-
-    RefPtr<const Wasm::RTT> m_rtt;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
- * Copyright (C) 2021 Igalia S.A. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +24,29 @@
  */
 
 #include "config.h"
-#include "BrandedStructure.h"
+#include "WebAssemblyGCStructure.h"
 
 #include "JSCInlines.h"
 
+#if ENABLE(WEBASSEMBLY)
+
 namespace JSC {
 
-BrandedStructure::BrandedStructure(VM& vm, Structure* previous, UniquedStringImpl* brandUid)
-    : Structure(vm, StructureVariant::Branded, previous)
-    , m_brand(brandUid)
-    , m_parentBrand(previous->isBrandedStructure() ? previous : nullptr, WriteBarrierEarlyInit)
-{
-    ASSERT(isBrandedStructure());
-}
+WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, JSGlobalObject* globalObject, const TypeInfo& typeInfo, const ClassInfo* classInfo, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
+    : Structure(vm, StructureVariant::WebAssemblyGC, globalObject, typeInfo, classInfo)
+    , m_rtt(WTFMove(rtt))
+    , m_type(WTFMove(type))
+{ }
 
-BrandedStructure::BrandedStructure(VM& vm, BrandedStructure* previous)
-    : Structure(vm, StructureVariant::Branded, previous)
-    , m_brand(previous->m_brand)
-    , m_parentBrand(previous->m_parentBrand.get(), WriteBarrierEarlyInit)
-{
-    ASSERT(isBrandedStructure());
-}
-
-Structure* BrandedStructure::create(VM& vm, Structure* previous, UniquedStringImpl* brandUid, DeferredStructureTransitionWatchpointFire* deferred)
+WebAssemblyGCStructure* WebAssemblyGCStructure::create(VM& vm, JSGlobalObject* globalObject, const TypeInfo& typeInfo, const ClassInfo* classInfo, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
 {
     ASSERT(vm.structureStructure);
-    BrandedStructure* newStructure = new (NotNull, allocateCell<BrandedStructure>(vm)) BrandedStructure(vm, previous, brandUid);
-    newStructure->finishCreation(vm, previous, deferred);
+    WebAssemblyGCStructure* newStructure = new (NotNull, allocateCell<WebAssemblyGCStructure>(vm)) WebAssemblyGCStructure(vm, globalObject, typeInfo, classInfo, WTFMove(type), WTFMove(rtt));
+    newStructure->finishCreation(vm);
     ASSERT(newStructure->type() == StructureType);
     return newStructure;
 }
 
 } // namespace JSC
+
+#endif

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "Structure.h"
+#include "WasmTypeDefinition.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+namespace WTF {
+
+class UniquedStringImpl;
+
+} // namespace WTF
+
+namespace JSC {
+
+// FIXME: It seems like almost all the fields of a Structure are useless to a wasm GC "object" since they can't have dynamic fields
+// e.g. PropertyTables, Transitions, SeenProperties, Prototype, etc.
+class WebAssemblyGCStructure final : public Structure {
+    typedef Structure Base;
+public:
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return &vm.webAssemblyGCStructureSpace();
+    }
+
+    const Wasm::RTT& rtt() const LIFETIME_BOUND { return m_rtt; }
+    const Wasm::TypeDefinition& typeDefinition() const LIFETIME_BOUND { return m_type; }
+
+    static WebAssemblyGCStructure* create(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
+
+    void destruct()
+    {
+        auto rtt = WTFMove(m_rtt);
+        auto type = WTFMove(m_type);
+    }
+
+    static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_rtt); }
+
+private:
+    WebAssemblyGCStructure(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
+
+    Ref<const Wasm::RTT> m_rtt;
+    Ref<const Wasm::TypeDefinition> m_type;
+};
+
+} // namespace JSC
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::WebAssemblyGCStructure)
+    static bool isType(const JSC::Structure& from)
+    {
+        return from.variant() == JSC::Structure::StructureVariant::WebAssemblyGC;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(WEBASSEMBLY)


### PR DESCRIPTION
#### 4ae6483cec93af044af3c2ca0b8b6baf1447843a
<pre>
[Wasm] GC objects should not require destructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=289811">https://bugs.webkit.org/show_bug.cgi?id=289811</a>
<a href="https://rdar.apple.com/147064715">rdar://147064715</a>

Reviewed by Yusuke Suzuki.

This patch removes the need for destructors on Wasm GC objects. To do this the RTT and TypeDefinition
have been moved into the structure rather than the object itself. This means adding a new Structure
subtype WebAssemblyGCStructure. This patch doesn&apos;t bother trying to cache or deduplicate these structures
because:

1) There&apos;s typically only one instance per module.
2) We don&apos;t have global GC so we can&apos;t duplicate across threads.
3) We don&apos;t do optimizations on the identity of the structure in Wasm so it&apos;s unlikely to do much.
4) JS can&apos;t access any fields from wasm structs/arrays directly.

Since we don&apos;t have a global GC all the structures have to be cached on the instance in a new trailing array
that has a typeIndex -&gt; structure map.

In a subsequent patch we will start allocating these objects directly in the JIT rather than in C++.

This change is a 40% win on Dart-flute-wasm in JS3 (11s -&gt; 7s).

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/BrandedStructure.cpp:
(JSC::BrandedStructure::BrandedStructure):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
(JSC::Structure::~Structure):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::variant const):
(JSC::Structure::isBrandedStructure):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::create):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayGetPayload):
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::validateWasmValue):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::decodeNonNullStructure):
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromObject):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::fillArray):
(JSC::Wasm::arrayNew):
(JSC::Wasm::copyElementsInReverse):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::arrayNewData):
(JSC::Wasm::arrayNewElem):
(JSC::Wasm::structNew):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::castReference):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::fill):
(JSC::JSWebAssemblyArray::createStructure): Deleted.
(JSC::JSWebAssemblyArray::destroy): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::createStructure):
(JSC::JSWebAssemblyArray::span):
(JSC::JSWebAssemblyArray::bytes):
(JSC::JSWebAssemblyArray::visitSpan):
(JSC::JSWebAssemblyArray::visitSpanNonVector):
(JSC::JSWebAssemblyArray::set):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::finishCreation):
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::tryCreate):
(JSC::JSWebAssemblyInstance::extraMemoryAllocated const): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::create):
(JSC::JSWebAssemblyStruct::createStructure): Deleted.
(JSC::JSWebAssemblyStruct::destroy): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
(JSC::JSWebAssemblyStruct::createStructure):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp:
(JSC::WebAssemblyGCObjectBase::WebAssemblyGCObjectBase):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:
(JSC::WebAssemblyGCObjectBase::gcStructure const):
(JSC::WebAssemblyGCObjectBase::rtt const):
(JSC::WebAssemblyGCObjectBase::rtt): Deleted.
(JSC::WebAssemblyGCObjectBase::offsetOfRTT): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp: Copied from Source/JavaScriptCore/runtime/BrandedStructure.cpp.
(JSC::WebAssemblyGCStructure::WebAssemblyGCStructure):
(JSC::WebAssemblyGCStructure::create):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h: Added.

Canonical link: <a href="https://commits.webkit.org/292257@main">https://commits.webkit.org/292257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec6af46324d290590cc872f99cb5aa1b279fa65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95405 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45911 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72768 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30032 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45246 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102489 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94028 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22455 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16392 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81153 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15750 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27563 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/116739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22083 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/116739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->