### PR TITLE
Use synchronous IPC for layout test output

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -403,7 +403,7 @@ void InjectedBundle::done(bool forceRepaint)
     setValue(body, "AudioResult", m_audioResult);
     setValue(body, "ForceRepaint", forceRepaint);
 
-    WKBundlePagePostMessageIgnoringFullySynchronousMode(page()->page(), toWK("Done").get(), body.get());
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("Done").get(), body.get(), nullptr);
     m_testRunner = nullptr;
 }
 
@@ -444,11 +444,8 @@ void InjectedBundle::outputText(StringView output, IsFinalTestOutput isFinalTest
         return;
     // FIXME: Do we really have to convert to UTF-8 instead of using toWK?
     auto string = output.tryGetUTF8();
-    // We use WKBundlePagePostMessageIgnoringFullySynchronousMode() instead of WKBundlePagePostMessage() to make sure that all text output
-    // is done via asynchronous IPC, even if the connection is in fully synchronous mode due to a WKBundlePagePostSynchronousMessageForTesting()
-    // call. Otherwise, messages logged via sync and async IPC may end up out of order and cause flakiness.
     auto messageName = isFinalTestOutput == IsFinalTestOutput::Yes ? toWK("FinalTextOutput") : toWK("TextOutput");
-    WKBundlePagePostMessageIgnoringFullySynchronousMode(page()->page(), messageName.get(), toWK(string ? string->data() : "Out of memory\n").get());
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), messageName.get(), toWK(string ? string->data() : "Out of memory\n").get(), nullptr);
 }
 
 void InjectedBundle::postNewBeforeUnloadReturnValue(bool value)

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -360,28 +360,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         ASSERT_NOT_REACHED();
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "Done")) {
-        auto messageBodyDictionary = dictionaryValue(messageBody);
-        m_pixelResultIsPending = booleanValue(messageBodyDictionary, "PixelResultIsPending");
-        if (!m_pixelResultIsPending) {
-            // Postpone page load stop if pixel result is still pending since
-            // cancelled image loads will paint as broken images.
-            WKPageStopLoading(TestController::singleton().mainWebView()->page());
-            m_pixelResult = static_cast<WKImageRef>(value(messageBodyDictionary, "PixelResult"));
-            ASSERT(!m_pixelResult || m_dumpPixels);
-        }
-        m_repaintRects = static_cast<WKArrayRef>(value(messageBodyDictionary, "RepaintRects"));
-        m_audioResult = static_cast<WKDataRef>(value(messageBodyDictionary, "AudioResult"));
-        m_forceRepaint = booleanValue(messageBodyDictionary, "ForceRepaint");
-        done();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "TextOutput") || WKStringIsEqualToUTF8CString(messageName, "FinalTextOutput")) {
-        m_textOutput.append(toWTFString(stringValue(messageBody)));
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "DumpToStdErr")) {
         fprintf(stderr, "%s", toWTFString(stringValue(messageBody)).utf8().data());
         return;
@@ -774,6 +752,28 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetWindowIsKey")) {
         TestController::singleton().mainWebView()->setWindowIsKey(booleanValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "Done")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        m_pixelResultIsPending = booleanValue(messageBodyDictionary, "PixelResultIsPending");
+        if (!m_pixelResultIsPending) {
+            // Postpone page load stop if pixel result is still pending since
+            // cancelled image loads will paint as broken images.
+            WKPageStopLoading(TestController::singleton().mainWebView()->page());
+            m_pixelResult = static_cast<WKImageRef>(value(messageBodyDictionary, "PixelResult"));
+            ASSERT(!m_pixelResult || m_dumpPixels);
+        }
+        m_repaintRects = static_cast<WKArrayRef>(value(messageBodyDictionary, "RepaintRects"));
+        m_audioResult = static_cast<WKDataRef>(value(messageBodyDictionary, "AudioResult"));
+        m_forceRepaint = booleanValue(messageBodyDictionary, "ForceRepaint");
+        done();
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "TextOutput") || WKStringIsEqualToUTF8CString(messageName, "FinalTextOutput")) {
+        m_textOutput.append(toWTFString(stringValue(messageBody)));
         return nullptr;
     }
 


### PR DESCRIPTION
#### 81427225c949f109aeacc4fc9819810fd6c1edd2
<pre>
Use synchronous IPC for layout test output
<a href="https://bugs.webkit.org/show_bug.cgi?id=289932">https://bugs.webkit.org/show_bug.cgi?id=289932</a>
<a href="https://rdar.apple.com/147271142">rdar://147271142</a>

Reviewed by NOBODY (OOPS!).

This is, believe it or not, a step towards getting more tests working with site isolation on.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::done):
(WTR::InjectedBundle::outputText):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceivePageMessageFromInjectedBundle):
(WTR::TestController::didReceiveSynchronousPageMessageFromInjectedBundleWithListener):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81427225c949f109aeacc4fc9819810fd6c1edd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23701 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72952 "Found 3 new test failures: http/tests/xmlhttprequest/xmlhttprequest-open-method-allowed.html http/tests/xmlhttprequest/xmlhttprequest-open-method-case-insensitive.html imported/w3c/web-platform-tests/loading/preloader-template.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30211 "Found 8 new test failures: http/tests/download/sandboxed-iframe-download-not-allowed.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js.html http/tests/resourceLoadStatistics/cname-cloaking-top-no-cname-sub-1p-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-no-cname-sub-no-cname.https.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-javascript-url-iframe-in-iframe.html http/tests/xmlhttprequest/xmlhttprequest-open-method-allowed.html http/tests/xmlhttprequest/xmlhttprequest-open-method-case-insensitive.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98663 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11653 "Found 23 new test failures: http/tests/app-privacy-report/app-attribution-post-request.html http/tests/app-privacy-report/user-attribution-post-request.html http/tests/download/sandboxed-iframe-download-not-allowed.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-decoration-same-site.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-without-link-decoration-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81548 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4250 "Found 23 new test failures: http/tests/download/sandboxed-iframe-download-not-allowed.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-decoration-same-site.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-without-link-decoration-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-1p-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-3p-cname.https.html ... (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102745 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22714 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16578 "Found 24 new test failures: http/tests/download/sandboxed-iframe-download-not-allowed.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-decoration-same-site.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-without-link-decoration-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-1p-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-3p-cname.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81995 "Found 15 new test failures: http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-decoration-same-site.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-without-link-decoration-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-1p-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-matching-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-no-cname.https.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81349 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25936 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3400 "Found 23 new test failures: http/tests/download/sandboxed-iframe-download-not-allowed.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-decoration-same-site.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-without-link-decoration-from-prevalent-resource.html http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-1p-cname.https.html http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-3p-cname.https.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22682 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->