### PR TITLE
REGRESSION (291478@main): [ macOS wk2 arm64 ] http/tests/site-isolation/fullscreen.html is a flaky failure

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,11 +1,9 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
-beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
+beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
 exitFullScreenForElement()
 beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
 
-FIXME: Size after entering should be 600x800 like it is with site isolation off.
-The size currently comes from screenRectOfContents.
 Size after entering fullscreen: 600x800
 iframe border style after transition: 0px none rgb(0, 0, 0)
 

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -13,6 +13,4 @@
 </script>
 <iframe id='frame' allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen.html" frameborder=0></iframe>
 <div id=mylog>
-FIXME: Size after entering should be 600x800 like it is with site isolation off.<br>
-The size currently comes from screenRectOfContents.<br>
 </div>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2010,8 +2010,6 @@ webkit.org/b/289254 [ Debug ] imported/w3c/web-platform-tests/mediacapture-strea
 
 webkit.org/b/289284 fast/canvas/image-buffer-resource-limits.html [ Pass Timeout Crash ]
 
-webkit.org/b/289347 [ arm64 ] http/tests/site-isolation/fullscreen.html [ Pass Failure ]
-
 # webkit.org/b/289298 [ macOS wk2 Release ] 3x imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-00*.html are flaky failures.
 [ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html [ Pass Failure ]
 [ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -229,6 +229,9 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
         enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTFMove(completionHandler));
     } };
 
+    if (RefPtr page = m_page.get(); page && page->preferences().siteIsolationEnabled())
+        co_await page->nextPresentationUpdate();
+
     co_return true;
 }
 


### PR DESCRIPTION
#### 43de8b9eaabfc4556c0fd2ad28758c3f79b65549
<pre>
REGRESSION (291478@main): [ macOS wk2 arm64 ] http/tests/site-isolation/fullscreen.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=289347">https://bugs.webkit.org/show_bug.cgi?id=289347</a>
<a href="https://rdar.apple.com/146487655">rdar://146487655</a>

Reviewed by Charlie Wolfe.

When entering fullscreen on an element in a site-isolated iframe, enterFullScreenForOwnerElementsInOtherProcesses
applies CSS to the owner element in another process.  During a presentation update, Messages::WebPage::UpdateFrameSize
is sent to the child frame after the parent frame changes the child frame&apos;s size.  In order to get the correct
starting and ending size, this needs to happen before Messages::WebFullScreenManagerProxy::BeganEnterFullScreen
is sent.  To accomplish this, I await the presentation update earlier in the enterFullscreen pipeline when site
isolation is enabled in addition to waiting in WebFullScreenManagerProxy::beganEnterFullScreen.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt:
* LayoutTests/http/tests/site-isolation/fullscreen.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):

Canonical link: <a href="https://commits.webkit.org/292289@main">https://commits.webkit.org/292289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0315df2336b1e74a6f3fb3ced91e2673c256d3fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95465 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15067 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45970 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23498 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72811 "Build is in progress. Recent messages:Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 12 flakes 104 failures; Uploaded test results; 18 flakes 63 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change; Passed layout tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30077 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53143 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/94953 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22515 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16445 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81850 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/95037 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/126/builds/25783 "Build is in progress. Recent messages:Running configuration; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82232 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81201 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; run-api-tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25783 "Build is in progress. Recent messages:Running configuration; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15841 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22483 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27654 "") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22142 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->