### PR TITLE
[HDR] Unify the names of the methods and the members of HDR content

### DIFF
--- a/LayoutTests/compositing/hdr/hdr-basic-image.html
+++ b/LayoutTests/compositing/hdr/hdr-basic-image.html
@@ -26,7 +26,7 @@
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
-                internals.setHasPaintedHDRContentForTesting(image);
+                internals.setHasHDRContentForTesting(image);
 
             var divElement = document.querySelector("div.image-box");
             divElement.style.backgroundImage = 'url(' + image.src + ')';

--- a/LayoutTests/compositing/hdr/hdr-css-image.html
+++ b/LayoutTests/compositing/hdr/hdr-css-image.html
@@ -43,7 +43,7 @@
                     let image = new Image;
                     image.onload = (e) => {
                         if (window.internals)
-                            internals.setHasPaintedHDRContentForTesting(image);
+                            internals.setHasHDRContentForTesting(image);
 
                         resolve({ width: image.width, height: image.height });
                     };

--- a/LayoutTests/compositing/hdr/hdr-svg-inline-image.html
+++ b/LayoutTests/compositing/hdr/hdr-svg-inline-image.html
@@ -25,7 +25,7 @@
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
-                internals.setHasPaintedHDRContentForTesting(image);
+                internals.setHasHDRContentForTesting(image);
 
             var imageElement = document.querySelector("svg.image-box image");
             imageElement.setAttribute("href", image.src);

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -25,7 +25,7 @@
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
-                internals.setHasPaintedHDRContentForTesting(image);
+                internals.setHasHDRContentForTesting(image);
 
             var divElement = document.querySelector("div.image-box");
             divElement.style.backgroundImage = 'url(' + image.src + ')';

--- a/LayoutTests/fast/images/hdr-css-image.html
+++ b/LayoutTests/fast/images/hdr-css-image.html
@@ -42,7 +42,7 @@
                     let image = new Image;
                     image.onload = (e) => {
                         if (window.internals)
-                            internals.setHasPaintedHDRContentForTesting(image);
+                            internals.setHasHDRContentForTesting(image);
 
                         resolve({ width: image.width, height: image.height });
                     };

--- a/LayoutTests/fast/images/hdr-svg-inline-image.html
+++ b/LayoutTests/fast/images/hdr-svg-inline-image.html
@@ -24,7 +24,7 @@
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
-                internals.setHasPaintedHDRContentForTesting(image);
+                internals.setHasHDRContentForTesting(image);
 
             var imageElement = document.querySelector("svg.image-box image");
             imageElement.setAttribute("href", image.src);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7713,12 +7713,12 @@ bool Document::hasSVGRootNode() const
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-bool Document::canDrawHDRContent() const
+bool Document::drawsHDRContent() const
 {
     if (!(settings().supportHDRDisplayEnabled() || settings().canvasPixelFormatEnabled()))
         return false;
 
-    if (!hasPaintedHDRContent())
+    if (!hasHDRContent())
         return false;
 
     if (RefPtr frameView = view())

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -631,9 +631,9 @@ public:
     virtual bool isFrameSet() const { return false; }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    void setHasPaintedHDRContent() { m_hasPaintedHDRContent = true; }
-    bool hasPaintedHDRContent() const { return m_hasPaintedHDRContent; }
-    bool canDrawHDRContent() const;
+    void setHasHDRContent() { m_hasHDRContent = true; }
+    bool hasHDRContent() const { return m_hasHDRContent; }
+    bool drawsHDRContent() const;
 #endif
 
     static constexpr ptrdiff_t documentClassesMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentClasses); }
@@ -2667,7 +2667,7 @@ private:
 #endif
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    bool m_hasPaintedHDRContent { false };
+    bool m_hasHDRContent { false };
 #endif
 
     bool m_hasViewTransitionPseudoElementTree { false };

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -370,7 +370,7 @@ CanvasRenderingContext2D* HTMLCanvasElement::createContext2d(const String& type,
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F) && HAVE(SUPPORT_HDR_DISPLAY)
     if (m_context->pixelFormat() == ImageBufferPixelFormat::RGBA16F)
-        document().setHasPaintedHDRContent();
+        document().setHasHDRContent();
 #endif
 
 #if USE(CA) || USE(SKIA)

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -363,9 +363,9 @@ void CachedImage::computeIntrinsicDimensions(Length& intrinsicWidth, Length& int
         image->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
 }
 
-bool CachedImage::hasPaintedHDRContent() const
+bool CachedImage::hasHDRContent() const
 {
-    return m_image && m_image->hasPaintedHDRContent();
+    return m_image && m_image->hasHDRContent();
 }
 
 void CachedImage::notifyObservers(const IntRect* changeRect)

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -97,7 +97,7 @@ public:
     LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize) const;
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
-    bool hasPaintedHDRContent() const;
+    bool hasHDRContent() const;
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -122,7 +122,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             orientation = currentFrameOrientation();
 
         auto headroom = options.headroom();
-        if (headroom == Headroom::FromImage && hasPaintedHDRContentForTesting())
+        if (headroom == Headroom::FromImage && hasHDRContentForTesting())
             fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
         else {
             if (headroom == Headroom::FromImage)

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -72,7 +72,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
-    bool hasPaintedHDRContent() const final { return hasPaintedHDRContentForTesting() || m_source->headroom() > Headroom::None; }
+    bool hasHDRContent() const final { return hasHDRContentForTesting() || m_source->headroom() > Headroom::None; }
     ImageOrientation orientation() const final { return m_source->orientation(); }
     unsigned frameCount() const final { return m_source->frameCount(); }
 #if ASSERT_ENABLED
@@ -91,8 +91,8 @@ public:
     bool isAsyncDecodingEnabledForTesting() const { return m_source->isAsyncDecodingEnabledForTesting(); }
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) { m_source->setClearDecoderAfterAsyncFrameRequestForTesting(enabled); }
-    void setHasPaintedHDRContentForTesting() { m_source->setHasPaintedHDRContentForTesting(); }
-    bool hasPaintedHDRContentForTesting() const { return m_source->hasPaintedHDRContentForTesting(); }
+    void setHasHDRContentForTesting() { m_source->setHasHDRContentForTesting(); }
+    bool hasHDRContentForTesting() const { return m_source->hasHDRContentForTesting(); }
     unsigned decodeCountForTesting() const { return m_source->decodeCountForTesting(); }
     unsigned blankDrawCountForTesting() const { return m_source->blankDrawCountForTesting(); }
 

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -192,8 +192,8 @@ private:
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) final { m_clearDecoderAfterAsyncFrameRequestForTesting = enabled; }
     void setAsyncDecodingEnabledForTesting(bool enabled) final { m_isAsyncDecodingEnabledForTesting = enabled; }
     bool isAsyncDecodingEnabledForTesting() const final { return m_isAsyncDecodingEnabledForTesting; }
-    void setHasPaintedHDRContentForTesting() final { m_hasPaintedHDRContentForTesting = true; }
-    bool hasPaintedHDRContentForTesting() const final { return m_hasPaintedHDRContentForTesting; }
+    void setHasHDRContentForTesting() final { m_hasHDRContentForTesting = true; }
+    bool hasHDRContentForTesting() const final { return m_hasHDRContentForTesting; }
 
     void dump(TextStream&) const final;
 
@@ -219,7 +219,7 @@ private:
     unsigned m_blankDrawCountForTesting { 0 };
     bool m_isAsyncDecodingEnabledForTesting { false };
     bool m_clearDecoderAfterAsyncFrameRequestForTesting { false };
-    bool m_hasPaintedHDRContentForTesting { false };
+    bool m_hasHDRContentForTesting { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -121,7 +121,7 @@ public:
     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> protectedData() const;
 
     virtual DestinationColorSpace colorSpace();
-    virtual bool hasPaintedHDRContent() const { return false; }
+    virtual bool hasHDRContent() const { return false; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -111,8 +111,8 @@ public:
     virtual void setClearDecoderAfterAsyncFrameRequestForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual void setAsyncDecodingEnabledForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual bool isAsyncDecodingEnabledForTesting() const { return false; }
-    virtual void setHasPaintedHDRContentForTesting() { RELEASE_ASSERT_NOT_REACHED(); }
-    virtual bool hasPaintedHDRContentForTesting() const { return false; }
+    virtual void setHasHDRContentForTesting() { RELEASE_ASSERT_NOT_REACHED(); }
+    virtual bool hasHDRContentForTesting() const { return false; }
 
     virtual void dump(WTF::TextStream&) const { }
 };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1715,9 +1715,9 @@ void RenderElement::didRemoveCachedImageClient(CachedImage& cachedImage)
 void RenderElement::imageContentChanged(CachedImage& cachedImage)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (!document().hasPaintedHDRContent()) {
-        if (cachedImage.hasPaintedHDRContent())
-            document().setHasPaintedHDRContent();
+    if (!document().hasHDRContent()) {
+        if (cachedImage.hasHDRContent())
+            document().setHasHDRContent();
     }
 #else
     UNUSED_PARAM(cachedImage);

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -434,9 +434,9 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element())) {
         page().didFinishLoadingImageForElement(*image);
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        if (!document().hasPaintedHDRContent()) {
-            if (cachedImage() && cachedImage()->hasPaintedHDRContent())
-                document().setHasPaintedHDRContent();
+        if (!document().hasHDRContent()) {
+            if (cachedImage() && cachedImage()->hasHDRContent())
+                document().setHasHDRContent();
         }
 #endif
     }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -408,8 +408,8 @@ RenderLayer::~RenderLayer()
 RenderLayer::PaintedContentRequest::PaintedContentRequest(const RenderLayer& owningLayer)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (owningLayer.renderer().document().canDrawHDRContent())
-        makePaintedHDRContentUnknown();
+    if (owningLayer.renderer().document().drawsHDRContent())
+        makeHDRContentUnknown();
 #else
     UNUSED_PARAM(owningLayer);
 #endif
@@ -5822,11 +5822,11 @@ static bool hasVisibleBoxDecorationsOrBackground(const RenderElement& renderer)
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-static bool isRenderElementWithHDR(const RenderElement& renderer)
+static bool rendererHasHDRContent(const RenderElement& renderer)
 {
     if (CheckedPtr imageRenderer = dynamicDowncast<RenderImage>(renderer)) {
         if (auto* cachedImage = imageRenderer->cachedImage()) {
-            if (cachedImage->hasPaintedHDRContent())
+            if (cachedImage->hasHDRContent())
                 return true;
         }
         return false;
@@ -5834,7 +5834,7 @@ static bool isRenderElementWithHDR(const RenderElement& renderer)
 
     if (CheckedPtr imageRenderer = dynamicDowncast<LegacyRenderSVGImage>(renderer)) {
         if (auto* cachedImage = imageRenderer->imageResource().cachedImage()) {
-            if (cachedImage->hasPaintedHDRContent())
+            if (cachedImage->hasHDRContent())
                 return true;
         }
         return false;
@@ -5902,8 +5902,8 @@ static void determineNonLayerDescendantsPaintedContent(const RenderElement& rend
         }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        if (!request.isPaintedHDRContentSatisfied() && isRenderElementWithHDR(*childElement)) {
-            request.setHasPaintedHDRContent();
+        if (!request.isHDRContentSatisfied() && rendererHasHDRContent(*childElement)) {
+            request.setHasHDRContent();
 
             if (request.isSatisfied())
                 return;
@@ -5923,11 +5923,11 @@ void RenderLayer::determineNonLayerDescendantsPaintedContent(PaintedContentReque
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-bool RenderLayer::isRenderElementWithHDR() const
+bool RenderLayer::rendererHasHDRContent() const
 {
     if (auto* imageDocument = dynamicDowncast<ImageDocument>(renderer().document()))
-        return imageDocument->hasPaintedHDRContent();
-    return WebCore::isRenderElementWithHDR(renderer());
+        return imageDocument->hasHDRContent();
+    return WebCore::rendererHasHDRContent(renderer());
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -568,15 +568,15 @@ public:
         bool isPaintedContentSatisfied() const { return hasPaintedContent != RequestState::Unknown; }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        void setHasPaintedHDRContent() { hasPaintedHDRContent = RequestState::True; }
-        void makePaintedHDRContentUnknown() { hasPaintedHDRContent = RequestState::Unknown; }
-        bool isPaintedHDRContentSatisfied() const { return hasPaintedHDRContent != RequestState::Unknown; }
+        void setHasHDRContent() { hasHDRContent = RequestState::True; }
+        void makeHDRContentUnknown() { hasHDRContent = RequestState::Unknown; }
+        bool isHDRContentSatisfied() const { return hasHDRContent != RequestState::Unknown; }
 #endif
 
         bool isSatisfied() const
         {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-            if (!isPaintedHDRContentSatisfied())
+            if (!isHDRContentSatisfied())
                 return false;
 #endif
             return isPaintedContentSatisfied();
@@ -584,7 +584,7 @@ public:
 
         RequestState hasPaintedContent { RequestState::Unknown };
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        RequestState hasPaintedHDRContent { RequestState::DontCare };
+        RequestState hasHDRContent { RequestState::DontCare };
 #endif
     };
 
@@ -596,7 +596,7 @@ public:
     void determineNonLayerDescendantsPaintedContent(PaintedContentRequest&) const;
 #if HAVE(SUPPORT_HDR_DISPLAY)
     // True if renderer itself draws HDR content, no traversal is done.
-    bool isRenderElementWithHDR() const;
+    bool rendererHasHDRContent() const;
 #endif
 
     // FIXME: We should ASSERT(!m_hasSelfPaintingLayerDescendantDirty); here but we hit the same bugs as visible content above.

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -393,7 +393,7 @@ private:
     bool isUnscaledBitmapOnly() const;
     bool isBitmapOnly() const;
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    bool isRenderElementWithHDR() const;
+    bool rendererHasHDRContent() const;
 #endif
 
     void updateDirectlyCompositedBoxDecorations(PaintedContentsInfo&, bool& didUpdateContentsRect);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -72,11 +72,11 @@ void LegacyRenderSVGImage::notifyFinished(CachedResource& newImage, const Networ
         return;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (!document().hasPaintedHDRContent()) {
+    if (!document().hasHDRContent()) {
         CachedImage* cachedImage = imageResource().cachedImage();
 
-        if (cachedImage && cachedImage->hasPaintedHDRContent()) {
-            document().setHasPaintedHDRContent();
+        if (cachedImage && cachedImage->hasHDRContent()) {
+            document().setHasHDRContent();
             page().didFinishLoadingImageForSVGImage(imageElement());
         }
     }

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -208,14 +208,14 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     return result;
 }
 
-bool SVGImage::hasPaintedHDRContent() const
+bool SVGImage::hasHDRContent() const
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (!m_page)
         return false;
 
     if (RefPtr localTopDocument = m_page->localTopDocument())
-        return localTopDocument->hasPaintedHDRContent();
+        return localTopDocument->hasHDRContent();
 #endif
     return false;
 }

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -95,7 +95,7 @@ private:
     // FIXME: Implement this to be less conservative.
     bool currentFrameKnownToBeOpaque() const final { return false; }
 
-    bool hasPaintedHDRContent() const final;
+    bool hasHDRContent() const final;
     RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) final;
 
     void startAnimationTimerFired();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1256,10 +1256,10 @@ void Internals::setForceUpdateImageDataEnabledForTesting(HTMLImageElement& eleme
         cachedImage->setForceUpdateImageDataEnabledForTesting(enabled);
 }
 
-void Internals::setHasPaintedHDRContentForTesting(HTMLImageElement& element)
+void Internals::setHasHDRContentForTesting(HTMLImageElement& element)
 {
     if (auto* bitmapImage = bitmapImageFromImageElement(element))
-        bitmapImage->setHasPaintedHDRContentForTesting();
+        bitmapImage->setHasHDRContentForTesting();
 }
 
 #if ENABLE(WEB_CODECS)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -270,7 +270,7 @@ public:
     unsigned remoteImagesCountForTesting() const;
     void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
     void setForceUpdateImageDataEnabledForTesting(HTMLImageElement&, bool enabled);
-    void setHasPaintedHDRContentForTesting(HTMLImageElement&);
+    void setHasHDRContentForTesting(HTMLImageElement&);
 
 #if ENABLE(WEB_CODECS)
     bool hasPendingActivity(const WebCodecsVideoDecoder&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -750,7 +750,7 @@ enum ContentsFormat {
     unsigned long remoteImagesCountForTesting();
     undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
     undefined setForceUpdateImageDataEnabledForTesting(HTMLImageElement element, boolean enabled);
-    undefined setHasPaintedHDRContentForTesting(HTMLImageElement element);
+    undefined setHasHDRContentForTesting(HTMLImageElement element);
 
     [Conditional=WEB_CODECS] boolean hasPendingActivity(WebCodecsVideoDecoder decoder);
 


### PR DESCRIPTION
#### 6a70e0be368696489e2f673a9c25434f24957fd3
<pre>
[HDR] Unify the names of the methods and the members of HDR content
<a href="https://bugs.webkit.org/show_bug.cgi?id=289880">https://bugs.webkit.org/show_bug.cgi?id=289880</a>
<a href="https://rdar.apple.com/147184369">rdar://147184369</a>

Reviewed by Simon Fraser.

Two names are only needed for HDR content:

1. hasHDRContent: This is true if an Image, RenderElement, RenderLayer,
   RenderLayerBacking or Document has HDR content.

2. drawsHDRContent:: This is true if a GraphicsLayer or Document can and must
   draw HDR content.

* LayoutTests/compositing/hdr/hdr-basic-image.html:
* LayoutTests/compositing/hdr/hdr-css-image.html:
* LayoutTests/compositing/hdr/hdr-svg-inline-image.html:
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-css-image.html:
* LayoutTests/fast/images/hdr-svg-inline-image.html:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::drawsHDRContent const):
(WebCore::Document::canDrawHDRContent const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::setHasHDRContent):
(WebCore::Document::hasHDRContent const):
(WebCore::Document::setHasPaintedHDRContent): Deleted.
(WebCore::Document::hasPaintedHDRContent const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContext2d):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::hasHDRContent const):
(WebCore::CachedImage::hasPaintedHDRContent const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::hasHDRContent const):
(WebCore::Image::hasPaintedHDRContent const): Deleted.
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::setHasHDRContentForTesting):
(WebCore::ImageSource::hasHDRContentForTesting const):
(WebCore::ImageSource::setHasPaintedHDRContentForTesting): Deleted.
(WebCore::ImageSource::hasPaintedHDRContentForTesting const): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::imageContentChanged):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::notifyFinished):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):
(WebCore::PaintedContentsInfo::isPaintsContentSatisfied const):
(WebCore::PaintedContentsInfo::paintsHDRContent):
(WebCore::PaintedContentsInfo::isContentsTypeSatisfied const):
(WebCore::PaintedContentsInfo::rendererHasHDRContent):
(WebCore::PaintedContentsInfo::determinePaintsContent):
(WebCore::PaintedContentsInfo::determineContentsType):
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::determinePaintsContent const):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
(WebCore::RenderLayerBacking::rendererHasHDRContent const):
(WebCore::PaintedContentsInfo::isRenderElementWithHDR): Deleted.
(WebCore::RenderLayerBacking::isRenderElementWithHDR const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::notifyFinished):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::hasHDRContent const):
(WebCore::SVGImage::hasPaintedHDRContent const): Deleted.
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setHasHDRContentForTesting):
(WebCore::Internals::setHasPaintedHDRContentForTesting): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/292268@main">https://commits.webkit.org/292268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558d20dadcd17b2e469ae6716849cd82dadd1b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30038 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3862 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102498 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27570 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->