### PR TITLE
Optimize some conditions involving `shouldPlaceVerticalScrollbarOnLeft()`

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2000,7 +2000,7 @@ LayoutUnit RenderBlock::textIndentOffset() const
 LayoutUnit RenderBlock::logicalLeftOffsetForContent() const
 {
     LayoutUnit logicalLeftOffset = writingMode().isHorizontal() ? borderLeft() + paddingLeft() : borderTop() + paddingTop();
-    if (shouldPlaceVerticalScrollbarOnLeft() && isHorizontalWritingMode())
+    if (isHorizontalWritingMode() && shouldPlaceVerticalScrollbarOnLeft())
         logicalLeftOffset += verticalScrollbarWidth();
     return logicalLeftOffset;
 }
@@ -2008,7 +2008,7 @@ LayoutUnit RenderBlock::logicalLeftOffsetForContent() const
 LayoutUnit RenderBlock::logicalRightOffsetForContent() const
 {
     LayoutUnit logicalRightOffset = writingMode().isHorizontal() ? borderLeft() + paddingLeft() : borderTop() + paddingTop();
-    if (shouldPlaceVerticalScrollbarOnLeft() && isHorizontalWritingMode())
+    if (isHorizontalWritingMode() && shouldPlaceVerticalScrollbarOnLeft())
         logicalRightOffset += verticalScrollbarWidth();
     logicalRightOffset += contentBoxLogicalWidth();
     return logicalRightOffset;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4058,8 +4058,8 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
     else
         inlineConstraints.convertLogicalLeftValue(computedValues.m_position);
 
-    if (auto* container = dynamicDowncast<RenderBox>(inlineConstraints.container())) {
-        if (container->shouldPlaceVerticalScrollbarOnLeft() && isHorizontalWritingMode())
+    if (isHorizontalWritingMode()) {
+        if (auto* container = dynamicDowncast<RenderBox>(inlineConstraints.container()); container && container->shouldPlaceVerticalScrollbarOnLeft())
             computedValues.m_position += container->verticalScrollbarWidth();
     }
 
@@ -4737,7 +4737,7 @@ LayoutRect RenderBox::flippedClientBoxRect() const
     if (hasNonVisibleOverflow()) {
         // Subtract space occupied by scrollbars. They are at their physical edge in this coordinate
         // system, so order is important here: first flip, then subtract scrollbars.
-        if (shouldPlaceVerticalScrollbarOnLeft() && isHorizontalWritingMode())
+        if (isHorizontalWritingMode() && shouldPlaceVerticalScrollbarOnLeft())
             rect.move(verticalScrollbarWidth(), 0);
         rect.contract(verticalScrollbarWidth(), horizontalScrollbarHeight());
     }

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -626,7 +626,7 @@ FloatRect RenderBoxModelObject::constrainingRectForStickyPosition() const
             scrollOffset = FloatPoint() + scrollableArea->scrollOffset();
 
         float scrollbarOffset = 0;
-        if (enclosingClippingBox.hasLayer() && enclosingClippingBox.shouldPlaceVerticalScrollbarOnLeft() && scrollableArea)
+        if (scrollableArea && enclosingClippingBox.hasLayer() && enclosingClippingBox.shouldPlaceVerticalScrollbarOnLeft())
             scrollbarOffset = scrollableArea->verticalScrollbarWidth(OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, isHorizontalWritingMode());
 
         constrainingRect.setLocation(FloatPoint(scrollOffset.x() + scrollbarOffset, scrollOffset.y()));

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -520,7 +520,7 @@ void RenderView::repaintViewRectangle(const LayoutRect& repaintRect) const
         // and the Renderer that contains the iframe. This transformation must account for a
         // left scrollbar (if one exists).
         Ref frameView = this->frameView();
-        if (frameView->shouldPlaceVerticalScrollbarOnLeft() && frameView->verticalScrollbar())
+        if (frameView->verticalScrollbar() && frameView->shouldPlaceVerticalScrollbarOnLeft())
             adjustedRect.move(LayoutSize(frameView->protectedVerticalScrollbar()->occupiedWidth(), 0));
 
         ownerBox->repaintRectangle(adjustedRect);


### PR DESCRIPTION
#### 7b6ce8281fc822ebf6bf9e033144c2b088a3f2de
<pre>
Optimize some conditions involving `shouldPlaceVerticalScrollbarOnLeft()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289841">https://bugs.webkit.org/show_bug.cgi?id=289841</a>
<a href="https://rdar.apple.com/147092838">rdar://147092838</a>

Reviewed by Alan Baradlay.

`isHorizontalWritingMode()` is a bit check on the RenderObject, so test it first,
before the more expensive `shouldPlaceVerticalScrollbarOnLeft()`. Flip a few other
tests in similar ways.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::logicalLeftOffsetForContent const):
(WebCore::RenderBlock::logicalRightOffsetForContent const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::flippedClientBoxRect const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::constrainingRectForStickyPosition const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::repaintViewRectangle const):

Canonical link: <a href="https://commits.webkit.org/292221@main">https://commits.webkit.org/292221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70a5c9557b61c2d01867f7e2cc5845e27473bebc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72671 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29943 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102381 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16306 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81668 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 42 flakes 117 failures; Uploaded test results; 34 flakes 78 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change; Passed layout tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15600 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27453 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->