### PR TITLE
Begin to make VideoPresentationManager more straightforward

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -88,8 +88,6 @@ public:
     virtual void returnVideoContentLayer() { };
     virtual void returnVideoView() { };
     virtual void didSetupFullscreen() { };
-    virtual void didEnterFullscreen(const FloatSize&) { };
-    virtual void failedToEnterFullscreen() { };
     virtual void willExitFullscreen() { };
     virtual void didExitFullscreen() { };
     virtual void didCleanupFullscreen() { };

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -97,7 +97,7 @@ public:
     WEBCORE_EXPORT virtual void setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT virtual AVPlayerViewController *avPlayerViewController() const = 0;
     WebAVPlayerController *playerController() const;
-    WEBCORE_EXPORT void enterFullscreen();
+    WEBCORE_EXPORT void enterFullscreen(CompletionHandler<void(std::optional<FloatSize>)>&&);
     WEBCORE_EXPORT virtual bool exitFullscreen(const FloatRect& finalRect);
     WEBCORE_EXPORT void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode);
     WEBCORE_EXPORT virtual void cleanupFullscreen();
@@ -244,7 +244,7 @@ protected:
 
     WEBCORE_EXPORT void enterFullscreenHandler(BOOL success, NSError *, NextActions = NextActions());
     WEBCORE_EXPORT void exitFullscreenHandler(BOOL success, NSError *, NextActions = NextActions());
-    void doEnterFullscreen();
+    void doEnterFullscreen(CompletionHandler<void(std::optional<FloatSize>)>&&);
     void doExitFullscreen();
     virtual void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) = 0;
     virtual void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) = 0;

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -258,7 +258,6 @@ VideoFullscreenControllerContext::~VideoFullscreenControllerContext()
 
 void VideoFullscreenControllerContext::requestUpdateInlineRect()
 {
-#if PLATFORM(IOS_FAMILY)
     ASSERT(isUIThread());
     WebThreadRun([protectedThis = Ref { *this }, this] () mutable {
         IntRect clientRect = elementRectInWindow(m_videoElement.get());
@@ -266,14 +265,10 @@ void VideoFullscreenControllerContext::requestUpdateInlineRect()
             m_interface->setInlineRect(clientRect, clientRect != IntRect(0, 0, 0, 0));
         });
     });
-#else
-    ASSERT_NOT_REACHED();
-#endif
 }
 
 void VideoFullscreenControllerContext::requestVideoContentLayer()
 {
-#if PLATFORM(IOS_FAMILY)
     ASSERT(isUIThread());
     WebThreadRun([protectedThis = Ref { *this }, this, videoFullscreenLayer = retainPtr([m_videoFullscreenView layer])] () mutable {
         [videoFullscreenLayer setBackgroundColor:cachedCGColor(WebCore::Color::transparentBlack).get()];
@@ -286,14 +281,10 @@ void VideoFullscreenControllerContext::requestVideoContentLayer()
             });
         });
     });
-#else
-    ASSERT_NOT_REACHED();
-#endif
 }
 
 void VideoFullscreenControllerContext::returnVideoContentLayer()
 {
-#if PLATFORM(IOS_FAMILY)
     ASSERT(isUIThread());
     WebThreadRun([protectedThis = Ref { *this }, this, videoFullscreenLayer = retainPtr([m_videoFullscreenView layer])] () mutable {
         [videoFullscreenLayer setBackgroundColor:cachedCGColor(WebCore::Color::transparentBlack).get()];
@@ -306,28 +297,14 @@ void VideoFullscreenControllerContext::returnVideoContentLayer()
             });
         });
     });
-#else
-    ASSERT_NOT_REACHED();
-#endif
 }
 
 void VideoFullscreenControllerContext::didSetupFullscreen()
 {
     ASSERT(isUIThread());
-#if PLATFORM(IOS_FAMILY)
     RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this] {
-        m_interface->enterFullscreen();
+        m_interface->enterFullscreen([] (auto) { });
     });
-#else
-    WebThreadRun([protectedThis = Ref { *this }, this, videoFullscreenLayer = retainPtr([m_videoFullscreenView layer])] () mutable {
-        [videoFullscreenLayer setBackgroundColor:cachedCGColor(WebCore::Color::transparentBlack)];
-        m_presentationModel->setVideoFullscreenLayer(videoFullscreenLayer.get(), [protectedThis = WTFMove(protectedThis), this] () mutable {
-            RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis), this] {
-                m_interface->enterFullscreen();
-            });
-        });
-    });
-#endif
 }
 
 void VideoFullscreenControllerContext::willExitFullscreen()
@@ -343,19 +320,9 @@ void VideoFullscreenControllerContext::willExitFullscreen()
 void VideoFullscreenControllerContext::didExitFullscreen()
 {
     ASSERT(isUIThread());
-#if PLATFORM(IOS_FAMILY)
     RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this] {
         m_interface->cleanupFullscreen();
     });
-#else
-    WebThreadRun([protectedThis = Ref { *this }, this] () mutable {
-        m_presentationModel->setVideoFullscreenLayer(nil, [protectedThis = WTFMove(protectedThis), this] () mutable {
-            RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis), this] {
-                m_interface->cleanupFullscreen();
-            });
-        });
-    });
-#endif
 }
 
 void VideoFullscreenControllerContext::didCleanupFullscreen()

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -81,7 +81,8 @@ public:
     void setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier) final { m_playerIdentifier = identifier; }
 
     WEBCORE_EXPORT void setupFullscreen(const IntRect& initialRect, NSWindow *parentWindow, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback);
-    WEBCORE_EXPORT void enterFullscreen();
+    WEBCORE_EXPORT void enterFullscreen(CompletionHandler<void(std::optional<FloatSize>)>&&);
+    void didEnterFullscreen(FloatSize);
     WEBCORE_EXPORT bool exitFullscreen(const IntRect& finalRect, NSWindow *parentWindow);
     WEBCORE_EXPORT void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode);
     WEBCORE_EXPORT void cleanupFullscreen();
@@ -137,6 +138,7 @@ private:
     RetainPtr<WebVideoPresentationInterfaceMacObjC> m_webVideoPresentationInterfaceObjC;
     bool m_documentIsVisible { true };
     Function<void()> m_documentBecameVisibleCallback;
+    CompletionHandler<void(std::optional<FloatSize>)> m_enterFullscreenCompletionHandler;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -108,8 +108,6 @@ private:
     void returnVideoContentLayer() final;
     void returnVideoView() final;
     void didSetupFullscreen() final;
-    void failedToEnterFullscreen() final;
-    void didEnterFullscreen(const WebCore::FloatSize&) final;
     void willExitFullscreen() final;
     void didExitFullscreen() final;
     void didCleanupFullscreen() final;
@@ -226,7 +224,7 @@ private:
     void audioSessionCategoryChanged(PlaybackSessionContextIdentifier, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy);
     void hasBeenInteractedWith(PlaybackSessionContextIdentifier);
     void setVideoDimensions(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
-    void enterFullscreen(PlaybackSessionContextIdentifier);
+    void enterFullscreen(PlaybackSessionContextIdentifier, CompletionHandler<void(std::optional<WebCore::FloatSize>)>&&);
     void exitFullscreen(PlaybackSessionContextIdentifier, WebCore::FloatRect finalRect, CompletionHandler<void(bool)>&&);
     void cleanupFullscreen(PlaybackSessionContextIdentifier);
     void preparedToReturnToInline(PlaybackSessionContextIdentifier, bool visible, WebCore::FloatRect inlineRect);
@@ -250,8 +248,6 @@ private:
     void didSetupFullscreen(PlaybackSessionContextIdentifier);
     void willExitFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);
-    void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
-    void didEnterFullscreen(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);
     void setVideoLayerFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);
     void setVideoLayerGravity(PlaybackSessionContextIdentifier, WebCore::MediaPlayerEnums::VideoGravity);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -36,7 +36,7 @@ messages -> VideoPresentationManagerProxy {
     SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
     SetPlayerIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier)
 #if !PLATFORM(IOS_FAMILY)
-    EnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
+    EnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId) -> (std::optional<WebCore::FloatSize> size)
 #endif
     ExitFullscreen(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect finalRect) -> (bool success)
     SetInlineRect(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect inlineRect, bool visible)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8652,10 +8652,6 @@ void WebPageProxy::didCleanupFullscreen(PlaybackSessionContextIdentifier)
         pageClient->didCleanupFullscreen();
 }
 
-void WebPageProxy::failedToEnterFullscreen(PlaybackSessionContextIdentifier identifier)
-{
-}
-
 #else
 
 void WebPageProxy::didEnterFullscreen()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2316,7 +2316,6 @@ public:
     bool canEnterFullscreen();
     void enterFullscreen();
 
-    void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
     void didEnterFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -35,8 +35,6 @@ messages -> VideoPresentationManager {
 #endif
     WillExitFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     DidExitFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
-    DidEnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::FloatSize> size)
-    FailedToEnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     DidCleanupFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     SetVideoLayerFrameFenced(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect bounds, MachSendRight machSendRight)
     SetVideoLayerGravityEnum(WebKit::PlaybackSessionContextIdentifier contextId, unsigned gravity)


### PR DESCRIPTION
#### 6d786410a1b6c3fc11dc75487656171986f692c8
<pre>
Begin to make VideoPresentationManager more straightforward
<a href="https://bugs.webkit.org/show_bug.cgi?id=289920">https://bugs.webkit.org/show_bug.cgi?id=289920</a>
<a href="https://rdar.apple.com/147260836">rdar://147260836</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::didSetupFullscreen):
(WebCore::VideoPresentationModel::didEnterFullscreen): Deleted.
(WebCore::VideoPresentationModel::failedToEnterFullscreen): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::enterFullscreen):
(WebCore::VideoPresentationInterfaceIOS::doEnterFullscreen):
(WebCore::VideoPresentationInterfaceIOS::enterFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::exitFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::didStartPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::failedToStartPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::didStopPictureInPicture):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::requestUpdateInlineRect):
(VideoFullscreenControllerContext::requestVideoContentLayer):
(VideoFullscreenControllerContext::returnVideoContentLayer):
(VideoFullscreenControllerContext::didSetupFullscreen):
(VideoFullscreenControllerContext::didExitFullscreen):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC boundsDidChangeForVideoViewContainer:]):
(WebCore::VideoPresentationInterfaceMac::~VideoPresentationInterfaceMac):
(WebCore::VideoPresentationInterfaceMac::enterFullscreen):
(WebCore::VideoPresentationInterfaceMac::didEnterFullscreen):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::enterFullscreen):
(WebKit::VideoPresentationManagerProxy::didSetupFullscreen):
(WebKit::VideoPresentationModelContext::failedToEnterFullscreen): Deleted.
(WebKit::VideoPresentationModelContext::didEnterFullscreen): Deleted.
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen): Deleted.
(WebKit::VideoPresentationManagerProxy::failedToEnterFullscreen): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::failedToEnterFullscreen): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::didSetupFullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d786410a1b6c3fc11dc75487656171986f692c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30106 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98507 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11532 "Found 13 new test failures: fast/forms/ios/focus-input-via-button.html media/media-fullscreen-loop-inline.html media/media-fullscreen-pause-inline.html media/media-fullscreen-return-to-inline.html media/picture-in-picture/picture-in-picture-api-css-selector.html media/picture-in-picture/picture-in-picture-api-enter-pip-4.html media/picture-in-picture/picture-in-picture-api-events.html media/picture-in-picture/picture-in-picture-api-exit-pip-1.html media/picture-in-picture/picture-in-picture-api-pip-window.html media/picture-in-picture/picture-in-picture-events.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81233 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15885 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27679 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22181 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25657 "Hash 6d786410 for PR 42584 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23923 "Hash 6d786410 for PR 42584 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->