### PR TITLE
Better encapsulate coordinate fixups in PositionedLayoutConstraints

### DIFF
--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -94,22 +94,22 @@ public:
     bool isBlockFlipped() const { return m_containingWritingMode.isBlockFlipped(); }
     bool isLogicalLeftInlineStart() const { return m_containingWritingMode.isLogicalLeftInlineStart(); }
     bool containingCoordsAreFlipped() const;
-    LayoutUnit containingSize() const { return m_containingRange.size(); }
 
+    LayoutUnit containingSize() const { return m_containingRange.size(); }
     LayoutUnit marginBeforeValue() const { return minimumValueForLength(m_marginBefore, m_marginPercentageBasis); }
     LayoutUnit marginAfterValue() const { return minimumValueForLength(m_marginAfter, m_marginPercentageBasis); }
     LayoutUnit insetBeforeValue() const { return minimumValueForLength(m_insetBefore, containingSize()); }
     LayoutUnit insetAfterValue() const { return minimumValueForLength(m_insetAfter, containingSize()); }
-    LayoutUnit availableContentSpace() const { return containingSize() - insetBeforeValue() - marginBeforeValue() - bordersPlusPadding() - marginAfterValue() - insetAfterValue(); } // This may be negative.
-    LayoutUnit insetModifiedContainingBlockSize() const { return containingSize() - insetBeforeValue() - insetAfterValue(); }
-
-    void convertLogicalLeftValue(LayoutUnit&) const;
-    void convertLogicalTopValue(LayoutUnit&, const RenderBox&, const LayoutUnit logicalHeightValue) const;
+    LayoutUnit insetModifiedContainingSize() const { return m_insetModifiedContainingRange.size(); }
+    LayoutUnit availableContentSpace() const { return insetModifiedContainingSize() - marginBeforeValue() - bordersPlusPadding() - marginAfterValue(); } // This may be negative.
 
     void resolvePosition(RenderBox::LogicalExtentComputedValues&) const;
     LayoutUnit resolveAlignmentAdjustment(const LayoutUnit unusedSpace) const;
     ItemPosition resolveAlignmentPosition() const;
     bool alignmentAppliesStretch(ItemPosition normalAlignment) const;
+
+    void fixupLogicalLeftPosition(RenderBox::LogicalExtentComputedValues&) const;
+    void fixupLogicalTopPosition(RenderBox::LogicalExtentComputedValues&, const RenderBox& renderer) const;
 
 private:
     void captureInsets(const RenderBox&, const LogicalBoxAxis selfAxis);
@@ -128,6 +128,7 @@ private:
 
     // These values are calculated by the constructor.
     LayoutRange m_containingRange;
+    LayoutRange m_insetModifiedContainingRange;
     LayoutUnit m_marginPercentageBasis;
     CheckedPtr<const RenderBoxModelObject> m_container;
     const WritingMode m_containingWritingMode;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1097,8 +1097,8 @@ bool AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(const Render
     auto anchorInlineSize = anchoredBox.logicalWidth() + anchoredBox.marginStart() + anchoredBox.marginEnd();
     auto anchorBlockSize = anchoredBox.logicalHeight() + anchoredBox.marginBefore() + anchoredBox.marginAfter();
 
-    return inlineConstraints.insetModifiedContainingBlockSize() < anchorInlineSize
-        || blockConstraints.insetModifiedContainingBlockSize() < anchorBlockSize;
+    return inlineConstraints.insetModifiedContainingSize() < anchorInlineSize
+        || blockConstraints.insetModifiedContainingSize() < anchorBlockSize;
 }
 
 } // namespace WebCore::Style

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1430,7 +1430,7 @@ void TreeResolver::sortPositionOptionsIfNeeded(PositionOptions& options, const S
 
     for (auto& optionStyle : options.optionStyles) {
         auto constraints = PositionedLayoutConstraints { *box, *optionStyle, boxAxis };
-        optionsForSorting.append({ WTFMove(optionStyle), constraints.insetModifiedContainingBlockSize() });
+        optionsForSorting.append({ WTFMove(optionStyle), constraints.insetModifiedContainingSize() });
     }
 
     // "Stably sort the position options list according to this size, with the largest coming first."


### PR DESCRIPTION
#### 587d18d0c38b403a354f903f967829658131a80e
<pre>
Better encapsulate coordinate fixups in PositionedLayoutConstraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=289914">https://bugs.webkit.org/show_bug.cgi?id=289914</a>
<a href="https://rdar.apple.com/147250575">rdar://147250575</a>

Reviewed by Alan Baradlay.

1. Caches the inset-modified containing block into PositionedLayoutConstraints.
2. Extracts various coordinate fixups into fixup methods in PositionedLayoutConstraints.
3. Compresses RenderBox fixup code into simply calling those fixup methods.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::PositionedLayoutConstraints):
Capture inset-modified containing block geometry.

(WebCore::PositionedLayoutConstraints::resolvePosition const):
Used cached inset-modified containing block geometry.

(WebCore::PositionedLayoutConstraints::fixupLogicalLeftPosition const):
(WebCore::PositionedLayoutConstraints::fixupLogicalTopPosition const):
(WebCore::PositionedLayoutConstraints::convertLogicalLeftValue const): Deleted.
(WebCore::PositionedLayoutConstraints::convertLogicalTopValue const): Deleted.
Incorporate remaining coordinate fixup and simplify parameters.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::containingSize const):
(WebCore::PositionedLayoutConstraints::insetModifiedContainingSize const):
(WebCore::PositionedLayoutConstraints::availableContentSpace const):
(WebCore::PositionedLayoutConstraints::insetModifiedContainingBlockSize const): Deleted.
Update accessors to use cached inset-modified containing block geometry.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):
(WebCore::adjustmentForRTLInlineBoxContainingBlock): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):
Update to use new methods.

Canonical link: <a href="https://commits.webkit.org/292344@main">https://commits.webkit.org/292344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9295b8cc9cb5fba7d7e8465632a63c397c944689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23803 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4213 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/4322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22821 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81422 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20386 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/26005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22788 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/22447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/25923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/24189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->