### PR TITLE
[GStreamer][WebCodecs] Improve robustness of AudioData handling

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -80,6 +80,11 @@ RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_
     gst_audio_info_set_format(&info, gstFormat, static_cast<int>(sampleRate), numberOfChannels, nullptr);
     GST_AUDIO_INFO_LAYOUT(&info) = layout;
 
+    if (!GST_AUDIO_INFO_IS_VALID(&info)) {
+        GST_WARNING("Invalid audio info, unable to create AudioData for it");
+        return nullptr;
+    }
+
     auto caps = adoptGRef(gst_audio_info_to_caps(&info));
     GST_TRACE("Creating raw audio wrapper with caps %" GST_PTR_FORMAT, caps.get());
     GST_MEMDUMP("Source", sourceData.data(), sourceData.size());
@@ -184,9 +189,11 @@ size_t PlatformRawAudioDataGStreamer::memoryCost() const
     return gst_buffer_get_size(gst_sample_get_buffer(m_sample.get()));
 }
 
-std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>> PlatformRawAudioDataGStreamer::planesOfSamples(size_t samplesOffset)
+std::optional<std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> PlatformRawAudioDataGStreamer::planesOfSamples(size_t samplesOffset)
 {
     GstMappedAudioBuffer mappedBuffer(m_sample, GST_MAP_READ);
+    if (!mappedBuffer)
+        return std::nullopt;
 
     switch (format()) {
     case AudioSampleFormat::U8:
@@ -203,7 +210,7 @@ std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std:
         return mappedBuffer.samples<float>(samplesOffset);
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return Vector<std::span<uint8_t>> { };
+    return std::nullopt;
 }
 
 #ifndef GST_DISABLE_GST_DEBUG
@@ -249,11 +256,13 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
     }
 
     auto source = audioData.planesOfSamples(sourceOffset * (audioData.isInterleaved() ? numberOfChannels() : 1));
+    if (!source)
+        return;
 
     if (isDestinationInterleaved) {
         // Copy of all channels of the source into the destination buffer and deinterleave.
         ASSERT(!planeIndex);
-        copyToInterleaved(source, destination, format, copyElementCount);
+        copyToInterleaved(*source, destination, format, copyElementCount);
         return;
     }
 
@@ -265,7 +274,9 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
     };
 
     WTF::switchOn(audioElementSpan(format, destination), [&](auto dst) {
-        switchOn(source, [&](auto& src) {
+        switchOn(*source, [&](auto& src) {
+            if (src[planeIndex].size() < copyElementCount)
+                return;
             copyElements(dst, src[planeIndex], copyElementCount);
         });
     });

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
@@ -50,7 +50,7 @@ public:
     const GstAudioInfo* info() const { return &m_info; }
 
     bool isInterleaved() const;
-    std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>> planesOfSamples(size_t);
+    std::optional<std::variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> planesOfSamples(size_t);
 
 private:
     PlatformRawAudioDataGStreamer(GRefPtr<GstSample>&&);


### PR DESCRIPTION
#### 265e7f6062f797d1e7568996283cc3ff7d223886
<pre>
[GStreamer][WebCodecs] Improve robustness of AudioData handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=289946">https://bugs.webkit.org/show_bug.cgi?id=289946</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch fixes assertions/crashes in PlatformRawAudioDataGStreamer raised due to poor error
handling and invalid input data.

Co-authored-by: Frédéric Wang &lt;fwang@igalia.com&gt;

* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::PlatformRawAudioData::create): Return nullptr in case the audio info is invalid.
(WebCore::PlatformRawAudioDataGStreamer::planesOfSamples): Return a nullopt if the GStreamer says
the audio data is invalid.
(WebCore::PlatformRawAudioData::copyTo): Return early if the audio data is invalid or if the size of
the source buffer is smaller than the requested copyElementCount.
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h: Change signature to
return an optional.

Canonical link: <a href="https://commits.webkit.org/292300@main">https://commits.webkit.org/292300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0908bb65c42e9e855c8d2dad187d2a3786d62a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72888 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30151 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98572 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45410 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22619 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25860 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22587 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->