### PR TITLE
Address Safer cpp failures in AudioDSPKernel

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.h
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.h
@@ -40,6 +40,7 @@ namespace WebCore {
 
 class BiquadProcessor final : public AudioDSPKernelProcessor {
     WTF_MAKE_TZONE_ALLOCATED(BiquadProcessor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BiquadProcessor);
 public:
     BiquadProcessor(BaseAudioContext&, float sampleRate, size_t numberOfChannels, bool autoInitialize);
 

--- a/Source/WebCore/Modules/webaudio/DelayProcessor.h
+++ b/Source/WebCore/Modules/webaudio/DelayProcessor.h
@@ -36,6 +36,7 @@ class AudioDSPKernel;
     
 class DelayProcessor final : public AudioDSPKernelProcessor {
     WTF_MAKE_TZONE_ALLOCATED(DelayProcessor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DelayProcessor);
 public:
     DelayProcessor(BaseAudioContext&, float sampleRate, unsigned numberOfChannels, double maxDelayTime);
     virtual ~DelayProcessor();

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -35,6 +35,7 @@ class IIRDSPKernel;
 
 class IIRProcessor final : public AudioDSPKernelProcessor {
     WTF_MAKE_TZONE_ALLOCATED(IIRProcessor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IIRProcessor);
 public:
     IIRProcessor(float sampleRate, unsigned numberOfChannels, const Vector<double>& feedforward, const Vector<double>& feedback, bool isFilterStable);
     ~IIRProcessor();

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 class WaveShaperProcessor final : public AudioDSPKernelProcessor {
     WTF_MAKE_TZONE_ALLOCATED(WaveShaperProcessor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WaveShaperProcessor);
 public:
     enum OverSampleType {
         OverSampleNone,

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -226,7 +226,6 @@ platform/ScrollingEffectsController.h
 platform/ThreadGlobalData.h
 platform/ThreadTimers.h
 platform/Timer.cpp
-platform/audio/AudioDSPKernel.h
 platform/audio/AudioDestination.h
 platform/audio/AudioHardwareListener.h
 platform/audio/AudioResamplerKernel.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -242,7 +242,6 @@ platform/ScrollingEffectsController.h
 platform/ThreadGlobalData.h
 platform/ThreadTimers.h
 platform/Timer.cpp
-platform/audio/AudioDSPKernel.h
 platform/audio/AudioDestination.h
 platform/audio/AudioHardwareListener.h
 platform/audio/AudioResamplerKernel.h

--- a/Source/WebCore/platform/audio/AudioDSPKernel.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernel.h
@@ -32,6 +32,7 @@
 #define AudioDSPKernel_h
 
 #include "AudioDSPKernelProcessor.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -49,8 +50,7 @@ public:
     }
 
     AudioDSPKernel(float sampleRate)
-        : m_kernelProcessor(0)
-        , m_sampleRate(sampleRate)
+        : m_sampleRate(sampleRate)
     {
     }
 
@@ -67,15 +67,15 @@ public:
     float sampleRate() const { return m_sampleRate; }
     double nyquist() const { return 0.5 * sampleRate(); }
 
-    AudioDSPKernelProcessor* processor() { return m_kernelProcessor; }
-    const AudioDSPKernelProcessor* processor() const { return m_kernelProcessor; }
+    AudioDSPKernelProcessor* processor() { return m_kernelProcessor.get(); }
+    const AudioDSPKernelProcessor* processor() const { return m_kernelProcessor.get(); }
 
     virtual double tailTime() const = 0;
     virtual double latencyTime() const = 0;
     virtual bool requiresTailProcessing() const = 0;
 
 protected:
-    AudioDSPKernelProcessor* m_kernelProcessor;
+    CheckedPtr<AudioDSPKernelProcessor> m_kernelProcessor;
     float m_sampleRate;
 };
 

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
@@ -33,6 +33,7 @@
 
 #include "AudioBus.h"
 #include "AudioProcessor.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
@@ -46,8 +47,9 @@ class AudioProcessor;
 // It uses one AudioDSPKernel object per channel to do the processing, thus there is no cross-channel processing.
 // Despite this limitation it turns out to be a very common and useful type of processor.
 
-class AudioDSPKernelProcessor : public AudioProcessor {
+class AudioDSPKernelProcessor : public AudioProcessor, public CanMakeThreadSafeCheckedPtr<AudioDSPKernelProcessor> {
     WTF_MAKE_TZONE_ALLOCATED(AudioDSPKernelProcessor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioDSPKernelProcessor);
 public:
     // numberOfChannels may be later changed if object is not yet in an "initialized" state
     AudioDSPKernelProcessor(float sampleRate, unsigned numberOfChannels);


### PR DESCRIPTION
#### af08e6e5e2e28753864fdbd07dc29780a45decab
<pre>
Address Safer cpp failures in AudioDSPKernel
<a href="https://bugs.webkit.org/show_bug.cgi?id=289864">https://bugs.webkit.org/show_bug.cgi?id=289864</a>
<a href="https://rdar.apple.com/problem/147146787">rdar://problem/147146787</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning in AudioDSPKernel.

* Source/WebCore/Modules/webaudio/BiquadProcessor.h:
* Source/WebCore/Modules/webaudio/DelayProcessor.h:
* Source/WebCore/Modules/webaudio/IIRProcessor.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/platform/audio/AudioDSPKernel.h:
(WebCore::AudioDSPKernel::AudioDSPKernel):
(WebCore::AudioDSPKernel::processor):
(WebCore::AudioDSPKernel::processor const):
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.h:

Canonical link: <a href="https://commits.webkit.org/292287@main">https://commits.webkit.org/292287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a42afb1782aa7946ac4dba327a33d206445d8ba7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15051 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4926 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100498 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45954 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22498 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16436 "15 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82184 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81199 "Failed to checkout and rebase branch from PR 42543") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20349 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3203 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15823 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27606 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->