### PR TITLE
[css-anchor-position-1] Test for inset-modified containing block when determining overflow

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the top of anchor expected 600 but got 800
-FAIL Should use the third fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 700
-FAIL Should use the second fallback position with enough space right assert_equals: Anchored element should be at the top of anchor expected 450 but got 800
-FAIL Should use the first fallback position with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 700
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 500
+FAIL Should use the second fallback position with enough space right assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
+FAIL Should use the first fallback position with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 500
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the top of anchor expected 600 but got 800
-FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got -115
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the right of anchor expected 135 but got -215
-FAIL Should use the first fallback position with enough space left and below assert_equals: Anchored element should be at the left of anchor expected 135 but got -115
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
+FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
+FAIL Should use the first fallback position with enough space left and below assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the bottom of anchor expected -15 but got -215
-FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got -115
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the right of anchor expected 135 but got -215
-FAIL Should use the first fallback position with enough space left and above assert_equals: Anchored element should be at the left of anchor expected 135 but got -115
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
+FAIL Should use the first fallback position with enough space left and above assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the top of anchor expected 600 but got 800
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 900
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the left of anchor expected 650 but got 1000
-FAIL Should use the first fallback position with enough space right and below assert_equals: Anchored element should be at the right of anchor expected 650 but got 900
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
+FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
+FAIL Should use the first fallback position with enough space right and below assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the bottom of anchor expected -15 but got -215
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 900
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the left of anchor expected 650 but got 1000
-FAIL Should use the first fallback position with enough space right and above assert_equals: Anchored element should be at the right of anchor expected 650 but got 900
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
+FAIL Should use the first fallback position with enough space right and above assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Should use the last fallback position initially assert_equals: Anchored element should be at the bottom of anchor expected 85 but got -115
-FAIL Should use the third fallback position with enough space above assert_equals: Anchored element should be at the left of anchor expected 358 but got 558
-FAIL Should use the second fallback position with enough space right assert_equals: Anchored element should be at the bottom of anchor expected 235 but got 35
-PASS Should use the first fallback position with enough space above and right
+PASS Should use the last fallback position initially
+FAIL Should use the third fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 235 but got 435
+FAIL Should use the second fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 358 but got 158
+FAIL Should use the first fallback position with enough space above and right assert_equals: Anchored element should be at the top of anchor expected 235 but got 435
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-002-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-offset-x="200" data-offset-y="0" data-expected-width="200" data-expected-height="100">
-      <span class="inline-spacer"></span>
-    </div>
-offsetLeft expected 200 but got 0
+PASS .target 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-003-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL .anchored 1 assert_equals:
-<div class="anchored exceeds-end" data-offset-x="22" data-offset-y="11"></div>
-offsetLeft expected 22 but got 0
-FAIL .anchored 2 assert_equals:
-<div class="anchored ltr vlr exceeds-start" data-offset-x="22" data-offset-y="11"></div>
-offsetLeft expected 22 but got 150
+PASS .anchored 1
+PASS .anchored 2
 PASS .anchored 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-grid-001-expected.txt
@@ -16,5 +16,5 @@
 
 FAIL .target 1 assert_equals:
 <div class="target" data-offset-x="135" data-offset-y="70" data-expected-height="100"></div>
-offsetLeft expected 135 but got 235
+height expected 100 but got 0
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -111,7 +111,7 @@ public:
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
     static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);
 
-    static bool overflowsContainingBlock(const RenderBox& anchoredBox);
+    static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1045,7 +1045,7 @@ bool Scope::invalidateForPositionTryFallbacks(LayoutDependencyUpdateContext& con
     bool invalidated = false;
 
     for (auto& box : m_document->renderView()->positionTryBoxes()) {
-        if (!AnchorPositionEvaluator::overflowsContainingBlock(box))
+        if (!AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(box))
             continue;
 
         CheckedPtr element = box.element();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1470,7 +1470,7 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
     if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Positioned)
         return ResolvedStyle { RenderStyle::clonePtr(*existingStyle) };
 
-    if (!AnchorPositionEvaluator::overflowsContainingBlock(*renderer)) {
+    if (!AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(*renderer)) {
         // We don't overflow anymore so this is a good style.
         options.chosen = true;
         return ResolvedStyle { RenderStyle::clonePtr(*existingStyle) };


### PR DESCRIPTION
#### 3569fb1b75f0213652ac8c74b6c12c715709e7f6
<pre>
[css-anchor-position-1] Test for inset-modified containing block when determining overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=289894">https://bugs.webkit.org/show_bug.cgi?id=289894</a>
<a href="https://rdar.apple.com/147215822">rdar://147215822</a>

Reviewed by Alan Baradlay.

Position-try overflow test should use inset-modified containing block.

<a href="https://drafts.csswg.org/css-anchor-position-1/#fallback-apply">https://drafts.csswg.org/css-anchor-position-1/#fallback-apply</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-grid-001-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock):
(WebCore::Style::AnchorPositionEvaluator::overflowsContainingBlock): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForPositionTryFallbacks):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::tryChoosePositionOption):

Canonical link: <a href="https://commits.webkit.org/292269@main">https://commits.webkit.org/292269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54496ba346d141aef7e5726cfc2eb960b6ee83c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72796 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22486 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16423 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15807 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27594 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->