### PR TITLE
Math.hypot() is significantly slower than Math.sqrt()

### DIFF
--- a/JSTests/microbenchmarks/math-hypot.js
+++ b/JSTests/microbenchmarks/math-hypot.js
@@ -1,0 +1,16 @@
+function hypot2(arg1, arg2) {
+  return Math.hypot(arg1, arg2);
+}
+
+function hypot3(arg1, arg2, arg3) {
+  return Math.hypot(arg1, arg2, arg3);
+}
+noInline(hypot2);
+noInline(hypot3);
+
+for (var i = 0; i < testLoopCount; ++i) {
+  hypot2(3, 4);
+  hypot2(9, 12);
+  hypot3(400.2, -3.4, 3);
+  hypot3(-24.3, -400.2, -0.4);
+}

--- a/JSTests/microbenchmarks/math-sqrt.js
+++ b/JSTests/microbenchmarks/math-sqrt.js
@@ -1,0 +1,12 @@
+function sqrt(arg) {
+  return Math.sqrt(arg);
+}
+
+noInline(sqrt);
+
+for (var i = 0; i < testLoopCount; ++i) {
+  sqrt(3);
+  sqrt(9);
+  sqrt(400.2);
+  sqrt(-24.3);
+}

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -199,6 +199,33 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncHypot, (JSGlobalObject* globalObject, Call
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     unsigned argsCount = callFrame->argumentCount();
+
+    if (argsCount == 1) {
+        double arg0 = callFrame->uncheckedArgument(0).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        return JSValue::encode(jsDoubleNumber(std::fabs(arg0)));
+    }
+    if (argsCount == 2) {
+        double arg0 = callFrame->uncheckedArgument(0).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        double arg1 = callFrame->uncheckedArgument(1).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (std::isinf(arg0) || std::isinf(arg1))
+            return JSValue::encode(jsDoubleNumber(+std::numeric_limits<double>::infinity()));
+        return JSValue::encode(jsDoubleNumber(std::hypot(arg0, arg1)));
+    }
+    if (argsCount == 3) {
+        double arg0 = callFrame->uncheckedArgument(0).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        double arg1 = callFrame->uncheckedArgument(1).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        double arg2 = callFrame->uncheckedArgument(2).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (std::isinf(arg0) || std::isinf(arg1) || std::isinf(arg2))
+            return JSValue::encode(jsDoubleNumber(+std::numeric_limits<double>::infinity()));
+        return JSValue::encode(jsDoubleNumber(std::hypotl(std::hypotl(arg0, arg1), arg2)));
+    }
+
     Vector<double, 8> args(argsCount, [&](size_t i) -> std::optional<double> {
         double argument = callFrame->uncheckedArgument(i).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, std::nullopt);


### PR DESCRIPTION
#### bdf66e673c2cd00105ced79e319cb12b8ba6b373
<pre>
Math.hypot() is significantly slower than Math.sqrt()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284631">https://bugs.webkit.org/show_bug.cgi?id=284631</a>

Reviewed by Yusuke Suzuki.

optimized `Math.hypot()` for cases with 1, 2 or 3 arguments

* JSTests/microbenchmarks/math-hypot.js: Added.
(hypot):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/292549@main">https://commits.webkit.org/292549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20fbda3215fb2c4ae55b200826697a03044eddcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46889 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73453 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46217 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89043 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103465 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94991 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81874 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3972 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16837 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28555 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118468 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23059 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->