### PR TITLE
[GTK][WPE] Wrong vector index calculated in Damage::unite()

### DIFF
--- a/LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html
+++ b/LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html
@@ -18,7 +18,7 @@
       processAnimationFrameSequence({skipFirstFrameToEnsureInitialPaintingDone: true}, [
           () => {
               // Draw few enough rects to avoid merging.
-              for (let i = 0; i < mergingThreshold - 1; i++) {
+              for (let i = 0; i < mergingThreshold; i++) {
                   ctx.fillRect(1 + (i % 25) * 4, 1 + Math.floor(i / 25) * 4, 1, 1);
               }
           },
@@ -27,14 +27,14 @@
               var damage = latestFrameDamage();
               assertValid(damage);
               var expectedRects = [];
-              for (let i = 0; i < mergingThreshold - 1; i++) {
+              for (let i = 0; i < mergingThreshold; i++) {
                   expectedRects.push([(i % 25) * 4, Math.floor(i / 25) * 4, 3, 3]);
               }
               assertRectsEq(damage.rects, expectedRects);
           },
           () => {
               // Draw enough rects to trigger merging.
-              for (let i = 0; i < mergingThreshold; i++) {
+              for (let i = 0; i <= mergingThreshold; i++) {
                   ctx.fillRect(1 + (i % 25) * 4, 1 + Math.floor(i / 25) * 4, 1, 1);
               }
           },

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -36,6 +36,9 @@ list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
 
     Tests/WebCore/UserAgentQuirks.cpp
+
+    Tests/WebCore/glib/Damage.cpp
+
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp
     Tests/WebCore/gstreamer/GstMappedBuffer.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -37,6 +37,9 @@ list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
 
     Tests/WebCore/UserAgentQuirks.cpp
+
+    Tests/WebCore/glib/Damage.cpp
+
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp
     Tests/WebCore/gstreamer/GstMappedBuffer.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include "Test.h"
+#include <WebCore/Damage.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+TEST(Damage, Basics)
+{
+    Damage damage;
+    EXPECT_FALSE(damage.isInvalid());
+    EXPECT_TRUE(damage.isEmpty());
+    EXPECT_EQ(damage.rects().size(), 0);
+}
+
+TEST(Damage, AddRect)
+{
+    Damage damage;
+    damage.add(IntRect { 100, 100, 200, 200 });
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // When there's only one rect, that should be the bounds.
+    EXPECT_EQ(damage.bounds().x(), 100);
+    EXPECT_EQ(damage.bounds().y(), 100);
+    EXPECT_EQ(damage.bounds().width(), 200);
+    EXPECT_EQ(damage.bounds().height(), 200);
+
+    // When there's only one rect, adding a rect already contained
+    // by the bounding box does nothing.
+    damage.add(IntRect { 150, 150, 100, 100 });
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding an empty rect does nothing.
+    damage.add(IntRect { });
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding a new rect not contained by previous one adds it to the list.
+    damage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_EQ(damage.rects().size(), 2);
+
+    // Now the bounding box contains the two rectangles.
+    EXPECT_EQ(damage.bounds().x(), 100);
+    EXPECT_EQ(damage.bounds().y(), 100);
+    EXPECT_EQ(damage.bounds().width(), 400);
+    EXPECT_EQ(damage.bounds().height(), 400);
+
+    // Adding a rect containing the bounds makes it the only rect.
+    damage.add(IntRect { 50, 50, 500, 500 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.bounds().x(), 50);
+    EXPECT_EQ(damage.bounds().y(), 50);
+    EXPECT_EQ(damage.bounds().width(), 500);
+    EXPECT_EQ(damage.bounds().height(), 500);
+
+    // Adding FloatRect takes the enclosingIntRect
+    damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.rects().last().x(), 1024);
+    EXPECT_EQ(damage.rects().last().y(), 1024);
+    EXPECT_EQ(damage.rects().last().width(), 51);
+    EXPECT_EQ(damage.rects().last().height(), 26);
+
+    // Adding an empty FloatRect does nothing.
+    damage.add(FloatRect { 1024.50, 1024.25, 0, 0 });
+    EXPECT_EQ(damage.rects().size(), 2);
+}
+
+TEST(Damage, AddDamage)
+{
+    Damage damage;
+    damage.add(IntRect { 100, 100, 200, 200 });
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding empty Damage does nothing.
+    Damage other;
+    damage.add(other);
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding a valid Damage adds its rectangles.
+    other.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_EQ(other.rects().size(), 1);
+    damage.add(other);
+    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.bounds().x(), 100);
+    EXPECT_EQ(damage.bounds().y(), 100);
+    EXPECT_EQ(damage.bounds().width(), 400);
+    EXPECT_EQ(damage.bounds().height(), 400);
+
+    // Adding an invalid Damage invalidates the Damage.
+    damage.add(Damage::invalid());
+    EXPECT_TRUE(damage.isInvalid());
+    EXPECT_EQ(damage.rects().size(), 0);
+}
+
+TEST(Damage, Unite)
+{
+    Damage damage;
+    damage.resize({ 512, 512 });
+
+    // Add several rects to the first tile.
+    damage.add(IntRect { 0, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 200, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 0, 200, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 200, 200, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 128, 128, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_FALSE(damage.rects()[0].isEmpty());
+    EXPECT_TRUE(damage.rects()[1].isEmpty());
+    EXPECT_TRUE(damage.rects()[2].isEmpty());
+    EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[0], damage.bounds());
+
+    damage = { };
+    damage.resize({ 512, 512 });
+
+    // Add several rects to the second tile.
+    damage.add(IntRect { 300, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 500, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 300, 200, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 500, 200, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 384, 128, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_TRUE(damage.rects()[0].isEmpty());
+    EXPECT_FALSE(damage.rects()[1].isEmpty());
+    EXPECT_TRUE(damage.rects()[2].isEmpty());
+    EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[1], damage.bounds());
+
+
+    damage = { };
+    damage.resize({ 512, 512 });
+
+    // Add several rects to the third tile.
+    damage.add(IntRect { 0, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 200, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 0, 500, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 200, 500, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 128, 384, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_TRUE(damage.rects()[0].isEmpty());
+    EXPECT_TRUE(damage.rects()[1].isEmpty());
+    EXPECT_FALSE(damage.rects()[2].isEmpty());
+    EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[2], damage.bounds());
+
+    damage = { };
+    damage.resize({ 512, 512 });
+
+    // Add several rects to the fourth tile.
+    damage.add(IntRect { 300, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 500, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 300, 500, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 500, 500, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 384, 384, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_TRUE(damage.rects()[0].isEmpty());
+    EXPECT_TRUE(damage.rects()[1].isEmpty());
+    EXPECT_TRUE(damage.rects()[2].isEmpty());
+    EXPECT_FALSE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[3], damage.bounds());
+
+
+    damage = { };
+    damage.resize({ 512, 512 });
+
+    // Add one rect per tile.
+    damage.add(IntRect { 0, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 300, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 0, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 300, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_FALSE(damage.rects()[0].isEmpty());
+    EXPECT_EQ(damage.rects()[0].x(), 0);
+    EXPECT_EQ(damage.rects()[0].y(), 0);
+    EXPECT_EQ(damage.rects()[0].width(), 4);
+    EXPECT_EQ(damage.rects()[0].height(), 4);
+    EXPECT_FALSE(damage.rects()[1].isEmpty());
+    EXPECT_EQ(damage.rects()[1].x(), 300);
+    EXPECT_EQ(damage.rects()[1].y(), 0);
+    EXPECT_EQ(damage.rects()[1].width(), 4);
+    EXPECT_EQ(damage.rects()[1].height(), 4);
+    EXPECT_FALSE(damage.rects()[2].isEmpty());
+    EXPECT_EQ(damage.rects()[2].x(), 0);
+    EXPECT_EQ(damage.rects()[2].y(), 300);
+    EXPECT_EQ(damage.rects()[2].width(), 4);
+    EXPECT_EQ(damage.rects()[2].height(), 4);
+    EXPECT_FALSE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[3].x(), 300);
+    EXPECT_EQ(damage.rects()[3].y(), 300);
+    EXPECT_EQ(damage.rects()[3].width(), 4);
+    EXPECT_EQ(damage.rects()[3].height(), 4);
+
+    damage = { };
+    damage.resize({ 512, 512 });
+
+    // Add rects with points off the grid area.
+    damage.add(IntRect { -2, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 50, -2, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 2);
+    damage.add(IntRect { 550, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 3);
+    damage.add(IntRect { 300, -2, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { -2, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 50, 550, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 300, 550, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    damage.add(IntRect { 550, 300, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_FALSE(damage.rects()[0].isEmpty());
+    EXPECT_EQ(damage.rects()[0].x(), -2);
+    EXPECT_EQ(damage.rects()[0].y(), -2);
+    EXPECT_EQ(damage.rects()[0].width(), 56);
+    EXPECT_EQ(damage.rects()[0].height(), 6);
+    EXPECT_FALSE(damage.rects()[1].isEmpty());
+    EXPECT_EQ(damage.rects()[1].x(), 300);
+    EXPECT_EQ(damage.rects()[1].y(), -2);
+    EXPECT_EQ(damage.rects()[1].width(), 254);
+    EXPECT_EQ(damage.rects()[1].height(), 6);
+    EXPECT_FALSE(damage.rects()[2].isEmpty());
+    EXPECT_EQ(damage.rects()[2].x(), -2);
+    EXPECT_EQ(damage.rects()[2].y(), 300);
+    EXPECT_EQ(damage.rects()[2].width(), 56);
+    EXPECT_EQ(damage.rects()[2].height(), 254);
+    EXPECT_FALSE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.rects()[3].x(), 300);
+    EXPECT_EQ(damage.rects()[3].y(), 300);
+    EXPECT_EQ(damage.rects()[3].width(), 254);
+    EXPECT_EQ(damage.rects()[3].height(), 254);
+
+    damage = { };
+    damage.resize({ 128, 128 });
+
+    // Add several rects and check that unite works for single tile grid.
+    damage.add(IntRect { 0, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 60, 60, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 70, 0, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 120, 60, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 0, 70, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 60, 70, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 70, 70, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+    damage.add(IntRect { 120, 120, 4, 4 });
+    EXPECT_EQ(damage.rects().size(), 1);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(GTK) || PLATFORM(WPE)


### PR DESCRIPTION
#### ac29a5c3090553a6fa69562670f267888d6424d5
<pre>
[GTK][WPE] Wrong vector index calculated in Damage::unite()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289955">https://bugs.webkit.org/show_bug.cgi?id=289955</a>

Reviewed by Alejandro G. Castro.

The problem is that we are using ceiledIntPoint() resulting in cell
indices starting at 1, we should use flooredIntPoint instead to get the
right cell indices starting at 0.
This patch also includes other improvements and cleanups to Damage and a
small change in behavior, now we start doing the unite when adding a new
rectangle that would increase the vector size over the maximum instead
of when the maximum is reached.
The patch also includes a new unit test.

* LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html:
* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::Damage):
(WebCore::Damage::bounds const):
(WebCore::Damage::resize):
(WebCore::Damage::add):
(WebCore::Damage::uniteExistingRects):
(WebCore::Damage::tileIndexForRect const):
(WebCore::Damage::unite):
(WebCore::Damage::invalidate): Deleted.
(WebCore::Damage::shouldUnite const): Deleted.
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp: Added.
(TestWebKitAPI::TEST(Damage, Basics)):
(TestWebKitAPI::TEST(Damage, AddRect)):
(TestWebKitAPI::TEST(Damage, AddDamage)):
(TestWebKitAPI::TEST(Damage, Unite)):

Canonical link: <a href="https://commits.webkit.org/292360@main">https://commits.webkit.org/292360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ff312280d608722bc871ab9247f0144d446fbeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72905 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81302 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15986 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->