### PR TITLE
[GStreamer] Switch makeGStreamerElement to have proper string management

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -124,7 +124,7 @@ void GStreamerMediaEndpoint::maybeInsertNetSimForElement(GstBin* bin, GstElement
 
     gst_pad_unlink(pad.get(), peer.get());
 
-    auto netsim = makeGStreamerElement("netsim", nullptr);
+    auto netsim = makeGStreamerElement("netsim"_s);
     gst_bin_add(GST_BIN_CAST(bin), netsim);
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "Configuring %" GST_PTR_FORMAT " for transport element %" GST_PTR_FORMAT, netsim, element);
@@ -160,7 +160,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
     });
 
     auto binName = makeString("webkit-webrtcbin-"_s, nPipeline++);
-    m_webrtcBin = makeGStreamerElement("webrtcbin", binName.ascii().data());
+    m_webrtcBin = makeGStreamerElement("webrtcbin"_s, binName);
     if (!m_webrtcBin)
         return false;
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -150,8 +150,8 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(const CreationOptions& opti
         }
     }
 
-    GstElement* audioConvert = makeGStreamerElement("audioconvert", nullptr);
-    GstElement* audioResample = makeGStreamerElement("audioresample", nullptr);
+    GstElement* audioConvert = makeGStreamerElement("audioconvert"_s);
+    GstElement* audioResample = makeGStreamerElement("audioresample"_s);
 
     auto queue = gst_element_factory_make("queue", nullptr);
     g_object_set(queue, "max-size-buffers", 2, "max-size-bytes", 0, "max-size-time", 0, nullptr);
@@ -167,7 +167,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(const CreationOptions& opti
         // 1) Some platform sinks don't support non-interleaved audio without special caps (rialtowebaudiosink).
         // 2) Interaudio sink/src doesn't fully support non-interleaved audio (webkit audio sink)
         // 3) audiomixer doesn't support non-interleaved audio in output pipeline (webkit audio sink)
-        GstElement* capsFilter = makeGStreamerElement("capsfilter", nullptr);
+        GstElement* capsFilter = makeGStreamerElement("capsfilter"_s);
         GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "layout", G_TYPE_STRING, "interleaved", nullptr));
         g_object_set(capsFilter, "caps", caps.get(), nullptr);
         gst_bin_add(GST_BIN_CAST(m_pipeline.get()), capsFilter);

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -294,7 +294,7 @@ void AudioFileReader::handleNewDeinterleavePad(GstPad* pad)
     // in an appsink so we can pull the data from each
     // channel. Pipeline looks like:
     // ... deinterleave ! appsink.
-    GstElement* sink = makeGStreamerElement("appsink", nullptr);
+    GstElement* sink = makeGStreamerElement("appsink"_s);
 
     if (!m_firstChannelType) {
         auto caps = adoptGRef(gst_pad_query_caps(pad, nullptr));
@@ -353,10 +353,10 @@ void AudioFileReader::plugDeinterleave(GstPad* pad)
     // A decodebin pad was added, plug in a deinterleave element to
     // separate each planar channel. Sub pipeline looks like
     // ... decodebin2 ! audioconvert ! audioresample ! capsfilter ! deinterleave.
-    GstElement* audioConvert  = makeGStreamerElement("audioconvert", nullptr);
-    GstElement* audioResample = makeGStreamerElement("audioresample", nullptr);
+    GstElement* audioConvert  = makeGStreamerElement("audioconvert"_s);
+    GstElement* audioResample = makeGStreamerElement("audioresample"_s);
     GstElement* capsFilter = gst_element_factory_make("capsfilter", nullptr);
-    m_deInterleave = makeGStreamerElement("deinterleave", "deinterleave");
+    m_deInterleave = makeGStreamerElement("deinterleave"_s, "deinterleave"_s);
 
     g_object_set(m_deInterleave.get(), "keep-positions", TRUE, nullptr);
     g_signal_connect_swapped(m_deInterleave.get(), "pad-added", G_CALLBACK(deinterleavePadAddedCallback), this);
@@ -410,11 +410,11 @@ void AudioFileReader::decodeAudioForBusCreation()
     }, this, nullptr);
 
     ASSERT(!m_data.empty());
-    auto* source = makeGStreamerElement("giostreamsrc", nullptr);
+    auto* source = makeGStreamerElement("giostreamsrc"_s);
     auto memoryStream = adoptGRef(g_memory_input_stream_new_from_data(m_data.data(), m_data.size(), nullptr));
     g_object_set(source, "stream", memoryStream.get(), nullptr);
 
-    m_decodebin = makeGStreamerElement("decodebin", "decodebin");
+    m_decodebin = makeGStreamerElement("decodebin"_s, "decodebin"_s);
     g_signal_connect(m_decodebin.get(), "autoplug-select", G_CALLBACK(decodebinAutoplugSelectCallback), nullptr);
     g_signal_connect_swapped(m_decodebin.get(), "pad-added", G_CALLBACK(decodebinPadAddedCallback), this);
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -111,7 +111,7 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
 
     m_audioSinkBin = gst_parse_bin_from_description("tee name=audioTee", true, nullptr);
 
-    auto* decodebin = makeGStreamerElement("uridecodebin3", nullptr);
+    auto* decodebin = makeGStreamerElement("uridecodebin3"_s);
 
     g_signal_connect_swapped(decodebin, "source-setup", G_CALLBACK(+[](AudioSourceProviderGStreamer* provider, GstElement* sourceElement) {
         if (!WEBKIT_IS_MEDIA_STREAM_SRC(sourceElement)) {
@@ -205,11 +205,11 @@ void AudioSourceProviderGStreamer::configureAudioBin(GstElement* audioBin, GstEl
 
     GstElement* audioTee = gst_element_factory_make("tee", "audioTee");
     GstElement* audioQueue = gst_element_factory_make("queue", nullptr);
-    GstElement* audioConvert = makeGStreamerElement("audioconvert", nullptr);
-    GstElement* audioConvert2 = makeGStreamerElement("audioconvert", nullptr);
-    GstElement* audioResample = makeGStreamerElement("audioresample", nullptr);
-    GstElement* audioResample2 = makeGStreamerElement("audioresample", nullptr);
-    GstElement* volumeElement = makeGStreamerElement("volume", "volume");
+    GstElement* audioConvert = makeGStreamerElement("audioconvert"_s);
+    GstElement* audioConvert2 = makeGStreamerElement("audioconvert"_s);
+    GstElement* audioResample = makeGStreamerElement("audioresample"_s);
+    GstElement* audioResample2 = makeGStreamerElement("audioresample"_s);
+    GstElement* volumeElement = makeGStreamerElement("volume"_s, "volume"_s);
 
     gst_bin_add_many(GST_BIN_CAST(m_audioSinkBin.get()), audioTee, audioQueue, audioConvert, audioResample, volumeElement, audioConvert2, audioResample2, audioSink, nullptr);
 
@@ -324,10 +324,10 @@ void AudioSourceProviderGStreamer::setClient(WeakPtr<AudioSourceProviderClient>&
         // ensure deinterleave and the sinks downstream receive buffers in
         // the format specified by the capsfilter.
         auto* audioQueue = gst_element_factory_make("queue", "queue");
-        auto* audioConvert = makeGStreamerElement("audioconvert", "audioconvert");
-        auto* audioResample = makeGStreamerElement("audioresample", "audioresample");
+        auto* audioConvert = makeGStreamerElement("audioconvert"_s, "audioconvert"_s);
+        auto* audioResample = makeGStreamerElement("audioresample"_s, "audioresample"_s);
         auto* capsFilter = gst_element_factory_make("capsfilter", "capsfilter");
-        auto* deInterleave = makeGStreamerElement("deinterleave", "deinterleave");
+        auto* deInterleave = makeGStreamerElement("deinterleave"_s, "deinterleave"_s);
 
         GST_DEBUG("Setting up audio deinterleave chain");
         g_object_set(deInterleave, "keep-positions", TRUE, nullptr);
@@ -377,7 +377,7 @@ void AudioSourceProviderGStreamer::handleNewDeinterleavePad(GstPad* pad)
     // channel. Pipeline looks like:
     // ... deinterleave ! queue ! appsink.
     auto* queue = gst_element_factory_make("queue", nullptr);
-    auto* sink = makeGStreamerElement("appsink", nullptr);
+    auto* sink = makeGStreamerElement("appsink"_s);
 
     static GstAppSinkCallbacks callbacks = {
         nullptr,

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -218,7 +218,7 @@ static void webKitWebAudioSrcConstructed(GObject* object)
     auto taskName = makeString("webaudioSrcTask"_s, taskId.exchangeAdd(1));
     gst_object_set_name(GST_OBJECT_CAST(priv->task.get()), taskName.ascii().data());
 
-    priv->source = makeGStreamerElement("appsrc", "webaudioSrc");
+    priv->source = makeGStreamerElement("appsrc"_s, "webaudioSrc"_s);
 
     // Configure the appsrc for minimal latency.
     g_object_set(priv->source.get(), "block", TRUE, "blocksize", priv->bufferSize, "format", GST_FORMAT_TIME, "is-live", TRUE, nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -87,7 +87,7 @@ static void webKitGLVideoSinkConstructed(GObject* object)
     GST_OBJECT_FLAG_SET(GST_OBJECT_CAST(sink), GST_ELEMENT_FLAG_SINK);
     gst_bin_set_suppressed_flags(GST_BIN_CAST(sink), static_cast<GstElementFlags>(GST_ELEMENT_FLAG_SOURCE | GST_ELEMENT_FLAG_SINK));
 
-    sink->priv->appSink = makeGStreamerElement("appsink", "webkit-gl-video-appsink");
+    sink->priv->appSink = makeGStreamerElement("appsink"_s, "webkit-gl-video-appsink"_s);
     ASSERT(sink->priv->appSink);
     g_object_set(sink->priv->appSink.get(), "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
 
@@ -102,8 +102,8 @@ static void webKitGLVideoSinkConstructed(GObject* object)
     if (imxVideoConvertG2D)
         gst_bin_add(GST_BIN_CAST(sink), imxVideoConvertG2D);
 
-    GstElement* upload = makeGStreamerElement("glupload", nullptr);
-    GstElement* colorconvert = makeGStreamerElement("glcolorconvert", nullptr);
+    GstElement* upload = makeGStreamerElement("glupload"_s);
+    GstElement* colorconvert = makeGStreamerElement("glcolorconvert"_s);
 
     ASSERT(upload);
     ASSERT(colorconvert);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -48,7 +48,7 @@ GStreamerAudioMixer::GStreamerAudioMixer()
     registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get());
 
-    m_mixer = makeGStreamerElement("audiomixer", nullptr);
+    m_mixer = makeGStreamerElement("audiomixer"_s);
     auto* audioSink = createAutoAudioSink({ });
 
     gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_mixer.get(), audioSink, nullptr);
@@ -88,13 +88,13 @@ void GStreamerAudioMixer::ensureState(GstStateChange stateChange)
 
 GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink)
 {
-    GstElement* src = makeGStreamerElement("interaudiosrc", nullptr);
+    GstElement* src = makeGStreamerElement("interaudiosrc"_s);
     g_object_set(src, "channel", GST_ELEMENT_NAME(interaudioSink), nullptr);
     g_object_set(interaudioSink, "channel", GST_ELEMENT_NAME(interaudioSink), nullptr);
 
     auto bin = gst_bin_new(nullptr);
-    auto audioResample = makeGStreamerElement("audioresample", nullptr);
-    auto audioConvert = makeGStreamerElement("audioconvert", nullptr);
+    auto audioResample = makeGStreamerElement("audioresample"_s);
+    auto audioConvert = makeGStreamerElement("audioconvert"_s);
     gst_bin_add_many(GST_BIN_CAST(bin), audioResample, audioConvert, nullptr);
     gst_element_link(audioConvert, audioResample);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -283,8 +283,7 @@ bool webkitGstSetElementStateSynchronously(GstElement*, GstState, Function<bool(
 GstBuffer* gstBufferNewWrappedFast(void* data, size_t length);
 
 // These functions should be used for elements not provided by WebKit itself and not provided by GStreamer -core.
-GstElement* makeGStreamerElement(const char* factoryName, const char* name);
-GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads);
+GstElement* makeGStreamerElement(ASCIILiteral factoryName, const String& name = emptyString());
 
 template<typename T>
 std::optional<T> gstStructureGet(const GstStructure*, ASCIILiteral key);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -47,14 +47,14 @@ static const Seconds s_releaseUnusedPipelinesTimerInterval = 30_s;
 
 GStreamerVideoFrameConverter::Pipeline::Pipeline(Type type)
     : m_type(type)
-    , m_src(makeGStreamerElement("appsrc", nullptr))
-    , m_sink(makeGStreamerElement("appsink", nullptr))
+    , m_src(makeGStreamerElement("appsrc"_s))
+    , m_sink(makeGStreamerElement("appsink"_s))
 {
     g_object_set(m_sink.get(), "enable-last-sample", FALSE, "max-buffers", 1, nullptr);
     switch (m_type) {
     case Type::SystemMemory: {
-        auto videoconvert = makeGStreamerElement("videoconvert", nullptr);
-        auto videoscale = makeGStreamerElement("videoscale", nullptr);
+        auto videoconvert = makeGStreamerElement("videoconvert"_s);
+        auto videoscale = makeGStreamerElement("videoscale"_s);
         m_pipeline = gst_element_factory_make("pipeline", "video-frame-converter");
         gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), videoconvert, videoscale, m_sink.get(), nullptr);
         gst_element_link_many(m_src.get(), videoconvert, videoscale, m_sink.get(), nullptr);
@@ -62,20 +62,20 @@ GStreamerVideoFrameConverter::Pipeline::Pipeline(Type type)
     }
 #if USE(GSTREAMER_GL)
     case Type::GLMemory: {
-        auto glcolorconvert = makeGStreamerElement("glcolorconvert", nullptr);
-        auto gldownload = makeGStreamerElement("gldownload", nullptr);
-        auto videoscale = makeGStreamerElement("videoscale", nullptr);
+        auto glcolorconvert = makeGStreamerElement("glcolorconvert"_s);
+        auto gldownload = makeGStreamerElement("gldownload"_s);
+        auto videoscale = makeGStreamerElement("videoscale"_s);
         m_pipeline = gst_element_factory_make("pipeline", "video-frame-converter-gl");
         gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), glcolorconvert, gldownload, videoscale, m_sink.get(), nullptr);
         gst_element_link_many(m_src.get(), glcolorconvert, gldownload, videoscale, m_sink.get(), nullptr);
         break;
     }
     case Type::DMABufMemory: {
-        auto glupload = makeGStreamerElement("glupload", nullptr);
-        m_capsfilter = makeGStreamerElement("capsfilter", nullptr);
-        auto glcolorconvert = makeGStreamerElement("glcolorconvert", nullptr);
-        auto gldownload = makeGStreamerElement("gldownload", nullptr);
-        auto videoscale = makeGStreamerElement("videoscale", nullptr);
+        auto glupload = makeGStreamerElement("glupload"_s);
+        m_capsfilter = makeGStreamerElement("capsfilter"_s);
+        auto glcolorconvert = makeGStreamerElement("glcolorconvert"_s);
+        auto gldownload = makeGStreamerElement("gldownload"_s);
+        auto videoscale = makeGStreamerElement("videoscale"_s);
         m_pipeline = gst_element_factory_make("pipeline", "video-frame-converter-gl");
         gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), glupload, m_capsfilter.get(), glcolorconvert, gldownload, videoscale, m_sink.get(), nullptr);
         gst_element_link_many(m_src.get(), glupload, m_capsfilter.get(), glcolorconvert, gldownload, videoscale, m_sink.get(), nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
@@ -67,7 +67,7 @@ void webKitTextCombinerHandleCaps(WebKitTextCombiner* combiner, GstPad* pad, con
         // Caps are plain text, we want a WebVTT encoder between the ghostpad and the combinerElement.
         if (!target || gstElementFactoryEquals(targetParent.get(), "webvttenc"_s)) {
             GST_DEBUG_OBJECT(combiner, "Setting up a WebVTT encoder");
-            auto* encoder = makeGStreamerElement("webvttenc", nullptr);
+            auto* encoder = makeGStreamerElement("webvttenc"_s);
             ASSERT(encoder);
 
             gst_bin_add(GST_BIN_CAST(combiner), encoder);
@@ -94,9 +94,9 @@ void webKitTextCombinerHandleCaps(WebKitTextCombiner* combiner, GstPad* pad, con
         GST_DEBUG_OBJECT(combiner, "Converting CEA-608 closed captions to WebVTT.");
         auto* encoder = gst_bin_new(nullptr);
         auto* queue = gst_element_factory_make("queue", nullptr);
-        auto* converter = makeGStreamerElement("ccconverter", nullptr);
+        auto* converter = makeGStreamerElement("ccconverter"_s);
         auto* rawCapsFilter = gst_element_factory_make("capsfilter", nullptr);
-        auto* webvttEncoder = makeGStreamerElement("cea608tott", nullptr);
+        auto* webvttEncoder = makeGStreamerElement("cea608tott"_s);
         auto* vttCapsFilter = gst_element_factory_make("capsfilter", nullptr);
 
         auto rawCaps = adoptGRef(gst_caps_new_simple("closedcaption/x-cea-608", "format", G_TYPE_STRING, "raw", nullptr));

--- a/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
@@ -79,7 +79,7 @@ static void webkitTextSinkConstructed(GObject* object)
     auto* sink = WEBKIT_TEXT_SINK(object);
     auto* priv = sink->priv;
 
-    priv->appSink = makeGStreamerElement("appsink", nullptr);
+    priv->appSink = makeGStreamerElement("appsink"_s);
     gst_bin_add(GST_BIN_CAST(sink), priv->appSink.get());
 
     auto pad = adoptGRef(gst_element_get_static_pad(priv->appSink.get(), "sink"));

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -165,32 +165,32 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
     configureVideoDecoderForHarnessing(element);
 
     auto* factory = gst_element_get_factory(element.get());
-    const char* parser = nullptr;
+    ASCIILiteral parser;
     if (codecName.startsWith("avc1"_s)) {
         m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h264", "stream-format", G_TYPE_STRING, "avc", "alignment", G_TYPE_STRING, "au", nullptr));
         if (auto codecData = wrapSpanData(config.description))
             gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
         if (!gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get()))
-            parser = "h264parse";
+            parser = "h264parse"_s;
     } else if (codecName.startsWith("av01"_s))
         m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "stream-format", G_TYPE_STRING, "obu-stream", "alignment", G_TYPE_STRING, "frame", nullptr));
     else if (codecName.startsWith("vp8"_s))
         m_inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp8"));
     else if (codecName.startsWith("vp09"_s)) {
         m_inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
-        parser = "vp9parse";
+        parser = "vp9parse"_s;
     } else if (codecName.startsWith("hvc1"_s)) {
         m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hvc1", "alignment", G_TYPE_STRING, "au", nullptr));
         if (auto codecData = wrapSpanData(config.description))
             gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
         if (!gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get()))
-            parser = "h265parse";
+            parser = "h265parse"_s;
     } else if (codecName.startsWith("hev1"_s)) {
         m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hev1", "alignment", G_TYPE_STRING, "au", nullptr));
         if (auto codecData = wrapSpanData(config.description))
             gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
         if (!gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get()))
-            parser = "h265parse";
+            parser = "h265parse"_s;
     } else {
         WTFLogAlways("Codec %s not wired in yet", codecName.ascii().data());
         return;
@@ -200,11 +200,11 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
         gst_caps_set_simple(m_inputCaps.get(), "width", G_TYPE_INT, config.width, "height", G_TYPE_INT, config.height, nullptr);
 
     GRefPtr<GstElement> harnessedElement;
-    if (parser) {
+    if (!parser.isEmpty()) {
         // The decoder won't accept the input caps, so put a parser in front.
-        auto* parserElement = makeGStreamerElement(parser, nullptr);
+        auto* parserElement = makeGStreamerElement(parser);
         if (!parserElement) {
-            GST_WARNING_OBJECT(element.get(), "Required parser %s not found, decoding will fail", parser);
+            GST_WARNING_OBJECT(element.get(), "Required parser %s not found, decoding will fail", parser.characters());
             m_inputCaps.clear();
             return;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -59,7 +59,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
             return false;
         }
 
-        sink->priv->interAudioSink = makeGStreamerElement("interaudiosink", nullptr);
+        sink->priv->interAudioSink = makeGStreamerElement("interaudiosink"_s);
         RELEASE_ASSERT(sink->priv->interAudioSink);
 
         gst_bin_add(GST_BIN_CAST(sink), sink->priv->interAudioSink.get());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h
@@ -30,7 +30,7 @@ namespace WebCore {
 class GStreamerHolePunchQuirkFake final : public GStreamerHolePunchQuirk {
 public:
     const ASCIILiteral identifier() const final { return "FakeHolePunch"_s; }
-    GstElement* createHolePunchVideoSink(bool, const MediaPlayer*) final { return makeGStreamerElement("fakevideosink", nullptr); }
+    GstElement* createHolePunchVideoSink(bool, const MediaPlayer*) final { return makeGStreamerElement("fakevideosink"_s); }
     bool setHolePunchVideoRectangle(GstElement*, const IntRect&) final { return true; }
 };
 

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
@@ -42,7 +42,7 @@ GstElement* GStreamerHolePunchQuirkRialto::createHolePunchVideoSink(bool isLegac
         return nullptr;
 
     // Rialto using holepunch.
-    GstElement* videoSink = makeGStreamerElement("rialtomsevideosink", nullptr);
+    GstElement* videoSink = makeGStreamerElement("rialtomsevideosink"_s);
     if (isPIPRequested)
         g_object_set(G_OBJECT(videoSink), "maxVideoWidth", 640, "maxVideoHeight", 480, "has-drm", FALSE, nullptr);
     return videoSink;

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
@@ -37,7 +37,7 @@ GstElement* GStreamerHolePunchQuirkWesteros::createHolePunchVideoSink(bool isLeg
         return nullptr;
 
     // Westeros using holepunch.
-    GstElement* videoSink = makeGStreamerElement("westerossink", "WesterosVideoSink");
+    GstElement* videoSink = makeGStreamerElement("westerossink"_s, "WesterosVideoSink"_s);
     g_object_set(videoSink, "zorder", 0.0f, nullptr);
     if (isPIPRequested) {
         g_object_set(videoSink, "res-usage", 0u, nullptr);

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -42,7 +42,7 @@ GstElement* GStreamerQuirkAmLogic::createWebAudioSink()
     // that causes resource acquisition in some cases interrupting any playback already running.
     // On Amlogic we need to set direct-mode=false prop before changing state to READY
     // but this is not possible with autoaudiosink.
-    auto sink = makeGStreamerElement("amlhalasink", nullptr);
+    auto sink = makeGStreamerElement("amlhalasink"_s);
     RELEASE_ASSERT_WITH_MESSAGE(sink, "amlhalasink should be available in the system but it is not");
     g_object_set(sink, "direct-mode", FALSE, nullptr);
     return sink;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -49,7 +49,7 @@ GStreamerQuirkRealtek::GStreamerQuirkRealtek()
 
 GstElement* GStreamerQuirkRealtek::createWebAudioSink()
 {
-    auto sink = makeGStreamerElement("rtkaudiosink", nullptr);
+    auto sink = makeGStreamerElement("rtkaudiosink"_s);
     RELEASE_ASSERT_WITH_MESSAGE(sink, "rtkaudiosink should be available in the system but it is not");
     g_object_set(sink, "media-tunnel", FALSE, "audio-service", TRUE, nullptr);
     return sink;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -81,7 +81,7 @@ void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet
 
 GstElement* GStreamerQuirkRialto::createAudioSink()
 {
-    auto sink = makeGStreamerElement("rialtomseaudiosink", nullptr);
+    auto sink = makeGStreamerElement("rialtomseaudiosink"_s);
     RELEASE_ASSERT_WITH_MESSAGE(sink, "rialtomseaudiosink should be available in the system but it is not");
     return sink;
 }
@@ -91,7 +91,7 @@ GstElement* GStreamerQuirkRialto::createWebAudioSink()
     if (GstElement* sink = webkitAudioSinkNew())
         return sink;
 
-    auto sink = makeGStreamerElement("rialtowebaudiosink", nullptr);
+    auto sink = makeGStreamerElement("rialtowebaudiosink"_s);
     RELEASE_ASSERT_WITH_MESSAGE(sink, "rialtowebaudiosink should be available in the system but it is not");
     return sink;
 }

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -100,13 +100,13 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
         }
     }
 
-    m_volumeElement = makeGStreamerElement("volume", nullptr);
-    m_pitchElement = makeGStreamerElement("pitch", nullptr);
+    m_volumeElement = makeGStreamerElement("volume"_s);
+    m_pitchElement = makeGStreamerElement("pitch"_s);
     if (!m_pitchElement)
         WTFLogAlways("The pitch GStreamer plugin is unavailable. The pitch property of Speech Synthesis is ignored.");
 
-    GRefPtr<GstElement> audioConvert = makeGStreamerElement("audioconvert", nullptr);
-    GRefPtr<GstElement> audioResample = makeGStreamerElement("audioresample", nullptr);
+    GRefPtr<GstElement> audioConvert = makeGStreamerElement("audioconvert"_s);
+    GRefPtr<GstElement> audioResample = makeGStreamerElement("audioresample"_s);
     if (m_pitchElement)
         gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), m_volumeElement.get(), audioConvert.get(), audioResample.get(), m_pitchElement.get(), audioSink.get(), nullptr);
     else

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -359,7 +359,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     auto useVideoConvertScale = StringView::fromLatin1(std::getenv("WEBKIT_GST_USE_VIDEOCONVERT_SCALE"));
     if (useVideoConvertScale == "1"_s) {
         if (!priv->videoConvert) {
-            priv->videoConvert = makeGStreamerElement("videoconvertscale", nullptr);
+            priv->videoConvert = makeGStreamerElement("videoconvertscale"_s);
             gst_bin_add(GST_BIN_CAST(self), priv->videoConvert.get());
 
             auto sinkPadTarget = adoptGRef(gst_element_get_static_pad(priv->videoConvert.get(), "sink"));
@@ -372,12 +372,12 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
         }
     } else {
         if (!priv->videoScale) {
-            priv->videoScale = makeGStreamerElement("videoscale", nullptr);
+            priv->videoScale = makeGStreamerElement("videoscale"_s);
             gst_bin_add(GST_BIN_CAST(self), priv->videoScale.get());
         }
 
         if (!priv->videoConvert) {
-            priv->videoConvert = makeGStreamerElement("videoconvert", nullptr);
+            priv->videoConvert = makeGStreamerElement("videoconvert"_s);
             gst_bin_add(GST_BIN_CAST(self), priv->videoConvert.get());
 
             auto sinkPadTarget = adoptGRef(gst_element_get_static_pad(priv->videoConvert.get(), "sink"));
@@ -391,7 +391,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     }
 
     if (encoderDefinition->parserName) {
-        priv->parser = makeGStreamerElement(encoderDefinition->parserName, nullptr);
+        priv->parser = makeGStreamerElement(encoderDefinition->parserName);
 
         if (!priv->outputCapsFilter) {
             priv->outputCapsFilter = gst_element_factory_make("capsfilter", nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -69,15 +69,15 @@ void GStreamerAudioCapturer::setSinkAudioCallback(SinkAudioDataCallback&& callba
 GstElement* GStreamerAudioCapturer::createConverter()
 {
     auto* bin = gst_bin_new(nullptr);
-    auto* audioconvert = makeGStreamerElement("audioconvert", nullptr);
-    auto* audioresample = makeGStreamerElement("audioresample", nullptr);
+    auto* audioconvert = makeGStreamerElement("audioconvert"_s);
+    auto* audioresample = makeGStreamerElement("audioresample"_s);
     gst_bin_add_many(GST_BIN_CAST(bin), audioconvert, audioresample, nullptr);
     gst_element_link(audioconvert, audioresample);
 
 #if USE(GSTREAMER_WEBRTC)
-    if (auto audioFilter = makeGStreamerElement("audiornnoise", nullptr)) {
-        auto audioconvert2 = makeGStreamerElement("audioconvert", nullptr);
-        auto audioresample2 = makeGStreamerElement("audioresample", nullptr);
+    if (auto audioFilter = makeGStreamerElement("audiornnoise"_s)) {
+        auto audioconvert2 = makeGStreamerElement("audioconvert"_s);
+        auto audioresample2 = makeGStreamerElement("audioresample"_s);
         gst_bin_add_many(GST_BIN_CAST(bin), audioconvert2, audioresample2, audioFilter, nullptr);
         gst_element_link_many(audioconvert2, audioresample2, audioFilter, audioconvert, nullptr);
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -67,7 +67,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
     GRefPtr<GstElement> encoder;
     if (encoding == "opus"_s) {
-        encoder = makeGStreamerElement("opusenc", nullptr);
+        encoder = makeGStreamerElement("opusenc"_s);
         if (!encoder)
             return nullptr;
 
@@ -96,11 +96,11 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
             }
         }
     } else if (encoding == "g722"_s)
-        encoder = makeGStreamerElement("avenc_g722", nullptr);
+        encoder = makeGStreamerElement("avenc_g722"_s);
     else if (encoding == "pcma"_s)
-        encoder = makeGStreamerElement("alawenc", nullptr);
+        encoder = makeGStreamerElement("alawenc"_s);
     else if (encoding == "pcmu"_s)
-        encoder = makeGStreamerElement("mulawenc", nullptr);
+        encoder = makeGStreamerElement("mulawenc"_s);
     else {
         GST_ERROR("Unsupported outgoing audio encoding: %s", encoding.ascii().data());
         return nullptr;
@@ -144,8 +144,8 @@ GStreamerAudioRTPPacketizer::GStreamerAudioRTPPacketizer(GRefPtr<GstCaps>&& inpu
     g_object_set(m_capsFilter.get(), "caps", rtpCaps.get(), nullptr);
     GST_DEBUG_OBJECT(m_bin.get(), "RTP caps: %" GST_PTR_FORMAT, rtpCaps.get());
 
-    m_audioconvert = makeGStreamerElement("audioconvert", nullptr);
-    m_audioresample = makeGStreamerElement("audioresample", nullptr);
+    m_audioconvert = makeGStreamerElement("audioconvert"_s);
+    m_audioresample = makeGStreamerElement("audioresample"_s);
     m_inputCapsFilter = gst_element_factory_make("capsfilter", nullptr);
     g_object_set(m_inputCapsFilter.get(), "caps", inputCaps.get(), nullptr);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -59,7 +59,7 @@ GStreamerCapturer::GStreamerCapturer(GStreamerCaptureDevice&& device, GRefPtr<Gs
     m_device.emplace(WTFMove(device));
 }
 
-GStreamerCapturer::GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>&& caps, CaptureDevice::DeviceType deviceType)
+GStreamerCapturer::GStreamerCapturer(ASCIILiteral sourceFactory, GRefPtr<GstCaps>&& caps, CaptureDevice::DeviceType deviceType)
     : m_caps(WTFMove(caps))
     , m_sourceFactory(sourceFactory)
     , m_deviceType(deviceType)
@@ -215,7 +215,7 @@ void GStreamerCapturer::setupPipeline()
         disconnectSimpleBusMessageCallback(pipeline());
     }
 
-    m_pipeline = makeElement("pipeline");
+    m_pipeline = makeElement("pipeline"_s);
     auto clock = adoptGRef(gst_system_clock_obtain());
     gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
     gst_element_set_base_time(m_pipeline.get(), 0);
@@ -227,11 +227,11 @@ void GStreamerCapturer::setupPipeline()
     GRefPtr<GstElement> source = createSource();
     GRefPtr<GstElement> converter = createConverter();
 
-    m_valve = makeElement("valve");
-    m_capsfilter = makeElement("capsfilter");
+    m_valve = makeElement("valve"_s);
+    m_capsfilter = makeElement("capsfilter"_s);
     auto queue = gst_element_factory_make("queue", nullptr);
     if (!m_sink)
-        m_sink = makeElement("appsink");
+        m_sink = makeElement("appsink"_s);
 
     gst_util_set_object_arg(G_OBJECT(m_capsfilter.get()), "caps-change-mode", "delayed");
 
@@ -249,9 +249,9 @@ void GStreamerCapturer::setupPipeline()
     gst_element_link_many(tail, m_capsfilter.get(), m_valve.get(), queue, m_sink.get(), nullptr);
 }
 
-GstElement* GStreamerCapturer::makeElement(const char* factoryName)
+GstElement* GStreamerCapturer::makeElement(ASCIILiteral factoryName)
 {
-    auto* element = makeGStreamerElement(factoryName, nullptr);
+    auto* element = makeGStreamerElement(factoryName);
     auto elementName = makeString(unsafeSpan(name()), "_capturer_"_s, unsafeSpan(GST_OBJECT_NAME(element)), '_', hex(reinterpret_cast<uintptr_t>(this)));
     gst_object_set_name(GST_OBJECT(element), elementName.ascii().data());
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -53,7 +53,7 @@ public:
 class GStreamerCapturer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerCapturer> {
 public:
     GStreamerCapturer(GStreamerCaptureDevice&&, GRefPtr<GstCaps>&&);
-    GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>&&, CaptureDevice::DeviceType);
+    GStreamerCapturer(ASCIILiteral sourceFactory, GRefPtr<GstCaps>&&, CaptureDevice::DeviceType);
     virtual ~GStreamerCapturer();
 
     void tearDown(bool disconnectSignals = true);
@@ -72,7 +72,7 @@ public:
 
     std::pair<GstClockTime, GstClockTime> queryLatency();
 
-    GstElement* makeElement(const char* factoryName);
+    GstElement* makeElement(ASCIILiteral factoryName);
     virtual GstElement* createSource();
     GstElement* source() { return m_src.get();  }
     virtual const char* name() = 0;
@@ -98,7 +98,7 @@ protected:
     std::optional<GStreamerCaptureDevice> m_device { };
     GRefPtr<GstCaps> m_caps;
     GRefPtr<GstElement> m_pipeline;
-    const char* m_sourceFactory;
+    ASCIILiteral m_sourceFactory;
 
 private:
     CaptureDevice::DeviceType m_deviceType;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -202,7 +202,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     }
 
     GST_DEBUG_OBJECT(m_bin.get(), "Preparing video decoder for depayloaded RTP packets");
-    GRefPtr<GstElement> decodebin = makeGStreamerElement("decodebin3", nullptr);
+    GRefPtr<GstElement> decodebin = makeGStreamerElement("decodebin3"_s);
     m_isDecoding = true;
 
     g_signal_connect(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer userData) {
@@ -253,7 +253,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
 
 GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
 {
-    GRefPtr<GstElement> parsebin = makeGStreamerElement("parsebin", nullptr);
+    GRefPtr<GstElement> parsebin = makeGStreamerElement("parsebin"_s);
     g_signal_connect(parsebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
         String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -163,7 +163,7 @@ public:
         }
 
         bool isCaptureTrack = track.isCaptureTrack();
-        m_src = makeGStreamerElement("appsrc", elementName.ascii().data());
+        m_src = makeGStreamerElement("appsrc"_s, elementName);
 
         g_object_set(m_src.get(), "is-live", TRUE, "format", GST_FORMAT_TIME, "min-percent", 100,
             "do-timestamp", isCaptureTrack, "handle-segment-change", TRUE, nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -40,7 +40,7 @@ WEBKIT_DEFINE_TYPE(GStreamerMockDevice, webkit_mock_device, GST_TYPE_DEVICE)
 static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* device, const char* name)
 {
     GST_INFO_OBJECT(device, "Creating source element for device %s", name);
-    auto* element = makeGStreamerElement("appsrc", name);
+    auto* element = makeGStreamerElement("appsrc"_s, String::fromLatin1(name));
     g_object_set(element, "format", GST_FORMAT_TIME, "is-live", TRUE, "do-timestamp", TRUE, nullptr);
     return element;
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -105,7 +105,7 @@ DisplayCaptureFactory& GStreamerVideoCaptureSource::displayFactory()
     return factory.get();
 }
 
-GStreamerVideoCaptureSource::GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, const gchar* sourceFactory, CaptureDevice::DeviceType deviceType, const NodeAndFD& nodeAndFd)
+GStreamerVideoCaptureSource::GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, ASCIILiteral sourceFactory, CaptureDevice::DeviceType deviceType, const NodeAndFD& nodeAndFd)
     : RealtimeVideoCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Camera, WTFMove(name) }, WTFMove(hashSalts), { })
     , m_capturer(adoptRef(*new GStreamerVideoCapturer(sourceFactory, deviceType)))
     , m_deviceType(deviceType)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -56,7 +56,7 @@ public:
     std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const final;
 
 protected:
-    GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const gchar* source_factory, CaptureDevice::DeviceType, const NodeAndFD&);
+    GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, ASCIILiteral sourceFactory, CaptureDevice::DeviceType, const NodeAndFD&);
     GStreamerVideoCaptureSource(GStreamerCaptureDevice&&, MediaDeviceHashSalts&&);
     virtual ~GStreamerVideoCaptureSource();
     void startProducingData() final;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -49,7 +49,7 @@ GStreamerVideoCapturer::GStreamerVideoCapturer(GStreamerCaptureDevice&& device)
     initializeVideoCapturerDebugCategory();
 }
 
-GStreamerVideoCapturer::GStreamerVideoCapturer(const char* sourceFactory, CaptureDevice::DeviceType deviceType)
+GStreamerVideoCapturer::GStreamerVideoCapturer(ASCIILiteral sourceFactory, CaptureDevice::DeviceType deviceType)
     : GStreamerCapturer(sourceFactory, adoptGRef(gst_caps_new_empty_simple("video/x-raw")), deviceType)
 {
     initializeVideoCapturerDebugCategory();
@@ -100,9 +100,9 @@ GstElement* GStreamerVideoCapturer::createConverter()
     }
 
     auto* bin = gst_bin_new(nullptr);
-    auto* videoscale = makeGStreamerElement("videoscale", "videoscale");
-    auto* videoconvert = makeGStreamerElement("videoconvert", nullptr);
-    auto* videorate = makeGStreamerElement("videorate", "videorate");
+    auto* videoscale = makeGStreamerElement("videoscale"_s, "videoscale"_s);
+    auto* videoconvert = makeGStreamerElement("videoconvert"_s);
+    auto* videorate = makeGStreamerElement("videorate"_s, "videorate"_s);
 
     // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/issues/97#note_56575
     g_object_set(videorate, "drop-only", TRUE, "average-period", UINT64_C(1), nullptr);
@@ -114,7 +114,7 @@ GstElement* GStreamerVideoCapturer::createConverter()
     auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
     g_object_set(m_videoSrcMIMETypeFilter.get(), "caps", caps.get(), nullptr);
 
-    auto* decodebin = makeGStreamerElement("decodebin3", nullptr);
+    auto* decodebin = makeGStreamerElement("decodebin3"_s);
     gst_bin_add_many(GST_BIN_CAST(bin), m_videoSrcMIMETypeFilter.get(), decodebin, nullptr);
     gst_element_link(m_videoSrcMIMETypeFilter.get(), decodebin);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -35,7 +35,7 @@ class GStreamerVideoCapturer final : public GStreamerCapturer {
     friend class MockRealtimeVideoSourceGStreamer;
 public:
     GStreamerVideoCapturer(GStreamerCaptureDevice&&);
-    GStreamerVideoCapturer(const char* sourceFactory, CaptureDevice::DeviceType);
+    GStreamerVideoCapturer(ASCIILiteral sourceFactory, CaptureDevice::DeviceType);
     ~GStreamerVideoCapturer() = default;
 
     GstElement* createSource() final;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -146,10 +146,10 @@ GStreamerVideoRTPPacketizer::GStreamerVideoRTPPacketizer(GRefPtr<GstElement>&& e
 
     GST_DEBUG_OBJECT(m_bin.get(), "RTP encoding parameters: %" GST_PTR_FORMAT, m_encodingParameters.get());
 
-    m_videoRate = makeGStreamerElement("videorate", nullptr);
+    m_videoRate = makeGStreamerElement("videorate"_s);
     // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/issues/97#note_56575
     g_object_set(m_videoRate.get(), "skip-to-first", TRUE, "drop-only", TRUE, "average-period", UINT64_C(1), nullptr);
-    m_frameRateCapsFilter = makeGStreamerElement("capsfilter", nullptr);
+    m_frameRateCapsFilter = makeGStreamerElement("capsfilter"_s);
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoRate.get(), m_frameRateCapsFilter.get(), nullptr);
 
     auto lastIdentifier = findLastExtensionId(rtpCaps.get());

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -66,12 +66,12 @@ void RealtimeOutgoingVideoSourceGStreamer::initializePreProcessor()
 
     m_preProcessor = gst_bin_new(nullptr);
 
-    auto videoConvert = makeGStreamerElement("videoconvert", nullptr);
+    auto videoConvert = makeGStreamerElement("videoconvert"_s);
 
-    auto videoFlip = makeGStreamerElement("autovideoflip", nullptr);
+    auto videoFlip = makeGStreamerElement("autovideoflip"_s);
     if (!videoFlip) {
         GST_DEBUG("autovideoflip element not available, falling back to videoflip");
-        videoFlip = makeGStreamerElement("videoflip", nullptr);
+        videoFlip = makeGStreamerElement("videoflip"_s);
     }
     gst_util_set_object_arg(G_OBJECT(videoFlip), "video-direction", "auto");
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -118,11 +118,11 @@ public:
         return m_pipeline.get();
     }
 
-    GstElement* makeElement(const gchar* factoryName)
+    GstElement* makeElement(ASCIILiteral factoryName)
     {
         static Atomic<uint32_t> elementId;
-        auto name = makeString(Name(), "-enc-"_s, unsafeSpan(factoryName), "-"_s, elementId.exchangeAdd(1));
-        auto* elem = makeGStreamerElement(factoryName, name.utf8().data());
+        auto name = makeString(Name(), "-enc-"_s, factoryName, "-"_s, elementId.exchangeAdd(1));
+        auto* elem = makeGStreamerElement(factoryName, name);
         return elem;
     }
 


### PR DESCRIPTION
#### b602c49c2b9f3a896acd327d0f0a13afb2e3c7db
<pre>
[GStreamer] Switch makeGStreamerElement to have proper string management
<a href="https://bugs.webkit.org/show_bug.cgi?id=289949">https://bugs.webkit.org/show_bug.cgi?id=289949</a>

Reviewed by Philippe Normand.

For the same price I removed the makeGStreamerBin function, that is supposed to be dead code.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::maybeInsertNetSimForElement):
(WebCore::GStreamerMediaEndpoint::initializePipeline):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::handleNewDeinterleavePad):
(WebCore::AudioFileReader::plugDeinterleave):
(WebCore::AudioFileReader::decodeAudioForBusCreation):
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
(WebCore::AudioSourceProviderGStreamer::configureAudioBin):
(WebCore::AudioSourceProviderGStreamer::setClient):
(WebCore::AudioSourceProviderGStreamer::handleNewDeinterleavePad):
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webKitWebAudioSrcConstructed):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::GStreamerAudioMixer):
(WebCore::GStreamerAudioMixer::registerProducer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::createAutoAudioSink):
(WebCore::makeGStreamerElement):
(WebCore::makeGStreamerBin): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp:
(WebCore::GStreamerVideoFrameConverter::Pipeline::Pipeline):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSinkGL):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSink):
* Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp:
(webKitTextCombinerHandleCaps):
* Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp:
(webkitTextSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::AppendPipeline):
(WebCore::createOptionalParserForFormat):
(WebCore::createOptionalEncoderForFormat):
(WebCore::AppendPipeline::Track::initializeElements):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h:
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp:
(WebCore::GStreamerHolePunchQuirkRialto::createHolePunchVideoSink):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp:
(WebCore::GStreamerHolePunchQuirkWesteros::createHolePunchVideoSink):
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp:
(WebCore::GStreamerQuirkAmLogic::createWebAudioSink):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp:
(WebCore::GStreamerQuirkRealtek::createWebAudioSink):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::createAudioSink):
(WebCore::GStreamerQuirkRialto::createWebAudioSink):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSetEncoder):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::createConverter):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
(WebCore::GStreamerAudioRTPPacketizer::create):
(WebCore::GStreamerAudioRTPPacketizer::GStreamerAudioRTPPacketizer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::GStreamerCapturer):
(WebCore::GStreamerCapturer::setupPipeline):
(WebCore::GStreamerCapturer::makeElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::createParser):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
(webkitMockDeviceCreateElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::GStreamerVideoCaptureSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::GStreamerVideoCapturer):
(WebCore::GStreamerVideoCapturer::createConverter):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::GStreamerVideoRTPPacketizer):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::initializePreProcessor):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::makeElement):
(WebCore::GStreamerWebRTCVideoDecoder::CreateFilter):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::LibWebRTCGStreamerVideoEncoder::makeElement):

Canonical link: <a href="https://commits.webkit.org/292349@main">https://commits.webkit.org/292349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b75f737292618fff79d2eedc19f8f1b3aa1d716e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95582 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102666 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22632 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16535 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81944 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81295 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->