### PR TITLE
[iOS] Add support for extending background colors beyond fixed-position containers when obscured insets are set

### DIFF
--- a/Source/WebCore/editing/mac/DictionaryLookup.h
+++ b/Source/WebCore/editing/mac/DictionaryLookup.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#include "CocoaView.h"
 #include "DictionaryPopupInfo.h"
 #include <wtf/Function.h>
 
@@ -40,10 +41,8 @@
 
 #if PLATFORM(MAC)
 using WKRevealController = id <NSImmediateActionAnimationController>;
-using CocoaView = NSView;
 #else
 using WKRevealController = id;
-using CocoaView = UIView;
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/cocoa/CocoaView.h
+++ b/Source/WebCore/platform/cocoa/CocoaView.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#if PLATFORM(MAC)
+
+OBJC_CLASS NSView;
+using CocoaView = NSView;
+
+#else
+
+OBJC_CLASS UIView;
+using CocoaView = UIView;
+
+#endif
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -32,6 +32,7 @@
 #import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
 #import "WKIntelligenceTextEffectCoordinator.h"
 #import "WKTextAnimationType.h"
+#import <WebCore/CocoaView.h>
 #import <WebCore/FixedContainerEdges.h>
 #import <WebKit/WKShareSheet.h>
 #import <WebKit/WKWebViewConfiguration.h>
@@ -440,6 +441,10 @@ struct PerWebProcessState {
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
     std::pair<Markable<WebKit::PDFPluginIdentifier>, RetainPtr<WKPDFPageNumberIndicator>> _pdfPageNumberIndicator;
 #endif
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    WebCore::RectEdges<RetainPtr<CocoaView>> _fixedColorExtensionViews;
+#endif
 }
 
 - (BOOL)_isValid;
@@ -507,8 +512,6 @@ struct PerWebProcessState {
 - (void)_clearWarningViewIfForMainFrameNavigation;
 - (void)_clearBrowsingWarningIfForMainFrameNavigation;
 
-- (const WebCore::FixedContainerEdges&)_coreFixedContainerEdges;
-
 - (std::optional<BOOL>)_resolutionForShareSheetImmediateCompletionForTesting;
 
 - (void)_didAccessBackForwardList NS_DIRECT;
@@ -518,6 +521,9 @@ struct PerWebProcessState {
 - (void)_dismissDigitalCredentialsPicker:(WTF::CompletionHandler<void(bool)>&&)completionHandler;
 #endif
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+- (void)_updateFixedColorExtensionViewFrames;
+#endif
 
 #if ENABLE(GAMEPAD)
 - (void)_setGamepadsRecentlyAccessed:(BOOL)gamepadsRecentlyAccessed;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2323,8 +2323,12 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (scrollView == _scrollView)
+    if (scrollView == _scrollView) {
         [_scrollView updateInteractiveScrollVelocity];
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+        [self _updateFixedColorExtensionViewFrames];
+#endif
+    }
 
     if (![self usesStandardContentView] && [_customContentView respondsToSelector:@selector(web_scrollViewDidScroll:)])
         [_customContentView web_scrollViewDidScroll:(UIScrollView *)scrollView];
@@ -4070,6 +4074,9 @@ static bool isLockdownModeWarningNeeded()
     _obscuredInsets = obscuredInsets;
 
     [self _scheduleVisibleContentRectUpdate];
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateFixedColorExtensionViewFrames];
+#endif
     [_warningView setContentInset:[self _computedObscuredInsetForWarningView]];
 }
 
@@ -4086,6 +4093,9 @@ static bool isLockdownModeWarningNeeded()
     _obscuredInsetEdgesAffectedBySafeArea = edges;
 
     [self _scheduleVisibleContentRectUpdate];
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [self _updateFixedColorExtensionViewFrames];
+#endif
 }
 
 - (UIEdgeInsets)_unobscuredSafeAreaInsets

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -794,7 +794,6 @@ public:
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     void updateContentInsetFillViews();
-    void updateFixedContentExtensionViews();
 #endif
 
 private:
@@ -1072,7 +1071,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     RetainPtr<WKNSContentInsetFillView> m_topContentInsetFillView;
-    WebCore::RectEdges<RetainPtr<NSView>> m_fixedColorExtensionViews;
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6915,69 +6915,6 @@ void WebViewImpl::fulfillDeferredImageAnalysisOverlayViewHierarchyTask()
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
-void WebViewImpl::updateFixedContentExtensionViews()
-{
-    if (!page().protectedPreferences()->contentInsetBackgroundFillEnabled())
-        return;
-
-    RetainPtr webView = view();
-    auto& fixedContainerEdges = [webView _coreFixedContainerEdges];
-    auto insets = obscuredContentInsets();
-    auto bounds = [webView bounds];
-
-    auto updateExtensionView = [&](BoxSide side, Function<NSRect()>&& computeFrame) {
-        BOOL needsView = insets.at(side) > 0 && fixedContainerEdges.fixedEdges.at(side);
-        RetainPtr extensionView = m_fixedColorExtensionViews.at(side);
-        if (needsView) {
-            if (!extensionView) {
-                extensionView = adoptNS([NSView new]);
-                [extensionView setWantsLayer:YES];
-                [extensionView layer].name = [NSString stringWithFormat:@"Fixed color extension fill (%s)", [side] {
-                    switch (side) {
-                    case BoxSide::Top:
-                        return "Top";
-                    case BoxSide::Right:
-                        return "Right";
-                    case BoxSide::Bottom:
-                        return "Bottom";
-                    case BoxSide::Left:
-                        return "Left";
-                    default:
-                        ASSERT_NOT_REACHED();
-                        return "";
-                    }
-                }()];
-                m_fixedColorExtensionViews.setAt(side, extensionView);
-                [webView addSubview:extensionView.get()];
-            }
-            RetainPtr predominantColor = cocoaColorOrNil(fixedContainerEdges.predominantColors.at(side));
-            [extensionView setBackgroundColor:predominantColor.get() ?: [webView underPageBackgroundColor]];
-            [extensionView setFrame:computeFrame()];
-        }
-        [extensionView setHidden:!needsView];
-    };
-
-    updateExtensionView(BoxSide::Top, [insets, bounds] {
-        return NSMakeRect(insets.left(), 0, NSWidth(bounds) - insets.left(), insets.top());
-    });
-
-    updateExtensionView(BoxSide::Left, [insets, bounds] {
-        return NSMakeRect(0, 0, insets.left(), NSHeight(bounds));
-    });
-
-    updateExtensionView(BoxSide::Right, [insets, bounds] {
-        return NSMakeRect(NSWidth(bounds) - insets.right(), 0, insets.right(), NSHeight(bounds));
-    });
-
-    updateExtensionView(BoxSide::Bottom, [insets, bounds] {
-        return NSMakeRect(insets.left(), NSHeight(bounds) - insets.bottom(), NSWidth(bounds) - insets.left(), insets.bottom());
-    });
-}
-
-#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
 } // namespace WebKit
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebViewImplAdditions.mm>)


### PR DESCRIPTION
#### dad4965a309ad44ea11bb8cb3a95712bb08b7caa
<pre>
[iOS] Add support for extending background colors beyond fixed-position containers when obscured insets are set
<a href="https://bugs.webkit.org/show_bug.cgi?id=289918">https://bugs.webkit.org/show_bug.cgi?id=289918</a>
<a href="https://rdar.apple.com/147258935">rdar://147258935</a>

Reviewed by Megan Gardner.

Extend background colors beyond the edges of fixed containers when `-[WKWebView _obscuredInsets]`
are present, on iOS. This primarily moves logic introduced in <a href="https://commits.webkit.org/292256@main">https://commits.webkit.org/292256@main</a>
out of `WebViewImpl` and into `WKWebView.mm`. See below for more details.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/mac/DictionaryLookup.h:
* Source/WebCore/platform/cocoa/CocoaView.h: Added.

Add a new WebCore `platform/` header that just defines `CocoaView` to be either `NSView` or
`UIView`. Deploy this in `DictionaryLookup.h` above, as well as `WKWebViewInternal.h` below.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):
(-[WKWebView _updateFixedContainerEdges:]):
(-[WKWebView _obscuredInsetsForFixedColorExtension]):
(-[WKWebView _containerForFixedColorExtension]):
(-[WKWebView _updateFixedColorExtensionViews]):

Moved here from (the macOS-specific) `WebViewImpl`. Also split out this logic across two methods:
(1) this method, which installs, updates the visibility, background colors, and frames for each
of the color extension views, and (2) another method right below, which only updates the frames of
each of the color extension views.

This allows us to only update frames when the insets or other geometry change, but perform a full
update when fixed-position container state changes.

(-[WKWebView _updateFixedColorExtensionViewFrames]):
(-[WKWebView _coreFixedContainerEdges]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewDidScroll:]):

Update the frame of the fixed color extension views whenever the main scroll view is scrolled. Note
that we install the extension views underneath the `WKScrollView` on iOS instead of the web view
itself, for compatibility with clients (e.g. Safari) which already install views below the scroll
view, and expect these views to not be covered by other views under the `WKWebView`.

(-[WKWebView _setObscuredInsets:]):
(-[WKWebView _setObscuredInsetEdgesAffectedBySafeArea:]):

Update the frame of the fixed color extension views whenever obscured insets change.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateFixedContentExtensionViews): Deleted.

Canonical link: <a href="https://commits.webkit.org/292308@main">https://commits.webkit.org/292308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecf726bfcd1418db63fcc797549bc2419f7958cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30115 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102602 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22568 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16476 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81890 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15899 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->