### PR TITLE
Update FileHandle::seek() to return a std::optional

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1349,8 +1349,8 @@ public:
             return;
 
         m_cachedBytecode->commitUpdates([&] (off_t offset, std::span<const uint8_t> data) {
-            long long result = handle.seek(offset, FileSystem::FileSeekOrigin::Beginning);
-            ASSERT_UNUSED(result, result != -1);
+            auto result = handle.seek(offset, FileSystem::FileSeekOrigin::Beginning);
+            ASSERT_UNUSED(result, !!result);
             auto bytesWritten = handle.write(data);
             ASSERT_UNUSED(bytesWritten, bytesWritten == data.size());
         });

--- a/Source/WTF/wtf/FileHandle.h
+++ b/Source/WTF/wtf/FileHandle.h
@@ -91,8 +91,7 @@ public:
     WTF_EXPORT_PRIVATE bool truncate(int64_t offset);
     WTF_EXPORT_PRIVATE std::optional<uint64_t> size();
 
-    // Returns the resulting offset from the beginning of the file if successful, -1 otherwise.
-    WTF_EXPORT_PRIVATE int64_t seek(int64_t offset, FileSeekOrigin);
+    WTF_EXPORT_PRIVATE std::optional<uint64_t> seek(int64_t offset, FileSeekOrigin);
 
     WTF_EXPORT_PRIVATE bool flush();
     WTF_EXPORT_PRIVATE std::optional<PlatformFileID> id();

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -74,10 +74,10 @@ bool FileHandle::flush()
     return m_handle && !fsync(*m_handle);
 }
 
-int64_t FileHandle::seek(int64_t offset, FileSeekOrigin origin)
+std::optional<uint64_t> FileHandle::seek(int64_t offset, FileSeekOrigin origin)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     int whence = SEEK_SET;
     switch (origin) {
@@ -94,7 +94,10 @@ int64_t FileHandle::seek(int64_t offset, FileSeekOrigin origin)
         ASSERT_NOT_REACHED();
         break;
     }
-    return static_cast<int64_t>(lseek(*m_handle, offset, whence));
+    auto result = lseek(*m_handle, offset, whence);
+    if (result < 0)
+        return { };
+    return static_cast<uint64_t>(result);
 }
 
 std::optional<PlatformFileID> FileHandle::id()

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -93,10 +93,10 @@ bool FileHandle::truncate(int64_t offset)
     return SetFileInformationByHandle(*m_handle, FileEndOfFileInfo, &eofInfo, sizeof(FILE_END_OF_FILE_INFO));
 }
 
-int64_t FileHandle::seek(int64_t offset, FileSeekOrigin origin)
+std::optional<uint64_t> FileHandle::seek(int64_t offset, FileSeekOrigin origin)
 {
     if (!m_handle)
-        return -1;
+        return { };
 
     DWORD moveMethod = FILE_BEGIN;
 
@@ -111,7 +111,7 @@ int64_t FileHandle::seek(int64_t offset, FileSeekOrigin origin)
     largeOffset.LowPart = SetFilePointer(*m_handle, largeOffset.LowPart, &largeOffset.HighPart, moveMethod);
 
     if (largeOffset.LowPart == INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR)
-        return -1;
+        return { };
 
     return largeOffset.QuadPart;
 }

--- a/Source/WebCore/platform/FileStream.cpp
+++ b/Source/WebCore/platform/FileStream.cpp
@@ -73,7 +73,7 @@ bool FileStream::openForRead(const String& path, long long offset, long long len
 
     // Jump to the beginning position if the file has been sliced.
     if (offset > 0) {
-        if (m_handle.seek(offset, FileSystem::FileSeekOrigin::Beginning) < 0)
+        if (!m_handle.seek(offset, FileSystem::FileSeekOrigin::Beginning))
             return false;
     }
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -300,7 +300,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
     case WebCore::FileSystemWriteCommandType::Write: {
         if (position) {
             auto result = activeWritableFile.handle.seek(*position, FileSystem::FileSeekOrigin::Beginning);
-            if (result == -1)
+            if (!result)
                 return FileSystemStorageError::Unknown;
         }
 
@@ -314,7 +314,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
             return FileSystemStorageError::MissingArgument;
 
         auto result = activeWritableFile.handle.seek(*position, FileSystem::FileSeekOrigin::Beginning);
-        if (result == -1)
+        if (!result)
             return FileSystemStorageError::Unknown;
 
         return std::nullopt;
@@ -328,7 +328,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
             return FileSystemStorageError::Unknown;
 
         auto currentOffset = activeWritableFile.handle.seek(0, FileSystem::FileSeekOrigin::Current);
-        if (currentOffset == -1 || static_cast<unsigned long long>(currentOffset) > *size)
+        if (!currentOffset || *currentOffset > *size)
             activeWritableFile.handle.seek(*size, FileSystem::FileSeekOrigin::Beginning);
 
         return std::nullopt;
@@ -361,10 +361,10 @@ std::optional<size_t> FileSystemStorageHandle::computeCommandSpace(WebCore::File
 
     uint64_t finalSize;
     auto currentOffset = activeWritableFile.handle.seek(position.value_or(0), FileSystem::FileSeekOrigin::Current);
-    if (currentOffset == -1)
+    if (!currentOffset)
         return { };
 
-    if (!WTF::safeAdd(static_cast<uint64_t>(currentOffset), dataBytes.size(), finalSize))
+    if (!WTF::safeAdd(*currentOffset, dataBytes.size(), finalSize))
         return { };
 
     return finalSize > *fileSize ? finalSize - *fileSize : 0;

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -351,7 +351,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             m_metaData.frameURLFiltersBytecodeSize = m_frameURLFiltersBytecodeWritten;
 
             WebKit::NetworkCache::Data header = encodeContentRuleListMetaData(m_metaData);
-            if (!m_fileError && m_fileHandle.seek(0ll, FileSeekOrigin::Beginning) == -1) {
+            if (!m_fileError && !m_fileHandle.seek(0ll, FileSeekOrigin::Beginning)) {
                 m_fileHandle = { };
                 m_fileError = true;
             }
@@ -650,7 +650,7 @@ void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& i
     // Invalidate the version by setting it to one less than the current version.
     header.version = CurrentContentRuleListFileVersion - 1;
 
-    if (fileHandle.seek(0, FileSeekOrigin::Beginning) == -1)
+    if (!fileHandle.seek(0, FileSeekOrigin::Beginning))
         return;
 
     auto bytesWritten = fileHandle.write(asByteSpan(header));
@@ -695,7 +695,7 @@ void ContentRuleListStore::corruptContentRuleListActionsMatchingEverything(const
     size_t dfaFirstInstructionOffset = urlFiltersOffset + sizeof(WebCore::ContentExtensions::DFAHeader);
     size_t urlFilterLocationOffset = dfaFirstInstructionOffset + 1;
 
-    if (fileHandle.seek(urlFilterLocationOffset, FileSeekOrigin::Beginning) == -1)
+    if (!fileHandle.seek(urlFilterLocationOffset, FileSeekOrigin::Beginning))
         return;
 
     // FIXME: we should check data[dfaFirstInstructionOffset] & DFABytecodeActionSizeMask) to decide how many bytes


### PR DESCRIPTION
#### 85b9898d9930da836bd5192502e8bb7886f882e4
<pre>
Update FileHandle::seek() to return a std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=289858">https://bugs.webkit.org/show_bug.cgi?id=289858</a>

Reviewed by Geoffrey Garen.

Update FileHandle::seek() to return a std::optional so we can return std::nullopt
in case of error, instead of -1.

* Source/JavaScriptCore/jsc.cpp:
* Source/WTF/wtf/FileHandle.h:
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::seek):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::seek):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::truncate):
(WebCore::FileSystemSyncAccessHandle::read):
(WebCore::FileSystemSyncAccessHandle::write):
* Source/WebCore/platform/FileStream.cpp:
(WebCore::FileStream::openForRead):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::executeCommandForWritableInternal):
(WebKit::FileSystemStorageHandle::computeCommandSpace):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::compiledToFile):
(API::ContentRuleListStore::invalidateContentRuleListVersion):
(API::ContentRuleListStore::corruptContentRuleListActionsMatchingEverything):

Canonical link: <a href="https://commits.webkit.org/292249@main">https://commits.webkit.org/292249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5951e2ea87f5013337f889beea42764ae9f35d8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29994 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3810 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45199 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88030 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102443 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93982 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22409 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16351 "Found 2 new test failures: html5lib/generated/run-entities01-data.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81115 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15691 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27517 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/116670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22037 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/116670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->