### PR TITLE
Fix Clang v20.1 compiler warnings

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -711,9 +711,11 @@ bool InlineContentConstrainer::shouldTrimTrailing(size_t inlineItemIndex, bool u
     return false;
 }
 
-SlidingWidth::SlidingWidth(const InlineContentConstrainer& inlineContentConstrainer, const InlineItemList& inlineItemList, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk)
+SlidingWidth::SlidingWidth(const InlineContentConstrainer& inlineContentConstrainer, [[maybe_unused]] const InlineItemList& inlineItemList, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk)
     : m_inlineContentConstrainer(inlineContentConstrainer)
+#if ASSERT_ENABLED
     , m_inlineItemList(inlineItemList)
+#endif
     , m_start(start)
     , m_end(start)
     , m_useFirstLineStyle(useFirstLineStyle)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -102,7 +102,9 @@ struct SlidingWidth {
 
 private:
     const InlineContentConstrainer& m_inlineContentConstrainer;
+#if ASSERT_ENABLED
     const InlineItemList& m_inlineItemList;
+#endif
     size_t m_start { 0 };
     size_t m_end { 0 };
     bool m_useFirstLineStyle { false };

--- a/Source/WebCore/platform/graphics/adwaita/ControlAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ControlAdwaita.cpp
@@ -31,9 +31,8 @@
 namespace WebCore {
 using namespace WebCore::Adwaita;
 
-ControlAdwaita::ControlAdwaita(ControlPart& owningPart, ControlFactoryAdwaita& controlFactory)
+ControlAdwaita::ControlAdwaita(ControlPart& owningPart, ControlFactoryAdwaita&)
     : PlatformControl(owningPart)
-    , m_controlFactory(controlFactory)
 {
 }
 

--- a/Source/WebCore/platform/graphics/adwaita/ControlAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/ControlAdwaita.h
@@ -41,9 +41,6 @@ public:
 
 protected:
     static Color accentColor(const ControlStyle&);
-
-private:
-    ControlFactoryAdwaita& m_controlFactory;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
@@ -81,9 +81,11 @@ std::unique_ptr<GLFence> GLFenceEGL::importFD(UnixFileDescriptor&& fd)
 }
 #endif
 
-GLFenceEGL::GLFenceEGL(EGLSyncKHR sync, bool isExportable)
+GLFenceEGL::GLFenceEGL(EGLSyncKHR sync, [[maybe_unused]] bool isExportable)
     : m_sync(sync)
+#if OS(UNIX)
     , m_isExportable(isExportable)
+#endif
 {
 }
 

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
@@ -45,7 +45,9 @@ private:
 #endif
 
     EGLSync m_sync { nullptr };
+#if OS(UNIX)
     bool m_isExportable { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -358,7 +358,7 @@ StringView filenameFromHTTPContentDisposition(StringView value)
         return value;
     }
 
-    return String();
+    return { };
 }
 
 String extractMIMETypeFromMediaType(const String& mediaType)

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -113,8 +113,9 @@ private:
     WeakPtr<WebKit::WebPageProxy> m_webPage;
     InsertionState m_insertionState { InsertionState::NotInserted };
     WebCore::AttachmentAssociatedElementType m_associatedElementType { WebCore::AttachmentAssociatedElementType::None };
-    bool m_hasEnclosingImage { false };
+#if PLATFORM(COCOA)
     bool m_isCreatedFromSerializedRepresentation { false };
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -91,10 +91,9 @@ namespace {
 class RemoteImageBufferSetProxyFlusher final : public ThreadSafeImageBufferSetFlusher {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlusher);
 public:
-    RemoteImageBufferSetProxyFlusher(RemoteImageBufferSetIdentifier identifier, Ref<RemoteImageBufferSetProxyFlushFence> flushState, unsigned generation)
+    RemoteImageBufferSetProxyFlusher(RemoteImageBufferSetIdentifier identifier, Ref<RemoteImageBufferSetProxyFlushFence> flushState, unsigned)
         : m_identifier(identifier)
         , m_flushState(WTFMove(flushState))
-        , m_generation(generation)
     { }
 
     bool flushAndCollectHandles(HashMap<RemoteImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>& handlesMap) final
@@ -111,7 +110,6 @@ public:
 private:
     RemoteImageBufferSetIdentifier m_identifier;
     Ref<RemoteImageBufferSetProxyFlushFence> m_flushState;
-    unsigned m_generation;
 };
 
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -149,14 +149,6 @@ private:
     WKBundlePageRef m_page;
     WKRetainPtr<WKBundleScriptWorldRef> m_world;
     bool m_didCommitMainFrameLoad { false };
-
-    enum FullscreenState {
-        NotInFullscreen,
-        EnteringFullscreen,
-        ExitingFullscreen,
-        InFullscreen,
-    };
-    FullscreenState m_fullscreenState { NotInFullscreen };
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 4bb5658007ea02e95c2578aecc1f5f358aa0f487
<pre>
Fix Clang v20.1 compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=289937">https://bugs.webkit.org/show_bug.cgi?id=289937</a>

Reviewed by Michael Catanzaro.

Fixed return-stack-address and unused-private-field warnings.

* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::SlidingWidth::SlidingWidth):
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h:
* Source/WebCore/platform/graphics/adwaita/ControlAdwaita.cpp:
(WebCore::ControlAdwaita::ControlAdwaita):
* Source/WebCore/platform/graphics/adwaita/ControlAdwaita.h:
* Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp:
(WebCore::GLFenceEGL::GLFenceEGL):
* Source/WebCore/platform/graphics/egl/GLFenceEGL.h:
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::filenameFromHTTPContentDisposition):
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:

Canonical link: <a href="https://commits.webkit.org/292322@main">https://commits.webkit.org/292322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca7f36727e5cc1be08d483c4c90d860575c795bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30137 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98558 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11573 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81917 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81268 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15936 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15392 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->