### PR TITLE
Simplify file locking APIs

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -161,7 +161,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     String cacheFilename = [m_cachePath path];
 
-    auto handle = FileSystem::openAndLockFile(cacheFilename, FileSystem::FileOpenMode::Read, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
+    auto handle = FileSystem::openFile(cacheFilename, FileSystem::FileOpenMode::Read, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
     if (!handle)
         return;
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1331,7 +1331,7 @@ public:
         });
 
         String filename = cachePath();
-        auto handle = FileSystem::openAndLockFile(filename, FileSystem::FileOpenMode::ReadWrite, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
+        auto handle = FileSystem::openFile(filename, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
         if (!handle)
             return;
 
@@ -1375,7 +1375,7 @@ private:
         if (filename.isNull())
             return;
 
-        auto handle = FileSystem::openAndLockFile(filename, FileSystem::FileOpenMode::Read, { FileSystem::FileLockMode::Shared, FileSystem::FileLockMode::Nonblocking });
+        auto handle = FileSystem::openFile(filename, FileSystem::FileOpenMode::Read, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Shared, FileSystem::FileLockMode::Nonblocking });
         if (!handle)
             return;
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -83,6 +83,7 @@ static void dumpWasmSource(const Vector<uint8_t>& source)
     auto fileHandle = FileSystem::openFile(WTF::makeString(unsafeSpan(file), (count++), ".wasm"_s),
         FileSystem::FileOpenMode::Truncate,
         FileSystem::FileAccessPermission::All,
+        { },
         /* failIfFileExists = */ true);
     if (!fileHandle) {
         dataLogLn("Error dumping wasm");

--- a/Source/WTF/wtf/FileHandle.cpp
+++ b/Source/WTF/wtf/FileHandle.cpp
@@ -32,11 +32,19 @@ namespace WTF::FileSystemImpl {
 
 FileHandle::FileHandle() = default;
 
+FileHandle::FileHandle(PlatformFileHandle handle, OptionSet<FileLockMode> lockMode)
+    : m_handle(handle)
+{
+#if USE(FILE_LOCK)
+    if (lockMode)
+        lock(lockMode);
+#else
+    UNUSED_PARAM(lockMode);
+#endif
+}
+
 FileHandle::FileHandle(FileHandle&& other)
     : m_handle(std::exchange(other.m_handle, std::nullopt))
-#if USE(FILE_LOCK)
-    , m_isLocked(std::exchange(other.m_isLocked, false))
-#endif
 { }
 
 FileHandle::~FileHandle()
@@ -49,9 +57,6 @@ FileHandle& FileHandle::operator=(FileHandle&& other)
     close();
 
     m_handle = std::exchange(other.m_handle, std::nullopt);
-#if USE(FILE_LOCK)
-    m_isLocked = std::exchange(other.m_isLocked, false);
-#endif
     return *this;
 }
 

--- a/Source/WTF/wtf/FileHandle.h
+++ b/Source/WTF/wtf/FileHandle.h
@@ -71,9 +71,9 @@ class FileHandle {
 public:
     WTF_EXPORT_PRIVATE FileHandle();
 
-    static FileHandle adopt(PlatformFileHandle handle)
+    static FileHandle adopt(PlatformFileHandle handle, OptionSet<FileLockMode> lockMode = { })
     {
-        return FileHandle { handle };
+        return FileHandle { handle, lockMode };
     }
 
     WTF_EXPORT_PRIVATE FileHandle(FileHandle&&);
@@ -91,8 +91,6 @@ public:
     WTF_EXPORT_PRIVATE int64_t read(std::span<uint8_t>);
 
     WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readAll();
-    WTF_EXPORT_PRIVATE bool lock(OptionSet<FileLockMode>);
-    WTF_EXPORT_PRIVATE bool unlock();
     WTF_EXPORT_PRIVATE bool truncate(int64_t offset);
     WTF_EXPORT_PRIVATE std::optional<uint64_t> size();
 
@@ -103,17 +101,14 @@ public:
     WTF_EXPORT_PRIVATE std::optional<PlatformFileID> id();
 
 private:
-    explicit FileHandle(PlatformFileHandle handle)
-        : m_handle(handle)
-    {
-    }
+    WTF_EXPORT_PRIVATE FileHandle(PlatformFileHandle, OptionSet<FileLockMode>);
 
+#if USE(FILE_LOCK)
+    bool lock(OptionSet<FileLockMode>);
+#endif
     void close();
 
     Markable<PlatformFileHandle, PlatformHandleTraits> m_handle;
-#if USE(FILE_LOCK)
-    bool m_isLocked { false };
-#endif
 };
 
 } // namespace FileSystemImpl

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -354,13 +354,6 @@ bool MappedFileData::mapFileHandle(FileHandle& handle, FileOpenMode openMode, Ma
 }
 #endif
 
-FileHandle openAndLockFile(const String& path, FileOpenMode openMode, OptionSet<FileLockMode> lockMode)
-{
-    auto handle = openFile(path, openMode);
-    handle.lock(lockMode);
-    return handle;
-}
-
 #if !PLATFORM(IOS_FAMILY)
 bool isSafeToUseMemoryMapForPath(const String&)
 {
@@ -400,7 +393,7 @@ bool markPurgeable(const String&)
 MappedFileData createMappedFileData(const String& path, size_t bytesSize, FileHandle* outputHandle)
 {
     constexpr bool failIfFileExists = true;
-    auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::User, failIfFileExists);
+    auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::User, { }, failIfFileExists);
 
     if (!handle)
         return { };

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -134,9 +134,7 @@ WTF_EXPORT_PRIVATE String createTemporaryFile(StringView prefix, StringView suff
 #if PLATFORM(COCOA)
 WTF_EXPORT_PRIVATE std::pair<FileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix);
 #endif
-WTF_EXPORT_PRIVATE FileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, bool failIfFileExists = false);
-
-WTF_EXPORT_PRIVATE FileHandle openAndLockFile(const String&, FileOpenMode, OptionSet<FileLockMode> = FileLockMode::Exclusive);
+WTF_EXPORT_PRIVATE FileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, OptionSet<FileLockMode> = { }, bool failIfFileExists = false);
 
 // Appends the contents of the file found at 'path' to the open FileHandle.
 // Returns true if the write was successful, false if it was not.

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -57,7 +57,7 @@ namespace WTF {
 
 namespace FileSystemImpl {
 
-FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission permission, bool failIfFileExists)
+FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission permission, OptionSet<FileLockMode> lockMode, bool failIfFileExists)
 {
     CString fsRep = fileSystemRepresentation(path);
 
@@ -91,7 +91,7 @@ FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission 
     else if (permission == FileAccessPermission::All)
         permissionFlag |= (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 
-    return FileHandle::adopt(open(fsRep.data(), platformFlag, permissionFlag));
+    return FileHandle::adopt(open(fsRep.data(), platformFlag, permissionFlag), lockMode);
 }
 
 std::optional<WallTime> fileCreationTime(const String& path)

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -124,11 +124,8 @@ std::optional<PlatformFileID> FileHandle::id()
 
 void FileHandle::close()
 {
-    if (!m_handle)
-        return;
-
-    unlock();
-    ::CloseHandle(*std::exchange(m_handle, std::nullopt));
+    if (auto handle = std::exchange(m_handle, std::nullopt))
+        ::CloseHandle(*handle);
 }
 
 std::optional<uint64_t> FileHandle::size()
@@ -141,18 +138,6 @@ std::optional<uint64_t> FileHandle::size()
         return std::nullopt;
 
     return getFileSizeFromByHandleFileInformationStructure(fileInformation);
-}
-
-bool FileHandle::lock(OptionSet<FileLockMode>)
-{
-    // Not implemented.
-    return false;
-}
-
-bool FileHandle::unlock()
-{
-    // Not implemented.
-    return false;
 }
 
 } // WTF::FileSystemImpl

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -177,7 +177,7 @@ std::pair<String, FileHandle> openTemporaryFile(StringView, StringView suffix)
     return { proposedPath, WTFMove(handle) };
 }
 
-FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission, bool failIfFileExists)
+FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission, OptionSet<FileLockMode> lockMode, bool failIfFileExists)
 {
     DWORD desiredAccess = 0;
     DWORD creationDisposition = 0;
@@ -202,7 +202,7 @@ FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission,
         creationDisposition = CREATE_NEW;
 
     String destination = path;
-    return FileHandle::adopt(CreateFile(destination.wideCharacters().data(), desiredAccess, shareMode, nullptr, creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr));
+    return FileHandle::adopt(CreateFile(destination.wideCharacters().data(), desiredAccess, shareMode, nullptr, creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr), lockMode);
 }
 
 String localUserSpecificStorageDirectory()

--- a/Source/WebCore/Modules/webdatabase/OriginLock.cpp
+++ b/Source/WebCore/Modules/webdatabase/OriginLock.cpp
@@ -45,7 +45,7 @@ void OriginLock::lock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     m_mutex.lock();
 
 #if USE(FILE_LOCK)
-    m_lockHandle = FileSystem::openAndLockFile(m_lockFileName, FileSystem::FileOpenMode::Truncate);
+    m_lockHandle = FileSystem::openFile(m_lockFileName, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Exclusive });
     if (!m_lockHandle) {
         // The only way we can get here is if the directory containing the lock
         // has been deleted or we were given a path to a non-existant directory.

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -159,7 +159,7 @@ void NetworkDataTaskDataURL::didDecodeDataURL(std::optional<WebCore::DataURLDeco
 
 void NetworkDataTaskDataURL::downloadDecodedData(Vector<uint8_t>&& data)
 {
-    auto downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, !m_allowOverwriteDownload);
+    auto downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, !m_allowOverwriteDownload);
     if (!downloadDestinationFile) {
 #if USE(CURL)
         ResourceError error(CURLE_WRITE_ERROR, m_response.url());

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -308,7 +308,7 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             invalidateAndCancel();
             break;
         case PolicyAction::Download: {
-            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, !m_allowOverwriteDownload);
+            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, !m_allowOverwriteDownload);
             if (!m_downloadDestinationFile) {
                 if (m_client)
                     m_client->didCompleteWithError(ResourceError(CURLE_WRITE_ERROR, m_response.url()));

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -54,7 +54,7 @@ void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)
     if (!rawData)
         return;
 
-    auto handle = FileSystem::openAndLockFile(path, FileSystem::FileOpenMode::Truncate);
+    auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { FileSystem::FileLockMode::Exclusive });
     if (!handle)
         return;
 

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -194,7 +194,7 @@ static OSStatus enableSandboxStyleFileQuarantine()
 #if USE(CACHE_COMPILED_SANDBOX)
 static std::optional<Vector<uint8_t>> fileContents(const String& path, bool shouldLock = false, OptionSet<FileSystem::FileLockMode> lockMode = FileSystem::FileLockMode::Exclusive)
 {
-    auto fileHandle = shouldLock ? FileSystem::openAndLockFile(path, FileSystem::FileOpenMode::Read, lockMode) : FileSystem::openFile(path, FileSystem::FileOpenMode::Read);
+    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Read, FileSystem::FileAccessPermission::All, lockMode);
     if (!fileHandle)
         return std::nullopt;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -232,7 +232,7 @@ TEST_F(FileSystemTest, UnicodeDirectoryName)
 // --------------------- Truncate ----------------------------
 TEST_F(FileSystemTest, openExistingFileTruncate)
 {
-    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, false);
+    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, false);
     EXPECT_TRUE(!!handle);
     // Check the existing file WAS truncated when the operation succeded.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), 0);
@@ -243,7 +243,7 @@ TEST_F(FileSystemTest, openExistingFileTruncate)
 
 TEST_F(FileSystemTest, openExistingFileTruncateFailIfFileExists)
 {
-    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, true);
+    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, true);
     EXPECT_TRUE(!handle);
     // Check the existing file wasn't truncated when the operation failed.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData));
@@ -252,7 +252,7 @@ TEST_F(FileSystemTest, openExistingFileTruncateFailIfFileExists)
 // -------------------- ReadWrite ----------------------------
 TEST_F(FileSystemTest, openExistingFileReadWrite)
 {
-    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, false);
+    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, { }, false);
     EXPECT_TRUE(!!handle);
     // ReadWrite mode shouldn't truncate the contents of the file.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData));
@@ -264,7 +264,7 @@ TEST_F(FileSystemTest, openExistingFileReadWrite)
 
 TEST_F(FileSystemTest, openExistingFileReadWriteFailIfFileExists)
 {
-    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, true);
+    auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, { }, true);
     EXPECT_TRUE(!handle);
     // Check the existing file wasn't truncated when the operation failed.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData));
@@ -287,7 +287,7 @@ TEST_F(FileSystemTest, openNonExistingFileTruncate)
     auto doesNotExistPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist"_s);
     EXPECT_FALSE(FileSystem::fileExists(doesNotExistPath));
 
-    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, false);
+    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, false);
     EXPECT_TRUE(!!handle);
 
     // The file exists at the latest by the time we request a flush (or close the handle).
@@ -300,7 +300,7 @@ TEST_F(FileSystemTest, openNonExistingFileTruncateFailIfFileExists)
     auto doesNotExistPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist"_s);
     EXPECT_FALSE(FileSystem::fileExists(doesNotExistPath));
 
-    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, true);
+    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, { }, true);
     EXPECT_TRUE(!!handle);
 
     // The file exists at the latest by the time we request a flush (or close the handle).
@@ -315,7 +315,7 @@ TEST_F(FileSystemTest, openNonExistingFileReadWrite)
     auto doesNotExistPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist"_s);
     EXPECT_FALSE(FileSystem::fileExists(doesNotExistPath));
 
-    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, false);
+    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, { }, false);
     EXPECT_TRUE(!!handle);
 
     // The file exists at the latest by the time we request a flush (or close the handle).
@@ -327,7 +327,7 @@ TEST_F(FileSystemTest, openNonExistingFileReadWriteFailIfFileExists)
     auto doesNotExistPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist"_s);
     EXPECT_FALSE(FileSystem::fileExists(doesNotExistPath));
 
-    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, true);
+    auto handle = FileSystem::openFile(doesNotExistPath, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::All, { }, true);
     EXPECT_TRUE(!!handle);
 
     // The file exists at the latest by the time we request a flush (or close the handle).


### PR DESCRIPTION
#### f2eb4230adf7e73e1236c3187687cd6ef8621e21
<pre>
Simplify file locking APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=289833">https://bugs.webkit.org/show_bug.cgi?id=289833</a>

Reviewed by Geoffrey Garen.

Simplify file locking APIs:
- Drop openFileAndLock() and instead pass the lockMode to openFile()
- Drop FileHandle::unlock() since it is not needed. We always hold the lock
  until we close the files and there is no need to unlock before closing the file
- Drop FileHandle::m_isLocked as it is no longer needed
- Make FileHandle::lock() private and instead pass the lockMode to the constructor
  since we never need to lock a file outside of openFile().

* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript readCache]):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
* Source/WTF/wtf/FileHandle.cpp:
(WTF::FileSystemImpl::FileHandle::FileHandle):
(WTF::FileSystemImpl::FileHandle::operator=):
* Source/WTF/wtf/FileHandle.h:
(WTF::FileSystemImpl::FileHandle::adopt):
(WTF::FileSystemImpl::FileHandle::FileHandle): Deleted.
(): Deleted.
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::createMappedFileData):
(WTF::FileSystemImpl::openAndLockFile): Deleted.
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::openFile):
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::close):
(WTF::FileSystemImpl::FileHandle::lock):
(WTF::FileSystemImpl::FileHandle::unlock): Deleted.
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openFile):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::close):
(WTF::FileSystemImpl::FileHandle::lock): Deleted.
(WTF::FileSystemImpl::FileHandle::unlock): Deleted.
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::openFile):
* Source/WebCore/Modules/webdatabase/OriginLock.cpp:
* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::writeToDisk):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):

Canonical link: <a href="https://commits.webkit.org/292222@main">https://commits.webkit.org/292222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12aabc317c1bf3d2e5ce760fda0f2d4fc64cb3d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95313 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14913 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29955 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3775 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45153 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87984 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102395 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93936 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82054 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81083 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15627 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15311 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27467 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116624 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21990 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->