### PR TITLE
[macOS] Selection color does not honor custom app accent colors

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
@@ -58,9 +58,11 @@ typedef NS_ENUM(NSInteger, NSUserAccentColor) {
     NSUserAccentColorPink,
 
     NSUserAccentColorNoColor = -1,
+    NSUserAccentColorMulticolor = -2,
 };
 
 extern "C" NSUserAccentColor NSColorGetUserAccentColor(void);
+extern "C" void NSColorSetUserAccentColor(NSUserAccentColor key, BOOL sendNotification);
 
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -496,11 +496,12 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     // This will be in a race with the closing of the Launch Services connection, so call it synchronously here.
     // The cost of calling this should be small, and it is not expected to have any impact on performance.
     _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSPersistenceSuppressRelaunchAtLoginKey, kCFBooleanTrue, nullptr);
-#endif
 
-#if PLATFORM(MAC)
     // App nap must be manually enabled when not running the NSApplication run loop.
     __CFRunLoopSetOptionsReason(__CFRunLoopOptionsEnableAppNap, CFSTR("Finished checkin as application - enable app nap"));
+
+    // Initialize the shared application so method calls using `NSApp` are not no-ops.
+    [NSApplication sharedApplication];
 #endif
 
 #if !ENABLE(CFPREFS_DIRECT_MODE)


### PR DESCRIPTION
#### 8b1ebb351d75cb4d484bc9467cd9abe0026f6bb0
<pre>
[macOS] Selection color does not honor custom app accent colors
<a href="https://bugs.webkit.org/show_bug.cgi?id=289912">https://bugs.webkit.org/show_bug.cgi?id=289912</a>
<a href="https://rdar.apple.com/146919866">rdar://146919866</a>

Reviewed by Richard Robinson.

App accent color support in WebKit works by forwarding the effective accent
color from the UI process to the web process, and updating the effective accent
color in the web process using `-[NSApplication _setAccentColor:]`.

More specifically, the web process attempts to set its accent color using
`[NSApp _setAccentColor:]`. `NSApp` is a static variable that is only set after
`-[NSApplication sharedApplication]` has been called once.

It appears that `-[NSApplication sharedApplication]` is no longer getting
invoked anywhere before WebKit attempts to set the accent color in the web
process. Consequently, `NSApp` is `nil`, `[NSApp _setAccentColor:]` is a
no-op, and the web process never updates its accent color.

Fix by calling `-[NSApplication sharedApplication]` upon process initialization,
and a regression test. This solution was chosen over updating the call site, as
other use of `NSApp` would remain risky.

* Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemColors.mm:
(TestWebKitAPI::TEST(WebKit, AppAccentColorAffectsSystemColors)):

The regression test does not directly test selection color, as that is not easy
to capture. Instead, it checks the value of a CSS system color, which should
follow the accent color.

Additionally, the test creates an additional web view for the sole purpose of
detecting when the user accent color has been correctly set in the global domain.
App accent colors do not apply unless the user accent color is &quot;multicolor&quot;.

This test still &quot;fails&quot; occasionally when the system&apos;s accent color is not
already set to &quot;multicolor&quot;, due to the preference update being slow. Since the
default setting is &quot;multicolor&quot;, and the test still passes 90% of the time when
the user has a custom value, the test exits early rather than failing if the
user accent color could not be updated in a reasonable time.

Canonical link: <a href="https://commits.webkit.org/292312@main">https://commits.webkit.org/292312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e50038ab100c2a48e94bbca2d8b8c5f0e89ac1a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98615 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86368 "Build is in progress. Recent messages:") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11328 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/4081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45453 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102696 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22662 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22914 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81312 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25903 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16007 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15388 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22630 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25765 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24031 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->