### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] amazon.com: Unable to select text on amazon in product description

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer-expected.txt
@@ -1,0 +1,10 @@
+Target
+Verifies that the highlight is visible when selecting text in a composited foreground layer
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS foundSelectionHighlight is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer.html
+++ b/LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-family: system-ui;
+    position: absolute;
+    height: 3000px;
+}
+
+.content {
+    font-size: 32px;
+    display: inline-block;
+}
+
+.sticky {
+    position: sticky;
+    width: 100px;
+    height: 100px;
+    top: 0;
+    border: 1px solid black;
+}
+
+.fixed {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    width: 100%;
+    height: 100%;
+    background: beige;
+    top: 0;
+    left: 0;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the highlight is visible when selecting text in a composited foreground layer");
+
+    await UIHelper.longPressElement(document.getElementById("target"));
+    await UIHelper.waitForSelectionToAppear();
+
+    let selectionRect = await UIHelper.selectionBounds();
+    let centerOfSelection = UIHelper.midPointOfRect(selectionRect);
+    let viewName = await UIHelper.frontmostViewAtPoint(centerOfSelection.x, centerOfSelection.y);
+    foundSelectionHighlight = viewName.includes('UITextSelection');
+    shouldBeTrue("foundSelectionHighlight");
+
+    if (!foundSelectionHighlight)
+        testFailed(`Found ${viewName} instead`);
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="sticky"></div>
+    <p class="content" id="target">Target</p>
+    <div id="description"></div>
+    <div id="console"></div>
+    <div class="fixed below"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6028,8 +6028,17 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
         if (!layer->isComposited())
             continue;
 
-        auto* layerBacking = layer->backing();
-        RefPtr graphicsLayer = layerBacking->scrolledContentsLayer() ?: layerBacking->graphicsLayer();
+        RefPtr graphicsLayer = [layer] -> RefPtr<GraphicsLayer> {
+            auto* backing = layer->backing();
+            if (RefPtr scrolledContentsLayer = backing->scrolledContentsLayer())
+                return scrolledContentsLayer;
+
+            if (RefPtr foregroundLayer = backing->foregroundLayer())
+                return foregroundLayer;
+
+            return backing->graphicsLayer();
+        }();
+
         if (!graphicsLayer)
             continue;
 


### PR DESCRIPTION
#### 9cb9f8b4de9e373ce6573d5ff43f30f4fad640f2
<pre>
[iOS] [SelectionHonorsOverflowScrolling] amazon.com: Unable to select text on amazon in product description
<a href="https://bugs.webkit.org/show_bug.cgi?id=289837">https://bugs.webkit.org/show_bug.cgi?id=289837</a>
<a href="https://rdar.apple.com/146977048">rdar://146977048</a>

Reviewed by Aditya Keerthi.

When `SelectionHonorsOverflowScrolling` is enabled, it&apos;s possible to get into a scenario where the
platform selection views are hosted within a layer that&apos;s covered by the layer, where the selected
content is actually painted. This may occur if the composited layer containing the selection paints
its content into a foreground layer, in the case where it has negative z-ordered compositing
descendants (refer to the new test case). The end result is that the native selection views are
covered by the `WKCompositingView` where the selected content is being rendered.

To fix this, instead of using the `graphicsLayer` of the `RenderLayer`&apos;s backing, we give priority
to the `foregroundLayer`, if it exists.

* LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-highlight-in-foreground-layer.html: Added.

Add a layout test to exercise this fix (reduced from an example Amazon product page).

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

See above.

Canonical link: <a href="https://commits.webkit.org/292213@main">https://commits.webkit.org/292213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f8849acdc37b9e1661997ad4176b5e973e9ec5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45809 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72677 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29948 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98311 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11350 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45148 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81704 "Failed to checkout and rebase branch from PR 42526") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3067 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15617 "Failed to checkout and rebase branch from PR 42526") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22326 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->