### PR TITLE
Fix build on non-Linux platforms

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -536,8 +536,10 @@ Page::~Page()
     if (RefPtr scrollingCoordinator = m_scrollingCoordinator)
         scrollingCoordinator->pageDestroyed();
 
+#if ENABLE(RESOURCE_USAGE)
     if (RefPtr resourceUsageOverlay = m_resourceUsageOverlay)
         resourceUsageOverlay->detachFromPage();
+#endif
 
     checkedBackForward()->close();
     if (!isUtilityPage())


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=285806

Reviewed by NOBODY (OOPS!).

m_resourceUsageOverlay is only defined when RESOURCE_USAGE is enabled:

   -isystem /usr/include/at-spi2-atk/2.0 -isystem /usr/include/at-spi-2.0 -isystem /usr/include/dbus-1.0 -isystem /usr/lib/x86_64-gnu/dbus-1.0/include -fdiagnostics-color=always -Wextra -Wall -pipe -fmax-errors=20 -Wno-odr -Wno-stringop-overread -Wno-stringop-overflow -Wno-nonnull -Wno-array-bounds -Wno-expansion-to-defined -Wno-noexcept-type -Wno-psabi -Wno-misleading-indentation -Wno-maybe-uninitialized -Wundef -Wpointer-arith -Wmissing-format-attribute -Wformat-security -Wcast-align -Wno-tautological-compare -fasynchronous-unwind-tables -g1 -O2 -ffile-prefix-map=/build/webkit2gtk-2.48.0=. -fstack-protector-strong -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -DNDEBUG -DG_DISABLE_CAST_CHECKS -fno-strict-aliasing -fno-exceptions -fno-rtti -fcoroutines -ffunction-sections -fdata-sections -std=c++23 -fPIC -fvisibility=hidden -pthread -DHWY_SHARED_DEFINE -DAVIF_DLL -DEB_DLL -DHAVE_HB_FEATURES_H -MD -MT Source/WebCore/CMakeFiles/WebCore.dir/__/__/WebCore/DerivedSources/unified-sources/UnifiedSource-767013ce-8.cpp.o -MF Source/WebCore/CMakeFiles/WebCore.dir/__/__/WebCore/DerivedSources/unified-sources/UnifiedSource-767013ce-8.cpp.o.d -o Source/WebCore/CMakeFiles/WebCore.dir/__/__/WebCore/DerivedSources/unified-sources/UnifiedSource-767013ce-8.cpp.o -c /build/webkit2gtk-2.48.0/build-soup3/WebCore/DerivedSources/unified-sources/UnifiedSource-767013ce-8.cpp
In file included from /build/webkit2gtk-2.48.0/build-soup3/WebCore/DerivedSources/unified-sources/UnifiedSource-767013ce-8.cpp:4: /build/webkit2gtk-2.48.0/Source/WebCore/page/Page.cpp: In destructor ‘WebCore::Page::~Page()’: /build/webkit2gtk-2.48.0/Source/WebCore/page/Page.cpp:542:39: error: ‘m_resourceUsageOverlay’ was not declared in this scope; did you mean ‘resourceUsageOverlay’?
  542 |     if (RefPtr resourceUsageOverlay = m_resourceUsageOverlay)
      |                                       ^~~~~~~~~~~~~~~~~~~~~~
      |                                       resourceUsageOverlay

* Source/WebCore/page/Page.cpp: (WebCore::Page::~Page):

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1947402e1324d399fba8310bc7abdc44e2900459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15093 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72830 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30097 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11521 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53162 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11227 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81417 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102575 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81870 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22793 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81221 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25797 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/4976 "") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15872 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27665 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->