### PR TITLE
`content-visibility:auto` and zooming can result in flickering between two states

### DIFF
--- a/LayoutTests/fast/css/content-visibility-zoom-expected.txt
+++ b/LayoutTests/fast/css/content-visibility-zoom-expected.txt
@@ -1,0 +1,7 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS lastSkipped is false
+PASS lastSkipped is true
+PASS lastSkipped is true
+

--- a/LayoutTests/fast/css/content-visibility-zoom.html
+++ b/LayoutTests/fast/css/content-visibility-zoom.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+    <title>content-visibility demo</title>
+    <style>
+        body {
+            zoom: 60%;
+        }
+        #contents {
+            margin: auto;
+            text-align: center;
+            max-width: 600px;
+        }
+
+        #contents > div {
+            border: 1px solid black;
+            border-radius: 2px;
+            margin: 1em;
+            min-height: 300px;
+        }
+        
+        .cv-auto {
+            content-visibility: auto;
+        }
+        
+        .tall {
+            height: 3000px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        window.testRunner?.waitUntilDone();
+        
+        let lastSkipped = false;
+        window.addEventListener('load', async () => {            
+            const target = document.getElementById('target');
+
+            await UIHelper.ensureStablePresentationUpdate();
+            shouldBe('lastSkipped', 'false');
+            
+            const visibilityChangePromise = new Promise((resolve) => {
+                target.addEventListener('contentvisibilityautostatechange', (event) => {
+                    lastSkipped = event.skipped;
+                    resolve();
+                });
+
+                const scrollDistance = 300 * 0.6 + 15;
+                window.scrollTo(0, scrollDistance);
+            });
+
+            await visibilityChangePromise;
+            shouldBe('lastSkipped', 'true');
+
+            await UIHelper.renderingUpdate();
+            shouldBe('lastSkipped', 'true');
+
+            window.testRunner?.notifyDone()
+        }, false);        
+    </script>
+</head>
+<body>
+    <div id="contents">
+        <div id="target" class="cv-auto"></div>
+        <div class="tall"></div>
+    </div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -33,6 +33,7 @@
 #include "FrameSelection.h"
 #include "IntersectionObserverCallback.h"
 #include "IntersectionObserverEntry.h"
+#include "Logging.h"
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
 #include "RenderStyleInlines.h"
@@ -40,6 +41,7 @@
 #include "StyleOriginatedAnimation.h"
 #include "VisibleSelection.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -115,12 +117,14 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
     OptionSet<ContentRelevancy> newRelevancy;
     if (oldRelevancy)
         newRelevancy = *oldRelevancy;
+
     auto setRelevancyValue = [&](ContentRelevancy reason, bool value) {
         if (value)
             newRelevancy.add(reason);
         else
             newRelevancy.remove(reason);
     };
+
     if (relevancyToCheck.contains(ContentRelevancy::OnScreen)) {
         auto viewportProximityIterator = m_elementViewportProximities.find(target);
         auto viewportProximity = ViewportProximity::Far;
@@ -152,6 +156,8 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
 
     if (oldRelevancy && oldRelevancy == newRelevancy)
         return false;
+
+    LOG_WITH_STREAM(ContentVisibility, stream << "ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement - relevancy of " << target << " changed from " << oldRelevancy << " to " << newRelevancy);
 
     auto wasSkippedContent = target.isRelevantToUser() ? IsSkippedContent::No : IsSkippedContent::Yes;
     target.setContentRelevancy(newRelevancy);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -3135,7 +3135,7 @@ std::partial_ordering treeOrderForTesting(TreeType type, const Node& a, const No
 
 TextStream& operator<<(TextStream& ts, const Node& node)
 {
-    ts << "node "_s << &node << ' ' << node.debugDescription();
+    ts << node.debugDescription();
     return ts;
 }
 

--- a/Source/WebCore/page/IntersectionObserverEntry.cpp
+++ b/Source/WebCore/page/IntersectionObserverEntry.cpp
@@ -49,7 +49,7 @@ IntersectionObserverEntry::IntersectionObserverEntry(const Init& init)
 TextStream& operator<<(TextStream& ts, const IntersectionObserverEntry& entry)
 {
     TextStream::GroupScope scope(ts);
-    ts << "IntersectionObserverEntry "_s << &entry;
+    ts << "IntersectionObserverEntry "_s << &entry << " target " << entry.target();
     ts.dumpProperty("time"_s, entry.time());
     
     if (entry.rootBounds())

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -94,6 +94,7 @@ namespace WebCore {
     M(CompositingOverlap) \
     M(ContentFiltering) \
     M(ContentObservation) \
+    M(ContentVisibility) \
     M(Crypto) \
     M(DatabaseTracker) \
     M(DigitalCredentials) \

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2501,10 +2501,14 @@ private:
 #endif
 };
 
+// Map from computed style values (which take zoom into account) to web-exposed values, which are zoom-independent.
 inline int adjustForAbsoluteZoom(int, const RenderStyle&);
 inline float adjustFloatForAbsoluteZoom(float, const RenderStyle&);
 inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit, const RenderStyle&);
 inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize, const RenderStyle&);
+
+// Map from zoom-independent style values to computed style values (which take zoom into account).
+inline float applyZoom(float, const RenderStyle&);
 
 constexpr BorderStyle collapsedBorderStyle(BorderStyle);
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1081,6 +1081,11 @@ inline LayoutUnit adjustLayoutUnitForAbsoluteZoom(LayoutUnit value, const Render
     return LayoutUnit(value / style.usedZoom());
 }
 
+inline float applyZoom(float value, const RenderStyle& style)
+{
+    return value * style.usedZoom();
+}
+
 constexpr BorderStyle collapsedBorderStyle(BorderStyle style)
 {
     if (style == BorderStyle::Outset)


### PR DESCRIPTION
#### 2fc3a23f8c299e091d80175954782bbd5d64d527
<pre>
`content-visibility:auto` and zooming can result in flickering between two states
<a href="https://bugs.webkit.org/show_bug.cgi?id=289840">https://bugs.webkit.org/show_bug.cgi?id=289840</a>
<a href="https://rdar.apple.com/144338810">rdar://144338810</a>

Reviewed by Tim Nguyen.

If a `content-visibility:auto` element is just above the viewport, and the user has zoomed
out via Command-minus (or the CSS `zoom` property shrinks the scale), then we&apos;d enter a bimodal
state where the element would compute as skipped, then unskipped, then skipped. This happened
because the height of the box would compute as different between the skipped and unskipped state;
the value returned by `RenderBox::overrideLogicalHeightForSizeContainment()` was wrong.

This happened because the dimensions stored via `setLastRememberedLogicalWidth/Height()` failed
to take zoom into account, so fix `CallbackForContainIntrinsicSize` to scale by the zoom scale.

Other changes improve logging, adding a simple `ContentVisibility` log channel, and making the
IntersectionObserver logging less noisy.

* LayoutTests/fast/css/content-visibility-zoom-expected.txt: Added.
* LayoutTests/fast/css/content-visibility-zoom.html: Added.
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):
* Source/WebCore/dom/Document.cpp:
(WebCore::CallbackForContainIntrinsicSize):
(WebCore::Document::updateIntersectionObservations):
* Source/WebCore/dom/Node.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/IntersectionObserverEntry.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::applyZoom):

Canonical link: <a href="https://commits.webkit.org/292226@main">https://commits.webkit.org/292226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/219ea9fa142020d72b22a5448017b57f18ae238b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98313 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11371 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11084 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3772 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 22 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81716 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81090 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15620 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27464 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->