### PR TITLE
WebCodecsVideoEncoder::configure should only update rates if there is an internal encoder

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt
@@ -5,4 +5,5 @@ PASS VP9 - bitrate
 PASS VP9 - framerate
 PASS H.264 - bitrate
 PASS H.264 - framerate
+PASS Configure after a reset
 

--- a/LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html
+++ b/LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html
@@ -94,6 +94,30 @@ function doTest(codec, title)
 doTest('vp8', "VP8");
 doTest('vp09.00.10.08', "VP9");
 doTest('avc1.42001E', "H.264");
+
+promise_test(async t => {
+    const encoder = new VideoEncoder({
+        output(chunk, metadata) { },
+        error(e) { }
+    });
+
+    const config = {
+        codec:'avc1.42001E',
+        width:320,
+        height:240,
+        bitrate:1000000,
+        framerate: 10
+    };
+
+    encoder.configure(config);
+    await new Promise(resolve => setTimeout(resolve, 500));
+    encoder.reset();
+
+    config.bitrate = 100000;
+    config.framerate = 1;
+
+    encoder.configure(config);
+}, "Configure after a reset");
 </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -171,7 +171,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
 
     bool isSupportedCodec = isSupportedEncoderCodec(config.codec, context.settingsValues());
     queueControlMessageAndProcess({ *this, [this, config = WTFMove(config), isSupportedCodec]() mutable {
-        if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
+        if (isSupportedCodec && m_internalEncoder && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config)) {
             updateRates(config);
             return WebCodecsControlMessageOutcome::Processed;
         }


### PR DESCRIPTION
#### 51f9023388fae9e087b9bb74d992ebc22feb3635
<pre>
WebCodecsVideoEncoder::configure should only update rates if there is an internal encoder
<a href="https://rdar.apple.com/147294536">rdar://147294536</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289943">https://bugs.webkit.org/show_bug.cgi?id=289943</a>

Reviewed by Jean-Yves Avenard.

We optimize the configure call when only bitrate/framerate changes.
When a reset call happens between two configure calls, we end up with no internal encoder.
In that case, the second configure call should do a regular full configure.

* LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt:
* LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):

Canonical link: <a href="https://commits.webkit.org/292301@main">https://commits.webkit.org/292301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/660f1254148e04f3edbca696af057f527ae2d0d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102648 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81925 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81276 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20360 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25855 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15951 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22582 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->