### PR TITLE
[Content Filtering] Avoid creating multiple WCRBrowserEngineClient instances

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -312,6 +312,7 @@ platform/cocoa/MediaUtilities.cpp
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/cocoa/NSURLUtilities.mm
 platform/cocoa/ParentalControlsContentFilter.mm
+platform/cocoa/ParentalControlsURLFilter.mm
 platform/cocoa/PasteboardCocoa.mm
 platform/cocoa/PasteboardCustomDataCocoa.mm
 platform/cocoa/PhotosFormatSoftLink.mm

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -83,7 +83,6 @@ public:
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    WEBCORE_EXPORT void setUsesWebContentRestrictions(bool);
     static bool isWebContentRestrictionsUnblockURL(const URL&);
 #endif
 
@@ -91,7 +90,7 @@ private:
     using State = PlatformContentFilter::State;
 
     struct Type {
-        Function<UniqueRef<PlatformContentFilter>()> create;
+        Function<UniqueRef<PlatformContentFilter>(const PlatformContentFilter::FilterParameters&)> create;
     };
     template <typename T> static Type type();
     WEBCORE_EXPORT static Vector<Type>& types();

--- a/Source/WebCore/loader/ContentFilterClient.h
+++ b/Source/WebCore/loader/ContentFilterClient.h
@@ -54,6 +54,10 @@ public:
     virtual ResourceError contentFilterDidBlock(ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) = 0;
     virtual void cancelMainResourceLoadForContentFilter(const ResourceError&) = 0;
     virtual void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData&) = 0;
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    virtual bool usesWebContentRestrictions() = 0;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2183,10 +2183,6 @@ void DocumentLoader::startLoadingMainResource()
     contentFilterInDocumentLoader() = frame && frame->view() && frame->protectedView()->platformWidget();
     if (contentFilterInDocumentLoader())
         m_contentFilter = !m_substituteData.isValid() ? ContentFilter::create(*this) : nullptr;
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    if (m_contentFilter)
-        m_contentFilter->setUsesWebContentRestrictions(DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter());
-#endif
 #endif
 
     auto url = m_request.url();
@@ -2643,6 +2639,13 @@ void DocumentLoader::handleProvisionalLoadFailureFromContentFilter(const URL& bl
 {
     protectedFrameLoader()->load(FrameLoadRequest(*frame(), blockedPageURL, substituteData));
 }
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+bool DocumentLoader::usesWebContentRestrictions()
+{
+    return DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter();
+}
+#endif
 #endif // ENABLE(CONTENT_FILTERING)
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -591,6 +591,9 @@ private:
     WEBCORE_EXPORT ResourceError contentFilterDidBlock(ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) final;
     WEBCORE_EXPORT void cancelMainResourceLoadForContentFilter(const ResourceError&) final;
     WEBCORE_EXPORT void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData&) final;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    WEBCORE_EXPORT bool usesWebContentRestrictions() final;
+#endif
 #endif
 
     void redirectReceived(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -102,7 +102,6 @@ private:
     UnblockRequesterFunction m_unblockRequester;
 #if HAVE(WEBCONTENTRESTRICTIONS)
     std::optional<URL> m_evaluatedURL;
-    mutable RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
 #endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -82,9 +82,11 @@ public:
     void setHostProcessAuditToken(const std::optional<audit_token_t>& token) { m_hostProcessAuditToken = token; }
 #endif
 
+    struct FilterParameters {
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    virtual void setUsesWebContentRestrictions(bool) { };
+        bool usesWebContentRestrictions { false };
 #endif
+    };
 
 protected:
     PlatformContentFilter() = default;

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -47,7 +47,7 @@ class NetworkExtensionContentFilter final : public PlatformContentFilter {
     friend UniqueRef<NetworkExtensionContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<NetworkExtensionContentFilter>();
 
 public:
-    static UniqueRef<NetworkExtensionContentFilter> create();
+    static UniqueRef<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -56,7 +56,7 @@ bool NetworkExtensionContentFilter::enabled()
     return isRequired();
 }
 
-UniqueRef<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create()
+UniqueRef<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
     return makeUniqueRef<NetworkExtensionContentFilter>();
 }

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -34,18 +34,16 @@
 OBJC_CLASS NSData;
 OBJC_CLASS WebFilterEvaluator;
 
-#if HAVE(WEBCONTENTRESTRICTIONS)
-OBJC_CLASS WCRBrowserEngineClient;
-#endif
-
 namespace WebCore {
+
+class ParentalControlsURLFilter;
 
 class ParentalControlsContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(ParentalControlsContentFilter);
-    friend UniqueRef<ParentalControlsContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsContentFilter>();
+    friend UniqueRef<ParentalControlsContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsContentFilter>(const PlatformContentFilter::FilterParameters&);
 
 public:
-    static UniqueRef<ParentalControlsContentFilter> create();
+    static UniqueRef<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override { }
     void responseReceived(const ResourceResponse&) override;
@@ -57,17 +55,13 @@ public:
 #endif
     
 private:
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    static bool enabled(bool usesWebContentRestrictions);
-#else
-    static bool enabled();
-#endif
+    explicit ParentalControlsContentFilter(const PlatformContentFilter::FilterParameters&);
+    bool enabled() const;
 
-    ParentalControlsContentFilter() = default;
     void updateFilterState();
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    void updateFilterState(bool shouldBlock, NSData *replacmentData);
-    void setUsesWebContentRestrictions(bool) final;
+    void updateFilterState(PlatformContentFilter::State, NSData *);
+    void enableURLFilter();
 #endif
 
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
@@ -75,7 +69,6 @@ private:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     bool m_usesWebContentRestrictions { false };
-    RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
     std::optional<URL> m_evaluatedURL;
 #endif
 };

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+OBJC_CLASS WCRBrowserEngineClient;
+
+namespace WebCore {
+
+class ParentalControlsURLFilter {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend UniqueRef<ParentalControlsURLFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsURLFilter>();
+public:
+    static ParentalControlsURLFilter& singleton();
+
+    bool isEnabled() const;
+    void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
+    void allowURL(const URL&, CompletionHandler<void(bool)>&&);
+
+private:
+    ParentalControlsURLFilter();
+
+    RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ParentalControlsURLFilter.h"
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#import <wtf/CompletionHandler.h>
+#import <wtf/MainThread.h>
+#import <wtf/URL.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+#import <pal/cocoa/WebContentRestrictionsSoftLink.h>
+
+namespace WebCore {
+
+static bool wcrBrowserEngineClientEnabled()
+{
+    return [PAL::getWCRBrowserEngineClientClass() shouldEvaluateURLs];
+}
+
+ParentalControlsURLFilter& ParentalControlsURLFilter::singleton()
+{
+    static MainThreadNeverDestroyed<UniqueRef<ParentalControlsURLFilter>> filter = makeUniqueRef< ParentalControlsURLFilter>();
+    return filter.get();
+}
+
+ParentalControlsURLFilter::ParentalControlsURLFilter()
+{
+    if (wcrBrowserEngineClientEnabled())
+        m_wcrBrowserEngineClient = adoptNS([PAL::allocWCRBrowserEngineClientInstance() init]);
+}
+
+bool ParentalControlsURLFilter::isEnabled() const
+{
+    return !!m_wcrBrowserEngineClient;
+}
+
+void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    if (!m_wcrBrowserEngineClient)
+        return completionHandler(true, nullptr);
+
+    [m_wcrBrowserEngineClient evaluateURL:url withCompletion:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+        ASSERT(isMainThread());
+
+        completionHandler(!shouldBlock, replacementData);
+    }).get()];
+}
+
+void ParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    if (!m_wcrBrowserEngineClient)
+        return completionHandler(true);
+
+    [m_wcrBrowserEngineClient allowURL:url withCompletion:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL didAllow, NSError *) mutable {
+        ASSERT(isMainThread());
+
+        completionHandler(didAllow);
+    }).get()];
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm
+++ b/Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <ImageIO/CGImageSource.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(WebCore, PhotosFormats);

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h
@@ -52,7 +52,7 @@ public:
     bool supportsMIMEType(const String& mimeType) const override;
     RefPtr<LegacyCDMSession> createSession(LegacyCDMSessionClient&) override;
 
-    LegacyCDM& cdm() const { return m_cdm.get(); }
+    LegacyCDM& cdm() const;
 
     void invalidateSession(CDMSessionMediaSourceAVFObjC*);
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
@@ -155,6 +155,11 @@ void CDMPrivateMediaSourceAVFObjC::deref() const
     m_cdm->deref();
 }
 
+LegacyCDM& CDMPrivateMediaSourceAVFObjC::cdm() const
+{
+    return m_cdm.get();
+}
+
 }
 
 #endif // ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
@@ -29,6 +29,7 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
 
 #import "CDMPrivateMediaSourceAVFObjC.h"
+#import "LegacyCDM.h"
 #import "Logging.h"
 #import "WebCoreNSErrorExtras.h"
 #import <AVFoundation/AVError.h>

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
@@ -36,6 +36,7 @@ class ButtonControlMac : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(ButtonControlMac);
 public:
     ButtonControlMac(ControlPart&, ControlFactoryMac&, NSButtonCell *);
+    ~ButtonControlMac();
 
 protected:
     void updateCellStates(const FloatRect&, const ControlStyle&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -42,6 +42,8 @@ ButtonControlMac::ButtonControlMac(ControlPart& part, ControlFactoryMac& control
     ASSERT(m_buttonCell);
 }
 
+ButtonControlMac::~ButtonControlMac() = default;
+
 void ButtonControlMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
 {
     ControlMac::updateCellStates(rect, style);

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -43,6 +43,7 @@ class ControlMac : public PlatformControl {
     WTF_MAKE_TZONE_ALLOCATED(ControlMac);
 public:
     ControlMac(ControlPart&, ControlFactoryMac&);
+    ~ControlMac();
 
 protected:
     static bool userPrefersContrast();

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -56,6 +56,8 @@ ControlMac::ControlMac(ControlPart& owningPart, ControlFactoryMac& controlFactor
 {
 }
 
+ControlMac::~ControlMac() = default;
+
 bool ControlMac::userPrefersContrast()
 {
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
@@ -40,6 +40,7 @@ class ImageControlsButtonMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(ImageControlsButtonMac);
 public:
     ImageControlsButtonMac(ImageControlsButtonPart&, ControlFactoryMac&, NSServicesRolloverButtonCell *);
+    ~ImageControlsButtonMac();
 
     static IntSize servicesRolloverButtonCellSize();
 

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -46,6 +46,8 @@ ImageControlsButtonMac::ImageControlsButtonMac(ImageControlsButtonPart& owningPa
 {
 }
 
+ImageControlsButtonMac::~ImageControlsButtonMac() = default;
+
 IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 {
     auto& controlFactory = ControlFactoryMac::shared();

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
@@ -38,6 +38,7 @@ class InnerSpinButtonMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(InnerSpinButtonMac);
 public:
     InnerSpinButtonMac(InnerSpinButtonPart&, ControlFactoryMac&, NSStepperCell *);
+    ~InnerSpinButtonMac();
 
 private:
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -48,6 +48,8 @@ InnerSpinButtonMac::InnerSpinButtonMac(InnerSpinButtonPart& owningPart, ControlF
 {
 }
 
+InnerSpinButtonMac::~InnerSpinButtonMac() = default;
+
 #if HAVE(NSSTEPPERCELL_INCREMENTING)
 IntOutsets InnerSpinButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
 {

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
@@ -38,6 +38,7 @@ class MenuListButtonMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(MenuListButtonMac);
 public:
     MenuListButtonMac(MenuListButtonPart&, ControlFactoryMac&);
+    ~MenuListButtonMac();
 
 private:
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -43,6 +43,8 @@ MenuListButtonMac::MenuListButtonMac(MenuListButtonPart& owningPart, ControlFact
 {
 }
 
+MenuListButtonMac::~MenuListButtonMac() = default;
+
 static void interpolateGradient(const CGFloat* rawInData, CGFloat* rawOutData, std::span<const float, 4> dark, std::span<const float, 4> light)
 {
     auto inData = unsafeMakeSpan(rawInData, 1);

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
@@ -38,6 +38,7 @@ class MenuListMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(MenuListMac);
 public:
     MenuListMac(MenuListPart& owningPart, ControlFactoryMac&, NSPopUpButtonCell *);
+    ~MenuListMac();
 
 private:
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -45,6 +45,8 @@ MenuListMac::MenuListMac(MenuListPart& owningPart, ControlFactoryMac& controlFac
     ASSERT(m_popUpButtonCell);
 }
 
+MenuListMac::~MenuListMac() = default;
+
 IntSize MenuListMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
     static constexpr std::array sizes {

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -37,6 +37,7 @@ class MeterMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(MeterMac);
 public:
     MeterMac(MeterPart& owningMeterPart, ControlFactoryMac&, NSLevelIndicatorCell*);
+    ~MeterMac();
 
 private:
     const MeterPart& owningMeterPart() const { return downcast<MeterPart>(m_owningPart); }

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -46,6 +46,8 @@ MeterMac::MeterMac(MeterPart& owningMeterPart, ControlFactoryMac& controlFactory
     ASSERT(m_levelIndicatorCell);
 }
 
+MeterMac::~MeterMac() = default;
+
 void MeterMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -39,6 +39,7 @@ class ProgressBarMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(ProgressBarMac);
 public:
     ProgressBarMac(ProgressBarPart&, ControlFactoryMac&);
+    ~ProgressBarMac();
 
 private:
     const ProgressBarPart& owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart); }

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -44,6 +44,8 @@ ProgressBarMac::ProgressBarMac(ProgressBarPart& owningPart, ControlFactoryMac& c
 {
 }
 
+ProgressBarMac::~ProgressBarMac() = default;
+
 IntSize ProgressBarMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
     static const std::array<IntSize, 4> sizes =

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
@@ -36,6 +36,7 @@ class SearchControlMac : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(SearchControlMac);
 public:
     SearchControlMac(ControlPart&, ControlFactoryMac&, NSSearchFieldCell *);
+    ~SearchControlMac();
 
 protected:
     void updateCellStates(const FloatRect&, const ControlStyle&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
@@ -40,6 +40,8 @@ SearchControlMac::SearchControlMac(ControlPart& part, ControlFactoryMac& control
     ASSERT(m_searchFieldCell);
 }
 
+SearchControlMac::~SearchControlMac() = default;
+
 void SearchControlMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
 {
     ControlMac::updateCellStates(rect, style);

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
@@ -38,6 +38,7 @@ class SliderThumbMac final : public ControlMac {
     WTF_MAKE_TZONE_ALLOCATED(SliderThumbMac);
 public:
     SliderThumbMac(SliderThumbPart&, ControlFactoryMac&, NSSliderCell *);
+    ~SliderThumbMac();
 
 private:
     void updateCellStates(const FloatRect&, const ControlStyle&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -46,6 +46,8 @@ SliderThumbMac::SliderThumbMac(SliderThumbPart& owningPart, ControlFactoryMac& c
     ASSERT(m_owningPart.type() == StyleAppearance::SliderThumbHorizontal || m_owningPart.type() == StyleAppearance::SliderThumbVertical);
 }
 
+SliderThumbMac::~SliderThumbMac() = default;
+
 void SliderThumbMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
 {
     ControlMac::updateCellStates(rect, style);

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -61,7 +61,7 @@ bool MockContentFilter::enabled()
     return enabled;
 }
 
-UniqueRef<MockContentFilter> MockContentFilter::create()
+UniqueRef<MockContentFilter> MockContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
     return makeUniqueRef<MockContentFilter>();
 }

--- a/Source/WebCore/testing/MockContentFilter.h
+++ b/Source/WebCore/testing/MockContentFilter.h
@@ -38,7 +38,7 @@ class MockContentFilter final : public PlatformContentFilter {
 
 public:
     static void ensureInstalled();
-    static UniqueRef<MockContentFilter> create();
+    static UniqueRef<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -290,9 +290,6 @@ bool NetworkResourceLoader::startContentFiltering(ResourceRequest& request)
 #if HAVE(AUDIT_TOKEN)
     m_contentFilter->setHostProcessAuditToken(protectedConnectionToWebProcess()->protectedNetworkProcess()->sourceApplicationAuditToken());
 #endif
-#if HAVE(WEBCONTENTRESTRICTIONS)
-    m_contentFilter->setUsesWebContentRestrictions(protectedConnectionToWebProcess()->usesWebContentRestrictionsForFilter());
-#endif
     m_contentFilter->startFilteringMainResource(request.url());
     if (!m_contentFilter->continueAfterWillSendRequest(request, ResourceResponse())) {
         m_contentFilter->stopFilteringMainResource();
@@ -300,6 +297,7 @@ bool NetworkResourceLoader::startContentFiltering(ResourceRequest& request)
     }
     return true;
 }
+
 #endif
 
 void NetworkResourceLoader::retrieveCacheEntry(const ResourceRequest& request)
@@ -2186,6 +2184,13 @@ void NetworkResourceLoader::handleProvisionalLoadFailureFromContentFilter(const 
     protectedConnectionToWebProcess()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(m_connection->webProcessIdentifier(), RegistrableDomain { WebCore::ContentFilter::blockedPageURL() }, LoadedWebArchive::No, [] { });
     send(Messages::WebResourceLoader::ContentFilterDidBlockLoad(m_unblockHandler, m_unblockRequestDeniedScript, m_contentFilter->blockedError(), blockedPageURL, substituteData));
 }
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+bool NetworkResourceLoader::usesWebContentRestrictions()
+{
+    return protectedConnectionToWebProcess()->usesWebContentRestrictionsForFilter();
+}
+#endif
 #endif // ENABLE(CONTENT_FILTERING)
 
 void NetworkResourceLoader::useRedirectionForCurrentNavigation(WebCore::ResourceResponse&& response)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -204,6 +204,9 @@ private:
     WebCore::ResourceError contentFilterDidBlock(WebCore::ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) final;
     void cancelMainResourceLoadForContentFilter(const WebCore::ResourceError&) final;
     void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, WebCore::SubstituteData&) final;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    bool usesWebContentRestrictions() final;
+#endif
 #endif
 
     void processClearSiteDataHeader(const WebCore::ResourceResponse&, CompletionHandler<void()>&&);


### PR DESCRIPTION
#### 4d8b71918acdc7d53f68ea74f5c5a53fbe44d7eb
<pre>
[Content Filtering] Avoid creating multiple WCRBrowserEngineClient instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=289915">https://bugs.webkit.org/show_bug.cgi?id=289915</a>
<a href="https://rdar.apple.com/147251812">rdar://147251812</a>

Reviewed by Chris Dumez and Ben Nham.

The initialization of WCRBrowserEngineClient can be slow, so we should avoid creating multiple WCRBrowserEngineClient
objects. This patch ensures a process only creates one WCRBrowserEngineClient instance by introducing
ParentalControlsContentFilter class, which is a wrapper of WCRBrowserEngineClient. ContentFilterUnblockHandler and
ContentFilter objects now always use the ParentalControlsContentFilter singleton to perform operations, instead
of their own instances.

To make the implementation more robust, instead of setting m_usesWebContentRestrictions to request using
WCRBrowserEngineClient after the creation of PlatformContentFilter object, we now set the flag at creation time, and the
flag cannot be changed after creation. This ensures no switch between implementations (WebFilterEvaluator v.s.
WCRBrowserEngineClient) after content filtering starts.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::create):
(WebCore::ContentFilter::setUsesWebContentRestrictions): Deleted.
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/ContentFilterClient.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
(WebCore::DocumentLoader::usesWebContentRestrictions):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
* Source/WebCore/platform/PlatformContentFilter.h:
(WebCore::PlatformContentFilter::setUsesWebContentRestrictions): Deleted.
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync const):
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::create):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::enabled const):
(WebCore::ParentalControlsContentFilter::create):
(WebCore::ParentalControlsContentFilter::ParentalControlsContentFilter):
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::ParentalControlsContentFilter::addData):
(WebCore::ParentalControlsContentFilter::finishedAddingData):
(WebCore::ParentalControlsContentFilter::unblockHandler const):
(WebCore::ParentalControlsContentFilter::updateFilterState):
(WebCore::ParentalControlsContentFilter::enabled): Deleted.
(WebCore::ParentalControlsContentFilter::setUsesWebContentRestrictions): Deleted.
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h: Copied from Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm.
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm: Added.
(WebCore::wcrBrowserEngineClientEnabled):
(WebCore::ParentalControlsURLFilter::singleton):
(WebCore::ParentalControlsURLFilter::ParentalControlsURLFilter):
(WebCore::ParentalControlsURLFilter::isEnabled const):
(WebCore::ParentalControlsURLFilter::isURLAllowed):
(WebCore::ParentalControlsURLFilter::allowURL):
* Source/WebCore/platform/cocoa/PhotosFormatSoftLink.mm:
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm:
(WebCore::CDMPrivateMediaSourceAVFObjC::cdm const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm:
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm:
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::create):
* Source/WebCore/testing/MockContentFilter.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
(WebKit::NetworkResourceLoader::usesWebContentRestrictions):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/292963@main">https://commits.webkit.org/292963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/405f04ad5da96b94e58a1716024a75b3b3300368

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13244 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47537 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24646 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27358 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18239 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24607 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->