### PR TITLE
[Cocoa] Adopt playback state properties of PIPViewController

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5894,6 +5894,21 @@ PictureInPictureAPIEnabled:
       default: true
   disableInLockdownMode: true
 
+PictureInPicturePlaybackStateEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Picture-in-Picture Playback State Enabled"
+  humanReadableDescription: "Picture-in-Picture Playback State Enabled"
+  condition: HAVE(PIP_SKIP_PREROLL)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+
 PitchCorrectionAlgorithm:
   type: uint32_t
   refinedType: WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -70,7 +70,14 @@ public:
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
 
+#if HAVE(PIP_SKIP_PREROLL)
+    WEBCORE_EXPORT void setPlaybackStateEnabled(bool);
+    bool isPlaybackStateEnabled() const { return m_playbackStateEnabled; }
+#endif
+
     // PlaybackSessionModelClient
+    WEBCORE_EXPORT void durationChanged(double) final;
+    WEBCORE_EXPORT void currentTimeChanged(double /* currentTime */, double /* anchorTime */) final;
     WEBCORE_EXPORT void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override;
     WEBCORE_EXPORT void externalPlaybackChanged(bool  enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName) override;
     WEBCORE_EXPORT void ensureControlsManager() override;
@@ -137,6 +144,10 @@ private:
     RetainPtr<WebVideoPresentationInterfaceMacObjC> m_webVideoPresentationInterfaceObjC;
     bool m_documentIsVisible { true };
     Function<void()> m_documentBecameVisibleCallback;
+
+#if HAVE(PIP_SKIP_PREROLL)
+    bool m_playbackStateEnabled { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -685,6 +685,10 @@ VideoPresentationManagerProxy::ModelInterfacePair VideoPresentationManagerProxy:
     Ref playbackSessionInterface = playbackSessionManagerProxy->ensureInterface(contextId);
     Ref interface = videoPresentationInterface(page.get(), playbackSessionInterface.get());
 
+#if HAVE(PIP_SKIP_PREROLL)
+    interface->setPlaybackStateEnabled(page->preferences().pictureInPicturePlaybackStateEnabled());
+#endif
+
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     interface->setPrefersSpatialAudioExperience(page->preferences().preferSpatialAudioExperience());
 #endif


### PR DESCRIPTION
#### 5d237fff07277b6813ee4da2ba03ce11e9babc5e
<pre>
[Cocoa] Adopt playback state properties of PIPViewController
<a href="https://rdar.apple.com/147281408">rdar://147281408</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289936">https://bugs.webkit.org/show_bug.cgi?id=289936</a>

Reviewed by Andy Estes.

Provide more playback state information to PIPViewController via -updatePlaybackStateUsingBlock:.

* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC updateRate:andTimeControlStatus:]):
(-[WebVideoPresentationInterfaceMacObjC setDuration:]):
(-[WebVideoPresentationInterfaceMacObjC updateRate:currentTime:atAnchorTime:]):
(-[WebVideoPresentationInterfaceMacObjC updateCurrentTime:atAnchorTime:]):
(-[WebVideoPresentationInterfaceMacObjC estimatedElapsedTime]):
(-[WebVideoPresentationInterfaceMacObjC setMuted:]):
(-[WebVideoPresentationInterfaceMacObjC setVolume:]):
(-[WebVideoPresentationInterfaceMacObjC setUpPIPForVideoView:withFrame:inWindow:]):
(-[WebVideoPresentationInterfaceMacObjC pipAction:skipInterval:]):
(WebCore::VideoPresentationInterfaceMac::VideoPresentationInterfaceMac):
(WebCore::VideoPresentationInterfaceMac::durationChanged):
(WebCore::VideoPresentationInterfaceMac::currentTimeChanged):
(WebCore::VideoPresentationInterfaceMac::rateChanged):
(WebCore::VideoPresentationInterfaceMac::mutedChanged):
(WebCore::VideoPresentationInterfaceMac::volumeChanged):
(-[WebVideoPresentationInterfaceMacObjC updateIsPlaying:newPlaybackRate:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/292425@main">https://commits.webkit.org/292425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54dfe63b0c61d6d9e37657a1f169599c38b59788

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95910 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45754 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94531 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20468 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28095 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118008 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22599 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->