### PR TITLE
[WebDriver][win] make the `New Window` command duplicates an application window, instead of creating new one.

### DIFF
--- a/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
@@ -71,6 +71,7 @@ void AutomationClient::closeAutomationSession()
 
         processPool->automationSession()->setClient(nullptr);
         processPool->setAutomationSession(nullptr);
+        processPool->setPagesControlledByAutomation(false);
     });
 }
 

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.h
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "APIAutomationSessionClient.h"
-#include "WebProcessPool.h"
-#include "WebView.h"
 #include <JavaScriptCore/RemoteInspectorServer.h>
 
 namespace WebKit {
@@ -41,21 +39,15 @@ public:
 
     // From API::AutomationSessionClient
     void requestNewPageWithOptions(WebKit::WebAutomationSession&, API::AutomationSessionBrowsingContextOptions, CompletionHandler<void(WebKit::WebPageProxy*)>&&) override;
+    void requestMaximizeWindowOfPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, CompletionHandler<void()>&&) override;
+    void requestHideWindowOfPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, CompletionHandler<void()>&&) override;
+    void requestRestoreWindowOfPage(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, CompletionHandler<void()>&&) override;
     void didDisconnectFromRemote(WebKit::WebAutomationSession&) override;
-
-    void retainWebView(Ref<WebView>&&);
-    void releaseWebView(WebPageProxy*);
 
 private:
     String m_sessionIdentifier;
     Inspector::RemoteInspector::Client::SessionCapabilities m_capabilities { };
 
-    static void close(WKPageRef, const void*);
-
-    static void didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef, const void*);
-    void didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef);
-
-    HashSet<Ref<WebView>> m_webViews;
 };
 
 } // namespace WebKit

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.h
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.h
@@ -100,4 +100,5 @@ private:
     std::unordered_map<std::wstring, std::wstring> m_acceptedServerTrustCerts;
     std::vector<WKRetainPtr<WKStringRef>> m_experimentalFeatureKeys;
     std::vector<WKRetainPtr<WKStringRef>> m_internalDebugFeatureKeys;
+    bool m_isControlledByAutomation { false };
 };


### PR DESCRIPTION
#### 21275f0da88bfb303cdff0e9681bcae7b8947f84
<pre>
[WebDriver][win] make the `New Window` command duplicates an application window, instead of creating new one.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289887">https://bugs.webkit.org/show_bug.cgi?id=289887</a>

Reviewed by Fujii Hironori.

Before this change, the WebDriver creates new WebPageProxy and WebView for the `New Window` command.
This method is simple but not appropriate for testing the application, as the newly created window
differs from the application&apos;s.
The purpose of this change is to solve the above problem.

The main change in this commit is that the AutomationSessionClient will no longer create a WebView
when it receives `New Window` command, but will instead call the `WKPageUIClient::createNewPage`.
The creation of the window is delegated to the application, which will allow for more correct testing.

Combined changes:
* Source/WebKit/UIProcess/win/AutomationClientWin.cpp:
(WebKit::AutomationClient::closeAutomationSession):
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp:
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
(WebKit::getRootWindowHandle):
(WebKit::AutomationSessionClient::requestMaximizeWindowOfPage):
(WebKit::AutomationSessionClient::requestHideWindowOfPage):
(WebKit::AutomationSessionClient::requestRestoreWindowOfPage):
(WebKit::AutomationSessionClient::close): Deleted.
(WebKit::AutomationSessionClient::didReceiveAuthenticationChallenge): Deleted.
(WebKit::AutomationSessionClient::retainWebView): Deleted.
(WebKit::AutomationSessionClient::releaseWebView): Deleted.
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.h:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::WebKitBrowserWindow):
(WebKitBrowserWindow::didReceiveAuthenticationChallenge):
(WebKitBrowserWindow::close):
* Tools/MiniBrowser/win/WebKitBrowserWindow.h:

Canonical link: <a href="https://commits.webkit.org/293505@main">https://commits.webkit.org/293505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81e0f0fb1d5473dbb8067ba195d75d7c7bd358f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32245 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106143 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84072 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83557 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28198 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5879 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19441 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16119 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30877 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->