### PR TITLE
REGRESSION(291982@main): Null pointer deference may happen if the page contains an SVGImage

### DIFF
--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -211,6 +211,9 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
 bool SVGImage::hasPaintedHDRContent() const
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    if (!m_page)
+        return false;
+
     if (RefPtr localTopDocument = m_page->localTopDocument())
         return localTopDocument->hasPaintedHDRContent();
 #endif


### PR DESCRIPTION
#### 04f643451ef291de53da0a5afbf9dee728f067d5
<pre>
REGRESSION(291982@main): Null pointer deference may happen if the page contains an SVGImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=289832">https://bugs.webkit.org/show_bug.cgi?id=289832</a>
<a href="https://rdar.apple.com/147082160">rdar://147082160</a>

Reviewed by Simon Fraser.

SVGImage::hasPaintedHDRContent() needs to null-check m_page.

* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::hasPaintedHDRContent const):

Canonical link: <a href="https://commits.webkit.org/292203@main">https://commits.webkit.org/292203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c1e5269c4b59155a47e0df513584e674baa114

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72655 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29930 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11322 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3747 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45120 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102362 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22328 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81048 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25619 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15298 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22298 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->