### PR TITLE
Move FileSystem::appendFileContentsToFileHandle() to the new FileHandle class

### DIFF
--- a/Source/WTF/wtf/FileHandle.cpp
+++ b/Source/WTF/wtf/FileHandle.cpp
@@ -86,4 +86,29 @@ std::optional<Vector<uint8_t>> FileHandle::readAll()
     return buffer;
 }
 
+bool FileHandle::appendFileContents(const String& path)
+{
+    auto source = openFile(path, FileOpenMode::Read);
+    if (!source)
+        return false;
+
+    static size_t bufferSize = 1 << 19;
+    Vector<uint8_t> buffer(bufferSize);
+
+    do {
+        auto readBytes = source.read(buffer.mutableSpan());
+
+        if (!readBytes)
+            return false;
+
+        if (write(buffer.span().first(*readBytes)) != readBytes)
+            return false;
+
+        if (*readBytes < bufferSize)
+            return true;
+    } while (true);
+
+    ASSERT_NOT_REACHED();
+}
+
 } // namespace WTF::FileSystemImpl

--- a/Source/WTF/wtf/FileHandle.h
+++ b/Source/WTF/wtf/FileHandle.h
@@ -97,6 +97,10 @@ public:
     WTF_EXPORT_PRIVATE bool flush();
     WTF_EXPORT_PRIVATE std::optional<PlatformFileID> id();
 
+    // Appends the contents of the file found at 'path' to the FileHandle.
+    // Returns true if the write was successful, false if it was not.
+    WTF_EXPORT_PRIVATE bool appendFileContents(const String& path);
+
 private:
     WTF_EXPORT_PRIVATE FileHandle(PlatformFileHandle, OptionSet<FileLockMode>);
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -252,32 +252,6 @@ String lastComponentOfPathIgnoringTrailingSlash(const String& path)
     return path.substring(position + 1, endOfSubstring - position);
 }
 
-bool appendFileContentsToFileHandle(const String& path, FileHandle& target)
-{
-    auto source = openFile(path, FileOpenMode::Read);
-    if (!source)
-        return false;
-
-    static size_t bufferSize = 1 << 19;
-    Vector<uint8_t> buffer(bufferSize);
-
-    do {
-        auto readBytes = source.read(buffer.mutableSpan());
-
-        if (!readBytes)
-            return false;
-
-        if (target.write(buffer.span().first(*readBytes)) != readBytes)
-            return false;
-
-        if (*readBytes < bufferSize)
-            return true;
-    } while (true);
-
-    ASSERT_NOT_REACHED();
-}
-
-
 bool filesHaveSameVolume(const String& fileA, const String& fileB)
 {
     if (fileA.isNull() || fileB.isNull())

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -136,10 +136,6 @@ WTF_EXPORT_PRIVATE std::pair<FileHandle, CString> createTemporaryFileInDirectory
 #endif
 WTF_EXPORT_PRIVATE FileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, OptionSet<FileLockMode> = { }, bool failIfFileExists = false);
 
-// Appends the contents of the file found at 'path' to the open FileHandle.
-// Returns true if the write was successful, false if it was not.
-WTF_EXPORT_PRIVATE bool appendFileContentsToFileHandle(const String& path, FileHandle&);
-
 WTF_EXPORT_PRIVATE bool hardLink(const String& targetPath, const String& linkPath);
 // Hard links a file if possible, copies it if not.
 WTF_EXPORT_PRIVATE bool hardLinkOrCopyFile(const String& targetPath, const String& linkPath);

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -370,7 +370,7 @@ bool BlobRegistryImpl::populateBlobsForFileWriting(const Vector<String>& blobURL
     return true;
 }
 
-static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, RefPtr<DataSegment>>>& filePathsOrDataBuffers, FileSystem::FileHandle&& file, const String& path)
+static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, RefPtr<DataSegment>>>& filePathsOrDataBuffers, FileSystem::FileHandle& file, const String& path)
 {
     if (path.isEmpty() || !file) {
         LOG_ERROR("Failed to open temporary file for writing a Blob");
@@ -386,7 +386,7 @@ static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, Ref
             }
         } else {
             ASSERT(!part.first.isEmpty());
-            if (!FileSystem::appendFileContentsToFileHandle(part.first, file)) {
+            if (!file.appendFileContents(part.first)) {
                 LOG_ERROR("Failed copying File contents to a Blob temporary file (%s to %s)", part.first.utf8().data(), path.utf8().data());
                 return false;
             }
@@ -407,7 +407,7 @@ void BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB(const Vector<Strin
         Vector<String> filePaths;
         for (auto& blob : blobsForWriting) {
             auto [tempFilePath, file] = FileSystem::openTemporaryFile("Blob"_s);
-            if (!writeFilePathsOrDataBuffersToFile(blob.filePathsOrDataBuffers, WTFMove(file), tempFilePath)) {
+            if (!writeFilePathsOrDataBuffersToFile(blob.filePathsOrDataBuffers, file, tempFilePath)) {
                 filePaths.clear();
                 break;
             }


### PR DESCRIPTION
#### aff861639324ef28887452fb4fd6f682e85e675a
<pre>
Move FileSystem::appendFileContentsToFileHandle() to the new FileHandle class
<a href="https://bugs.webkit.org/show_bug.cgi?id=289860">https://bugs.webkit.org/show_bug.cgi?id=289860</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/FileHandle.cpp:
(WTF::FileSystemImpl::FileHandle::appendFileContents):
* Source/WTF/wtf/FileHandle.h:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::appendFileContentsToFileHandle): Deleted.
* Source/WTF/wtf/FileSystem.h:
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::writeFilePathsOrDataBuffersToFile):
(WebCore::BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB):

Canonical link: <a href="https://commits.webkit.org/292232@main">https://commits.webkit.org/292232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62f6c9f63c0775edcc00037ca8c8fa9db57171b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72725 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45201 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88032 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102445 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93984 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16353 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82090 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/81117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25692 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27519 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/116672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22039 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/116672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->