### PR TITLE
[GStreamer][WebAudio] Invalid memory alignment in AudioArray

### DIFF
--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -58,6 +58,9 @@ public:
             return;
 
         Checked<size_t> initialSize = sizeof(T) * n;
+#if USE(GSTREAMER)
+        m_allocation = MallocSpan<T>::zeroedMalloc(initialSize);
+#else
         // Accelerate.framework behaves differently based on input vector alignment. And each implementation
         // has very small difference in output! We ensure 32byte alignment so that we will always take the most
         // optimized implementation if possible, which makes the result deterministic.
@@ -65,6 +68,7 @@ public:
 
         m_allocation = MallocSpan<T, FastAlignedMalloc>::alignedMalloc(alignment, initialSize);
         zero();
+#endif
     }
 
     std::span<T> span() { return m_allocation.mutableSpan(); }
@@ -118,7 +122,11 @@ public:
     }
 
 private:
+#if USE(GSTREAMER)
+    MallocSpan<T> m_allocation;
+#else
     MallocSpan<T, FastAlignedMalloc> m_allocation;
+#endif
 };
 
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename T>, AudioArray<T>);


### PR DESCRIPTION
#### 6d62ebc8d8422be836268f873fb4637af0ff3daa
<pre>
[GStreamer][WebAudio] Invalid memory alignment in AudioArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=289960">https://bugs.webkit.org/show_bug.cgi?id=289960</a>

Reviewed by Xabier Rodriguez-Calvar.

The GStreamer FFTFrame implementation doesn&apos;t align its allocated memory on 32 bytes, the AudioArray
data shouldn&apos;t be aligned either.

* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::resize):

Canonical link: <a href="https://commits.webkit.org/292354@main">https://commits.webkit.org/292354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b16735b84688c1c4337471dcdc20dcbaa6bc02fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72907 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98594 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11604 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86342 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53239 "Found 2 new API test failures: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102675 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81298 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15985 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22609 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27766 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->