### PR TITLE
Remove `isSpatialNavigationEnabled`

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -80,7 +80,6 @@
 #include "ShadowRoot.h"
 #include "SimpleCaretAnimator.h"
 #include "SimpleRange.h"
-#include "SpatialNavigation.h"
 #include "StyleProperties.h"
 #include "StyleTreeResolver.h"
 #include "TypedElementDescendantIteratorInlines.h"
@@ -1574,7 +1573,7 @@ bool FrameSelection::modify(Alteration alter, SelectionDirection direction, Text
     if (position.isNull())
         return false;
 
-    if (m_document && isSpatialNavigationEnabled(m_document->frame())) {
+    if (m_document && m_document->settings().spatialNavigationEnabled()) {
         if (!wasRange && alter == Alteration::Move && position == originalStartPosition)
             return false;
     }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -57,7 +57,6 @@
 #include "RenderMenuList.h"
 #include "RenderTheme.h"
 #include "Settings.h"
-#include "SpatialNavigation.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -1144,7 +1143,7 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
     if (!RenderTheme::singleton().popsMenuByArrowKeys())
         return false;
 
-    if (!isSpatialNavigationEnabled(document().protectedFrame().get())) {
+    if (!document().settings().spatialNavigationEnabled()) {
         if (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s) {
             focus();
             protectedDocument()->updateStyleIfNeeded();
@@ -1188,7 +1187,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         // When using spatial navigation, we want to be able to navigate away
         // from the select element when the user hits any of the arrow keys,
         // instead of changing the selection.
-        if (isSpatialNavigationEnabled(document().protectedFrame().get())) {
+        if (document().settings().spatialNavigationEnabled()) {
             if (!m_activeSelectionState)
                 return;
         }
@@ -1237,7 +1236,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         int keyCode = keyboardEvent->keyCode();
         bool handled = false;
 
-        if (keyCode == ' ' && isSpatialNavigationEnabled(document().protectedFrame().get())) {
+        if (keyCode == ' ' && document().settings().spatialNavigationEnabled()) {
             // Use space to toggle arrow key handling for selection change or spatial navigation.
             m_activeSelectionState = !m_activeSelectionState;
             keyboardEvent->setDefaultHandled();
@@ -1498,7 +1497,7 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
             handled = true;
         }
 
-        if (isSpatialNavigationEnabled(frame.get())) {
+        if (document().settings().spatialNavigationEnabled()) {
             // Check if the selection moves to the boundary.
             if (keyIdentifier == "Left"_s || keyIdentifier == "Right"_s || ((keyIdentifier == "Down"_s || keyIdentifier == "Up"_s) && endIndex == m_activeSelectionEndIndex))
                 return;
@@ -1514,9 +1513,9 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
             setActiveSelectionEndIndex(endIndex);
 
 #if PLATFORM(COCOA)
-            m_allowsNonContiguousSelection = m_multiple && isSpatialNavigationEnabled(frame.get());
+            m_allowsNonContiguousSelection = m_multiple && document().settings().spatialNavigationEnabled();
 #else
-            m_allowsNonContiguousSelection = m_multiple && (isSpatialNavigationEnabled(frame.get()) || keyboardEvent->ctrlKey());
+            m_allowsNonContiguousSelection = m_multiple && (document().settings().spatialNavigationEnabled() || keyboardEvent->ctrlKey());
 #endif
             bool selectNewItem = keyboardEvent->shiftKey() || !m_allowsNonContiguousSelection;
 

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -32,7 +32,6 @@
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "NodeTraversal.h"
-#include "SpatialNavigation.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -136,7 +135,7 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
     // Tested in WinIE, and even for RTL, left still means previous radio button (and so moves
     // to the right).  Seems strange, but we'll match it.
     // However, when using Spatial Navigation, we need to be able to navigate without changing the selection.
-    if (isSpatialNavigationEnabled(element->document().frame()))
+    if (element->document().settings().spatialNavigationEnabled())
         return ShouldCallBaseEventHandler::Yes;
     bool forward = (key == "Down"_s || key == "Right"_s);
 
@@ -190,7 +189,7 @@ bool RadioInputType::isKeyboardFocusable(KeyboardEvent* event) const
     RefPtr element = this->element();
     ASSERT(element);
     // When using Spatial Navigation, every radio button should be focusable.
-    if (isSpatialNavigationEnabled(element->document().frame()))
+    if (element->document().settings().spatialNavigationEnabled())
         return true;
 
     // Never allow keyboard tabbing to leave you in the same radio group.  Always

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -119,7 +119,6 @@
 #include "SelectionRestorationMode.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
-#include "SpatialNavigation.h"
 #include "StaticPasteboard.h"
 #include "StyleCachedImage.h"
 #include "TextEvent.h"
@@ -4909,7 +4908,7 @@ void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, Keybo
 {
     ASSERT(event.type() == eventNames().keydownEvent);
 
-    if (!isSpatialNavigationEnabled(protectedFrame().ptr())) {
+    if (!m_frame->document()->settings().spatialNavigationEnabled()) {
         ScrollLogicalDirection direction;
         switch (focusDirection) {
         case FocusDirection::Down:

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -86,11 +86,6 @@ FocusCandidate::FocusCandidate(Node* node, FocusDirection direction)
     isOffscreenAfterScrolling = hasOffscreenRect(protectedVisibleNode.get(), direction);
 }
 
-bool isSpatialNavigationEnabled(const LocalFrame* frame)
-{
-    return (frame && frame->settings().spatialNavigationEnabled());
-}
-
 static RectsAlignment alignmentForRects(FocusDirection direction, const LayoutRect& curRect, const LayoutRect& targetRect, const LayoutSize& viewSize)
 {
     // If we found a node in full alignment, but it is too far away, ignore it.

--- a/Source/WebCore/page/SpatialNavigation.h
+++ b/Source/WebCore/page/SpatialNavigation.h
@@ -44,8 +44,6 @@ inline int fudgeFactor()
     return 2;
 }
 
-bool isSpatialNavigationEnabled(const LocalFrame*);
-
 // Spatially speaking, two given elements in a web page can be:
 // 1) Fully aligned: There is a full intersection between the rects, either
 //    vertically or horizontally.


### PR DESCRIPTION
#### 663734c9139709404e1b1a556c720814bd2dfaa3
<pre>
Remove `isSpatialNavigationEnabled`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289827">https://bugs.webkit.org/show_bug.cgi?id=289827</a>
<a href="https://rdar.apple.com/147078730">rdar://147078730</a>

Reviewed by Ryosuke Niwa.

We can just consult `Document::settings()` directly.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::modify):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::platformHandleKeydownEvent):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::listBoxDefaultEventHandler):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::handleKeydownEvent):
(WebCore::RadioInputType::isKeyboardFocusable const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultArrowEventHandler):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::isSpatialNavigationEnabled): Deleted.
* Source/WebCore/page/SpatialNavigation.h:

Canonical link: <a href="https://commits.webkit.org/292212@main">https://commits.webkit.org/292212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e58d3dab4e7751f1b59878975afb6e05853ff08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95287 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14887 "Build is in progress. Recent messages:Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102369 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22335 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16293 "Failed to checkout and rebase branch from PR 42512") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81658 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81062 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15588 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27440 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->