### PR TITLE
Release assertion failure (m_topLayerElements is not empty) in Document::removedLastRef

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-document-gc-crash-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-document-gc-crash-expected.txt
@@ -1,0 +1,2 @@
+This tests requesting a fullscreen then removing the element. WebKit should not crash.
+PASS

--- a/LayoutTests/fullscreen/fullscreen-document-gc-crash.html
+++ b/LayoutTests/fullscreen/fullscreen-document-gc-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<body>
+<script>
+(async () => {
+    globalThis.testRunner?.dumpAsText();
+    globalThis.testRunner?.waitUntilDone();
+
+    if (sessionStorage.getItem('count') > 20) {
+        document.body.innerHTML = '<p>This tests requesting a fullscreen then removing the element. WebKit should not crash.<br>PASS</p>';
+        globalThis.testRunner?.dumpAsText();
+        globalThis.testRunner?.notifyDone();
+        return;
+    }
+
+    internals.withUserGesture(() => { });
+
+    let div = document.createElement('div');
+    document.body.appendChild(div);
+
+    div.webkitRequestFullscreen();
+
+    const count = sessionStorage.getItem('count') || 0;
+    sessionStorage.setItem('count', count + 1);
+    await navigation.reload({ info: {} });
+
+    await navigator.locks.query();
+    div.remove();
+    globalThis.GCController?.collect();
+
+})();
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4382,6 +4382,7 @@ static void forEachRenderLayer(Element& element, const std::function<void(Render
 void Element::addToTopLayer()
 {
     RELEASE_ASSERT(!isInTopLayer());
+    RELEASE_ASSERT(isConnected());
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     forEachRenderLayer(*this, [](RenderLayer& layer) {


### PR DESCRIPTION
#### 408fe7fd1e84633edbfa80484ee3163faaf7676a
<pre>
Release assertion failure (m_topLayerElements is not empty) in Document::removedLastRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=289848">https://bugs.webkit.org/show_bug.cgi?id=289848</a>

Reviewed by Tim Nguyen.

The release assertion was caused by a disconnected element entering fullscreen in the top layer.
Because a disconnected element may never receive Element::removedFromAncestor, this results in
the element being left in Document::m_topLayerElements even after removeDetachedChildren.

The bug was fixed by 291478@main. This PR adds a test for this particular crash and introduces
a new release assert in Element::addToTopLayer to catch a bug like this in an earlier point.

* LayoutTests/fullscreen/fullscreen-document-gc-crash-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-document-gc-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addToTopLayer):

Canonical link: <a href="https://commits.webkit.org/292248@main">https://commits.webkit.org/292248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a9dd3a4b209359ae5a1987fb151e6528604d52c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72698 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29961 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3781 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102404 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22370 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16320 "Found 2 new test failures: fast/webgpu/type-checker-array-without-argument.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81088 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15638 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15322 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27476 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->