### PR TITLE
Add support for generating a consumer for CSS properties that use <unicode-range-token>

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1076,6 +1076,7 @@ css/parser/CSSPropertyParserConsumer+Transform.cpp
 css/parser/CSSPropertyParserConsumer+Transitions.cpp
 css/parser/CSSPropertyParserConsumer+UI.cpp
 css/parser/CSSPropertyParserConsumer+URL.cpp
+css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp
 css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
 css/parser/CSSPropertyParserConsumer+WillChange.cpp
 css/parser/CSSSelectorParser.cpp

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -184,7 +184,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     RefPtr fontWidth = style.getPropertyCSSValue(CSSPropertyFontWidth);
     RefPtr srcList = dynamicDowncast<CSSValueList>(style.getPropertyCSSValue(CSSPropertySrc));
     RefPtr unicodeRange = style.getPropertyCSSValue(CSSPropertyUnicodeRange);
-    CSSValueList* rangeList = downcast<CSSValueList>(unicodeRange.get());
+    RefPtr rangeList = downcast<CSSValueList>(unicodeRange.get());
     RefPtr featureSettings = style.getPropertyCSSValue(CSSPropertyFontFeatureSettings);
     RefPtr display = style.getPropertyCSSValue(CSSPropertyFontDisplay);
     RefPtr sizeAdjust = style.getPropertyCSSValue(CSSPropertySizeAdjust);

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12547,9 +12547,8 @@
             },
             "unicode-range": {
                 "codegen-properties": {
-                    "parser-function": "consumeFontFaceUnicodeRange",
-                    "parser-grammar-unused": "<urange>#",
-                    "parser-grammar-unused-reason": "Needs support for primitive <urange>."
+                    "parser-grammar": "<unicode-range-token>#@(no-single-item-opt)",
+                    "parser-exported": true
                 },
                 "specification": {
                     "category": "css-fonts",

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -141,7 +141,6 @@ RefPtr<CSSValue> parseFontFaceSizeAdjust(const String&, ScriptExecutionContext&)
 // MARK: @font-face 'unicode-range'
 // https://drafts.csswg.org/css-fonts-4/#unicode-range-desc
 RefPtr<CSSValueList> parseFontFaceUnicodeRange(const String&, ScriptExecutionContext&);
-RefPtr<CSSValueList> consumeFontFaceUnicodeRange(CSSParserTokenRange&, const CSSParserContext&);
 
 // MARK: @font-face 'font-display'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-display

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2016 The Chromium Authors. All rights reserved
+ * Copyright (C) 2021 Metrological Group B.V.
+ * Copyright (C) 2021 Igalia S.L.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+UnicodeRange.h"
+
+#include "CSSParserTokenRange.h"
+#include "CSSUnicodeRangeValue.h"
+#include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringParsingBuffer.h>
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+static bool consumeOptionalDelimiter(CSSParserTokenRange& range, UChar value)
+{
+    if (!(range.peek().type() == DelimiterToken && range.peek().delimiter() == value))
+        return false;
+    range.consume();
+    return true;
+}
+
+static StringView consumeIdentifier(CSSParserTokenRange& range)
+{
+    if (range.peek().type() != IdentToken)
+        return { };
+    return range.consume().value();
+}
+
+static bool consumeAndAppendOptionalNumber(StringBuilder& builder, CSSParserTokenRange& range, CSSParserTokenType type = NumberToken)
+{
+    if (range.peek().type() != type)
+        return false;
+    auto originalText = range.consume().originalText();
+    if (originalText.isNull())
+        return false;
+    builder.append(originalText);
+    return true;
+}
+
+static bool consumeAndAppendOptionalDelimiter(StringBuilder& builder, CSSParserTokenRange& range, UChar value)
+{
+    if (!consumeOptionalDelimiter(range, value))
+        return false;
+    builder.append(value);
+    return true;
+}
+
+static void consumeAndAppendOptionalQuestionMarks(StringBuilder& builder, CSSParserTokenRange& range)
+{
+    while (consumeAndAppendOptionalDelimiter(builder, range, '?')) { }
+}
+
+static String consumeUnicodeRangeString(CSSParserTokenRange& range)
+{
+    if (!equalLettersIgnoringASCIICase(consumeIdentifier(range), "u"_s))
+        return { };
+    StringBuilder builder;
+    if (consumeAndAppendOptionalNumber(builder, range, DimensionToken))
+        consumeAndAppendOptionalQuestionMarks(builder, range);
+    else if (consumeAndAppendOptionalNumber(builder, range)) {
+        if (!(consumeAndAppendOptionalNumber(builder, range, DimensionToken) || consumeAndAppendOptionalNumber(builder, range)))
+            consumeAndAppendOptionalQuestionMarks(builder, range);
+    } else if (consumeOptionalDelimiter(range, '+')) {
+        builder.append('+');
+        if (auto identifier = consumeIdentifier(range); !identifier.isNull())
+            builder.append(identifier);
+        else if (!consumeAndAppendOptionalDelimiter(builder, range, '?'))
+            return { };
+        consumeAndAppendOptionalQuestionMarks(builder, range);
+    } else
+        return { };
+    return builder.toString();
+}
+
+struct UnicodeRange {
+    char32_t start;
+    char32_t end;
+};
+
+// MARK: <unicode-range-token> consuming (unresolved)
+static std::optional<UnicodeRange> consumeUnicodeRangeTokenUnresolved(CSSParserTokenRange& range)
+{
+    return readCharactersForParsing(consumeUnicodeRangeString(range), [&](auto buffer) -> std::optional<UnicodeRange> {
+        if (!skipExactly(buffer, '+'))
+            return std::nullopt;
+        char32_t start = 0;
+        unsigned hexDigitCount = 0;
+        while (buffer.hasCharactersRemaining() && isASCIIHexDigit(*buffer)) {
+            if (++hexDigitCount > 6)
+                return std::nullopt;
+            start <<= 4;
+            start |= toASCIIHexValue(*buffer++);
+        }
+        auto end = start;
+        while (skipExactly(buffer, '?')) {
+            if (++hexDigitCount > 6)
+                return std::nullopt;
+            start <<= 4;
+            end <<= 4;
+            end |= 0xF;
+        }
+        if (!hexDigitCount)
+            return std::nullopt;
+        if (start == end && buffer.hasCharactersRemaining()) {
+            if (!skipExactly(buffer, '-'))
+                return std::nullopt;
+            end = 0;
+            hexDigitCount = 0;
+            while (buffer.hasCharactersRemaining() && isASCIIHexDigit(*buffer)) {
+                if (++hexDigitCount > 6)
+                    return std::nullopt;
+                end <<= 4;
+                end |= toASCIIHexValue(*buffer++);
+            }
+            if (!hexDigitCount)
+                return std::nullopt;
+        }
+        if (buffer.hasCharactersRemaining())
+            return std::nullopt;
+        return { { start, end } };
+    });
+}
+
+RefPtr<CSSValue> consumeUnicodeRangeToken(CSSParserTokenRange& range)
+{
+    auto rangeCopy = range;
+
+    auto unicodeRange = consumeUnicodeRangeTokenUnresolved(rangeCopy);
+    rangeCopy.consumeWhitespace();
+    if (!unicodeRange || unicodeRange->end > UCHAR_MAX_VALUE || unicodeRange->start > unicodeRange->end)
+        return nullptr;
+
+    range = rangeCopy;
+    return CSSUnicodeRangeValue::create(unicodeRange->start, unicodeRange->end);
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+struct CSSParserContext;
+
+namespace CSSPropertyParserHelpers {
+
+// https://drafts.csswg.org/css-syntax-3/#typedef-unicode-range-token
+
+// MARK: <unicode-range-token> consuming (value)
+RefPtr<CSSValue> consumeUnicodeRangeToken(CSSParserTokenRange&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -1632,7 +1632,8 @@ class ReferenceTerm:
         BuiltinSchema.Entry('dashed-ident'),
         BuiltinSchema.Entry('url'),
         BuiltinSchema.Entry('feature-tag-value'),
-        BuiltinSchema.Entry('variation-tag-value')
+        BuiltinSchema.Entry('variation-tag-value'),
+        BuiltinSchema.Entry('unicode-range-token'),
     )
 
     class StringParameter:
@@ -4540,6 +4541,7 @@ class GenerateCSSPropertyParsing:
                     "CSSPropertyParserConsumer+Transitions.h",
                     "CSSPropertyParserConsumer+UI.h",
                     "CSSPropertyParserConsumer+URL.h",
+                    "CSSPropertyParserConsumer+UnicodeRange.h",
                     "CSSPropertyParserConsumer+ViewTransition.h",
                     "CSSPropertyParserConsumer+WillChange.h",
                     "CSSQuadValue.h",
@@ -6167,6 +6169,8 @@ class TermGeneratorReferenceTerm(TermGenerator):
                 return True
             elif isinstance(builtin, BuiltinVariationTagValueConsumer):
                 return True
+            elif isinstance(builtin, BuiltinUnicodeRangeTokenConsumer):
+                return False
             else:
                 raise Exception(f"Unknown builtin type used: {builtin.name.name}")
         else:

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp
@@ -59,6 +59,7 @@
 #include "CSSPropertyParserConsumer+Transitions.h"
 #include "CSSPropertyParserConsumer+UI.h"
 #include "CSSPropertyParserConsumer+URL.h"
+#include "CSSPropertyParserConsumer+UnicodeRange.h"
 #include "CSSPropertyParserConsumer+ViewTransition.h"
 #include "CSSPropertyParserConsumer+WillChange.h"
 #include "CSSQuadValue.h"


### PR DESCRIPTION
#### a4a5158644d38ea54704affd81594996812698f9
<pre>
Add support for generating a consumer for CSS properties that use &lt;unicode-range-token&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=289854">https://bugs.webkit.org/show_bug.cgi?id=289854</a>

Reviewed by Darin Adler.

Moves support for consuming &lt;unicode-range-token&gt; values into its own
file as it is a primitive defined in css-syntax, not css-fonts.

This allow generation of:
    @font-face unicode-range

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSFontSelector.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.cpp: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnicodeRange.h: Added.

Canonical link: <a href="https://commits.webkit.org/292235@main">https://commits.webkit.org/292235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a127f14575dbd48dba59b968ddd5acbafea9985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72729 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29995 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98365 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11116 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/3814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81291 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/3909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16355 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20293 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25694 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15694 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27521 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->