### PR TITLE
platform-enabled-swift-args.resp introduces a WTF:installhdrs dependency on WebKitAdditions

### DIFF
--- a/Source/WTF/Scripts/generate-platform-args
+++ b/Source/WTF/Scripts/generate-platform-args
@@ -17,7 +17,8 @@ system_framework_search_paths = shlex.split(
 system_header_search_paths = shlex.split(
     '{SYSTEM_HEADER_SEARCH_PATHS}'.format_map(os.environ))
 preprocessor_definitions = shlex.split(
-    'RELEASE_WITHOUT_OPTIMIZATIONS {GCC_PREPROCESSOR_DEFINITIONS}'.format_map(os.environ))
+    '__WK_GENERATING_PLATFORM_ARGS__ RELEASE_WITHOUT_OPTIMIZATIONS '
+    '{GCC_PREPROCESSOR_DEFINITIONS}'.format_map(os.environ))
 archs = shlex.split(os.environ['ARCHS'])
 
 if os.environ['DEPLOYMENT_LOCATION'] == 'YES':

--- a/Source/WTF/wtf/Platform.h
+++ b/Source/WTF/wtf/Platform.h
@@ -69,7 +69,9 @@
 
 /* ==== Platform additions: additions to Platform.h from outside the main repository ==== */
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AdditionalPlatform.h>)
+/* rdar://147082710: Temporarily work around unavailability of WebKitAdditions
+   when generating platform-enabled-swift-args.resp in installhdrs actions. */
+#if USE(APPLE_INTERNAL_SDK) && !defined(__WK_GENERATING_PLATFORM_ARGS__) && __has_include(<WebKitAdditions/AdditionalPlatform.h>)
 #include <WebKitAdditions/AdditionalPlatform.h>
 #endif
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -72,7 +72,9 @@
 
 /* ==== Platform additions: additions to PlatformEnable.h from outside the main repository ==== */
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AdditionalFeatureDefines.h>)
+/* rdar://147082710: Temporarily work around unavailability of WebKitAdditions
+   when generating platform-enabled-swift-args.resp in installhdrs actions. */
+#if USE(APPLE_INTERNAL_SDK) && !defined(__WK_GENERATING_PLATFORM_ARGS__) && __has_include(<WebKitAdditions/AdditionalFeatureDefines.h>)
 #include <WebKitAdditions/AdditionalFeatureDefines.h>
 #endif
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -44,7 +44,9 @@
 /* ==== Platform additions: additions to PlatformHave.h from outside the main repository ==== */
 
 // This can't use USE(APPLE_INTERNAL_SDK) because this comes before PlatformUse.h.
-#if PLATFORM(COCOA) && __has_include(<WebKitAdditions/AdditionalPlatformHave.h>)
+/* rdar://147082710: Temporarily work around unavailability of WebKitAdditions
+   when generating platform-enabled-swift-args.resp in installhdrs actions. */
+#if PLATFORM(COCOA) && !defined(__WK_GENERATING_PLATFORM_ARGS__) && __has_include(<WebKitAdditions/AdditionalPlatformHave.h>)
 #include <WebKitAdditions/AdditionalPlatformHave.h>
 #endif
 


### PR DESCRIPTION
#### ca5726399ac9febe6b09778ea9e26a57b26d6fac
<pre>
platform-enabled-swift-args.resp introduces a WTF:installhdrs dependency on WebKitAdditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=289834">https://bugs.webkit.org/show_bug.cgi?id=289834</a>
<a href="https://rdar.apple.com/147082710">rdar://147082710</a>

Reviewed by Alexey Proskuryakov.

Temporarily work around an internal build race condition by refusing to
include WebKitAdditions headers when generating
platform-enable-swift-args.resp files.

* Source/WTF/Scripts/generate-platform-args:
* Source/WTF/wtf/Platform.h:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/PlatformHave.h:

Canonical link: <a href="https://commits.webkit.org/292201@main">https://commits.webkit.org/292201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/657798f6126046ede4f9b030c9a17d907d57d1a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95284 "Build is in progress. Recent messages:Running apply-patch; Checked out pull request; 1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45784 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23314 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98287 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52993 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/94776 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45123 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87954 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93906 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22331 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82031 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/81065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25629 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22301 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27434 "Build is in progress. Recent messages:") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116594 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21960 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->