### PR TITLE
Correct parsing of javascript: URLs

### DIFF
--- a/LayoutTests/fast/loader/comment-only-javascript-url-expected.txt
+++ b/LayoutTests/fast/loader/comment-only-javascript-url-expected.txt
@@ -1,17 +1,13 @@
 ALERT: 0
 ALERT: 1
 ALERT: 2
-ALERT: 3
-ALERT: 4
-ALERT: 5
-ALERT: 6
 Tests that we properly handle JavaScript URLs containing comment characters, newlines, and carriage returns.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS No JavaScript URLs executed.
-PASS JavaScript URLs were executed.
+PASS Ignorable JavaScript URLs were ignored.
+PASS All executable JavaScript URLs were executed.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/loader/comment-only-javascript-url.html
+++ b/LayoutTests/fast/loader/comment-only-javascript-url.html
@@ -13,52 +13,46 @@ var count = 0;
 </head>
 <body>
 <script>
-function filtered(url){
-    var parser = document.createElement('a');
+function maybeClick(url) {
+    const parser = document.createElement('a');
     parser.href = url;
-    if (parser.protocol.indexOf("javascript") == -1) {
-  	    parser.click();
-    }
-}
-
-function unfiltered(url){
-    var parser = document.createElement('a');
-    parser.href = url;
-    if (parser.protocol === "javascript:") {
-  	    parser.click();
-    };
+    parser.click();
 }
 
 description("Tests that we properly handle JavaScript URLs containing comment characters, newlines, and carriage returns.");
 
-let cases = [ "javascript:alert(count); ++count;",
+const ignoreCases = [
     "javascript:// A fun test%0aalert(count); ++count;",
     "javascript://:%0aalert(count); ++count;",
     "javascript://:%0dalert(count); ++count;",
-    "javascript://:%0a%0dalert(count); ++count;",
+    "javascript://:%0a%0dalert(count); ++count;"
+];
+
+const executeCases = [
+    "javascript:alert(count); ++count;",
     "javascript://%0a://%0dalert(count); ++count;",
     "javascript://%0d//:%0aalert(count); ++count;"
 ];
 
-for (var c in cases)
-    filtered(cases[c]);
+for (const c of ignoreCases)
+    maybeClick(c);
 
 setTimeout(function () {
-    if (!count)
-        testPassed("No JavaScript URLs executed.");
+    if (count)
+        testFailed("A to be ignored JavaScript URL was executed.");
     else
-        testFailed("JavaScript URLs were executed.")
+        testPassed("Ignorable JavaScript URLs were ignored.");
 
-    for (var c in cases)
-        unfiltered(cases[c]);
+    for (const c of executeCases)
+        maybeClick(c);
 
-    setTimeout(function() {
-        if (count == cases.length)
-            testPassed("JavaScript URLs were executed.")
+    setTimeout(() => {
+        if (count != executeCases.length)
+            testFailed("An executable JavaScript URLs was ignored.");
         else
-            testFailed("No JavaScript URLs executed.");
+            testPassed("All executable JavaScript URLs were executed.");
 
-    	finishJSTest();        
+        finishJSTest();
     }, 0);
 }, 0);
 </script>

--- a/LayoutTests/http/tests/security/denied-base-url-javascript-url-expected.txt
+++ b/LayoutTests/http/tests/security/denied-base-url-javascript-url-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Blocked setting javascript:// This is JavaScript as the base URL because it does not have an allowed scheme.
+CONSOLE MESSAGE: Blocked setting javascript:// This is JavaScript as the base URL because it is not a valid URL.
 
 PASS 'javascript:' is an invalid base URL.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_include=javascript-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_include=javascript-expected.txt
@@ -9,7 +9,7 @@ PASS Parsing: <> against <about:blank>
 PASS Parsing: <javascript://example.com:8080/pathname?search#hash> against <about:blank>
 PASS Parsing: <javascript:///test> against <about:blank>
 PASS Parsing: <javascript://test/a/../b> against <about:blank>
-FAIL Parsing: <javascript://:443> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
-FAIL Parsing: <javascript://test:test> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
-FAIL Parsing: <javascript://[:1]> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
+PASS Parsing: <javascript://:443> against <about:blank>
+PASS Parsing: <javascript://test:test> against <about:blank>
+PASS Parsing: <javascript://[:1]> against <about:blank>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element_include=javascript-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element_include=javascript-expected.txt
@@ -10,7 +10,7 @@ PASS Parsing: <> against <about:blank>
 PASS Parsing: <javascript://example.com:8080/pathname?search#hash> against <about:blank>
 PASS Parsing: <javascript:///test> against <about:blank>
 PASS Parsing: <javascript://test/a/../b> against <about:blank>
-FAIL Parsing: <javascript://:443> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
-FAIL Parsing: <javascript://test:test> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
-FAIL Parsing: <javascript://[:1]> against <about:blank> assert_unreached: Expected URL to fail parsing Reached unreachable code
+PASS Parsing: <javascript://:443> against <about:blank>
+PASS Parsing: <javascript://test:test> against <about:blank>
+PASS Parsing: <javascript://[:1]> against <about:blank>
 Link with embedded \n is parsed correctly

--- a/LayoutTests/imported/w3c/web-platform-tests/url/javascript-urls.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/javascript-urls.window-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected token ':'
-
-FAIL javascript: URL that fails to parse due to invalid host assert_equals: Property is undefined immediately after the click expected (undefined) undefined but got (number) 1
+PASS javascript: URL that fails to parse due to invalid host
 PASS javascript: URL that fails to parse due to invalid host and has a U+0009 in scheme
 PASS javascript: URL with extra slashes at the start
 FAIL javascript: URL without an opaque path assert_equals: Property is undefined immediately after the click expected (undefined) undefined but got (number) 1

--- a/LayoutTests/platform/glib/fast/loader/javascript-url-hierarchical-execution-expected.txt
+++ b/LayoutTests/platform/glib/fast/loader/javascript-url-hierarchical-execution-expected.txt
@@ -1,0 +1,11 @@
+Policy delegate: attempt to load javascript://Spaceballs: The Comment! with navigation type 'link clicked'
+<rdar://problem/6904941> and https://bugs.webkit.org/show_bug.cgi?id=25300
+
+This tests to see what WebKit does with javascript urls of the form "javascript://".
+On the one hand, these are detected as hierarchical urls and usually marked invalid.
+On the other hand, the contents after "javascript:" are valid javascript code - a comment - that should be executed.
+If you click the link below and WebKit navigates - probably to an error page - then we're marking it as an invalid hierarchical URL and not trying to execute it.
+Instead, clicking it should appear to do nothing and you should remain at this page.
+In DumpRenderTree, if the custom policy delegate indicates that a load was attempted, then the test failed.
+
+Click me to test

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -379,7 +379,7 @@ bool isDefaultPortForProtocol(uint16_t port, StringView protocol)
 
 bool URL::protocolIsJavaScript() const
 {
-    return WTF::protocolIsJavaScript(string());
+    return protocolIs("javascript"_s);
 }
 
 bool URL::protocolIs(StringView protocol) const
@@ -956,9 +956,9 @@ String URL::strippedForUseAsReport() const
     return makeString(StringView(m_string).left(m_userStart), StringView(m_string).substring(end, m_pathEnd - end));
 }
 
-bool protocolIsJavaScript(StringView string)
+bool isValidJavaScriptURL(StringView string)
 {
-    return protocolIsInternal(string, "javascript"_s);
+    return URL(string.toStringWithoutCopying()).protocolIsJavaScript();
 }
 
 bool protocolIsInHTTPFamily(StringView url)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -310,13 +310,13 @@ WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, NOESCAPE const Fun
 WTF_EXPORT_PRIVATE const URL& NODELETE aboutBlankURL();
 WTF_EXPORT_PRIVATE const URL& NODELETE aboutSrcDocURL();
 
+WTF_EXPORT_PRIVATE bool isValidJavaScriptURL(StringView url);
+
 // Functions to do URL operations on strings.
 // These are operations that aren't faster on a parsed URL.
 // These are also different from the WTF::URL functions in that they don't require the string to be a valid and parsable URL.
-// This is especially important because valid javascript URLs are not necessarily considered valid by WTF::URL.
 
 WTF_EXPORT_PRIVATE bool protocolIs(StringView url, ASCIILiteral protocol);
-WTF_EXPORT_PRIVATE bool protocolIsJavaScript(StringView url);
 WTF_EXPORT_PRIVATE bool NODELETE protocolIsInHTTPFamily(StringView url);
 
 WTF_EXPORT_PRIVATE std::optional<uint16_t> defaultPortForProtocol(StringView protocol);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4894,9 +4894,12 @@ void Document::processBaseElement()
     if (!href.isNull())
         baseElementURL = completeURL(href, fallbackBaseURL());
     if (m_baseElementURL != baseElementURL) {
-        if (!protect(contentSecurityPolicy())->allowBaseURI(baseElementURL))
+        if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isEmpty() && !baseElementURL.isValid()) {
             m_baseElementURL = { };
-        else if (settings().shouldRestrictBaseURLSchemes() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL)) {
+            addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked setting "_s, baseElementURL.stringCenterEllipsizedToLength(), " as the base URL because it is not a valid URL."_s));
+        } else if (!protect(contentSecurityPolicy())->allowBaseURI(baseElementURL))
+            m_baseElementURL = { };
+        else if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isEmpty() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL)) {
             m_baseElementURL = { };
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked setting "_s, baseElementURL.stringCenterEllipsizedToLength(), " as the base URL because it does not have an allowed scheme."_s));
         } else

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2855,7 +2855,7 @@ bool Element::isEventHandlerAttribute(const Attribute& attribute) const
 
 bool Element::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
-    return isURLAttribute(attribute) && WTF::protocolIsJavaScript(attribute.value());
+    return isURLAttribute(attribute) && WTF::isValidJavaScriptURL(attribute.value());
 }
 
 void Element::stripScriptingAttributes(Vector<Attribute>& attributeVector) const

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -39,10 +39,7 @@ String URLDecomposition::origin() const
 
 String URLDecomposition::protocol() const
 {
-    auto fullURL = this->fullURL();
-    if (WTF::protocolIsJavaScript(fullURL.string()))
-        return "javascript:"_s;
-    return makeString(fullURL.protocol(), ':');
+    return makeString(this->fullURL().protocol(), ':');
 }
 
 void URLDecomposition::setProtocol(StringView value)

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -452,7 +452,7 @@ void InspectorFrontendHost::killText(const String& text, bool shouldPrependToKil
 
 void InspectorFrontendHost::openURLExternally(const String& url)
 {
-    if (WTF::protocolIsJavaScript(url))
+    if (WTF::isValidJavaScriptURL(url))
         return;
 
     if (m_client)

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1009,9 +1009,9 @@ String DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWind
     return makeString(message, "Protocols, domains, and ports must match."_s);
 }
 
-bool DOMWindow::isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const String& urlString)
+bool DOMWindow::isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const URL& url)
 {
-    if (!WTF::protocolIsJavaScript(urlString))
+    if (!url.protocolIsJavaScript())
         return false;
 
     // If this LocalDOMWindow isn't currently active in the Frame, then there's no
@@ -1051,7 +1051,7 @@ bool DOMWindow::passesSetLocationSecurityChecks(const LocalDOMWindow& activeWind
     if (navigationState == CanNavigateState::Unable)
         return false;
 
-    if (isInsecureScriptAccess(activeWindow, completedURL.string()))
+    if (isInsecureScriptAccess(activeWindow, completedURL))
         return false;
     return true;
 }

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -229,7 +229,7 @@ public:
     bool isCurrentlyDisplayedInFrame() const;
     void printErrorMessage(const String&) const;
     String crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin);
-    bool isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const String& urlString);
+    bool isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const URL&);
 
 protected:
     bool passesSetLocationSecurityChecks(const LocalDOMWindow& activeWindow, const URL& completedURL, CanNavigateState& navigationState);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2881,7 +2881,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     }
 
     RefPtr window = newFrame->window();
-    if (window && window->isInsecureScriptAccess(activeWindow, completedURL.string()))
+    if (window && window->isInsecureScriptAccess(activeWindow, completedURL))
         return noopener ? RefPtr<Frame> { nullptr } : newFrame;
 
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
@@ -2979,7 +2979,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
 
         URL completedURL = protect(firstFrame->document())->completeURL(urlString);
 
-        if (protect(targetFrame->window())->isInsecureScriptAccess(activeWindow, completedURL.string()))
+        if (protect(targetFrame->window())->isInsecureScriptAccess(activeWindow, completedURL))
             return &targetFrame->windowProxy();
 
         if (urlString.isEmpty())

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -178,6 +178,7 @@ bool SecurityPolicy::shouldInheritSecurityOriginFromOwner(const URL& url)
 bool SecurityPolicy::isBaseURLSchemeAllowed(const URL& url)
 {
     // See <https://github.com/whatwg/html/issues/2249>.
+    ASSERT(url.isValid());
     return !url.protocolIsData() && !url.protocolIsJavaScript();
 }
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -150,11 +150,11 @@ bool SVGAnimationElement::isSupportedAttribute(const QualifiedName& attrName)
 bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
     if (attribute.name() == SVGNames::fromAttr || attribute.name() == SVGNames::toAttr)
-        return WTF::protocolIsJavaScript(attribute.value());
+        return WTF::isValidJavaScriptURL(attribute.value());
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue))
+            if (WTF::isValidJavaScriptURL(innerValue))
                 return true;
         }
         return false;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4265,6 +4265,10 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
 
     if (m_policyDelegateEnabled) {
         auto url = adoptWK(WKURLRequestCopyURL(request.get()));
+        if (!url) {
+            WKFramePolicyListenerUse(listener);
+            return;
+        }
         auto urlScheme = adoptWK(WKURLCopyScheme(url.get()));
 
         StringBuilder stringBuilder;


### PR DESCRIPTION
#### ec67268e3a28ca49a6b63ae51114c5edd4f5ed96
<pre>
Correct parsing of javascript: URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=289831">https://bugs.webkit.org/show_bug.cgi?id=289831</a>

Reviewed by Chris Dumez.

Switch URL::protocolIsJavaScript() from a string prefix check to a
scheme check. With 207670@main we more eagerly recognized non-parseable
URLs as javascript: URLs to align with other browsers, but other
browsers ignore non-parseable javascript: URLs these days and so should
we. The free function protocolIsJavaScript() is renamed to
isJavaScriptURL() and now parses its input first.

The reason this does not make us fully pass
url/javascript-urls.window.js like Chrome is because we don&apos;t execute
javascript: URLs from a task.

Since invalid javascript: URLs no longer match protocolIsJavaScript(),
callers that relied on the string prefix check needed updating:

- URLDecomposition::protocol() had a workaround for javascript: URLs
  that parsed as hierarchical — no longer needed since those now
  properly fail to parse.

- DOMWindow::isInsecureScriptAccess() now takes a const URL&amp; and uses
  the scheme check. Invalid javascript: URLs won&apos;t match, but they also
  can&apos;t execute since the downstream execution path uses the same
  check.

- SecurityPolicy::isBaseURLSchemeAllowed() now asserts url.isValid().
  Document::processBaseElement() handles invalid URLs before calling it:
  empty URLs (no base element) are allowed, non-empty invalid URLs are
  blocked behind the existing shouldRestrictBaseURLSchemes setting.

- WebKitTestRunner&apos;s decidePolicyForNavigationAction crashed on invalid
  URLs because the C API (WKURLRequestCopyURL) returns null for them
  and the code didn&apos;t null-check. Added a null check. (We do want
  invalid URLs to be able to reach this far unfortunately.
  TestWebKitAPI.WebKit.NavigateToInvalidURL and
  TestWebKitAPI.WKNavigationAction.BlobRequestBody both verify this but
  were using a Cocoa API that did not crash. Reaching this point with
  an invalid javascript: URL is what&apos;s novel, but should be okay.)

Canonical link: <a href="https://commits.webkit.org/311381@main">https://commits.webkit.org/311381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2891fe00a8b011d11c02f12e3af47749a4a518b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165629 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102127 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22733 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20946 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13401 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148856 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168112 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17641 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129676 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87471 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17236 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188768 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93392 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->