### PR TITLE
Address Safer cpp failures in ChildChangeInvalidation

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -684,7 +684,6 @@ rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
 storage/Storage.cpp
 style/AttributeChangeInvalidation.cpp
-style/ChildChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp
 style/CustomPropertyRegistry.cpp
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -73,7 +73,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
             if (isFirst && invalidationRuleSet.isNegation == IsNegation::No) {
                 // If this :has() matches ignoring this mutation, nothing actually changes and we don't need to invalidate.
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
-                auto* sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
+                RefPtr sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
                 if (sibling && selectorChecker.match(*selector, *sibling, checkingContext)) {
                     matchingHasSelectors.add(selector);
                     continue;
@@ -112,8 +112,8 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
 void ChildChangeInvalidation::invalidateForChangeOutsideHasScope()
 {
     // FIXME: This is a performance footgun. Any mutation will trigger a full document traversal.
-    if (auto* invalidationRuleSet = parentElement().styleResolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet())
-        Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(parentElement(), invalidationRuleSet);
+    if (RefPtr invalidationRuleSet = parentElement().styleResolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet())
+        Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(parentElement(), invalidationRuleSet.get());
 }
 
 void ChildChangeInvalidation::invalidateForHasBeforeMutation()
@@ -243,15 +243,15 @@ void ChildChangeInvalidation::traverseRemovedElements(Function&& function)
     auto& features = parentElement().styleResolver().ruleSets().features();
     bool needsDescendantTraversal = Style::needsDescendantTraversal(features);
 
-    auto* firstToRemove = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement->nextElementSibling() : parentElement().firstElementChild();
+    RefPtr firstToRemove = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement->nextElementSibling() : parentElement().firstElementChild();
 
-    for (auto* toRemove = firstToRemove; toRemove != m_childChange.nextSiblingElement; toRemove = toRemove->nextElementSibling()) {
+    for (RefPtr toRemove = firstToRemove; toRemove != m_childChange.nextSiblingElement; toRemove = toRemove->nextElementSibling()) {
         function(*toRemove);
 
         if (!needsDescendantTraversal)
             continue;
 
-        for (auto& descendant : descendantsOfType<Element>(*toRemove))
+        for (Ref descendant : descendantsOfType<Element>(*toRemove))
             function(descendant);
     }
 }
@@ -262,7 +262,7 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     if (!m_childChange.isInsertion())
         return;
 
-    auto* newElement = [&] {
+    RefPtr newElement = [&] {
         auto* previous = m_childChange.previousSiblingElement;
         auto* candidate = previous ? ElementTraversal::nextSibling(*previous) : ElementTraversal::firstChild(parentElement());
         if (candidate == m_childChange.nextSiblingElement)
@@ -279,7 +279,7 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     if (!needsDescendantTraversal(features))
         return;
 
-    for (auto& descendant : descendantsOfType<Element>(*newElement))
+    for (Ref descendant : descendantsOfType<Element>(*newElement))
         function(descendant);
 }
 
@@ -289,10 +289,10 @@ void ChildChangeInvalidation::traverseRemainingExistingSiblings(Function&& funct
     if (m_childChange.isInsertion() && m_childChange.type == ContainerNode::ChildChange::Type::AllChildrenReplaced)
         return;
 
-    for (auto* child = m_childChange.previousSiblingElement; child; child = child->previousElementSibling())
+    for (RefPtr child = m_childChange.previousSiblingElement; child; child = child->previousElementSibling())
         function(*child);
 
-    for (auto* child = m_childChange.nextSiblingElement; child; child = child->nextElementSibling())
+    for (RefPtr child = m_childChange.nextSiblingElement; child; child = child->nextElementSibling())
         function(*child);
 }
 
@@ -314,11 +314,11 @@ static void invalidateForForwardPositionalRules(Element& parent, Element* elemen
     if (!childrenAffected && !descendantsAffected)
         return;
 
-    for (auto* sibling = elementAfterChange; sibling; sibling = sibling->nextElementSibling()) {
+    for (RefPtr sibling = elementAfterChange; sibling; sibling = sibling->nextElementSibling()) {
         if (childrenAffected)
             sibling->invalidateStyleInternal();
         if (descendantsAffected) {
-            for (auto* siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
+            for (RefPtr siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
                 siblingChild->invalidateStyleForSubtreeInternal();
         }
     }
@@ -332,11 +332,11 @@ static void invalidateForBackwardPositionalRules(Element& parent, Element* eleme
     if (!childrenAffected && !descendantsAffected)
         return;
 
-    for (auto* sibling = elementBeforeChange; sibling; sibling = sibling->previousElementSibling()) {
+    for (RefPtr sibling = elementBeforeChange; sibling; sibling = sibling->previousElementSibling()) {
         if (childrenAffected)
             sibling->invalidateStyleInternal();
         if (descendantsAffected) {
-            for (auto* siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
+            for (RefPtr siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
                 siblingChild->invalidateStyleForSubtreeInternal();
         }
     }
@@ -373,28 +373,28 @@ void ChildChangeInvalidation::invalidateAfterFinishedParsingChildren(Element& pa
 
     checkForEmptyStyleChange(parent);
 
-    auto* lastChildElement = ElementTraversal::lastChild(parent);
+    RefPtr lastChildElement = ElementTraversal::lastChild(parent);
     if (!lastChildElement)
         return;
 
     if (parent.childrenAffectedByLastChildRules())
         invalidateForLastChildState(*lastChildElement, false);
 
-    invalidateForBackwardPositionalRules(parent, lastChildElement);
+    invalidateForBackwardPositionalRules(parent, lastChildElement.get());
 }
 
 void ChildChangeInvalidation::checkForSiblingStyleChanges()
 {
-    auto& parent = parentElement();
-    auto* elementBeforeChange = m_childChange.previousSiblingElement;
-    auto* elementAfterChange = m_childChange.nextSiblingElement;
+    Ref parent = parentElement();
+    RefPtr elementBeforeChange = m_childChange.previousSiblingElement;
+    RefPtr elementAfterChange = m_childChange.nextSiblingElement;
 
     // :first-child. In the parser callback case, we don't have to check anything, since we were right the first time.
     // In the DOM case, we only need to do something if |afterChange| is not 0.
     // |afterChange| is 0 in the parser case, so it works out that we'll skip this block.
-    if (parent.childrenAffectedByFirstChildRules() && elementAfterChange) {
+    if (parent->childrenAffectedByFirstChildRules() && elementAfterChange) {
         // Find our new first child.
-        RefPtr<Element> newFirstElement = ElementTraversal::firstChild(parent);
+        RefPtr<Element> newFirstElement = ElementTraversal::firstChild(parent.get());
 
         // This is the insert/append case.
         if (newFirstElement != elementAfterChange)
@@ -407,9 +407,9 @@ void ChildChangeInvalidation::checkForSiblingStyleChanges()
 
     // :last-child. In the parser callback case, we don't have to check anything, since we were right the first time.
     // In the DOM case, we only need to do something if |afterChange| is not 0.
-    if (parent.childrenAffectedByLastChildRules() && elementBeforeChange) {
+    if (parent->childrenAffectedByLastChildRules() && elementBeforeChange) {
         // Find our new last child.
-        RefPtr<Element> newLastElement = ElementTraversal::lastChild(parent);
+        RefPtr<Element> newLastElement = ElementTraversal::lastChild(parent.get());
 
         if (newLastElement != elementBeforeChange)
             invalidateForLastChildState(*elementBeforeChange, true);
@@ -419,10 +419,10 @@ void ChildChangeInvalidation::checkForSiblingStyleChanges()
             invalidateForLastChildState(*newLastElement, false);
     }
 
-    invalidateForSiblingCombinators(elementAfterChange);
+    invalidateForSiblingCombinators(elementAfterChange.get());
 
-    invalidateForForwardPositionalRules(parent, elementAfterChange);
-    invalidateForBackwardPositionalRules(parent, elementBeforeChange);
+    invalidateForForwardPositionalRules(parent, elementAfterChange.get());
+    invalidateForBackwardPositionalRules(parent, elementBeforeChange.get());
 }
 
 }


### PR DESCRIPTION
#### 1f810241f93d6db7d7e959aba334d12e26ac5a5a
<pre>
Address Safer cpp failures in ChildChangeInvalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=289843">https://bugs.webkit.org/show_bug.cgi?id=289843</a>
<a href="https://rdar.apple.com/problem/147095654">rdar://problem/147095654</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning in ChildChangeInvalidation.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangeOutsideHasScope):
(WebCore::Style::ChildChangeInvalidation::traverseRemovedElements):
(WebCore::Style::ChildChangeInvalidation::traverseAddedElements):
(WebCore::Style::ChildChangeInvalidation::traverseRemainingExistingSiblings):
(WebCore::Style::invalidateForForwardPositionalRules):
(WebCore::Style::invalidateForBackwardPositionalRules):
(WebCore::Style::ChildChangeInvalidation::invalidateAfterFinishedParsingChildren):
(WebCore::Style::ChildChangeInvalidation::checkForSiblingStyleChanges):

Canonical link: <a href="https://commits.webkit.org/292233@main">https://commits.webkit.org/292233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d50df035936932d0344d32f7f33519d266a131b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3807 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81109 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3104 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15681 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27513 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->