### PR TITLE
Use arrays instead of dictionaries to return pixels in TestWebKitAPI.AdvancedPrivacyProtections.VerifyPixelsFromNoisyCanvas2DAPI

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.js
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.js
@@ -92,15 +92,15 @@ function fullTextCanvasImageData() {
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
 }
 
-function initialCanvasImageDataAsObject(imageData, length) {
+function initialCanvasImageDataAsArray(imageData, length) {
     if (length < 0)
-        return {};
+        return [];
     if (length > imageData.data.length)
         length = imageData.data.length;
-    let obj = {};
+    let array = [];
     for (let i = 0; i < length; ++i)
-      obj[i] = imageData.data[i];
-    return obj;
+        array.push(imageData.data[i]);
+    return array;
 }
 
 function isHorizontalLinearGradientCanvasGradient() {
@@ -128,20 +128,20 @@ function isVerticalLinearGradientCanvasGradient() {
     return true;
 }
 
-function initialTextCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullTextCanvasImageData(), length);
+function initialTextCanvasImageDataAsArray(length) {
+    return initialCanvasImageDataAsArray(fullTextCanvasImageData(), length);
 }
 
-function initialHorizontalLinearGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullHorizontalLinearGradientCanvasImageData(), length);
+function initialHorizontalLinearGradientCanvasImageDataAsArray(length) {
+    return initialCanvasImageDataAsArray(fullHorizontalLinearGradientCanvasImageData(), length);
 }
 
-function initialVerticalLinearGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullVerticalLinearGradientCanvasImageData(), length);
+function initialVerticalLinearGradientCanvasImageDataAsArray(length) {
+    return initialCanvasImageDataAsArray(fullVerticalLinearGradientCanvasImageData(), length);
 }
 
-function initialRadialGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullRadialGradientCanvasImageData(), length);
+function initialRadialGradientCanvasImageDataAsArray(length) {
+    return initialCanvasImageDataAsArray(fullRadialGradientCanvasImageData(), length);
 }
 
 async function fullCanvasHash(data) {


### PR DESCRIPTION
#### 87b47cbf0b69681b3ad194210e048e15ff10ad02
<pre>
Use arrays instead of dictionaries to return pixels in TestWebKitAPI.AdvancedPrivacyProtections.VerifyPixelsFromNoisyCanvas2DAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=289813">https://bugs.webkit.org/show_bug.cgi?id=289813</a>
<a href="https://rdar.apple.com/147066003">rdar://147066003</a>

Reviewed by Sihui Liu and Wenson Hsieh.

This doesn&apos;t change any functionality, but it makes the test run in debug builds in ~4 seconds
instead of ~25 seconds.  This should help it to not time out.  See <a href="https://rdar.apple.com/146674117">rdar://146674117</a>

* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.js:
(initialCanvasImageDataAsArray):
(initialTextCanvasImageDataAsArray):
(initialHorizontalLinearGradientCanvasImageDataAsArray):
(initialVerticalLinearGradientCanvasImageDataAsArray):
(initialRadialGradientCanvasImageDataAsArray):
(initialCanvasImageDataAsObject): Deleted.
(initialTextCanvasImageDataAsObject): Deleted.
(initialHorizontalLinearGradientCanvasImageDataAsObject): Deleted.
(initialVerticalLinearGradientCanvasImageDataAsObject): Deleted.
(initialRadialGradientCanvasImageDataAsObject): Deleted.

Canonical link: <a href="https://commits.webkit.org/292188@main">https://commits.webkit.org/292188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4e80b992aabde990ef6eb64c054c608bf54985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100275 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45732 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23262 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/45732 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98234 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3696 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81620 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81016 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25588 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22249 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27375 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21908 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->