### PR TITLE
REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -35,6 +35,7 @@
 #import "MouseSupportUIDelegate.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestPDFDocument.h"
 #import "TestWKWebView.h"
@@ -260,12 +261,7 @@ UNIFIED_PDF_TEST(SnapshotsPaintPageContent)
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_StablePresentationUpdateCallback)
-#else
 UNIFIED_PDF_TEST(StablePresentationUpdateCallback)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:TestWebKitAPI::configurationForWebViewTestingUnifiedPDF().get()]);
 
@@ -283,12 +279,7 @@ UNIFIED_PDF_TEST(StablePresentationUpdateCallback)
 
 #endif
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_PasswordFormShouldDismissAfterNavigation)
-#else
 UNIFIED_PDF_TEST(PasswordFormShouldDismissAfterNavigation)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
 
@@ -309,12 +300,7 @@ UNIFIED_PDF_TEST(PasswordFormShouldDismissAfterNavigation)
     EXPECT_EQ(colorsBefore, colorsAfter);
 }
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_WebProcessShouldNotCrashWithUISideCompositingDisabled)
-#else
 UNIFIED_PDF_TEST(WebProcessShouldNotCrashWithUISideCompositingDisabled)
-#endif
 {
     UISideCompositingScope scope { UISideCompositingState::Disabled };
 
@@ -333,12 +319,7 @@ UNIFIED_PDF_TEST(WebProcessShouldNotCrashWithUISideCompositingDisabled)
 
 #if PLATFORM(IOS_FAMILY)
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_SpeakSelection)
-#else
 UNIFIED_PDF_TEST(SpeakSelection)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
@@ -346,12 +327,7 @@ UNIFIED_PDF_TEST(SpeakSelection)
     EXPECT_WK_STREQ(@"Test PDF Content\n555-555-1234", [webView textForSpeakSelection]);
 }
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_CopySelectedText)
-#else
 UNIFIED_PDF_TEST(CopySelectedText)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
@@ -363,12 +339,7 @@ UNIFIED_PDF_TEST(CopySelectedText)
     EXPECT_WK_STREQ(@"Test", [[UIPasteboard generalPasteboard] string]);
 }
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_SelectTextInRotatedPage)
-#else
 UNIFIED_PDF_TEST(SelectTextInRotatedPage)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test-rotated-cw-90" withExtension:@"pdf"]]];
@@ -387,12 +358,7 @@ UNIFIED_PDF_TEST(SelectTextInRotatedPage)
     EXPECT_WK_STREQ("Test", [contentView selectedText]);
 }
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_LookUpSelectedText)
-#else
 UNIFIED_PDF_TEST(LookUpSelectedText)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
@@ -435,12 +401,7 @@ UNIFIED_PDF_TEST(LookUpSelectedText)
     EXPECT_EQ(selectedRangeInLookupContext.length, 3U);
 }
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_PrintPDFUsingPrintInteractionController)
-#else
 UNIFIED_PDF_TEST(PrintPDFUsingPrintInteractionController)
-#endif
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
 
@@ -536,13 +497,10 @@ UNIFIED_PDF_TEST(KeepScrollPositionAtOriginAfterAnimatedResize)
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_MouseDidMoveOverPDF)
-#else
 UNIFIED_PDF_TEST(MouseDidMoveOverPDF)
-#endif
 {
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
+
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     RetainPtr delegate = adoptNS([MouseSupportUIDelegate new]);
 
@@ -562,6 +520,8 @@ UNIFIED_PDF_TEST(MouseDidMoveOverPDF)
 #if ENABLE(IOS_TOUCH_EVENTS)
 UNIFIED_PDF_TEST(SelectionClearsOnAnchorLinkTap)
 {
+    TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
+
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
     RetainPtr preferences = adoptNS([[WKWebpagePreferences alloc] init]);
     [preferences _setMouseEventPolicy:_WKWebsiteMouseEventPolicySynthesizeTouchEvents];
@@ -585,12 +545,7 @@ UNIFIED_PDF_TEST(SelectionClearsOnAnchorLinkTap)
 
 #endif
 
-// rdar://144724909 (REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures (287579))
-#if !defined(NDEBUG)
-UNIFIED_PDF_TEST(DISABLED_LoadPDFWithSandboxCSPDirective)
-#else
 UNIFIED_PDF_TEST(LoadPDFWithSandboxCSPDirective)
-#endif
 {
     runLoadPDFWithSandboxCSPDirectiveTest([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
 }


### PR DESCRIPTION
#### 555d88497d88eda6c0f4289b9d6d515979a0e93b
<pre>
REGRESSION(290220@main): [ iOS ] 12x TestWebKitAPI.UnifiedPDF* (api-tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=287579">https://bugs.webkit.org/show_bug.cgi?id=287579</a>
<a href="https://rdar.apple.com/144724909">rdar://144724909</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
I can&apos;t reproduce the debug-only failures, so re-enable these tests.
(If EWS disagrees, we can diagnose there).

Also, bring up a UIApp for the tests that are disabled because mouse events need a UIApp now.

Canonical link: <a href="https://commits.webkit.org/292311@main">https://commits.webkit.org/292311@main</a>
</pre>
