### PR TITLE
[JSC] Optimize Array Growth in JSObject::ensureLengthSlow with Efficient Zeroing Strategies

### DIFF
--- a/JSTests/microbenchmarks/array-push-4.js
+++ b/JSTests/microbenchmarks/array-push-4.js
@@ -1,0 +1,5 @@
+let arr = [];
+let count = 21987326 + 1;
+for (let i = 0; i < count; i++) {
+    arr.push(i);
+}

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -42,6 +42,7 @@ public:
     virtual ~AlignedMemoryAllocator();
     
     virtual void* tryAllocateAlignedMemory(size_t alignment, size_t size) = 0;
+    virtual void* tryAllocateAlignedMemory(size_t alignment, size_t, bool&) = 0;
     virtual void freeAlignedMemory(void*) = 0;
     
     // This can't be pure virtual as it breaks our Dumpable concept.
@@ -58,6 +59,7 @@ public:
     virtual void* tryAllocateMemory(size_t) = 0;
     virtual void freeMemory(void*) = 0;
     virtual void* tryReallocateMemory(void*, size_t) = 0;
+    virtual void zeroMemoryPage(void*, size_t) = 0;
 
 private:
     SinglyLinkedListWithTail<BlockDirectory> m_directories;

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -144,7 +144,7 @@ void* CompleteSubspace::tryAllocateSlow(VM& vm, size_t size, GCDeferralContext* 
     return allocation->cell();
 }
 
-void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* oldCell, size_t size, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
+void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* oldCell, size_t size, GCDeferralContext* deferralContext, AllocationFailureMode failureMode, ZeroingInfo& info)
 {
     if constexpr (validateDFGDoesGC)
         vm.verifyCanGC();
@@ -175,7 +175,7 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
     if (oldAllocation->isOnList())
         oldAllocation->remove();
 
-    PreciseAllocation* allocation = oldAllocation->tryReallocate(size, this);
+    PreciseAllocation* allocation = oldAllocation->tryReallocate(size, this, info);
     if (UNLIKELY(!allocation)) {
         RELEASE_ASSERT_RESOURCE_AVAILABLE(failureMode != AllocationFailureMode::Assert, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
         m_preciseAllocations.append(oldAllocation);

--- a/Source/JavaScriptCore/heap/CompleteSubspace.h
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.h
@@ -43,7 +43,7 @@ public:
     Allocator allocatorForNonInline(size_t, AllocatorForMode);
 
     void* allocate(VM&, size_t, GCDeferralContext*, AllocationFailureMode);
-    void* reallocatePreciseAllocationNonVirtual(VM&, HeapCell*, size_t, GCDeferralContext*, AllocationFailureMode);
+    void* reallocatePreciseAllocationNonVirtual(VM&, HeapCell*, size_t, GCDeferralContext*, AllocationFailureMode, ZeroingInfo&);
     
     static constexpr ptrdiff_t offsetOfAllocatorForSizeStep() { return OBJECT_OFFSETOF(CompleteSubspace, m_allocatorForSizeStep); }
     

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
@@ -49,6 +49,16 @@ void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignmen
 
 }
 
+void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size, bool& isZeroed)
+{
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    isZeroed = false;
+    return m_heap.memalign(alignment, size, true);
+#else
+    return tryFastCompactAlignedMalloc(alignment, size, isZeroed);
+#endif
+}
+
 void FastMallocAlignedMemoryAllocator::freeAlignedMemory(void* basePtr)
 {
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
@@ -88,6 +98,15 @@ void* FastMallocAlignedMemoryAllocator::tryReallocateMemory(void* pointer, size_
     return m_heap.realloc(pointer, size);
 #else
     return FastCompactMalloc::tryRealloc(pointer, size);
+#endif
+}
+
+void FastMallocAlignedMemoryAllocator::zeroMemoryPage(void* pointer, size_t size)
+{
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    m_heap.zeroMemory(pointer, size);
+#else
+    FastCompactMalloc::zeroMemoryPage(pointer, size);
 #endif
 }
 

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
@@ -39,6 +39,7 @@ public:
     ~FastMallocAlignedMemoryAllocator() final;
     
     void* tryAllocateAlignedMemory(size_t alignment, size_t size) final;
+    void* tryAllocateAlignedMemory(size_t alignment, size_t, bool&) final;
     void freeAlignedMemory(void*) final;
     
     void dump(PrintStream&) const final;
@@ -46,6 +47,7 @@ public:
     void* tryAllocateMemory(size_t) final;
     void freeMemory(void*) final;
     void* tryReallocateMemory(void*, size_t) final;
+    void zeroMemoryPage(void*, size_t) final;
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 private:

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -53,6 +53,11 @@ void* GigacageAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment,
 #endif
 }
 
+void* GigacageAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t, size_t, bool&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void GigacageAlignedMemoryAllocator::freeAlignedMemory(void* basePtr)
 {
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
@@ -92,6 +97,11 @@ void* GigacageAlignedMemoryAllocator::tryReallocateMemory(void* pointer, size_t 
 #else
     return Gigacage::tryRealloc(m_kind, pointer, size);
 #endif
+}
+
+void GigacageAlignedMemoryAllocator::zeroMemoryPage(void*, size_t)
+{
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
@@ -40,6 +40,7 @@ public:
     ~GigacageAlignedMemoryAllocator() final;
     
     void* tryAllocateAlignedMemory(size_t alignment, size_t size) final;
+    void* tryAllocateAlignedMemory(size_t alignment, size_t, bool&) final;
     void freeAlignedMemory(void*) final;
     
     void dump(PrintStream&) const final;
@@ -47,6 +48,7 @@ public:
     void* tryAllocateMemory(size_t) final;
     void freeMemory(void*) final;
     void* tryReallocateMemory(void*, size_t) final;
+    void zeroMemoryPage(void*, size_t) final;
 
 private:
     Gigacage::Kind m_kind;

--- a/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
+++ b/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
@@ -80,6 +80,16 @@ void* IsoMemoryAllocatorBase::tryAllocateAlignedMemory(size_t alignment, size_t 
     return result;
 }
 
+void* IsoMemoryAllocatorBase::tryAllocateAlignedMemory(size_t, size_t, bool&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void IsoMemoryAllocatorBase::zeroMemoryPage(void*, size_t)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void IsoMemoryAllocatorBase::freeAlignedMemory(void* basePtr)
 {
     Locker locker { m_lock };

--- a/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.h
+++ b/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.h
@@ -40,7 +40,9 @@ public:
     ~IsoMemoryAllocatorBase() override;
 
     void* tryAllocateAlignedMemory(size_t alignment, size_t size) final;
+    void* tryAllocateAlignedMemory(size_t alignment, size_t, bool&) final;
     void freeAlignedMemory(void*) final;
+    void zeroMemoryPage(void*, size_t) final;
 
 protected:
     void releaseMemoryFromSubclassDestructor();

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -81,11 +81,10 @@ PreciseAllocation* PreciseAllocation::tryCreate(JSC::Heap& heap, size_t size, Su
     if constexpr (validateDFGDoesGC)
         heap.vm().verifyCanGC();
 
-    size_t adjustedAlignmentAllocationSize = headerSize() + size + halfAlignment + cacheLineAdjustment;
     static_assert(halfAlignment == 8, "We assume that memory returned by malloc has alignment >= 8.");
     
     // We must use tryAllocateMemory instead of tryAllocateAlignedMemory since we want to use "realloc" feature.
-    void* space = subspace->alignedMemoryAllocator()->tryAllocateMemory(adjustedAlignmentAllocationSize);
+    void* space = subspace->alignedMemoryAllocator()->tryAllocateMemory(adjustedAlignmentAllocationSize(size));
     if (!space)
         return nullptr;
 
@@ -109,10 +108,10 @@ PreciseAllocation* PreciseAllocation::tryCreate(JSC::Heap& heap, size_t size, Su
     return new (NotNull, space) PreciseAllocation(heap, size, subspace, indexInSpace, adjustment);
 }
 
-PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subspace)
+PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subspace, ZeroingInfo& info)
 {
     ASSERT(!isLowerTierPrecise());
-    size_t adjustedAlignmentAllocationSize = headerSize() + size + halfAlignment + cacheLineAdjustment;
+    size_t newAllocationSize = adjustedAlignmentAllocationSize(size);
     static_assert(halfAlignment == 8, "We assume that memory returned by malloc has alignment >= 8.");
 
     ASSERT(subspace == m_subspace);
@@ -121,9 +120,30 @@ PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subsp
     unsigned oldAdjustment = m_adjustment;
     void* oldBasePointer = basePointer();
 
-    void* newSpace = subspace->alignedMemoryAllocator()->tryReallocateMemory(oldBasePointer, adjustedAlignmentAllocationSize);
-    if (!newSpace)
-        return nullptr;
+    void* newSpace = nullptr;
+    size_t pageSize = WTF::pageSize();
+    info.usePageZeroing = newAllocationSize > 16 * MB;
+    if (info.shouldZeroFill && info.usePageZeroing) {
+        size_t oldAllocationSize = adjustedAlignmentAllocationSize(oldCellSize);
+        newAllocationSize = roundUpToMultipleOf(pageSize, newAllocationSize);
+        newSpace = subspace->alignedMemoryAllocator()->tryAllocateAlignedMemory(pageSize, newAllocationSize, info.isZeroed);
+        if (!newSpace)
+            return nullptr;
+
+        uintptr_t newStart = reinterpret_cast<uintptr_t>(newSpace);
+        ASSERT(newStart == roundUpToMultipleOf(pageSize, newStart));
+        info.allocationEndAddress = newStart + newAllocationSize;
+
+        auto destination = unsafeMakeSpan(reinterpret_cast<char8_t*>(newSpace), oldAllocationSize);
+        auto source = unsafeMakeSpan(reinterpret_cast<char8_t*>(oldBasePointer), oldAllocationSize);
+        memcpySpan(destination, source);
+
+        subspace->alignedMemoryAllocator()->freeMemory(oldBasePointer);
+    } else {
+        newSpace = subspace->alignedMemoryAllocator()->tryReallocateMemory(oldBasePointer, newAllocationSize);
+        if (!newSpace)
+            return nullptr;
+    }
 
     void* newBasePointer = newSpace;
     unsigned newAdjustment = halfAlignment;

--- a/Source/JavaScriptCore/heap/PreciseAllocation.h
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.h
@@ -36,6 +36,13 @@ namespace JSC {
 class IsoSubspace;
 class SlotVisitor;
 
+struct ZeroingInfo {
+    bool shouldZeroFill { false };
+    bool usePageZeroing { false };
+    bool isZeroed { false };
+    uintptr_t allocationEndAddress { 0 };
+};
+
 // WebKit has a good malloc that already knows what to do for large allocations. The GC shouldn't
 // have to think about such things. That's where PreciseAllocation comes in. We will allocate large
 // objects directly using malloc, and put the PreciseAllocation header just before them. We can detect
@@ -51,7 +58,7 @@ public:
 
     PreciseAllocation* reuseForLowerTierPrecise();
 
-    PreciseAllocation* tryReallocate(size_t, Subspace*);
+    PreciseAllocation* tryReallocate(size_t, Subspace*, ZeroingInfo&);
     
     ~PreciseAllocation();
     
@@ -154,6 +161,8 @@ public:
 
     bool isLowerTierPrecise() const { return m_lowerTierPreciseIndex != UINT8_MAX; }
     uint8_t lowerTierPreciseIndex() const { return m_lowerTierPreciseIndex; }
+
+    static constexpr size_t adjustedAlignmentAllocationSize(size_t cellSize) { return headerSize() + cellSize + halfAlignment + cacheLineAdjustment; }
 
     static constexpr unsigned alignment = MarkedBlock::atomSize;
     static constexpr unsigned halfAlignment = alignment / 2;

--- a/Source/JavaScriptCore/runtime/Butterfly.h
+++ b/Source/JavaScriptCore/runtime/Butterfly.h
@@ -131,6 +131,7 @@ using ContiguousDoubles = ContiguousData<double>;
 using ContiguousJSValues = ContiguousData<WriteBarrier<Unknown>>;
 using ConstContiguousDoubles = ContiguousData<const double>;
 using ConstContiguousJSValues = ContiguousData<const WriteBarrier<Unknown>>;
+struct ZeroingInfo;
 
 class Butterfly {
     WTF_MAKE_NONCOPYABLE(Butterfly);
@@ -234,7 +235,7 @@ public:
     Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
     Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure*, size_t newIndexingPayloadSizeInBytes);
 
-    Butterfly* reallocArrayRightIfPossible(VM&, GCDeferralContext&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
+    Butterfly* reallocArrayRightIfPossible(VM&, GCDeferralContext&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes, ZeroingInfo&); // Assumes that preCapacity is zero, and asserts as much.
 
     Butterfly* resizeArray(VM&, JSObject* intendedOwner, size_t propertyCapacity, bool oldHasIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newPreCapacity, bool newHasIndexingHeader, size_t newIndexingPayloadSizeInBytes);
     Butterfly* resizeArray(VM&, JSObject* intendedOwner, Structure*, size_t newPreCapacity, size_t newIndexingPayloadSizeInBytes); // Assumes that you're not changing whether or not the object has an indexing header.

--- a/Source/JavaScriptCore/runtime/ButterflyInlines.h
+++ b/Source/JavaScriptCore/runtime/ButterflyInlines.h
@@ -198,7 +198,8 @@ inline Butterfly* Butterfly::growArrayRight(
 inline Butterfly* Butterfly::reallocArrayRightIfPossible(
     VM& vm, GCDeferralContext& deferralContext, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity,
     bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes,
-    size_t newIndexingPayloadSizeInBytes)
+    size_t newIndexingPayloadSizeInBytes,
+    ZeroingInfo& info)
 {
     ASSERT_UNUSED(oldStructure, !indexingHeader()->preCapacity(oldStructure));
     ASSERT_UNUSED(intendedOwner, hadIndexingHeader == oldStructure->hasIndexingHeader(intendedOwner));
@@ -213,7 +214,7 @@ inline Butterfly* Butterfly::reallocArrayRightIfPossible(
     // Objects with no properties are common in arrays, and we are focusing on very large array crafted by repeating Array#push, so... that's fine!
     bool canRealloc = !propertyCapacity && !vm.heap.mutatorShouldBeFenced() && std::bit_cast<HeapCell*>(theBase)->isPreciseAllocation();
     if (canRealloc) {
-        void* newBase = vm.auxiliarySpace().reallocatePreciseAllocationNonVirtual(vm, std::bit_cast<HeapCell*>(theBase), newSize, &deferralContext, AllocationFailureMode::ReturnNull);
+        void* newBase = vm.auxiliarySpace().reallocatePreciseAllocationNonVirtual(vm, std::bit_cast<HeapCell*>(theBase), newSize, &deferralContext, AllocationFailureMode::ReturnNull, info);
         if (!newBase)
             return nullptr;
         return fromBase(newBase, 0, propertyCapacity);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -3789,6 +3789,12 @@ bool JSObject::ensureLengthSlow(VM& vm, unsigned length)
     unsigned availableOldLength =
         Butterfly::availableContiguousVectorLength(propertyCapacity, oldVectorLength);
     Butterfly* newButterfly = nullptr;
+
+    bool isDouble = hasDouble(indexingType());
+    ZeroingInfo info { .shouldZeroFill = !isDouble };
+    size_t oldPayloadBytes = oldVectorLength * sizeof(EncodedJSValue);
+    size_t newPayloadBytes = availableOldLength * sizeof(EncodedJSValue);
+
     if (availableOldLength >= length) {
         // This is the case where someone else selected a vector length that caused internal
         // fragmentation. If we did our jobs right, this would never happen. But I bet we will mess
@@ -3797,22 +3803,42 @@ bool JSObject::ensureLengthSlow(VM& vm, unsigned length)
     } else {
         newVectorLength = Butterfly::optimalContiguousVectorLength(
             propertyCapacity, std::min(length * 2, MAX_STORAGE_VECTOR_LENGTH));
+        newPayloadBytes = newVectorLength * sizeof(EncodedJSValue);
         butterfly = butterfly->reallocArrayRightIfPossible(
             vm, deferralContext, this, structure, propertyCapacity, true,
-            oldVectorLength * sizeof(EncodedJSValue),
-            newVectorLength * sizeof(EncodedJSValue));
+            oldPayloadBytes, newPayloadBytes, info);
         if (!butterfly)
             return false;
         newButterfly = butterfly;
     }
 
-    if (hasDouble(indexingType())) {
+    if (!info.shouldZeroFill) {
+        ASSERT(hasDouble(indexingType()));
         for (unsigned i = oldVectorLength; i < newVectorLength; ++i)
             butterfly->indexingPayload<double>()[i] = PNaN;
-    } else {
-        for (unsigned i = oldVectorLength; i < newVectorLength; ++i)
-            butterfly->indexingPayload<WriteBarrier<Unknown>>()[i].clear();
+    } else if (!info.isZeroed) {
+        char8_t* payloadStart = reinterpret_cast<char8_t*>(&butterfly->indexingPayload<WriteBarrier<Unknown>>()[0]);
+        char8_t* newPayloadStart = payloadStart + oldPayloadBytes;
+        if (info.usePageZeroing) {
+            ASSERT(info.allocationEndAddress && reinterpret_cast<uintptr_t>(payloadStart) + newPayloadBytes <= info.allocationEndAddress);
+
+            size_t pageSize = WTF::pageSize();
+            uintptr_t alignedNewPayloadStart = roundUpToMultipleOf(pageSize, reinterpret_cast<uintptr_t>(newPayloadStart));
+            size_t memSetBytes = alignedNewPayloadStart - reinterpret_cast<uintptr_t>(newPayloadStart);
+            zeroSpan(unsafeMakeSpan(newPayloadStart, memSetBytes));
+
+            ASSERT(info.allocationEndAddress == roundUpToMultipleOf(pageSize, info.allocationEndAddress));
+            vm.auxiliarySpace().alignedMemoryAllocator()->zeroMemoryPage(reinterpret_cast<void*>(alignedNewPayloadStart), info.allocationEndAddress - alignedNewPayloadStart);
+        } else
+            zeroSpan(unsafeMakeSpan(newPayloadStart, newPayloadBytes - oldPayloadBytes));
     }
+
+#if ASSERT_ENABLED
+    if (info.shouldZeroFill) {
+        for (unsigned i = oldVectorLength; i < newVectorLength; ++i)
+            ASSERT(!butterfly->indexingPayload<WriteBarrier<Unknown>>()[i]);
+    }
+#endif
 
     if (newButterfly) {
         butterfly->setVectorLength(newVectorLength);

--- a/Source/WTF/wtf/DebugHeap.cpp
+++ b/Source/WTF/wtf/DebugHeap.cpp
@@ -76,6 +76,11 @@ void DebugHeap::free(void* object)
     malloc_zone_free(m_zone, object);
 }
 
+void DebugHeap::zeroMemory(void* object, size_t size)
+{
+    zeroSpan(unsafeMakeSpan(reinterpret_cast<char8_t*>(object), memSetBytes));
+}
+
 } // namespace WTF
 
 #endif // ENABLE(MALLOC_HEAP_BREAKDOWN)

--- a/Source/WTF/wtf/DebugHeap.h
+++ b/Source/WTF/wtf/DebugHeap.h
@@ -51,6 +51,7 @@ public:
     WTF_EXPORT_PRIVATE void* memalign(size_t alignment, size_t, bool crashOnFailure);
     WTF_EXPORT_PRIVATE void* realloc(void*, size_t);
     WTF_EXPORT_PRIVATE void free(void*);
+    WTF_EXPORT_PRIVATE void zeroMemory(void*, size_t);
 
 private:
 #if OS(DARWIN)

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -178,6 +178,11 @@ void fastAlignedFree(void* p)
     _aligned_free(p);
 }
 
+void fastZeroMemoryPage(void* p, size_t size)
+{
+    memset(p, 0, size);
+}
+
 #else
 
 void* fastAlignedMalloc(size_t alignment, size_t size) 
@@ -198,6 +203,11 @@ void* tryFastAlignedMalloc(size_t alignment, size_t size)
 void fastAlignedFree(void* p) 
 {
     free(p);
+}
+
+void fastZeroMemoryPage(void* p, size_t size)
+{
+    memset(p, 0, size);
 }
 
 #endif // OS(WINDOWS)
@@ -323,6 +333,11 @@ TryMallocReturnValue tryFastCompactCalloc(size_t numElements, size_t elementSize
 TryMallocReturnValue tryFastCompactRealloc(void* ptr, size_t size) { return tryFastRealloc(ptr, size); }
 void* fastCompactAlignedMalloc(size_t alignment, size_t size) { return fastAlignedMalloc(alignment, size); }
 void* tryFastCompactAlignedMalloc(size_t alignment, size_t size) { return tryFastAlignedMalloc(alignment, size); }
+void* tryFastCompactAlignedMalloc(size_t alignment, size_t size, bool& isZeroed)
+{
+    isZeroed = false;
+    return tryFastAlignedMalloc(alignment, size);
+}
 
 } // namespace WTF
 
@@ -651,6 +666,11 @@ void fastAlignedFree(void* p)
     bmalloc::api::free(p);
 }
 
+void fastZeroMemoryPage(void* p, size_t size)
+{
+    bmalloc::api::zeroMemoryPage(p, size);
+}
+
 TryMallocReturnValue tryFastMalloc(size_t size)
 {
     FAIL_IF_EXCEEDS_LIMIT(size);
@@ -755,6 +775,19 @@ void* tryFastCompactAlignedMalloc(size_t alignment, size_t size)
     FAIL_IF_EXCEEDS_LIMIT(size);
     assertMallocRestrictionForCurrentThreadScope();
     void* result = bmalloc::api::tryMemalign(alignment, size, bmalloc::CompactAllocationMode::Compact);
+#if ENABLE(MALLOC_HEAP_BREAKDOWN) && TRACK_MALLOC_CALLSTACK
+    if (!AvoidRecordingScope::avoidRecordingCount())
+        MallocCallTracker::singleton().recordMalloc(result, size);
+#endif
+    BPROFILE_ALLOCATION(COMPACTIBLE, result, size);
+    return result;
+}
+
+void* tryFastCompactAlignedMalloc(size_t alignment, size_t size, bool& isZeroed)
+{
+    FAIL_IF_EXCEEDS_LIMIT(size);
+    assertMallocRestrictionForCurrentThreadScope();
+    void* result = bmalloc::api::tryMemalign(alignment, size, &isZeroed, bmalloc::CompactAllocationMode::Compact);
 #if ENABLE(MALLOC_HEAP_BREAKDOWN) && TRACK_MALLOC_CALLSTACK
     if (!AvoidRecordingScope::avoidRecordingCount())
         MallocCallTracker::singleton().recordMalloc(result, size);

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -166,6 +166,7 @@ WTF_EXPORT_PRIVATE TryMallocReturnValue tryFastCalloc(size_t numElements, size_t
 WTF_EXPORT_PRIVATE TryMallocReturnValue tryFastRealloc(void*, size_t);
 
 WTF_EXPORT_PRIVATE void fastFree(void*);
+WTF_EXPORT_PRIVATE void fastZeroMemoryPage(void*, size_t);
 
 // Allocations from fastAlignedMalloc() must be freed using fastAlignedFree().
 WTF_EXPORT_PRIVATE void* fastAlignedMalloc(size_t alignment, size_t) RETURNS_NONNULL;
@@ -187,6 +188,7 @@ WTF_EXPORT_PRIVATE char* fastCompactStrDup(const char*) RETURNS_NONNULL;
 WTF_EXPORT_PRIVATE void* fastCompactMemDup(const void*, size_t);
 WTF_EXPORT_PRIVATE void* fastCompactAlignedMalloc(size_t alignment, size_t) RETURNS_NONNULL;
 WTF_EXPORT_PRIVATE void* tryFastCompactAlignedMalloc(size_t alignment, size_t);
+WTF_EXPORT_PRIVATE void* tryFastCompactAlignedMalloc(size_t alignment, size_t, bool&);
 
 WTF_EXPORT_PRIVATE size_t fastMallocSize(const void*);
 
@@ -316,6 +318,8 @@ struct FastCompactMalloc {
 
     static void* zeroedMalloc(size_t size) { return fastCompactZeroedMalloc(size); }
 
+    static void zeroMemoryPage(void* p, size_t size) { fastZeroMemoryPage(p, size); }
+
     static void* tryZeroedMalloc(size_t size)
     {
         auto result = tryFastCompactZeroedMalloc(size);
@@ -417,6 +421,7 @@ using WTF::FastFree;
 using WTF::isFastMallocEnabled;
 using WTF::fastCalloc;
 using WTF::fastFree;
+using WTF::fastZeroMemoryPage;
 using WTF::fastMalloc;
 using WTF::fastMallocGoodSize;
 using WTF::fastMallocSize;

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -114,6 +114,15 @@ BINLINE void* zeroedMalloc(size_t size, CompactAllocationMode mode, HeapKind kin
 #endif
 }
 
+BINLINE void zeroMemoryPage(void* base, size_t size)
+{
+#if BUSE(LIBPAS)
+    pas_page_malloc_zero_fill(base, size);
+#else
+    memset(base, 0, size);
+#endif
+}
+
 BEXPORT void* mallocOutOfLine(size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary);
 
 // Returns null on failure.
@@ -126,6 +135,25 @@ BINLINE void* tryMemalign(size_t alignment, size_t size, CompactAllocationMode m
         &heapForKind(gigacageKind(kind)), size, alignment, asPasAllocationMode(mode));
 #else
     BUNUSED(mode);
+    return Cache::tryAllocate(kind, alignment, size);
+#endif
+}
+
+// Returns null on failure.
+BINLINE void* tryMemalign(size_t alignment, size_t size, bool* isZeroed, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary)
+{
+#if BUSE(LIBPAS)
+    pas_allocation_result result;
+    if (!isGigacage(kind))
+        result = bmalloc_try_allocate_with_alignment_impl(size, alignment, asPasAllocationMode(mode));
+    else
+        result = bmalloc_try_allocate_auxiliary_with_alignment_inline_impl(
+            &heapForKind(gigacageKind(kind)), size, alignment, asPasAllocationMode(mode));
+    *isZeroed = result.zero_mode == pas_zero_mode_is_all_zero;
+    return (void*)result.begin;
+#else
+    BUNUSED(mode);
+    *isZeroed = false;
     return Cache::tryAllocate(kind, alignment, size);
 #endif
 }

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -243,8 +243,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_allocate_auxiliary_zeroed_inline(pas_prim
         size).begin;
 }
 
-static PAS_ALWAYS_INLINE void*
-bmalloc_try_allocate_auxiliary_with_alignment_inline(pas_primitive_heap_ref* heap_ref,
+static PAS_ALWAYS_INLINE pas_allocation_result
+bmalloc_try_allocate_auxiliary_with_alignment_inline_impl(pas_primitive_heap_ref* heap_ref,
                                                      size_t size,
                                                      size_t alignment,
                                                      pas_allocation_mode allocation_mode)
@@ -252,8 +252,17 @@ bmalloc_try_allocate_auxiliary_with_alignment_inline(pas_primitive_heap_ref* hea
     pas_allocation_result result;
     result = bmalloc_try_allocate_auxiliary_impl_inline_only(heap_ref, size, alignment, allocation_mode);
     if (PAS_LIKELY(result.did_succeed))
-        return (void*)result.begin;
-    return bmalloc_try_allocate_auxiliary_with_alignment_casual(heap_ref, size, alignment, allocation_mode);
+        return result;
+    return bmalloc_try_allocate_auxiliary_impl_casual_case(heap_ref, size, alignment, allocation_mode);
+}
+
+static PAS_ALWAYS_INLINE void*
+bmalloc_try_allocate_auxiliary_with_alignment_inline(pas_primitive_heap_ref* heap_ref,
+                                                     size_t size,
+                                                     size_t alignment,
+                                                     pas_allocation_mode allocation_mode)
+{
+    return (void*)bmalloc_try_allocate_auxiliary_with_alignment_inline_impl(heap_ref, size, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -189,6 +189,9 @@ pas_page_malloc_try_allocate_without_deallocating_padding(
 
 void pas_page_malloc_zero_fill(void* base, size_t size)
 {
+    if (PAS_UNLIKELY(!size))
+        return;
+
     size_t page_size;
     void* result_ptr;
 


### PR DESCRIPTION
#### 05279577ef852027110ca8eebf5eeb5bb5b6c4c8
<pre>
[JSC] Optimize Array Growth in JSObject::ensureLengthSlow with Efficient Zeroing Strategies
<a href="https://bugs.webkit.org/show_bug.cgi?id=290056">https://bugs.webkit.org/show_bug.cgi?id=290056</a>
<a href="https://rdar.apple.com/147423210">rdar://147423210</a>

Reviewed by NOBODY (OOPS!).

This patch enhances the performance of JSObject::ensureLengthSlow by
optimizing how newly allocated memory is cleared. Instead of using a
per-element loop to initialize storage for non-double arrays, it now
employs more efficient zeroing techniques:

1. Memset for Small Allocations: Uses memset for clearing small memory
   regions instead of iterating over elements.

2. Page-Zeroing for Large Allocations: Introduces ZeroingInfo to track
   allocation behavior, leveraging mmap-based zeroing for large buffers
   when applicable.

These changes significantly reduce overhead when growing large arrays,
particularly benefiting workloads with heavy Array#push operations.
This patch offers ~14% progression on the microbenchmark `array-push-4.js`.

* JSTests/microbenchmarks/array-push-4.js: Added.
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::reallocatePreciseAllocationNonVirtual):
* Source/JavaScriptCore/heap/CompleteSubspace.h:
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp:
(JSC::FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory):
(JSC::FastMallocAlignedMemoryAllocator::zeroMemoryPage):
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp:
(JSC::GigacageAlignedMemoryAllocator::tryAllocateAlignedMemory):
(JSC::GigacageAlignedMemoryAllocator::zeroMemoryPage):
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp:
(JSC::IsoMemoryAllocatorBase::tryAllocateAlignedMemory):
(JSC::IsoMemoryAllocatorBase::zeroMemoryPage):
* Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.h:
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::tryCreate):
(JSC::PreciseAllocation::tryReallocate):
* Source/JavaScriptCore/heap/PreciseAllocation.h:
(JSC::PreciseAllocation::adjustedAlignmentAllocationSize):
* Source/JavaScriptCore/runtime/Butterfly.h:
* Source/JavaScriptCore/runtime/ButterflyInlines.h:
(JSC::Butterfly::reallocArrayRightIfPossible):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::ensureLengthSlow):
* Source/WTF/wtf/DebugHeap.cpp:
(WTF::DebugHeap::zeroMemory):
* Source/WTF/wtf/DebugHeap.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastZeroMemoryPage):
(WTF::tryFastCompactAlignedMalloc):
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastCompactMalloc::zeroMemoryPage):
* Source/bmalloc/bmalloc/bmalloc.h:
(bmalloc::api::zeroMemoryPage):
(bmalloc::api::tryMemalign):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_try_allocate_auxiliary_with_alignment_inline_impl):
(bmalloc_try_allocate_auxiliary_with_alignment_inline):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_zero_fill):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05279577ef852027110ca8eebf5eeb5bb5b6c4c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96709 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47229 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73714 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99712 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12512 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54049 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46557 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89382 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103805 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95330 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82755 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83536 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82141 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4331 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17253 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28894 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118957 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23398 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33464 "Found 2327 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice1.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice4.js.default, ChakraCore.yaml/ChakraCore/test/Array/memcopy_missing_values.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativeIntPop.js.default, ChakraCore.yaml/ChakraCore/test/Array/protoLookup.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse2.js.default, ChakraCore.yaml/ChakraCore/test/Array/sliceArrayForceBtreeBug616623.js.default, ChakraCore.yaml/ChakraCore/test/Array/toString.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->