### PR TITLE
Web Inspector: Heap: custom elements should each have their own category instead of `HTMLElement`

### DIFF
--- a/LayoutTests/inspector/heap/snapshot-expected.txt
+++ b/LayoutTests/inspector/heap/snapshot-expected.txt
@@ -3,9 +3,24 @@ Test for the Heap.snapshot command.
 
 == Running test suite: Heap.snapshot
 -- Running test case: TriggerSnapshot
-PASS: Should not have an error creating a snapshot.
 PASS: Snapshot size should be greater than 1kb.
 PASS: Snapshot object count should be greater than 100.
+
 PASS: Snapshot should include a class category for 'Window'.
 PASS: Snapshot should include at least one 'Window' instance.
+
+PASS: Snapshot should include a class category for 'TestClass'.
+PASS: 'TestClass' category should include one object.
+PASS: Snapshot should include one 'TestClass' instance.
+PASS: 'TestClass' instance should have object flag.
+
+PASS: Snapshot should include a class category for 'TestCustomElement1'.
+PASS: 'TestCustomElement1' category should include one element.
+PASS: Snapshot should include one 'TestCustomElement1' instance.
+PASS: 'TestCustomElement1' instance should have element flag.
+
+PASS: Snapshot should include a class category for 'TestCustomElement2'.
+PASS: 'TestCustomElement2' category should include one element.
+PASS: Snapshot should include one 'TestCustomElement2' instance.
+PASS: 'TestCustomElement2' instance should have element flag.
 

--- a/LayoutTests/inspector/heap/snapshot.html
+++ b/LayoutTests/inspector/heap/snapshot.html
@@ -3,6 +3,15 @@
 <head>
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
+class TestClass { }
+let testClassInstance = new TestClass;
+
+class TestCustomElement1 extends HTMLElement { }
+customElements.define("test-custom-element-1", TestCustomElement1);
+
+class TestCustomElement2 extends HTMLElement { }
+customElements.define("test-custom-element-2", TestCustomElement2);
+
 function test()
 {
     let suite = InspectorTest.createAsyncSuite("Heap.snapshot");
@@ -10,21 +19,48 @@ function test()
     suite.addTestCase({
         name: "TriggerSnapshot",
         description: "Calling Heap.snapshot should create a heap snapshot.",
-        test(resolve, reject) {
-            HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
-                InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
-                let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
-                    InspectorTest.expectThat(snapshot.totalSize > 1024, "Snapshot size should be greater than 1kb.");
-                    InspectorTest.expectThat(snapshot.totalObjectCount > 100, "Snapshot object count should be greater than 100.");
-                    InspectorTest.expectThat(snapshot.categories.get("Window"), "Snapshot should include a class category for 'Window'.");
-                    snapshot.instancesWithClassName("Window", (windows) => {
-                        InspectorTest.expectThat(windows.length > 0, "Snapshot should include at least one 'Window' instance.");
-                        resolve();
-                    });
-                });
-            });
+        async test() {
+            let {timestamp, snapshotData} = await HeapAgent.snapshot();
+
+            let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
+            let {objectId, snapshot: serializedSnapshot} = await new Promise((resolve, reject) => workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotData, resolve));
+
+            let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
+            InspectorTest.expectGreaterThan(snapshot.totalSize, 1024, "Snapshot size should be greater than 1kb.");
+            InspectorTest.expectGreaterThan(snapshot.totalObjectCount, 100, "Snapshot object count should be greater than 100.");
+
+            InspectorTest.newline();
+
+            InspectorTest.expectThat(snapshot.categories.get("Window"), "Snapshot should include a class category for 'Window'.");
+            let windows = await new Promise((resolve, reject) => snapshot.instancesWithClassName("Window", resolve));
+            InspectorTest.expectGreaterThan(windows.length, 0, "Snapshot should include at least one 'Window' instance.");
+
+            InspectorTest.newline();
+
+            let testClassCategory = snapshot.categories.get("TestClass");
+            InspectorTest.expectThat(testClassCategory, "Snapshot should include a class category for 'TestClass'.");
+            InspectorTest.expectEqual(testClassCategory?.objectCount, 1, "'TestClass' category should include one object.");
+            let testClasses = await new Promise((resolve, reject) => snapshot.instancesWithClassName("TestClass", resolve));
+            InspectorTest.expectEqual(testClasses.length, 1, "Snapshot should include one 'TestClass' instance.");
+            InspectorTest.expectTrue(testClasses[0]?.isObjectType, "'TestClass' instance should have object flag.");
+
+            InspectorTest.newline();
+
+            let testCustomElement1Category = snapshot.categories.get("TestCustomElement1");
+            InspectorTest.expectThat(testCustomElement1Category, "Snapshot should include a class category for 'TestCustomElement1'.");
+            InspectorTest.expectEqual(testCustomElement1Category?.elementCount, 1, "'TestCustomElement1' category should include one element.");
+            let testCustomElement1s = await new Promise((resolve, reject) => snapshot.instancesWithClassName("TestCustomElement1", resolve));
+            InspectorTest.expectEqual(testCustomElement1s.length, 1, "Snapshot should include one 'TestCustomElement1' instance.");
+            InspectorTest.expectTrue(testCustomElement1s[0]?.isElementType, "'TestCustomElement1' instance should have element flag.");
+
+            InspectorTest.newline();
+
+            let testCustomElement2Category = snapshot.categories.get("TestCustomElement2");
+            InspectorTest.expectThat(testCustomElement2Category, "Snapshot should include a class category for 'TestCustomElement2'.");
+            InspectorTest.expectEqual(testCustomElement2Category?.elementCount, 1, "'TestCustomElement2' category should include one element.");
+            let testCustomElement2s = await new Promise((resolve, reject) => snapshot.instancesWithClassName("TestCustomElement2", resolve));
+            InspectorTest.expectEqual(testCustomElement2s.length, 1, "Snapshot should include one 'TestCustomElement2' instance.");
+            InspectorTest.expectTrue(testCustomElement2s[0]?.isElementType, "'TestCustomElement2' instance should have element flag.");
         }
     });
 
@@ -34,5 +70,7 @@ function test()
 </head>
 <body onload="runTest()">
 <p>Test for the Heap.snapshot command.</p>
+<test-custom-element-1></test-custom-element-1>
+<test-custom-element-2></test-custom-element-2>
 </body>
 </html>

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -192,7 +192,7 @@ bool HeapSnapshotBuilder::previousSnapshotHasNodeForCell(JSCell* cell, NodeIdent
 //  Inspector snapshots:
 //
 //   {
-//      "version": 2,
+//      "version": 3,
 //      "type": "Inspector",
 //      // [<address>, <labelIndex>, <wrappedAddress>] only present in GCDebuggingSnapshot-type snapshots
 //      "nodes": [
@@ -219,7 +219,7 @@ bool HeapSnapshotBuilder::previousSnapshotHasNodeForCell(JSCell* cell, NodeIdent
 //  GC heap debugger snapshots:
 //
 //   {
-//      "version": 2,
+//      "version": 3,
 //      "type": "GCDebugging",
 //      "nodes": [
 //          <nodeId>, <sizeInBytes>, <nodeClassNameIndex>, <flags>, <labelIndex>, <cellEddress>, <wrappedAddress>,
@@ -259,6 +259,7 @@ bool HeapSnapshotBuilder::previousSnapshotHasNodeForCell(JSCell* cell, NodeIdent
 //       - 0b0000 - no flags
 //       - 0b0001 - internal instance
 //       - 0b0010 - Object subclassification
+//       - 0b0100 - Element subclassification
 //
 //     <edgeTypeIndex>
 //       - index into the "edgeTypes" list.
@@ -274,6 +275,7 @@ bool HeapSnapshotBuilder::previousSnapshotHasNodeForCell(JSCell* cell, NodeIdent
 enum class NodeFlags {
     Internal      = 1 << 0,
     ObjectSubtype = 1 << 1,
+    ElementSubtype = 1 << 2,
 };
 
 static uint8_t edgeTypeToNumber(EdgeType type)
@@ -309,18 +311,15 @@ static ASCIILiteral snapshotTypeToString(HeapSnapshotBuilder::SnapshotType type)
     return "Inspector"_s;
 }
 
-String HeapSnapshotBuilder::json()
-{
-    return json([] (const HeapSnapshotNode&) { return true; });
-}
-
 void HeapSnapshotBuilder::setLabelForCell(JSCell* cell, const String& label)
 {
     m_cellLabels.set(cell, label);
 }
 
-String HeapSnapshotBuilder::descriptionForCell(JSCell *cell) const
+String HeapSnapshotBuilder::descriptionForNode(const HeapSnapshotNode& node)
 {
+    JSCell* cell = node.cell;
+
     if (cell->isString())
         return emptyString(); // FIXME: get part of string.
 
@@ -328,13 +327,16 @@ String HeapSnapshotBuilder::descriptionForCell(JSCell *cell) const
 
     if (structure->classInfoForCells()->isSubClassOf(Structure::info())) {
         Structure* cellAsStructure = jsCast<Structure*>(cell);
-        return cellAsStructure->classInfoForCells()->className;
+        String className = cellAsStructure->classInfoForCells()->className;
+        if (m_client)
+            className = m_client->heapSnapshotBuilderOverrideClassName(*this, cell, className);
+        return className;
     }
 
     return emptyString();
 }
 
-String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowNodeCallback)
+String HeapSnapshotBuilder::json()
 {
     VM& vm = m_profiler.vm();
     DeferGCForAWhile deferGC(vm);
@@ -359,8 +361,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     StringBuilder json(m_overflowPolicy);
 
     auto appendNodeJSON = [&] (const HeapSnapshotNode& node) {
-        // Let the client decide if they want to allow or disallow certain nodes.
-        if (!allowNodeCallback(node))
+        if (m_client && m_client->heapSnapshotBuilderIgnoreNode(*this, node.cell))
             return;
 
         unsigned flags = 0;
@@ -381,6 +382,9 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
                     className = JSObject::calculatedClassName(object);
             }
         }
+
+        if (m_client)
+            className = m_client->heapSnapshotBuilderOverrideClassName(*this, node.cell, className);
 
         auto result = classNameIndexes.add(className, nextClassNameIndex);
         if (result.isNewEntry)
@@ -407,7 +411,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
                     }
                 }
 
-                String description = descriptionForCell(node.cell);
+                String description = descriptionForNode(node);
                 if (description.length()) {
                     if (nodeLabel.length())
                         nodeLabel.append(' ');
@@ -429,6 +433,9 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
                 wrappedAddress = m_wrappedObjectPointers.get(node.cell);
             }
         }
+
+        if (m_client && m_client->heapSnapshotBuilderIsElement(*this, node.cell))
+            flags |= static_cast<unsigned>(NodeFlags::ElementSubtype);
 
         // <nodeId>, <sizeInBytes>, <nodeClassNameIndex>, <flags>, [<labelIndex>, <cellAddress>, <wrappedAddress>]
         json.append(',', node.identifier, ',', node.cell->estimatedSizeInBytes(vm), ',', classNameIndex, ',', flags);
@@ -465,7 +472,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     };
 
     // version
-    json.append("{\"version\":2"_s);
+    json.append("{\"version\":3"_s);
 
     // type
     json.append(",\"type\":\""_s, snapshotTypeToString(m_snapshotType), '"');

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HeapObserver.h"
+#include "HeapSnapshotBuilder.h"
 #include "InspectorAgentBase.h"
 #include "InspectorBackendDispatchers.h"
 #include "InspectorFrontendDispatchers.h"
@@ -42,7 +43,7 @@ namespace Inspector {
 
 class InjectedScriptManager;
 
-class JS_EXPORT_PRIVATE InspectorHeapAgent : public InspectorAgentBase, public HeapBackendDispatcherHandler, public JSC::HeapObserver {
+class JS_EXPORT_PRIVATE InspectorHeapAgent : public InspectorAgentBase, public HeapBackendDispatcherHandler, public JSC::HeapObserver, public JSC::HeapSnapshotBuilder::Client {
     WTF_MAKE_NONCOPYABLE(InspectorHeapAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorHeapAgent);
 public:
@@ -66,6 +67,9 @@ public:
     // JSC::HeapObserver
     void willGarbageCollect() final;
     void didGarbageCollect(JSC::CollectionScope) final;
+
+    // JSC::HeapSnapshotBuilder::Client
+    bool heapSnapshotBuilderIgnoreNode(JSC::HeapSnapshotBuilder&, JSC::JSCell*) final;
 
 protected:
     void clearHeapSnapshots();

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -40,8 +40,12 @@ public:
     ~PageHeapAgent();
 
     // HeapBackendDispatcherHandler
-    Inspector::Protocol::ErrorStringOr<void> enable();
-    Inspector::Protocol::ErrorStringOr<void> disable();
+    Inspector::Protocol::ErrorStringOr<void> enable() override;
+    Inspector::Protocol::ErrorStringOr<void> disable() override;
+
+    // JSC::HeapSnapshotBuilder::Client
+    String heapSnapshotBuilderOverrideClassName(JSC::HeapSnapshotBuilder&, JSC::JSCell*, const String& currentClassName) override;
+    bool heapSnapshotBuilderIsElement(JSC::HeapSnapshotBuilder&, JSC::JSCell*) override;
 
     // InspectorInstrumentation
     void mainFrameNavigated();

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js
@@ -25,7 +25,7 @@
 
 WI.HeapSnapshotNodeProxy = class HeapSnapshotNodeProxy
 {
-    constructor(target, snapshotObjectId, {id, className, size, retainedSize, internal, isObjectType, gcRoot, dead, dominatorNodeIdentifier, hasChildren})
+    constructor(target, snapshotObjectId, {id, className, size, retainedSize, internal, isObjectType, isElementType, gcRoot, dead, dominatorNodeIdentifier, hasChildren})
     {
         console.assert(target instanceof WI.Target, target);
 
@@ -38,6 +38,7 @@ WI.HeapSnapshotNodeProxy = class HeapSnapshotNodeProxy
         this.retainedSize = retainedSize;
         this.internal = internal;
         this.isObjectType = isObjectType;
+        this.isElementType = isElementType;
         this.gcRoot = gcRoot;
         this.dead = dead;
         this.dominatorNodeIdentifier = dominatorNodeIdentifier;

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -622,7 +622,9 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
                     let previewContainer = builderElement.appendChild(document.createElement("span"));
                     previewContainer.classList.add("inline-lossless");
 
-                    let preview = WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject(parameter, WI.ObjectPreviewView.Mode.Brief);
+                    let preview = WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject(parameter, {
+                        objectPreviewViewMode: WI.ObjectPreviewView.Mode.Brief,
+                    });
                     let isPreviewView = preview instanceof WI.ObjectPreviewView;
 
                     if (isPreviewView)
@@ -648,7 +650,9 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
                 let previewContainer = builderElement.appendChild(document.createElement("span"));
                 previewContainer.classList.add("console-message-preview");
 
-                let preview = WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject(parameter, WI.ObjectPreviewView.Mode.Brief);
+                let preview = WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject(parameter, {
+                    objectPreviewViewMode: WI.ObjectPreviewView.Mode.Brief,
+                });
                 let isPreviewView = preview instanceof WI.ObjectPreviewView;
 
                 if (isPreviewView)

--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.js
@@ -281,19 +281,19 @@ WI.FormattedValue.createElementForPropertyPreview = function(propertyPreview)
     return WI.FormattedValue.createElementForTypesAndValue(propertyPreview.type, propertyPreview.subtype, propertyPreview.value, undefined, true, false);
 };
 
-WI.FormattedValue.createObjectPreviewOrFormattedValueForObjectPreview = function(objectPreview, previewViewMode)
+WI.FormattedValue.createObjectPreviewOrFormattedValueForObjectPreview = function(objectPreview, options = {})
 {
     if (objectPreview.subtype === "node")
-        return WI.FormattedValue.createElementForNodePreview(objectPreview);
+        return WI.FormattedValue.createElementForNodePreview(objectPreview, options);
 
     if (objectPreview.type === "function")
         return WI.FormattedValue.createElementForFunctionWithName(objectPreview.description);
 
     const object = null;
-    return new WI.ObjectPreviewView(object, objectPreview, previewViewMode).element;
+    return new WI.ObjectPreviewView(object, objectPreview, options).element;
 };
 
-WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject = function(object, previewViewMode)
+WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject = function(object, options = {})
 {
     if (object.subtype === "node")
         return WI.FormattedValue.createElementForNode(object);
@@ -302,7 +302,7 @@ WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject = function(
         return WI.FormattedValue.createElementForError(object);
 
     if (object.preview)
-        return new WI.ObjectPreviewView(object, object.preview, previewViewMode);
+        return new WI.ObjectPreviewView(object, object.preview, options);
 
     return WI.FormattedValue.createElementForRemoteObject(object);
 };

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClassDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClassDataGridNode.js
@@ -61,10 +61,10 @@ WI.HeapSnapshotClassDataGridNode = class HeapSnapshotClassDataGridNode extends W
 
         if (columnIdentifier === "className") {
             const internal = false;
-            let {className, isObjectSubcategory} = this._data;
+            let {className, isObjectSubcategory, isElementSubcategory} = this._data;
             let fragment = document.createDocumentFragment();
             let iconElement = fragment.appendChild(document.createElement("img"));
-            iconElement.classList.add("icon", WI.HeapSnapshotClusterContentView.iconStyleClassNameForClassName(className, internal, isObjectSubcategory));
+            iconElement.classList.add("icon", WI.HeapSnapshotClusterContentView.iconStyleClassNameForClassName(className, internal, isObjectSubcategory, isElementSubcategory));
             let nameElement = fragment.appendChild(document.createElement("span"));
             nameElement.classList.add("class-name");
             nameElement.textContent = className;

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js
@@ -58,10 +58,12 @@ WI.HeapSnapshotClusterContentView = class HeapSnapshotClusterContentView extends
 
     // Static
 
-    static iconStyleClassNameForClassName(className, internal, isObjectType)
+    static iconStyleClassNameForClassName(className, internal, isObjectType, isElementType)
     {
         if (internal)
             return "native";
+        if (isElementType)
+            return "node";
         if (isObjectType)
             return "object";
 

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
@@ -218,7 +218,7 @@ WI.HeapSnapshotInstancesDataGridTree = class HeapSnapshotInstancesDataGridTree e
         // Populate the first level with the different classes.
         let skipInternalOnlyObjects = !WI.settings.engineeringShowInternalObjectsInHeapSnapshot.value;
 
-        for (let [className, {size, retainedSize, count, internalCount, deadCount, objectCount}] of this.heapSnapshot.categories) {
+        for (let [className, {size, retainedSize, count, internalCount, deadCount, objectCount, elementCount}] of this.heapSnapshot.categories) {
             console.assert(count > 0);
 
             // Possibly skip internal only classes.
@@ -233,8 +233,9 @@ WI.HeapSnapshotInstancesDataGridTree = class HeapSnapshotInstancesDataGridTree e
             // If over half of the objects with this class name are Object sub-types, treat this as an Object category.
             // This can happen if the page has a JavaScript Class with the same name as a native class.
             let isObjectSubcategory = (objectCount / count) > 0.5;
+            let isElementSubcategory = (elementCount / count) > 0.5;
 
-            this.appendChild(new WI.HeapSnapshotClassDataGridNode({className, size, retainedSize, isObjectSubcategory, count: liveCount}, this));
+            this.appendChild(new WI.HeapSnapshotClassDataGridNode({className, size, retainedSize, isObjectSubcategory, isElementSubcategory, count: liveCount}, this));
         }
 
         this.didPopulate();

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
@@ -25,7 +25,7 @@
 
 WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
 {
-    constructor(object, preview, mode)
+    constructor(object, preview, {objectPreviewViewMode} = {})
     {
         console.assert(!object || object instanceof WI.RemoteObject);
         console.assert(preview instanceof WI.ObjectPreview);
@@ -34,7 +34,7 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
 
         this._object = object || null;
         this._preview = preview;
-        this._mode = mode || WI.ObjectPreviewView.Mode.Full;
+        this._mode = objectPreviewViewMode || WI.ObjectPreviewView.Mode.Full;
 
         this._element = document.createElement("span");
         this._element.className = "object-preview";


### PR DESCRIPTION
#### 5c1282ed9528b7276478130fbaa4d369dea0d5cc
<pre>
Web Inspector: Heap: custom elements should each have their own category instead of `HTMLElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289935">https://bugs.webkit.org/show_bug.cgi?id=289935</a>

Reviewed by Ryosuke Niwa.

Custom JS `class` instances are given a separate top-level category in the &quot;Instances&quot; view, so custom elements should too (instead of being lumped into `HTMLElement`) since they&apos;re pretty much the same concept.

* Source/JavaScriptCore/heap/HeapSnapshotBuilder.h:
(JSC::HeapSnapshotBuilder::Client::heapSnapshotBuilderIgnoreNode): Added.
(JSC::HeapSnapshotBuilder::Client::heapSnapshotBuilderOverrideClassName): Added.
(JSC::HeapSnapshotBuilder::Client::heapSnapshotBuilderIsElement): Added.
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::descriptionForNode): Renamed from `descriptionForCell`.
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::snapshot):
(Inspector::InspectorHeapAgent::heapSnapshotBuilderIgnoreNode): Added.
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
(WebCore::PageHeapAgent::heapSnapshotBuilderOverrideClassName): Added.
(WebCore::PageHeapAgent::heapSnapshotBuilderIsElement): Added.
Add a way for callers to override the what the class name is for a given `HeapSnapshotNode`.
Additionally, since DOM nodes are treated differently (i.e. they&apos;re rendered as HTML instead of a JS object), add a way to `HeapSnapshotNode` as such (i.e. `NodeFlags::ElementSubtype`).

* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
(HeapSnapshot):
(HeapSnapshot.updateCategoriesAndMetadata):
(HeapSnapshot.prototype.serializeNode):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js:
(WI.HeapSnapshotNodeProxy):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClassDataGridNode.js:
(WI.HeapSnapshotClassDataGridNode.prototype.createCellContent):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js:
(WI.HeapSnapshotClusterContentView.iconStyleClassNameForClassName):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js:
(WI.HeapSnapshotInstancesDataGridTree.prototype.populateTopLevel):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js:
(WI.HeapSnapshotInstanceDataGridNode.prototype.createCellContent):
(WI.HeapSnapshotInstanceDataGridNode.prototype._getRemoteObject):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateWindowPreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populatePreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._mouseoverHandler.appendPathRow):
Use an element icon instead of an object icon if the `HeapSnapshotNode` is marked as a DOM node (i.e. `NodeFlags::ElementSubtype`).

* Source/WebInspectorUI/UserInterface/Views/FormattedValue.js:
(WI.FormattedValue.createObjectPreviewOrFormattedValueForObjectPreview):
(WI.FormattedValue.createObjectPreviewOrFormattedValueForRemoteObject):
* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js:
(WI.ObjectPreviewView):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype._appendFormattedArguments):
Pass along an `options = {}` so that a `remoteObjectAccessor` can be defined for highlighting DOM nodes (i.e. `NodeFlags::ElementSubtype`) in the heap snapshot.

* LayoutTests/inspector/heap/snapshot.html:
* LayoutTests/inspector/heap/snapshot-expected.txt:

Canonical link: <a href="https://commits.webkit.org/292456@main">https://commits.webkit.org/292456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c529ee5f0c6593550dbb675111dd23e886d2a93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99126 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45967 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/88796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/4683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103213 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94744 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23190 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26301 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23153 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118221 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22812 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->