### PR TITLE
`getBoundingClientRect()` should ignore nested element when height is zero

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001-expected.txt
@@ -1,0 +1,6 @@
+non-empty
+
+PASS t1.getBoundingClientRect().width
+PASS t2.getBoundingClientRect().width
+PASS t3.getBoundingClientRect().width
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level" />
+<link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsetwidth" />
+<link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-range-getboundingclientrect" />
+<link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+div {
+  width: 500px;
+}
+.inline-block {
+  display: inline-block;
+  width: 100px;
+  height: 1px;
+  background: blue;
+}
+.w200 {
+  width: 200px;
+}
+</style>
+<body>
+  <!-- The `<span>` contains an empty block child -->
+  <div>
+    <span id="t1" class="target">
+      <div class="inline-block"></div>
+      <div></div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+
+  <!-- The `<span>` contains non-empty block child -->
+  <div>
+    <span id="t2" class="target">
+      <div class="inline-block"></div>
+      <div>non-empty</div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+
+  <!-- The `<span>` contains empty but non-zero height block child -->
+  <div>
+    <span id="t3" class="target">
+      <div class="inline-block"></div>
+      <div style="height: 100px"></div>
+      <div class="inline-block w200"></div>
+    </span>
+  </div>
+<script>
+// The `getBoundingClientRect` spec[1] says to ignore rects "of which the
+// height or width is not zero."
+// [1] https://www.w3.org/TR/cssom-view-1/#dom-range-getboundingclientrect
+function testGetBoundingClientRect() {
+  test(()=> { assert_equals(t1.getBoundingClientRect().width, 200); },
+                            `t1.getBoundingClientRect().width`);
+  test(()=> { assert_equals(t2.getBoundingClientRect().width, 500); },
+                            `t2.getBoundingClientRect().width`);
+  test(()=> { assert_equals(t3.getBoundingClientRect().width, 500); },
+                            `t3.getBoundingClientRect().width`);
+}
+testGetBoundingClientRect();
+
+// Skip testing `offsetWidth` because the 3 implementations return different
+// values for these cases, and the expectations aren't clear from the spec.
+// https://github.com/w3c/csswg-drafts/issues/6588
+function testOffsetWidth() {
+  test(()=> { assert_equals(t1.offsetWidth, 200); }, `t1.offsetWidth`);
+  test(()=> { assert_equals(t2.offsetWidth, 500); }, `t2.offsetWidth`);
+  test(()=> { assert_equals(t3.offsetWidth, 500); }, `t3.offsetWidth`);
+}
+// testOffsetWidth();
+</script>
+</body>

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -968,7 +968,7 @@ void RenderBoxModelObject::collectAbsoluteQuadsForContinuation(Vector<FloatQuad>
 {
     ASSERT(continuation());
     for (auto* nextInContinuation = this->continuation(); nextInContinuation; nextInContinuation = nextInContinuation->continuation()) {
-        if (auto blockBox = dynamicDowncast<RenderBlock>(*nextInContinuation)) {
+        if (auto blockBox = dynamicDowncast<RenderBlock>(*nextInContinuation); blockBox && blockBox->height() && blockBox->width()) {
             // For blocks inside inlines, we include margins so that we run right up to the inline boxes
             // above and below us (thus getting merged with them to form a single irregular shape).
             auto logicalRect = FloatRect { 0, -blockBox->collapsedMarginBefore(), blockBox->width(),


### PR DESCRIPTION
#### b95d50c21bf59ad92719958f60c0cf7d29d472bd
<pre>
`getBoundingClientRect()` should ignore nested element when height is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=267622">https://bugs.webkit.org/show_bug.cgi?id=267622</a>

Reviewed by Alan Baradlay.

`getBoundingClientRect()` was returning incorrect layout information when an element had its height set to zero.
it was including the non-zero value of the other dimension,
which resulted in an inaccurate bounding rectangle.

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/block-in-inline-client-rects-001.html: Added.
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::collectAbsoluteQuadsForContinuation const):

Canonical link: <a href="https://commits.webkit.org/292521@main">https://commits.webkit.org/292521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a99cbdb662ffdc50eba30000b3363ae583555eb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100991 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73145 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103019 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94552 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22998 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16828 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81546 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16335 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->