### PR TITLE
Encode AffineTransform from contiguous array

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -33,6 +33,7 @@
 #include "FloatSize.h"
 #include <array>
 #include <optional>
+#include <span>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -65,6 +66,7 @@ class AffineTransform {
 public:
     constexpr AffineTransform();
     constexpr AffineTransform(double a, double b, double c, double d, double e, double f);
+    constexpr AffineTransform(std::span<const double, 6>);
 
 #if USE(CG)
     WEBCORE_EXPORT AffineTransform(const CGAffineTransform&);
@@ -197,6 +199,8 @@ public:
     operator SkMatrix() const;
 #endif
 
+    constexpr std::span<const double, 6> span() const LIFETIME_BOUND;
+
     static AffineTransform makeTranslation(FloatSize delta)
     {
         return AffineTransform(1, 0, 0, 1, delta.width(), delta.height());
@@ -237,6 +241,16 @@ constexpr AffineTransform::AffineTransform()
 constexpr AffineTransform::AffineTransform(double a, double b, double c, double d, double e, double f)
     : m_transform { { a, b, c, d, e, f } }
 {
+}
+
+constexpr AffineTransform::AffineTransform(std::span<const double, 6> transform)
+    : m_transform { transform[0], transform[1], transform[2], transform[3], transform[4], transform[5] }
+{
+}
+
+constexpr std::span<const double, 6> AffineTransform::span() const
+{
+    return m_transform;
 }
 
 static constexpr inline AffineTransform identity;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -486,12 +486,7 @@ struct WebCore::CharacterRange {
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::AffineTransform {
-    double a()
-    double b()
-    double c()
-    double d()
-    double e()
-    double f()
+    std::span<const double, 6> span();
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatPoint {


### PR DESCRIPTION
#### d4a207fb5bee9a0dae88d0108274323423ce379d
<pre>
Encode AffineTransform from contiguous array
<a href="https://bugs.webkit.org/show_bug.cgi?id=289951">https://bugs.webkit.org/show_bug.cgi?id=289951</a>
<a href="https://rdar.apple.com/147305275">rdar://147305275</a>

Reviewed by Simon Fraser.

Commands with AffineTransform appear in traces. Try to speed them up
by encoding the values as one 6 element array, not 6 individual
elements.

* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
(WebCore::AffineTransform::AffineTransform):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/292405@main">https://commits.webkit.org/292405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23138cdd063dddf395d38c8ed4ce13b4b728af8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72894 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53226 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81958 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81290 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15969 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->