### PR TITLE
[WTF] Parameterize backing allocators for HashTable/HashMap/RobinHoodHashTable

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -87,10 +87,12 @@ template<typename> class ArrayOf;
 struct VectorBufferMalloc;
 struct EmbeddedFixedVectorMalloc;
 struct SegmentedVectorMalloc;
+struct HashTableMalloc;
 #else
 using VectorBufferMalloc = FastMalloc;
 using EmbeddedFixedVectorMalloc = FastMalloc;
 using SegmentedVectorMalloc = FastMalloc;
+using HashTableMalloc = FastMalloc;
 #endif
 
 template<typename> struct DefaultRefDerefTraits;
@@ -163,11 +165,11 @@ template<typename T> struct KeyValuePairKeyExtractor;
 template<typename KeyTraits, typename MappedTraits> struct KeyValuePairTraits;
 template<typename KeyTypeArg, typename ValueTypeArg> struct KeyValuePair;
 enum class ShouldValidateKey : bool { No, Yes };
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes> class HashTable;
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey = ShouldValidateKey::Yes, typename Malloc = HashTableMalloc> class HashTable;
 template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Value>> class HashCountedSet;
-template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashMap;
-template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<KeyArg>, typename KeyTraits = HashTraits<KeyArg>, typename MappedTraits = HashTraits<MappedArg>, typename HashTraits = HashTableTraits>
-using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No>;
+template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes, typename = HashTableMalloc> class HashMap;
+template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<KeyArg>, typename KeyTraits = HashTraits<KeyArg>, typename MappedTraits = HashTraits<MappedArg>, typename HashTraits = HashTableTraits, typename Malloc = HashTableMalloc>
+using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No, Malloc>;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashSet;
 template<typename ValueArg, typename = DefaultHash<ValueArg>> class ListHashSet;
 template<typename ValueArg, typename HashArg = DefaultHash<ValueArg>, typename TraitsArg = HashTraits<ValueArg>, typename TableTraitsArg = HashTableTraits>

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -32,7 +32,7 @@ template<typename T> struct KeyValuePairKeyExtractor {
     static const typename T::KeyType& extract(const T& p) { return p.key; }
 };
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename Malloc>
 class HashMap final {
     WTF_MAKE_FAST_ALLOCATED;
 private:
@@ -58,7 +58,7 @@ private:
 
     using HashFunctions = HashArg;
 
-    using HashTableType = typename TableTraitsArg::template TableType<KeyType, KeyValuePairType, KeyValuePairKeyExtractor<KeyValuePairType>, HashFunctions, KeyValuePairTraits, KeyTraits, shouldValidateKey>;
+    using HashTableType = typename TableTraitsArg::template TableType<KeyType, KeyValuePairType, KeyValuePairKeyExtractor<KeyValuePairType>, HashFunctions, KeyValuePairTraits, KeyTraits, shouldValidateKey, Malloc>;
 
     class HashMapKeysProxy;
     class HashMapValuesProxy;
@@ -281,95 +281,95 @@ struct HashMapEnsureTranslatorAdapter {
     }
 };
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::swap(HashMap& other)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::swap(HashMap& other)
 {
     m_impl.swap(other.m_impl);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::size() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::size() const
 {
     return m_impl.size(); 
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::capacity() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::capacity() const
 { 
     return m_impl.capacity(); 
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline size_t HashMap<T, U, V, W, X, Y, shouldValidateKey>::byteSize() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline size_t HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::byteSize() const
 {
     return m_impl.byteSize();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::isEmpty() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::isEmpty() const
 {
     return m_impl.isEmpty();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::begin() -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() -> iterator
 {
     return m_impl.begin();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::end() -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() -> iterator
 {
     return m_impl.end();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::begin() const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() const -> const_iterator
 {
     return m_impl.begin();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::end() const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() const -> const_iterator
 {
     return m_impl.end();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const KeyType& key) -> iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) -> iterator
 {
     return m_impl.find(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const KeyType& key) const -> const_iterator
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) const -> const_iterator
 {
     return m_impl.find(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(const KeyType& key) const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::contains(const KeyType& key) const
 {
     return m_impl.contains(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const TYPE& value) -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) -> iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(const TYPE& value) const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) const -> const_iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const TYPE& value) const -> MappedPeekType
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::get(const TYPE& value) const -> MappedPeekType
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template lookup<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
     if (!entry)
@@ -377,9 +377,9 @@ auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const TYPE& value) const 
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(const TYPE& value) const -> MappedPeekType
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::inlineGet(const TYPE& value) const -> MappedPeekType
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
     if (!entry)
@@ -387,16 +387,16 @@ auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(const TYPE& value) 
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(const TYPE& value) const
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::contains(const TYPE& value) const
 {
     return m_impl.template contains<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(const TYPE& value)
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(const TYPE& value)
 {
     auto it = find<HashTranslator>(value);
     if (it == end())
@@ -405,9 +405,9 @@ inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(const TYPE& val
     return true;
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K, typename V>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineSet(K&& key, V&& value) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::inlineSet(K&& key, V&& value) -> AddResult
 {
     AddResult result = inlineAdd(std::forward<K>(key), std::forward<V>(value));
     if (!result.isNewEntry) {
@@ -417,96 +417,96 @@ auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTra
     return result;
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K, typename V>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineAdd(K&& key, V&& value) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::inlineAdd(K&& key, V&& value) -> AddResult
 {
     return m_impl.template add<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::inlineEnsure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::inlineEnsure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return m_impl.template add<HashMapEnsureTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::set(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineSet(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::set(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineSet(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename K>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename K, typename V>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(K&& key, V&& value) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(K&& key, V&& value) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::add(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineAdd(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::fastAdd(const KeyType& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(const KeyType& key, T&& mapped) -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::fastAdd(KeyType&& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(KeyType&& key, T&& mapped) -> AddResult
 {
     return inlineAdd(WTFMove(key), std::forward<T>(mapped));
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(const KeyType& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(const KeyType& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return inlineEnsure(key, functor);
 }
 
-template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey>::ensure(KeyType&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(KeyType&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
 {
     return inlineEnsure(std::forward<KeyType>(key), functor);
 }
     
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const KeyType& key) const -> MappedPeekType
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::get(const KeyType& key) const -> MappedPeekType
 {
     return get<IdentityTranslatorType>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::getOptional(const KeyType& key) const -> std::optional<MappedType>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::getOptional(const KeyType& key) const -> std::optional<MappedType>
 {
     auto* entry = const_cast<HashTableType&>(m_impl).template lookup<IdentityTranslatorType>(key);
     if (!entry)
@@ -514,8 +514,8 @@ inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::getOptional(const KeyT
     return { entry->value };
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
-ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::inlineGet(const KeyType& key) const -> MappedPeekType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::inlineGet(const KeyType& key) const -> MappedPeekType
 {
     KeyValuePairType* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<IdentityTranslatorType>(key);
     if (!entry)
@@ -523,8 +523,8 @@ ALWAYS_INLINE auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::inli
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(iterator it)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(iterator it)
 {
     if (it.m_impl == m_impl.end())
         return false;
@@ -533,32 +533,32 @@ inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(iterator it)
     return true;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::removeIf(NOESCAPE const Invocable<bool(KeyValuePairType&)> auto& functor)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::removeIf(NOESCAPE const Invocable<bool(KeyValuePairType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(const KeyType& key)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(const KeyType& key)
 {
     return remove(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::clear()
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::clear()
 {
     m_impl.clear();
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
-auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::take(const KeyType& key) -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::take(const KeyType& key) -> MappedTakeType
 {
     return take(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
-auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::take(iterator it) -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::take(iterator it) -> MappedTakeType
 {
     if (it == end())
         return MappedTraits::take(MappedTraits::emptyValue());
@@ -567,8 +567,8 @@ auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::take(iterator it) 
     return value;
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
-auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::takeOptional(const KeyType& key) -> std::optional<MappedType>
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::takeOptional(const KeyType& key) -> std::optional<MappedType>
 {
     auto it = find(key);
     if (it == end())
@@ -576,36 +576,36 @@ auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::takeOptional(const
     return take(it);
 }
 
-template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey>
-auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey>::takeFirst() -> MappedTakeType
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+auto HashMap<T, U, V, W, MappedTraits, Y, shouldValidateKey, M>::takeFirst() -> MappedTakeType
 {
     return take(begin());
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return m_impl.template contains<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     KeyValuePairType* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
     if (!entry)
@@ -613,23 +613,23 @@ inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(std::add_con
     return MappedTraits::peek(entry->value);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     return inlineGet(key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return remove(find(key));
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
 {
     iterator it = find(key);
     if (it == end())
@@ -639,63 +639,63 @@ inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::take(std::add_const_t<
     return value;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type
 {
     return find(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type
 {
     return find(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
 {
     return contains(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
 {
     return inlineGet(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
 {
     return inlineGet(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
 {
     return remove(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type
 {
     return take(&key);
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::checkConsistency() const
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline void HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::checkConsistency() const
 {
     m_impl.checkTableConsistency();
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::isValidKey(const KeyType& key)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::isValidKey(const KeyType& key)
 {
     if (KeyTraits::isDeletedValue(key))
         return false;
@@ -711,13 +711,13 @@ inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey>::isValidKey(const KeyTy
     return true;
 }
 
-template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
-bool operator==(const HashMap<T, U, V, W, X, Y, shouldValidateKey>& a, const HashMap<T, U, V, W, X, Y, shouldValidateKey>& b)
+template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
+bool operator==(const HashMap<T, U, V, W, X, Y, shouldValidateKey, M>& a, const HashMap<T, U, V, W, X, Y, shouldValidateKey>& b)
 {
     if (a.size() != b.size())
         return false;
 
-    typedef typename HashMap<T, U, V, W, X, Y, shouldValidateKey>::const_iterator const_iterator;
+    typedef typename HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::const_iterator const_iterator;
 
     const_iterator end = a.end();
     const_iterator notFound = b.end();

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -43,7 +43,7 @@ public:
     using ValueType = typename ValueTraits::TraitType;
 
 private:
-    using HashTableType = typename TableTraitsArg::template TableType<ValueType, ValueType, IdentityExtractor, HashFunctions, ValueTraits, ValueTraits, shouldValidateKey>;
+    using HashTableType = typename TableTraitsArg::template TableType<ValueType, ValueType, IdentityExtractor, HashFunctions, ValueTraits, ValueTraits, shouldValidateKey, FastMalloc>;
 
 public:
     // HashSet iterators have the following structure:

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -59,7 +59,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 class RobinHoodHashTable;
 
 // 95% load factor. This a bit regress "insertion" performance, while it keeps lookup performance sane.
@@ -103,10 +103,10 @@ struct FastRobinHoodHashTableSizePolicy {
 // [1]: https://codecapsule.com/2013/11/11/robin-hood-hashing/
 // [2]: https://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/
 // [3]: https://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 class RobinHoodHashTable {
 public:
-    using HashTableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>;
+    using HashTableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>;
     using iterator = HashTableIterator<HashTableType, Key, Value, Extractor, HashFunctions, Traits, KeyTraits>;
     using const_iterator = HashTableConstIterator<HashTableType, Key, Value, Extractor, HashFunctions, Traits, KeyTraits>;
     using ValueTraits = Traits;
@@ -309,9 +309,9 @@ public:
 #endif
 };
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template<typename HashTranslator, typename T>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::checkKey(const T& key)
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::checkKey(const T& key)
 {
     if constexpr (!ASSERT_ENABLED && shouldValidateKey == ShouldValidateKey::No)
         return;
@@ -325,16 +325,16 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     RELEASE_ASSERT(!HashTranslator::equal(Extractor::extract(deletedValue), key));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template<typename HashTranslator, typename T>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::lookup(const T& key) -> ValueType*
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::lookup(const T& key) -> ValueType*
 {
     return inlineLookup<HashTranslator>(key);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template<typename HashTranslator, typename T>
-ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::inlineLookup(const T& key) -> ValueType*
+ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::inlineLookup(const T& key) -> ValueType*
 {
     checkKey<HashTranslator>(key);
 
@@ -369,15 +369,15 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
     }
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::initializeBucket(ValueType& bucket)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::initializeBucket(ValueType& bucket)
 {
     HashTableBucketInitializer<Traits::emptyValueIsZero>::template initialize<Traits>(bucket);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template<typename HashTranslator, typename T>
-ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 
@@ -438,8 +438,8 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
     return AddResult(makeKnownGoodIterator(entry), true);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::maintainProbeDistanceForAdd(ValueType&& value, unsigned index, unsigned distance, unsigned size, unsigned sizeMask, unsigned tableHash)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::maintainProbeDistanceForAdd(ValueType&& value, unsigned index, unsigned distance, unsigned size, unsigned sizeMask, unsigned tableHash)
 {
     using std::swap; // For C++ ADL.
     index = (index + 1) & sizeMask;
@@ -465,9 +465,9 @@ ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
 }
 
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template<typename HashTranslator, typename T>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 
@@ -529,8 +529,8 @@ inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     return AddResult(makeKnownGoodIterator(entry), true);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::reinsert(ValueType&& value)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::reinsert(ValueType&& value)
 {
     using std::swap; // For C++ ADL.
     unsigned size = tableSize();
@@ -559,9 +559,9 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     }
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template <typename HashTranslator, typename T>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::find(const T& key) -> iterator
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::find(const T& key) -> iterator
 {
     if (!m_table)
         return end();
@@ -573,9 +573,9 @@ auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     return makeKnownGoodIterator(entry);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template <typename HashTranslator, typename T>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::find(const T& key) const -> const_iterator
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::find(const T& key) const -> const_iterator
 {
     if (!m_table)
         return end();
@@ -587,9 +587,9 @@ auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     return makeKnownGoodConstIterator(entry);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
 template <typename HashTranslator, typename T>
-bool RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::contains(const T& key) const
+bool RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::contains(const T& key) const
 {
     if (!m_table)
         return false;
@@ -597,23 +597,23 @@ bool RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     return const_cast<RobinHoodHashTable*>(this)->lookup<HashTranslator>(key);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::removeAndInvalidateWithoutEntryConsistencyCheck(ValueType* pos)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::removeAndInvalidateWithoutEntryConsistencyCheck(ValueType* pos)
 {
     invalidateIterators(this);
     remove(pos);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::removeAndInvalidate(ValueType* pos)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::removeAndInvalidate(ValueType* pos)
 {
     invalidateIterators(this);
     internalCheckTableConsistency();
     remove(pos);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::remove(ValueType* pos)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::remove(ValueType* pos)
 {
     // This is removal via "backward-shift-deletion". This basically shift existing entries to removed empty entry place so that we make
     // the table as if no removal happened so far. This decreases distance-to-initial-bucket (DIB) of the subsequent entries by 1. This maintains
@@ -655,8 +655,8 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::remove(iterator it)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::remove(iterator it)
 {
     if (it == end())
         return;
@@ -664,8 +664,8 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     removeAndInvalidate(const_cast<ValueType*>(it.m_iterator.m_position));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::removeWithoutEntryConsistencyCheck(iterator it)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::removeWithoutEntryConsistencyCheck(iterator it)
 {
     if (it == end())
         return;
@@ -673,8 +673,8 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     removeAndInvalidateWithoutEntryConsistencyCheck(const_cast<ValueType*>(it.m_iterator.m_position));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::removeWithoutEntryConsistencyCheck(const_iterator it)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::removeWithoutEntryConsistencyCheck(const_iterator it)
 {
     if (it == end())
         return;
@@ -682,14 +682,14 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
     removeAndInvalidateWithoutEntryConsistencyCheck(const_cast<ValueType*>(it.m_position));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::remove(const KeyType& key)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::remove(const KeyType& key)
 {
     remove(find(key));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::allocateTable(unsigned size) -> ValueType*
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::allocateTable(unsigned size) -> ValueType*
 {
     // would use a template member function with explicit specializations here, but
     // gcc doesn't appear to support that
@@ -702,16 +702,16 @@ auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     return result;
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::deallocateTable(ValueType* table, unsigned size)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::deallocateTable(ValueType* table, unsigned size)
 {
     for (unsigned i = 0; i < size; ++i)
         table[i].~ValueType();
     HashTableMalloc::free(table);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::expand()
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::expand()
 {
     unsigned newSize;
     unsigned oldSize = tableSize();
@@ -723,8 +723,8 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     rehash(newSize);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::computeBestTableSize(unsigned keyCount)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::computeBestTableSize(unsigned keyCount)
 {
     unsigned bestTableSize = WTF::roundUpToPowerOfTwo(keyCount);
 
@@ -752,15 +752,15 @@ constexpr unsigned RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
     return std::max(bestTableSize, minimumTableSize);
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::shrinkToBestSize()
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::shrinkToBestSize()
 {
     unsigned minimumTableSize = KeyTraits::minimumTableSize;
     rehash(std::max(minimumTableSize, computeBestTableSize(keyCount())));
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::rehash(unsigned newTableSize)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::rehash(unsigned newTableSize)
 {
     internalCheckTableConsistencyExceptSize();
 
@@ -785,8 +785,8 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::clear()
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::clear()
 {
     invalidateIterators(this);
     if (!m_table)
@@ -801,8 +801,8 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::RobinHoodHashTable(const RobinHoodHashTable& other)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::RobinHoodHashTable(const RobinHoodHashTable& other)
 {
     if (!other.m_tableSize || !other.m_keyCount)
         return;
@@ -823,8 +823,8 @@ RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Size
     internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::swap(RobinHoodHashTable& other)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::swap(RobinHoodHashTable& other)
 {
     using std::swap; // For C++ ADL.
     invalidateIterators(this);
@@ -840,16 +840,16 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     other.internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::operator=(const RobinHoodHashTable& other) -> RobinHoodHashTable&
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::operator=(const RobinHoodHashTable& other) -> RobinHoodHashTable&
 {
     RobinHoodHashTable tmp(other);
     swap(tmp);
     return *this;
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::RobinHoodHashTable(RobinHoodHashTable&& other)
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::RobinHoodHashTable(RobinHoodHashTable&& other)
 {
     invalidateIterators(&other);
 
@@ -863,8 +863,8 @@ inline RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTrait
     other.internalCheckTableConsistency();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::operator=(RobinHoodHashTable&& other) -> RobinHoodHashTable&
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::operator=(RobinHoodHashTable&& other) -> RobinHoodHashTable&
 {
     RobinHoodHashTable temp(WTFMove(other));
     swap(temp);
@@ -874,14 +874,14 @@ inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
 
 #if ASSERT_ENABLED
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::checkTableConsistency() const
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::checkTableConsistency() const
 {
     checkTableConsistencyExceptSize();
 }
 
-template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey>
-void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey>::checkTableConsistencyExceptSize() const
+template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, ShouldValidateKey shouldValidateKey, typename Malloc>
+void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, shouldValidateKey, Malloc>::checkTableConsistencyExceptSize() const
 {
     if (!m_table)
         return;
@@ -910,18 +910,18 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 #endif // ASSERT_ENABLED
 
 struct MemoryCompactLookupOnlyRobinHoodHashTableTraits {
-    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, MemoryCompactLookupOnlyRobinHoodHashTableSizePolicy, shouldValidateKey>;
+    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey, typename Malloc>
+    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, MemoryCompactLookupOnlyRobinHoodHashTableSizePolicy, shouldValidateKey, Malloc>;
 };
 
 struct MemoryCompactRobinHoodHashTableTraits {
-    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, MemoryCompactRobinHoodHashTableSizePolicy, shouldValidateKey>;
+    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey, typename Malloc>
+    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, MemoryCompactRobinHoodHashTableSizePolicy, shouldValidateKey, Malloc>;
 };
 
 struct FastRobinHoodHashTableTraits {
-    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, FastRobinHoodHashTableSizePolicy, shouldValidateKey>;
+    template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey, typename Malloc>
+    using TableType = RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, FastRobinHoodHashTableSizePolicy, shouldValidateKey, Malloc>;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 850b4c3e0580b1f652556dcb764b1a956a189832
<pre>
[WTF] Parameterize backing allocators for HashTable/HashMap/RobinHoodHashTable
<a href="https://rdar.apple.com/147083892">rdar://147083892</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289836">https://bugs.webkit.org/show_bug.cgi?id=289836</a>

Reviewed by Keith Miller.

This allows us to pass in an allocator a la Vector/SegmentedVector,
which up until now has not been possible. This does not change the
actual allocator used when allocating the structure itself.

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/HashMap.h:
(WTF::M&gt;::swap):
(WTF::M&gt;::size const):
(WTF::M&gt;::capacity const):
(WTF::M&gt;::byteSize const):
(WTF::M&gt;::isEmpty const):
(WTF::M&gt;::begin):
(WTF::M&gt;::end):
(WTF::M&gt;::begin const):
(WTF::M&gt;::end const):
(WTF::M&gt;::find):
(WTF::M&gt;::find const):
(WTF::M&gt;::contains const):
(WTF::M&gt;::get const):
(WTF::M&gt;::inlineGet const):
(WTF::M&gt;::remove):
(WTF::M&gt;::inlineSet):
(WTF::M&gt;::inlineAdd):
(WTF::M&gt;::inlineEnsure):
(WTF::M&gt;::set):
(WTF::M&gt;::ensure):
(WTF::M&gt;::add):
(WTF::M&gt;::fastAdd):
(WTF::M&gt;::getOptional const):
(WTF::M&gt;::removeIf):
(WTF::M&gt;::clear):
(WTF::M&gt;::take):
(WTF::M&gt;::takeOptional):
(WTF::M&gt;::takeFirst):
(WTF::M&gt;::checkConsistency const):
(WTF::M&gt;::isValidKey):
(WTF::operator==):
(WTF::shouldValidateKey&gt;::swap): Deleted.
(WTF::shouldValidateKey&gt;::size const): Deleted.
(WTF::shouldValidateKey&gt;::capacity const): Deleted.
(WTF::shouldValidateKey&gt;::byteSize const): Deleted.
(WTF::shouldValidateKey&gt;::isEmpty const): Deleted.
(WTF::shouldValidateKey&gt;::begin): Deleted.
(WTF::shouldValidateKey&gt;::end): Deleted.
(WTF::shouldValidateKey&gt;::begin const): Deleted.
(WTF::shouldValidateKey&gt;::end const): Deleted.
(WTF::shouldValidateKey&gt;::find): Deleted.
(WTF::shouldValidateKey&gt;::find const): Deleted.
(WTF::shouldValidateKey&gt;::contains const): Deleted.
(WTF::shouldValidateKey&gt;::get const): Deleted.
(WTF::shouldValidateKey&gt;::inlineGet const): Deleted.
(WTF::shouldValidateKey&gt;::remove): Deleted.
(WTF::shouldValidateKey&gt;::inlineSet): Deleted.
(WTF::shouldValidateKey&gt;::inlineAdd): Deleted.
(WTF::shouldValidateKey&gt;::inlineEnsure): Deleted.
(WTF::shouldValidateKey&gt;::set): Deleted.
(WTF::shouldValidateKey&gt;::ensure): Deleted.
(WTF::shouldValidateKey&gt;::add): Deleted.
(WTF::shouldValidateKey&gt;::fastAdd): Deleted.
(WTF::shouldValidateKey&gt;::getOptional const): Deleted.
(WTF::shouldValidateKey&gt;::removeIf): Deleted.
(WTF::shouldValidateKey&gt;::clear): Deleted.
(WTF::shouldValidateKey&gt;::take): Deleted.
(WTF::shouldValidateKey&gt;::takeOptional): Deleted.
(WTF::shouldValidateKey&gt;::takeFirst): Deleted.
(WTF::shouldValidateKey&gt;::checkConsistency const): Deleted.
(WTF::shouldValidateKey&gt;::isValidKey): Deleted.
* Source/WTF/wtf/HashSet.h:
* Source/WTF/wtf/HashTable.h:
(WTF::Malloc&gt;::HashTable):
(WTF::Malloc&gt;::checkKey):
(WTF::Malloc&gt;::lookup):
(WTF::Malloc&gt;::inlineLookup):
(WTF::Malloc&gt;::lookupForReinsert):
(WTF::Malloc&gt;::fullLookupForWriting):
(WTF::Malloc&gt;::addUniqueForInitialization):
(WTF::Malloc&gt;::initializeBucket):
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::Malloc&gt;::reinsert):
(WTF::Malloc&gt;::find):
(WTF::Malloc&gt;::find const):
(WTF::Malloc&gt;::contains const):
(WTF::Malloc&gt;::removeAndInvalidateWithoutEntryConsistencyCheck):
(WTF::Malloc&gt;::removeAndInvalidate):
(WTF::Malloc&gt;::remove):
(WTF::Malloc&gt;::removeWithoutEntryConsistencyCheck):
(WTF::Malloc&gt;::removeIf):
(WTF::Malloc&gt;::takeIf):
(WTF::Malloc&gt;::allocateTable):
(WTF::Malloc&gt;::deallocateTable):
(WTF::Malloc&gt;::expand):
(WTF::Malloc&gt;::computeBestTableSize):
(WTF::Malloc&gt;::shrinkToBestSize):
(WTF::Malloc&gt;::deleteReleasedWeakBuckets):
(WTF::Malloc&gt;::rehash):
(WTF::Malloc&gt;::clear):
(WTF::Malloc&gt;::swap):
(WTF::=):
(WTF::Malloc&gt;::checkTableConsistency const):
(WTF::Malloc&gt;::checkTableConsistencyExceptSize const):
(WTF::shouldValidateKey&gt;::HashTable): Deleted.
(WTF::shouldValidateKey&gt;::checkKey): Deleted.
(WTF::shouldValidateKey&gt;::lookup): Deleted.
(WTF::shouldValidateKey&gt;::inlineLookup): Deleted.
(WTF::shouldValidateKey&gt;::lookupForReinsert): Deleted.
(WTF::shouldValidateKey&gt;::fullLookupForWriting): Deleted.
(WTF::shouldValidateKey&gt;::addUniqueForInitialization): Deleted.
(WTF::shouldValidateKey&gt;::initializeBucket): Deleted.
(WTF::shouldValidateKey&gt;::add): Deleted.
(WTF::shouldValidateKey&gt;::addPassingHashCode): Deleted.
(WTF::shouldValidateKey&gt;::reinsert): Deleted.
(WTF::shouldValidateKey&gt;::find): Deleted.
(WTF::shouldValidateKey&gt;::find const): Deleted.
(WTF::shouldValidateKey&gt;::contains const): Deleted.
(WTF::shouldValidateKey&gt;::removeAndInvalidateWithoutEntryConsistencyCheck): Deleted.
(WTF::shouldValidateKey&gt;::removeAndInvalidate): Deleted.
(WTF::shouldValidateKey&gt;::remove): Deleted.
(WTF::shouldValidateKey&gt;::removeWithoutEntryConsistencyCheck): Deleted.
(WTF::shouldValidateKey&gt;::removeIf): Deleted.
(WTF::shouldValidateKey&gt;::takeIf): Deleted.
(WTF::shouldValidateKey&gt;::allocateTable): Deleted.
(WTF::shouldValidateKey&gt;::deallocateTable): Deleted.
(WTF::shouldValidateKey&gt;::expand): Deleted.
(WTF::shouldValidateKey&gt;::computeBestTableSize): Deleted.
(WTF::shouldValidateKey&gt;::shrinkToBestSize): Deleted.
(WTF::shouldValidateKey&gt;::deleteReleasedWeakBuckets): Deleted.
(WTF::shouldValidateKey&gt;::rehash): Deleted.
(WTF::shouldValidateKey&gt;::clear): Deleted.
(WTF::shouldValidateKey&gt;::swap): Deleted.
(WTF::shouldValidateKey&gt;::checkTableConsistency const): Deleted.
(WTF::shouldValidateKey&gt;::checkTableConsistencyExceptSize const): Deleted.
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::checkKey):
(WTF::Malloc&gt;::lookup):
(WTF::Malloc&gt;::inlineLookup):
(WTF::Malloc&gt;::initializeBucket):
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::maintainProbeDistanceForAdd):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::Malloc&gt;::reinsert):
(WTF::Malloc&gt;::find):
(WTF::Malloc&gt;::find const):
(WTF::Malloc&gt;::contains const):
(WTF::Malloc&gt;::removeAndInvalidateWithoutEntryConsistencyCheck):
(WTF::Malloc&gt;::removeAndInvalidate):
(WTF::Malloc&gt;::remove):
(WTF::Malloc&gt;::removeWithoutEntryConsistencyCheck):
(WTF::Malloc&gt;::allocateTable):
(WTF::Malloc&gt;::deallocateTable):
(WTF::Malloc&gt;::expand):
(WTF::Malloc&gt;::computeBestTableSize):
(WTF::Malloc&gt;::shrinkToBestSize):
(WTF::Malloc&gt;::rehash):
(WTF::Malloc&gt;::clear):
(WTF::Malloc&gt;::RobinHoodHashTable):
(WTF::Malloc&gt;::swap):
(WTF::=):
(WTF::Malloc&gt;::checkTableConsistency const):
(WTF::Malloc&gt;::checkTableConsistencyExceptSize const):
(WTF::shouldValidateKey&gt;::checkKey): Deleted.
(WTF::shouldValidateKey&gt;::lookup): Deleted.
(WTF::shouldValidateKey&gt;::inlineLookup): Deleted.
(WTF::shouldValidateKey&gt;::initializeBucket): Deleted.
(WTF::shouldValidateKey&gt;::add): Deleted.
(WTF::shouldValidateKey&gt;::maintainProbeDistanceForAdd): Deleted.
(WTF::shouldValidateKey&gt;::addPassingHashCode): Deleted.
(WTF::shouldValidateKey&gt;::reinsert): Deleted.
(WTF::shouldValidateKey&gt;::find): Deleted.
(WTF::shouldValidateKey&gt;::find const): Deleted.
(WTF::shouldValidateKey&gt;::contains const): Deleted.
(WTF::shouldValidateKey&gt;::removeAndInvalidateWithoutEntryConsistencyCheck): Deleted.
(WTF::shouldValidateKey&gt;::removeAndInvalidate): Deleted.
(WTF::shouldValidateKey&gt;::remove): Deleted.
(WTF::shouldValidateKey&gt;::removeWithoutEntryConsistencyCheck): Deleted.
(WTF::shouldValidateKey&gt;::allocateTable): Deleted.
(WTF::shouldValidateKey&gt;::deallocateTable): Deleted.
(WTF::shouldValidateKey&gt;::expand): Deleted.
(WTF::shouldValidateKey&gt;::computeBestTableSize): Deleted.
(WTF::shouldValidateKey&gt;::shrinkToBestSize): Deleted.
(WTF::shouldValidateKey&gt;::rehash): Deleted.
(WTF::shouldValidateKey&gt;::clear): Deleted.
(WTF::shouldValidateKey&gt;::RobinHoodHashTable): Deleted.
(WTF::shouldValidateKey&gt;::swap): Deleted.
(WTF::shouldValidateKey&gt;::checkTableConsistency const): Deleted.
(WTF::shouldValidateKey&gt;::checkTableConsistencyExceptSize const): Deleted.

Canonical link: <a href="https://commits.webkit.org/292241@main">https://commits.webkit.org/292241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0ff77fbce6374734d5a8dca1457d0cdb5c45f2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45167 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87998 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102409 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93950 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16324 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81717 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25667 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15644 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27481 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/116638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22004 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/116638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->