### PR TITLE
Re

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -45,7 +45,7 @@ from webkitpy.port.image_diff import ImageDiffResult
 from webkitpy.xcode.device_type import DeviceType
 
 
-def parse_args(extra_args=None, tests_included=False, new_results=False, print_nothing=True):
+def parse_args(extra_args=None, tests_included=False, new_results=False):
     extra_args = extra_args or []
     args = []
     if not '--platform' in extra_args:

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -45,7 +45,7 @@ from webkitpy.port.image_diff import ImageDiffResult
 from webkitpy.xcode.device_type import DeviceType
 
 
-def parse_args(extra_args=None, tests_included=False, new_results=False):
+def parse_args(extra_args=None, tests_included=False, new_results=False, print_nothing=True):
     extra_args = extra_args or []
     args = []
     if not '--platform' in extra_args:

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -116,7 +116,7 @@ class MockIo:
     def __init__(self, mock_file):
         self.mock_file = mock_file
 
-    def open(self, _):  # NOLINT
+    def open(self, unused_filename, unused_mode, unused_encoding, _):  # NOLINT
         # (lint doesn't like open as a method name)
         return self.mock_file
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -116,7 +116,7 @@ class MockIo:
     def __init__(self, mock_file):
         self.mock_file = mock_file
 
-    def open(self, unused_filename, unused_mode, unused_encoding, _):  # NOLINT
+    def open(self, _):  # NOLINT
         # (lint doesn't like open as a method name)
         return self.mock_file
 

--- a/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
+++ b/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
@@ -44,7 +44,7 @@ class FeatureDefinesChecker(object):
         self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
-    def check(self):
+    def check(self, inline=None):
         if self._file_path not in FEATURE_DEFINE_FILES:
             self._handle_style_error(0, 'featuredefines/new', 5, "Patch introduces a new FeatureDefines.xcconfig, which check-webkit-style doesn't know about. Please add it to the list in featuredefines.py.")
             return

--- a/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
+++ b/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
@@ -44,7 +44,7 @@ class FeatureDefinesChecker(object):
         self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
-    def check(self, inline=None):
+    def check(self):
         if self._file_path not in FEATURE_DEFINE_FILES:
             self._handle_style_error(0, 'featuredefines/new', 5, "Patch introduces a new FeatureDefines.xcconfig, which check-webkit-style doesn't know about. Please add it to the list in featuredefines.py.")
             return

--- a/Tools/Scripts/webkitpy/test/main_unittest.py
+++ b/Tools/Scripts/webkitpy/test/main_unittest.py
@@ -68,7 +68,7 @@ class TesterTest(unittest.TestCase):
             root_logger.handlers = []
 
             tester.printer.stream = errors
-            tester.finder.find_names = lambda args, run_all: []
+            tester.finder.find_names = lambda args: []
             with OutputCapture(level=logging.INFO) as captured:
                 self.assertFalse(tester.run([]))
 


### PR DESCRIPTION
#### ce2f441a8b43122965cc27249ef2b64ebe15798c
<pre>
Remove Unused Python Code for Better Readability
<a href="https://bugs.webkit.org/show_bug.cgi?id=289844#">https://bugs.webkit.org/show_bug.cgi?id=289844#</a>

Reviewed by NOBODY (OOPS!).

The fix eliminates redundant code that was not being used, preventing potential conflicts and improving the efficiency of the script.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(parse_args):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(MockIo.open):
* Tools/Scripts/webkitpy/test/main_unittest.py:
(TesterTest.serial_test_no_tests_found):
</pre>
----------------------------------------------------------------------
#### 41f0636185e5b3fc8e64a3c8ff70654d3f1c9557
<pre>
Revert &quot;Remove Unused Python Code for Better Readability&quot;

This reverts commit d1f8fe61efa3ee402e592bed9f70a2f519ba5b9c.
</pre>
----------------------------------------------------------------------
#### d1f8fe61efa3ee402e592bed9f70a2f519ba5b9c
<pre>
Remove Unused Python Code for Better Readability
<a href="https://bugs.webkit.org/show_bug.cgi?id=289844#">https://bugs.webkit.org/show_bug.cgi?id=289844#</a>

Reviewed by NOBODY (OOPS!).

By removing unnecessary code, the script becomes cleaner, reducing the possibility of unintended behavior or side effects

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(parse_args):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(MockIo.open):
* Tools/Scripts/webkitpy/style/checkers/featuredefines.py:
(FeatureDefinesChecker.check):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce2f441a8b43122965cc27249ef2b64ebe15798c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14912 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4770 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72690 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98315 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86035 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocus (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53019 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/94804 "Found 37 webkitpy test failures: webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_missing_results, webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_new_baseline, webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_reset_results, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_full_results_html, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_no_http_and_force, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_results_directory_absolute, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_results_directory_default, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_results_directory_relative, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_run_force, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_run_singly_actually_runs_tests ...") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3774 "Failed to checkout and rebase branch from PR 42529") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45152 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102394 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93935 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22608 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82053 "Failed to checkout and rebase branch from PR 42529") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81080 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25657 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/4770 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15626 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->