### PR TITLE
[JSC] Fix Clang 20 compiler warnings

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -314,12 +314,14 @@ inline AccessGenerationResult::AccessGenerationResult(Kind kind, Ref<InlineCache
 
 class InlineCacheCompiler {
 public:
-    InlineCacheCompiler(JITType jitType, VM& vm, JSGlobalObject* globalObject, ECMAMode ecmaMode, StructureStubInfo& stubInfo)
+    InlineCacheCompiler([[maybe_unused]] JITType jitType, VM& vm, JSGlobalObject* globalObject, ECMAMode ecmaMode, StructureStubInfo& stubInfo)
         : m_vm(vm)
         , m_globalObject(globalObject)
         , m_stubInfo(stubInfo)
         , m_ecmaMode(ecmaMode)
+#if ASSERT_ENABLED
         , m_jitType(jitType)
+#endif
     {
     }
 
@@ -431,7 +433,9 @@ private:
     JSGlobalObject* const m_globalObject;
     StructureStubInfo& m_stubInfo;
     const ECMAMode m_ecmaMode { ECMAMode::sloppy() };
+#if ASSERT_ENABLED
     JITType m_jitType;
+#endif
     CCallHelpers* m_jit { nullptr };
     ScratchRegisterAllocator* m_allocator { nullptr };
     MacroAssembler::JumpList m_success;

--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp
@@ -35,15 +35,7 @@
 
 namespace JSC { namespace DFG {
 
-DesiredWeakReferences::DesiredWeakReferences()
-    : m_codeBlock(nullptr)
-{
-}
-
-DesiredWeakReferences::DesiredWeakReferences(CodeBlock* codeBlock)
-    : m_codeBlock(codeBlock)
-{
-}
+DesiredWeakReferences::DesiredWeakReferences() = default;
 
 DesiredWeakReferences::~DesiredWeakReferences() = default;
 

--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
@@ -46,7 +46,6 @@ class CommonData;
 class DesiredWeakReferences {
 public:
     DesiredWeakReferences();
-    DesiredWeakReferences(CodeBlock*);
     ~DesiredWeakReferences();
 
     void addLazily(JSCell*);
@@ -60,7 +59,6 @@ public:
     template<typename Visitor> void visitChildren(Visitor&);
 
 private:
-    CodeBlock* m_codeBlock;
     UncheckedKeyHashSet<JSCell*> m_cells;
     UncheckedKeyHashSet<StructureID> m_structures;
     FixedVector<WriteBarrier<JSCell>> m_finalizedCells;

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -140,7 +140,6 @@ Plan::Plan(CodeBlock* passedCodeBlock, CodeBlock* profiledDFGCodeBlock,
         , m_compilation(UNLIKELY(m_vm->m_perBytecodeProfiler) ? adoptRef(new Profiler::Compilation(m_vm->m_perBytecodeProfiler->ensureBytecodesFor(m_codeBlock), profilerCompilationKindForMode(mode))) : nullptr)
         , m_inlineCallFrames(adoptRef(new InlineCallFrameSet()))
         , m_identifiers(m_codeBlock)
-        , m_weakReferences(m_codeBlock)
         , m_transitions(m_codeBlock)
 {
     RELEASE_ASSERT(m_codeBlock->alternative()->jitCode());

--- a/Source/JavaScriptCore/jit/JITSafepoint.h
+++ b/Source/JavaScriptCore/jit/JITSafepoint.h
@@ -54,7 +54,6 @@ public:
         
         bool m_didGetCancelled;
         bool m_wasChecked;
-        bool m_keepDependenciesLive;
     };
     
     Safepoint(JITPlan&, Result&);

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -116,7 +116,7 @@ static StringView functionCallBase(StringView sourceText)
         // and their closing parenthesis, the text range passed into the message appender 
         // will not include the text in between these parentheses, it will just be the desired
         // text that precedes the parentheses.
-        return String();
+        return { };
     }
 
     unsigned parenStack = 1;
@@ -149,7 +149,7 @@ static StringView functionCallBase(StringView sourceText)
         // in the above string processing. This algorithm is mostly best effort
         // and it works for most JS text in practice. However, if we determine
         // that the algorithm failed, we should just return the empty value.
-        return String();
+        return { };
     }
 
     // Don't display the ?. of an optional call.

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -84,7 +84,8 @@ TEST(WTF, StringViewEmptyVsNull)
     else
         SUCCEED();
 
-    StringView viewWithCharacters(String("hello"_s));
+    String string { "hello"_s };
+    StringView viewWithCharacters(string);
     EXPECT_FALSE(viewWithCharacters.isNull());
     EXPECT_FALSE(viewWithCharacters.isEmpty());
 


### PR DESCRIPTION
#### 2a4b0488dd389b62f4d9e71b485b1747cb4bb4ff
<pre>
[JSC] Fix Clang 20 compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=289933">https://bugs.webkit.org/show_bug.cgi?id=289933</a>

Reviewed by Justin Michaud.

Fixed dangling, return-stack-address and unused-private-field warnings.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
(JSC::InlineCacheCompiler::InlineCacheCompiler):
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp:
(JSC::DFG::DesiredWeakReferences::DesiredWeakReferences): Deleted.
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::Plan):
* Source/JavaScriptCore/jit/JITSafepoint.h:
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::functionCallBase):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewEmptyVsNull)):

Canonical link: <a href="https://commits.webkit.org/292393@main">https://commits.webkit.org/292393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d09cbbd7fb1174ace2378ad0c63a245b922a4c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72873 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45394 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88221 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102637 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94173 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22603 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16509 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81266 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20446 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27728 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116966 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22230 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->