### PR TITLE
[CoreIPC] [GPU] WebCore::SVGFilter expression/effects members are not validated

### DIFF
--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -1,0 +1,102 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const streamConnection = CoreIPC.newStreamConnection();
+
+    const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = streamConnection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+    remoteRenderingBackend.CreateImageBuffer({
+        logicalSize: {width: 128, height: 128},
+        renderingMode: 0,
+        renderingPurpose: 0,
+        resolutionScale: 1.0,
+        colorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}},
+        pixelFormat: 0,
+        renderingResourceIdentifier: imageBufferIdentifier
+    });
+    const didCreateBackendReply = streamConnection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
+
+    const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+
+    try {
+        remoteImageBuffer.FilteredNativeImage({
+            filter: {
+                subclasses: {
+                    variantType: 'WebCore::SVGFilter',
+                    variant: {
+                        targetBoundingBox: {
+                            location: {x: 0, y: 0},
+                            size: {width: 0, height: 0},
+                        },
+                        primitiveUnits: 0,
+                        expression: {
+                            alias: [
+                                {index: 1337, level: 0, geometry: 0}    // Adds an expression with an OOB index
+                            ]
+                        },
+                        effects: [
+                            {
+                                subclasses: {
+                                    variantType: 'WebCore::FEBlend',
+                                    variant: {
+                                        blendMode: 8,
+                                        operatingColorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}
+                                    }
+                                }
+                            }
+                        ],
+                        renderingResourceIdentifierIfExists: {},
+                        filterRenderingModes: 1,
+                        filterScale: {width: 0, height: 0},
+                        filterRegion: {
+                            location: {x: 0, y: 0},
+                            size: {width: 0, height: 0}
+                        },
+                    }
+                },
+            }
+        });
+    } catch(err) {
+        // We expect validation to fail and return a TypeError to us. If we get any other kind of error,
+        // log this so we can address the issue as this may indicate the test is non-functional. If the
+        // validation we are testing is not functioning correctly, the GPU process will crash and the
+        // test will fail.
+        //
+        // Replace this with a specific check for an IPC message validation failure when the
+        // enhancement in rdar://147337600 is implemented.
+        if(!(err instanceof TypeError)) {
+            console.log("Test failed: expected TypeError, got " + err);
+        }
+    }
+
+    streamConnection.connection.invalidate();
+
+    // Allow some time for the GPUP to receive the FilteredNativeImage message, otherwise we can finish
+    // the test before we detect a possible GPUP crash.
+    setTimeout(()=>{
+        window.testRunner?.notifyDone();
+    }, 500);
+}, 20);
+
+</script>
+
+This test passes if WebKit does not crash.

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -312,6 +312,16 @@ RefPtr<FilterImage> SVGFilter::apply(FilterImage* sourceImage, FilterResults& re
     return stack.takeLast();
 }
 
+bool SVGFilter::isValidSVGFilterExpression(const SVGFilterExpression& expression, const FilterEffectVector& effects)
+{
+    for (const auto& term : expression) {
+        if (term.index >= effects.size())
+            return false;
+    }
+
+    return true;
+}
+
 FilterStyleVector SVGFilter::createFilterStyles(GraphicsContext& context, const Filter&, const FilterStyle& sourceStyle) const
 {
     return createFilterStyles(context, sourceStyle);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -62,6 +62,7 @@ public:
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 
+    WEBCORE_EXPORT static bool isValidSVGFilterExpression(const SVGFilterExpression&, const FilterEffectVector&);
 private:
     SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
     SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, const FloatSize& filterScale, const FloatRect& filterRegion);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7714,7 +7714,7 @@ class WebCore::FilterOperations {
     WebCore::FloatRect targetBoundingBox();
     WebCore::SVGUnitTypes::SVGUnitType primitiveUnits();
     WebCore::SVGFilterExpression expression();
-    Vector<Ref<WebCore::FilterEffect>> effects();
+    [Validator='WebCore::SVGFilter::isValidSVGFilterExpression(*expression, *effects)'] Vector<Ref<WebCore::FilterEffect>> effects();
     std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();


### PR DESCRIPTION
#### 45047bcfe94e948beb0f3a2ca6cebf03fa2a118f
<pre>
[CoreIPC] [GPU] WebCore::SVGFilter expression/effects members are not validated
<a href="https://bugs.webkit.org/show_bug.cgi?id=289947">https://bugs.webkit.org/show_bug.cgi?id=289947</a>
<a href="https://rdar.apple.com/142968121">rdar://142968121</a>

Reviewed by Said Abou-Hallawa.

Introduce validation at the IPC boundary to ensure SVGFilter expression indicies are in-bounds of the provided effects.

* LayoutTests/ipc/invalid-svgfilter-expression-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html: Added.
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::isValidSVGFilterExpression):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/292483@main">https://commits.webkit.org/292483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21a20b74aa898c659e3afdd735702552abb85a7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73182 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30408 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4455 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103081 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81595 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3623 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16399 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28178 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->