### PR TITLE
IPInt table.fill should pop its operands from the stack

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-table-fill.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-table-fill.js
@@ -9,7 +9,8 @@ let wat = `
     (func (export "size") (result i32)
         (table.size $table)
     )
-    (func (export "fill") (param i32 i32)
+    (func (export "fill") (param i32 i32) (result i32)
+        (i32.const 42)
         (local.get 0)
         (ref.null func)
         (local.get 1)
@@ -28,7 +29,7 @@ async function test() {
     const { size, fill, isnull } = instance.exports;
     assert.eq(size(), 5);
     assert.eq(isnull(0), 0);
-    fill(0, 5);
+    assert.eq(fill(0, 5), 42);
     assert.eq(isnull(0), 1);
 }
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3766,7 +3766,7 @@ instructionLabel(_memory_init)
     move sp, a2
     loadi 1[MC], a1
     operationCallMayThrow(macro() cCall3(_ipint_extern_memory_init) end)
-    addq 3*StackValueSize, sp
+    addq 3 * StackValueSize, sp
     loadb [MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata))) # xxx check
@@ -3810,7 +3810,7 @@ instructionLabel(_table_init)
     move sp, a1
     leap [MC], a2 # IPInt::tableInitMetadata
     operationCallMayThrow(macro() cCall3(_ipint_extern_table_init) end)
-    addp 3*StackValueSize, sp
+    addp 3 * StackValueSize, sp
     loadb IPInt::TableInitMetadata::instructionLength[MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::TableInitMetadata)))
@@ -3830,7 +3830,7 @@ instructionLabel(_table_copy)
     move sp, a1
     move MC, a2
     operationCallMayThrow(macro() cCall3(_ipint_extern_table_copy) end)
-    addp 3*StackValueSize, sp
+    addp 3 * StackValueSize, sp
     loadb IPInt::TableCopyMetadata::instructionLength[MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::TableCopyMetadata)))
@@ -3863,6 +3863,7 @@ instructionLabel(_table_fill)
     move sp, a1
     move MC, a2
     operationCallMayThrow(macro() cCall3(_ipint_extern_table_fill) end)
+    addp 3 * StackValueSize, sp
     loadb IPInt::TableFillMetadata::instructionLength[MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::TableFillMetadata)))

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -122,6 +122,8 @@ def print_stack(proc, frame, result, num_entries=None):
     ptr = frame.sp
     i = 0
 
+    print(f'stack height: {(pl - ptr) // 16}', file=result)
+
     if ptr == pl:
         print('no stack entries', file=result)
     else:


### PR DESCRIPTION
#### 74b216bb19b2119bed128ca004bb5d9b25bcfb9e
<pre>
IPInt table.fill should pop its operands from the stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=289916">https://bugs.webkit.org/show_bug.cgi?id=289916</a>
<a href="https://rdar.apple.com/144077195">rdar://144077195</a>

Reviewed by Yusuke Suzuki.

During execution, table.fill uses the stack pointer to pass multiple arguments to the operation.
However, we do not move the stack pointer down in this case, meaning that we end up having three
extra values on the stack. This seems to be the only operation where we miss doing this.

* JSTests/wasm/ipint-tests/ipint-test-table-fill.js:
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.i2i.func.param.i32.result.i32.table.table.5.funcref.elem.i32.const.0.0.0.0.0.0.func.export.string_appeared_here.result.i32.table.size.table.func.export.string_appeared_here.param.i32.i32.result.i32.i32.const.42.local.0.ref.null.func.local.1.table.fill.table.func.export.string_appeared_here.param.i32.result.i32.local.0.table.table.ref.is_null.async test):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.i2i.func.param.i32.result.i32.table.table.5.funcref.elem.i32.const.0.0.0.0.0.0.func.export.string_appeared_here.result.i32.table.size.table.func.export.string_appeared_here.param.i32.i32.local.0.ref.null.func.local.1.table.fill.table.func.export.string_appeared_here.param.i32.result.i32.local.0.table.table.ref.is_null.async test): Deleted.
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Tools/lldb/debug_ipint.py:
(print_stack):

Canonical link: <a href="https://commits.webkit.org/292309@main">https://commits.webkit.org/292309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da727d54296befbcad3ac079e63b3e1802071510

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3939 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45322 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88149 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102565 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94101 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81214 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25793 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22499 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27655 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116894 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22158 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->