### PR TITLE
Update FileHandle::write() / read() to return a std::optional

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -183,14 +183,14 @@ private:
         }
 
         for (const auto& page : m_pages) {
-            int bytesWritten = m_fileHandle.write(page.span());
-            if (bytesWritten == -1) {
+            auto bytesWritten = m_fileHandle.write(page.span());
+            if (!bytesWritten) {
                 error = BytecodeCacheError::StandardError(errno);
                 return nullptr;
             }
 
-            if (static_cast<size_t>(bytesWritten) != page.size()) {
-                error = BytecodeCacheError::WriteError(bytesWritten, page.size());
+            if (*bytesWritten != page.size()) {
+                error = BytecodeCacheError::WriteError(*bytesWritten, page.size());
                 return nullptr;
             }
         }

--- a/Source/WTF/wtf/FileHandle.cpp
+++ b/Source/WTF/wtf/FileHandle.cpp
@@ -75,9 +75,9 @@ std::optional<Vector<uint8_t>> FileHandle::readAll()
 
     Vector<uint8_t> buffer(bytesToRead);
     size_t totalBytesRead = 0;
-    int bytesRead;
+    uint64_t bytesRead;
 
-    while ((bytesRead = read(buffer.mutableSpan().subspan(totalBytesRead))) > 0)
+    while ((bytesRead = read(buffer.mutableSpan().subspan(totalBytesRead)).value_or(0)))
         totalBytesRead += bytesRead;
 
     if (totalBytesRead != bytesToRead)

--- a/Source/WTF/wtf/FileHandle.h
+++ b/Source/WTF/wtf/FileHandle.h
@@ -85,11 +85,8 @@ public:
     bool isValid() const { return !!m_handle; }
     explicit operator bool() const { return isValid(); }
 
-    // Returns number of bytes actually written if successful, -1 otherwise.
-    WTF_EXPORT_PRIVATE int64_t write(std::span<const uint8_t>);
-    // Returns number of bytes actually read if successful, -1 otherwise.
-    WTF_EXPORT_PRIVATE int64_t read(std::span<uint8_t>);
-
+    WTF_EXPORT_PRIVATE std::optional<uint64_t> write(std::span<const uint8_t>);
+    WTF_EXPORT_PRIVATE std::optional<uint64_t> read(std::span<uint8_t>);
     WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readAll();
     WTF_EXPORT_PRIVATE bool truncate(int64_t offset);
     WTF_EXPORT_PRIVATE std::optional<uint64_t> size();

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -126,7 +126,7 @@ WTF_EXPORT_PRIVATE String stringFromFileSystemRepresentation(const char*);
 using Salt = std::array<uint8_t, 8>;
 WTF_EXPORT_PRIVATE std::optional<Salt> readOrMakeSalt(const String& path);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(const String& path);
-WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, std::span<const uint8_t>);
+WTF_EXPORT_PRIVATE std::optional<uint64_t> overwriteEntireFile(const String& path, std::span<const uint8_t>);
 
 // Prefix is what the filename should be prefixed with, not the full path.
 WTF_EXPORT_PRIVATE std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView suffix = { });

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -37,30 +37,30 @@
 
 namespace WTF::FileSystemImpl {
 
-int64_t FileHandle::read(std::span<uint8_t> data)
+std::optional<uint64_t> FileHandle::read(std::span<uint8_t> data)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     do {
         auto bytesRead = ::read(*m_handle, data.data(), data.size());
         if (bytesRead >= 0)
             return bytesRead;
     } while (errno == EINTR);
-    return -1;
+    return { };
 }
 
-int64_t FileHandle::write(std::span<const uint8_t> data)
+std::optional<uint64_t> FileHandle::write(std::span<const uint8_t> data)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     do {
         auto bytesWritten = ::write(*m_handle, data.data(), data.size());
         if (bytesWritten >= 0)
             return bytesWritten;
     } while (errno == EINTR);
-    return -1;
+    return { };
 }
 
 bool FileHandle::truncate(int64_t offset)

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -50,30 +50,30 @@ static std::optional<uint64_t> getFileSizeFromByHandleFileInformationStructure(c
     return fileSize.QuadPart;
 }
 
-int64_t FileHandle::read(std::span<uint8_t> data)
+std::optional<uint64_t> FileHandle::read(std::span<uint8_t> data)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     DWORD bytesRead;
     bool success = ::ReadFile(*m_handle, data.data(), data.size(), &bytesRead, nullptr);
 
     if (!success)
-        return -1;
-    return static_cast<int64_t>(bytesRead);
+        return { };
+    return static_cast<uint64_t>(bytesRead);
 }
 
-int64_t FileHandle::write(std::span<const uint8_t> data)
+std::optional<uint64_t> FileHandle::write(std::span<const uint8_t> data)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     DWORD bytesWritten;
     bool success = WriteFile(*m_handle, data.data(), data.size(), &bytesWritten, nullptr);
 
     if (!success)
-        return -1;
-    return static_cast<int64_t>(bytesWritten);
+        return { };
+    return static_cast<uint64_t>(bytesWritten);
 }
 
 bool FileHandle::flush()

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -136,11 +136,11 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::read(BufferSource&& 
             return Exception { ExceptionCode::InvalidStateError, "Failed to read at offset"_s };
     }
 
-    int result = m_file.read(buffer.mutableSpan());
-    if (result == -1)
+    auto result = m_file.read(buffer.mutableSpan());
+    if (!result)
         return Exception { ExceptionCode::InvalidStateError, "Failed to read from file"_s };
 
-    return result;
+    return *result;
 }
 
 ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&& buffer, FileSystemSyncAccessHandle::FilesystemReadWriteOptions options)
@@ -162,11 +162,11 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&&
     if (!requestSpaceForWrite(*options.at, buffer.length()))
         return Exception { ExceptionCode::QuotaExceededError };
 
-    int result = m_file.write(buffer.span());
-    if (result == -1)
+    auto result = m_file.write(buffer.span());
+    if (!result)
         return Exception { ExceptionCode::InvalidStateError, "Failed to write to file"_s };
 
-    return result;
+    return *result;
 }
 
 void FileSystemSyncAccessHandle::stop()

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -104,7 +104,7 @@ static RetainPtr<NSURL> writeToTemporaryFile(WebCore::Model& modelSource)
     auto [filePath, fileHandle] = FileSystem::openTemporaryFile("ModelFile"_s, ".usdz"_s);
     ASSERT(fileHandle);
 
-    size_t byteCount = fileHandle.write(modelSource.data()->makeContiguous()->span());
+    auto byteCount = fileHandle.write(modelSource.data()->makeContiguous()->span());
     ASSERT_UNUSED(byteCount, byteCount == modelSource.data()->size());
     fileHandle = { };
 

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -40,9 +40,9 @@ bool writeAllToFile(FileSystem::FileHandle& file, const T& container)
     auto bytes = spanReinterpretCast<const uint8_t>(container.span());
     while (!bytes.empty()) {
         auto written = file.write(bytes);
-        if (written == -1)
+        if (!written)
             return false;
-        skip(bytes, written);
+        skip(bytes, *written);
     }
     return true;
 }

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1286,18 +1286,18 @@ bool ApplicationCacheStorage::writeDataToUniqueFileInDirectory(FragmentedSharedB
         fullPath = FileSystem::pathByAppendingComponent(directory, path);
     } while (FileSystem::parentPath(fullPath) != directory || FileSystem::fileExists(fullPath));
     
-    int64_t writtenBytes = 0;
+    uint64_t writtenBytes = 0;
     {
         auto handle = FileSystem::openFile(fullPath, FileSystem::FileOpenMode::Truncate);
         if (!handle)
             return false;
 
         data.forEachSegment([&](auto segment) {
-            writtenBytes += handle.write(segment);
+            writtenBytes += handle.write(segment).value_or(0);
         });
     }
     
-    if (writtenBytes != static_cast<int64_t>(data.size())) {
+    if (writtenBytes != data.size()) {
         FileSystem::deleteFile(fullPath);
         return false;
     }

--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -73,12 +73,12 @@ Expected<String, ArchiveError> ArchiveResource::saveToDisk(const String& directo
     auto filePath = FileSystem::pathByAppendingComponent(directory, m_relativeFilePath);
     FileSystem::makeAllDirectories(FileSystem::parentPath(filePath));
     auto fileData = data().extractData();
-    int bytesWritten = FileSystem::overwriteEntireFile(filePath, fileData.span());
+    auto bytesWritten = FileSystem::overwriteEntireFile(filePath, fileData.span());
 
-    if (bytesWritten < 0)
+    if (!bytesWritten)
         return makeUnexpected(ArchiveError::FileSystemError);
 
-    if ((size_t)bytesWritten != fileData.size()) {
+    if (*bytesWritten != fileData.size()) {
         FileSystem::deleteFile(filePath);
         return makeUnexpected(ArchiveError::FileSystemError);
     }

--- a/Source/WebCore/platform/FileStream.cpp
+++ b/Source/WebCore/platform/FileStream.cpp
@@ -95,15 +95,15 @@ int FileStream::read(std::span<uint8_t> buffer)
 
     long long remaining = m_totalBytesToRead - m_bytesProcessed;
     int bytesToRead = remaining < static_cast<int>(buffer.size()) ? static_cast<int>(remaining) : static_cast<int>(buffer.size());
-    int bytesRead = 0;
+    std::optional<uint64_t> bytesRead = 0;
     if (bytesToRead > 0)
         bytesRead = m_handle.read(buffer.first(bytesToRead));
-    if (bytesRead < 0)
+    if (!bytesRead)
         return -1;
-    if (bytesRead > 0)
-        m_bytesProcessed += bytesRead;
+    if (*bytesRead > 0)
+        m_bytesProcessed += *bytesRead;
 
-    return bytesRead;
+    return *bytesRead;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -75,7 +75,7 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
     CGDataConsumerCallbacks callbacks = {
         [](void* info, const void* buffer, size_t count) -> size_t {
             auto& handle = *static_cast<FileSystem::FileHandle*>(info);
-            return handle.write(unsafeMakeSpan(static_cast<const uint8_t*>(buffer), count));
+            return handle.write(unsafeMakeSpan(static_cast<const uint8_t*>(buffer), count)).value_or(0);
         },
         nullptr
     };

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -143,18 +143,18 @@ std::optional<size_t> CurlFormDataStream::readFromFile(const FormDataElement::En
     }
 
     auto readBytes = m_fileHandle.read({ byteCast<uint8_t>(buffer), size });
-    if (readBytes < 0) {
+    if (!readBytes) {
         LOG(Network, "Curl - Failed while trying to read %s for upload\n", fileData.filename.utf8().data());
         m_fileHandle = { };
         return std::nullopt;
     }
 
-    if (!readBytes) {
+    if (!*readBytes) {
         m_fileHandle = { };
         ++m_elementPosition;
     }
 
-    return readBytes;
+    return *readBytes;
 }
 
 std::optional<size_t> CurlFormDataStream::readFromData(const Vector<uint8_t>& data, char* buffer, size_t size)

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -465,16 +465,16 @@ void NetworkDataTaskBlob::download()
 bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
 {
     ASSERT(isDownload());
-    int bytesWritten = m_downloadFile.write(data);
-    if (static_cast<size_t>(bytesWritten) != data.size()) {
+    auto bytesWritten = m_downloadFile.write(data);
+    if (bytesWritten != data.size()) {
         didFailDownload(cancelledError(m_firstRequest));
         return false;
     }
 
-    m_downloadBytesWritten += bytesWritten;
+    m_downloadBytesWritten += *bytesWritten;
     RefPtr download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
-    download->didReceiveData(bytesWritten, m_downloadBytesWritten, m_totalSize);
+    download->didReceiveData(*bytesWritten, m_downloadBytesWritten, m_totalSize);
     return true;
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -177,7 +177,7 @@ void NetworkDataTaskDataURL::downloadDecodedData(Vector<uint8_t>&& data)
     downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, download.copyRef());
     download->didCreateDestination(m_pendingDownloadLocation);
 
-    if (downloadDestinationFile.write(data.span()) == -1) {
+    if (!downloadDestinationFile.write(data.span())) {
         downloadDestinationFile = { };
         FileSystem::deleteFile(m_pendingDownloadLocation);
 #if USE(CURL)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -195,14 +195,14 @@ void ServiceWorkerDownloadTask::didReceiveData(const IPC::SharedBufferReference&
     if (!m_downloadFile)
         return;
 
-    size_t bytesWritten = m_downloadFile.write(data.span());
+    auto bytesWritten = m_downloadFile.write(data.span());
 
     if (bytesWritten != data.size()) {
         didFailDownload();
         return;
     }
 
-    callOnMainRunLoop([this, protectedThis = Ref { *this }, bytesWritten] {
+    callOnMainRunLoop([this, protectedThis = Ref { *this }, bytesWritten = *bytesWritten] {
         m_downloadBytesWritten += bytesWritten;
         if (RefPtr download = protectedNetworkProcess()->downloadManager().download(*m_pendingDownloadID))
             download->didReceiveData(bytesWritten, m_downloadBytesWritten, std::max(m_expectedContentLength.value_or(0), m_downloadBytesWritten));

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -199,7 +199,7 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         RELEASE_ASSERT(download);
         uint64_t bytesWritten = 0;
         for (auto& segment : buffer.get()) {
-            if (m_downloadDestinationFile.write(segment.segment->span()) == -1) {
+            if (!m_downloadDestinationFile.write(segment.segment->span())) {
                 download->didFail(ResourceError(CURLE_WRITE_ERROR, m_response.url()), { });
                 invalidateAndCancel();
                 return;

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -186,7 +186,7 @@ void BackgroundFetchStoreManager::storeFetchAfterQuotaCheck(const String& identi
     m_ioQueue->dispatch([queue = Ref { m_taskQueue }, filePath = WTFMove(filePath).isolatedCopy(), responseBodyIndexToClear, data = WTFMove(data), callback = WTFMove(callback)]() mutable {
         // FIXME: Cover the case of partial write.
         auto writtenSize = FileSystem::overwriteEntireFile(filePath, data);
-        auto result = static_cast<size_t>(writtenSize) == data.size() ? StoreResult::OK : StoreResult::InternalError;
+        auto result = writtenSize == data.size() ? StoreResult::OK : StoreResult::InternalError;
         if (result == StoreResult::OK && responseBodyIndexToClear)
             FileSystem::deleteFile(makeString(filePath, '-', *responseBodyIndexToClear));
         RELEASE_LOG_ERROR_IF(result == StoreResult::InternalError, ServiceWorker, "BackgroundFetchStoreManager::storeFetch failed writing");
@@ -225,7 +225,7 @@ void BackgroundFetchStoreManager::storeFetchResponseBodyChunk(const String& iden
         if (auto handle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::ReadWrite); handle) {
             // FIXME: Cover the case of partial write.
             auto writtenSize = handle.write(data->span());
-            if (static_cast<size_t>(writtenSize) == data->size())
+            if (writtenSize == data->size())
                 result = StoreResult::OK;
         }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -531,12 +531,12 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
             auto recordBlobData = recordBlobDatas[index];
             FileSystem::makeAllDirectories(FileSystem::parentPath(recordFile));
             if (!recordBlobData.isEmpty())  {
-                if (FileSystem::overwriteEntireFile(recordBlobFilePath(recordFile), recordBlobData) == -1) {
+                if (!FileSystem::overwriteEntireFile(recordBlobFilePath(recordFile), recordBlobData)) {
                     result = false;
                     continue;
                 }
             }
-            if (FileSystem::overwriteEntireFile(recordFile, recordData) == -1)
+            if (!FileSystem::overwriteEntireFile(recordFile, recordData))
                 result = false;
         }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -138,7 +138,7 @@ static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
 
     auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
     auto value = String::number(size).utf8();
-    return FileSystem::overwriteEntireFile(sizeFilePath, byteCast<uint8_t>(value.span())) != -1;
+    return !!FileSystem::overwriteEntireFile(sizeFilePath, byteCast<uint8_t>(value.span()));
 }
 
 static String saltFilePath(const String& saltDirectory)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -304,8 +304,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
                 return FileSystemStorageError::Unknown;
         }
 
-        int result = activeWritableFile.handle.write(dataBytes);
-        if (result == -1)
+        if (!activeWritableFile.handle.write(dataBytes))
             return FileSystemStorageError::Unknown;
 
         return std::nullopt;

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -59,8 +59,8 @@ void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)
         return;
 
     auto writtenBytes = handle.write(rawData->span());
-    if (writtenBytes != static_cast<int64_t>(rawData->size()))
-        RELEASE_LOG_ERROR(DiskPersistency, "Disk persistency: We only wrote %d out of %zu bytes to disk", static_cast<unsigned>(writtenBytes), rawData->size());
+    if (writtenBytes != rawData->size())
+        RELEASE_LOG_ERROR(DiskPersistency, "Disk persistency: We only wrote %" PRIu64 " out of %zu bytes to disk", *writtenBytes, rawData->size());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -201,7 +201,7 @@ static std::optional<Vector<uint8_t>> fileContents(const String& path, bool shou
     std::array<uint8_t, 4096> chunk;
     Vector<uint8_t> contents;
     contents.reserveInitialCapacity(chunk.size());
-    while (size_t bytesRead = fileHandle.read(chunk))
+    while (auto bytesRead = fileHandle.read(chunk).value_or(0))
         contents.append(std::span { chunk }.first(bytesRead));
     contents.shrinkToFit();
 
@@ -379,7 +379,7 @@ static bool writeSandboxDataToCacheFile(const SandboxInfo& info, const Vector<ui
     // then rename it to the final cache path.
     auto temporaryPath = makeString(info.filePath, '-', getpid());
     auto fileHandle = FileSystem::openFile(temporaryPath, FileSystem::FileOpenMode::Truncate);
-    if (fileHandle.write(cacheFile.span()) != safeCast<int>(cacheFile.size())) {
+    if (fileHandle.write(cacheFile.span()) != cacheFile.size()) {
         FileSystem::deleteFile(temporaryPath);
         return false;
     }

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -265,7 +265,7 @@ static bool writeDataToFile(const WebKit::NetworkCache::Data& fileData, FileHand
 {
     bool success = true;
     fileData.apply([&fileHandle, &success](std::span<const uint8_t> span) {
-        if (fileHandle.write(span) == -1) {
+        if (!fileHandle.write(span)) {
             success = false;
             return false;
         }
@@ -395,7 +395,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
     invalidHeader.fill(0xFF);
 
     // This header will be rewritten in CompilationClient::finalize.
-    if (temporaryFileHandle.write(invalidHeader) == -1) {
+    if (!temporaryFileHandle.write(invalidHeader)) {
         WTFLogAlways("Content Rule List compiling failed: Writing header to file failed.");
         return makeUnexpected(ContentRuleListStore::Error::CompileFailed);
     }
@@ -644,8 +644,7 @@ void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& i
 
     ContentRuleListMetaData header;
 
-    auto bytesRead = fileHandle.read(asMutableByteSpan(header));
-    if (bytesRead != sizeof(header))
+    if (fileHandle.read(asMutableByteSpan(header)) != sizeof(header))
         return;
 
     // Invalidate the version by setting it to one less than the current version.

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -365,7 +365,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 - (void)completeLoad
 {
     ASSERT(_fileHandle);
-    size_t byteCount = _fileHandle.write(span(_data.get()));
+    auto byteCount = _fileHandle.write(span(_data.get()));
     _fileHandle = { };
 
     if (byteCount != _data.get().length) {

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -111,10 +111,10 @@ void WebInspectorUIProxy::showSavePanelForSingleFile(HWND parentWindow, Vector<W
         auto content = saveDatas[0].content.utf8();
         auto contentSize = content.length();
         auto bytesWritten = fileHandle.write(byteCast<uint8_t>(content.span()));
-        if (bytesWritten == -1 || static_cast<size_t>(bytesWritten) != contentSize) {
+        if (bytesWritten != contentSize) {
             auto message = systemErrorMessage(GetLastError());
             if (message.isEmpty())
-                message = makeString("Error: writeToFile returns "_s, bytesWritten, ", contentLength = "_s, content.length());
+                message = makeString("Error: writeToFile returns "_s, bytesWritten ? static_cast<int64_t>(*bytesWritten) : -1, ", contentLength = "_s, content.length());
             MessageBox(parentWindow, message.wideCharacters().data(), L"Export HAR", MB_OK | MB_ICONEXCLAMATION);
         }
     } else {

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -300,7 +300,7 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
         auto [filePath, fileHandle] = FileSystem::openTemporaryFile("QuickLook"_s, suffix);
         ASSERT(fileHandle);
 
-        size_t byteCount = fileHandle.write(buffer->span());
+        auto byteCount = fileHandle.write(buffer->span());
         ASSERT_UNUSED(byteCount, byteCount == buffer->size());
         fileHandle = { };
 

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -109,7 +109,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
     if (!fileHandle)
         return NO;
 
-    auto byteCount = static_cast<std::size_t>(fileHandle.write(model.data()->span()));
+    auto byteCount = fileHandle.write(model.data()->span());
     ASSERT_UNUSED(byteCount, byteCount == model.data()->size());
     _filePath = filePath;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -40,8 +40,9 @@ constexpr auto FileSystemTestData = "This is a test"_s;
 
 static void createTestFile(const String& path)
 {
-    int written = FileSystem::overwriteEntireFile(path, FileSystemTestData.span8());
-    EXPECT_GE(written, 0);
+    auto written = FileSystem::overwriteEntireFile(path, FileSystemTestData.span8());
+    EXPECT_TRUE(written);
+    EXPECT_GE(*written, 0u);
 }
 
 // FIXME: Refactor FileSystemTest and FragmentedSharedBufferTest as a single class.

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -60,8 +60,8 @@ public:
         auto handle = WTFMove(result.second);
         ASSERT_TRUE(!!handle);
 
-        int rc = handle.write(byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
-        ASSERT_NE(rc, -1);
+        auto rc = handle.write(byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
+        ASSERT_TRUE(!!rc);
     }
     
     void TearDown() override
@@ -346,8 +346,8 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
         auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate);
         ASSERT_FALSE(!handle);
 
-        int rc = handle.write(byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
-        ASSERT_NE(rc, -1);
+        auto rc = handle.write(byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
+        ASSERT_TRUE(!!rc);
 
         auto firstCommand = createCommand(tempFilePath(), FileMonitorRevisedData);
         rc = system(firstCommand.utf8().data());


### PR DESCRIPTION
#### 084c4253ea4feca90fc5178200d0af379d2d11cb
<pre>
Update FileHandle::write() / read() to return a std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=289824">https://bugs.webkit.org/show_bug.cgi?id=289824</a>

Reviewed by Timothy Hatcher.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::releaseMapped):
* Source/WTF/wtf/FileHandle.cpp:
(WTF::FileSystemImpl::FileHandle::readAll):
* Source/WTF/wtf/FileHandle.h:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::appendFileContentsToFileHandle):
(WTF::FileSystemImpl::readOrMakeSalt):
(WTF::FileSystemImpl::overwriteEntireFile):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::read):
(WTF::FileSystemImpl::FileHandle::write):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::read):
(WTF::FileSystemImpl::FileHandle::write):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::read):
(WebCore::FileSystemSyncAccessHandle::write):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm:
(WebCore::writeToTemporaryFile):
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::writeAllToFile):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::writeDataToUniqueFileInDirectory):
* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::saveToDisk):
* Source/WebCore/platform/FileStream.cpp:
(WebCore::FileStream::read):
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage):
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::readFromFile):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::writeDownload):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::didReceiveData):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::storeFetchAfterQuotaCheck):
(WebKit::BackgroundFetchStoreManager::storeFetchResponseBodyChunk):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::executeCommandForWritableInternal):
* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::writeToDisk):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
(WebKit::writeSandboxDataToCacheFile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::writeDataToFile):
(API::compiledToFile):
(API::ContentRuleListStore::invalidateContentRuleListVersion):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::convertChromeExtensionToTemporaryZipFile):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::showSavePanelForSingleFile):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::prepareQuickLookImageURL const):
* Source/WebKit/UIProcess/ios/WKModelView.mm:
(-[WKModelView createFileForModel:]):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::createTestFile):
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
(TestWebKitAPI::TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)):

Canonical link: <a href="https://commits.webkit.org/292229@main">https://commits.webkit.org/292229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5190ea9b9bae6f2534860daf3ad7bac5c8f5553e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98341 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11379 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45178 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88009 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102420 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93961 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22386 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16331 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81096 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15657 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15315 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27492 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/116649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22015 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/116649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->