### PR TITLE
StringImpl refcounting should be atomic

### DIFF
--- a/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.cpp
+++ b/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.cpp
@@ -30,13 +30,13 @@
 
 namespace JSC {
 
-void DirectEvalCodeCache::setSlow(JSGlobalObject* globalObject, JSCell* owner, const String& evalSource, BytecodeIndex bytecodeIndex, DirectEvalExecutable* evalExecutable)
+void DirectEvalCodeCache::setSlow(JSGlobalObject* globalObject, JSCell* owner, const CacheLookupKey& cacheKey, DirectEvalExecutable* evalExecutable)
 {
     if (!evalExecutable->allowDirectEvalCache())
         return;
 
     Locker locker { m_lock };
-    m_cacheMap.set(CacheKey(evalSource, bytecodeIndex), WriteBarrier<DirectEvalExecutable>(globalObject->vm(), owner, evalExecutable));
+    m_cacheMap.set(cacheKey, WriteBarrier<DirectEvalExecutable>(globalObject->vm(), owner, evalExecutable));
 }
 
 void DirectEvalCodeCache::clear()

--- a/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
+++ b/Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h
@@ -39,11 +39,20 @@ namespace JSC {
 
     class DirectEvalCodeCache {
     public:
+        enum class RopeSuffix : uint8_t {
+            None,
+            FunctionCall
+        };
+
+        class CacheLookupKey;
+
         class CacheKey {
+            friend class CacheLookupKey;
         public:
-            CacheKey(const String& source, BytecodeIndex bytecodeIndex)
-                : m_source(source.impl())
+            CacheKey(StringImpl* source, BytecodeIndex bytecodeIndex, RopeSuffix ropeSuffix)
+                : m_source(source)
                 , m_bytecodeIndex(bytecodeIndex)
+                , m_ropeSuffix(ropeSuffix)
             {
             }
 
@@ -54,13 +63,13 @@ namespace JSC {
 
             CacheKey() = default;
 
-            unsigned hash() const { return m_source->hash() ^ m_bytecodeIndex.asBits(); }
+            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits() + enumToUnderlyingType(m_ropeSuffix); }
 
             bool isEmptyValue() const { return !m_source; }
 
             bool operator==(const CacheKey& other) const
             {
-                return m_bytecodeIndex == other.m_bytecodeIndex && WTF::equal(m_source.get(), other.m_source.get());
+                return m_bytecodeIndex == other.m_bytecodeIndex && m_ropeSuffix == other.m_ropeSuffix && WTF::equal(m_source.get(), other.m_source.get());
             }
 
             bool isHashTableDeletedValue() const { return m_source.isHashTableDeletedValue(); }
@@ -82,17 +91,61 @@ namespace JSC {
         private:
             RefPtr<StringImpl> m_source;
             BytecodeIndex m_bytecodeIndex;
+            RopeSuffix m_ropeSuffix;
         };
 
-        DirectEvalExecutable* tryGet(const String& evalSource, BytecodeIndex bytecodeIndex)
+        class CacheLookupKey {
+            void* operator new(size_t) = delete;
+
+        public:
+            CacheLookupKey(StringImpl* source, BytecodeIndex bytecodeIndex, RopeSuffix ropeSuffix)
+                : m_source(source)
+                , m_bytecodeIndex(bytecodeIndex)
+                , m_ropeSuffix(ropeSuffix)
+            {
+            }
+
+            CacheLookupKey() = default;
+
+            unsigned hash() const { return m_source->hash() + m_bytecodeIndex.asBits() + enumToUnderlyingType(m_ropeSuffix); }
+
+            bool operator==(const CacheKey& other) const
+            {
+                return m_bytecodeIndex == other.m_bytecodeIndex && m_ropeSuffix == other.m_ropeSuffix && WTF::equal(m_source, other.m_source.get());
+            }
+
+            operator CacheKey() const
+            {
+                return CacheKey(m_source, m_bytecodeIndex, m_ropeSuffix);
+            }
+
+        private:
+            SUPPRESS_UNCOUNTED_MEMBER StringImpl* m_source;
+            BytecodeIndex m_bytecodeIndex;
+            RopeSuffix m_ropeSuffix;
+        };
+
+        struct CacheLookupKeyHashTranslator {
+            static unsigned hash(const CacheLookupKey& key)
+            {
+                return key.hash();
+            }
+
+            static bool equal(const CacheKey& a, const CacheLookupKey& b)
+            {
+                return b == a;
+            }
+        };
+
+        DirectEvalExecutable* get(const CacheLookupKey& cacheKey)
         {
-            return m_cacheMap.inlineGet(CacheKey(evalSource, bytecodeIndex)).get();
+            return m_cacheMap.inlineGet<CacheLookupKeyHashTranslator>(cacheKey).get();
         }
         
-        void set(JSGlobalObject* globalObject, JSCell* owner, const String& evalSource, BytecodeIndex bytecodeIndex, DirectEvalExecutable* evalExecutable)
+        void set(JSGlobalObject* globalObject, JSCell* owner, const CacheLookupKey& cacheKey, DirectEvalExecutable* evalExecutable)
         {
             if (m_cacheMap.size() < maxCacheEntries)
-                setSlow(globalObject, owner, evalSource, bytecodeIndex, evalExecutable);
+                setSlow(globalObject, owner, cacheKey, evalExecutable);
         }
 
         bool isEmpty() const { return m_cacheMap.isEmpty(); }
@@ -104,7 +157,7 @@ namespace JSC {
     private:
         static constexpr int maxCacheEntries = 64;
 
-        void setSlow(JSGlobalObject*, JSCell* owner, const String& evalSource, BytecodeIndex, DirectEvalExecutable*);
+        void setSlow(JSGlobalObject*, JSCell* owner, const CacheLookupKey& cacheKey, DirectEvalExecutable*);
 
         typedef UncheckedKeyHashMap<CacheKey, WriteBarrier<DirectEvalExecutable>, CacheKey::Hash, CacheKey::HashTraits> EvalCacheMap;
         EvalCacheMap m_cacheMap;

--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.h
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EnsureStillAliveHere.h"
+#include <wtf/text/StringView.h>
 
 namespace JSC {
 
@@ -66,6 +67,10 @@ class JSCell;
 
 template<typename T>
 struct GCOwnedDataScope {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    GCOwnedDataScope() = default;
+
     GCOwnedDataScope(const JSCell* cell, T value)
         : owner(cell)
         , data(value)
@@ -87,8 +92,8 @@ struct GCOwnedDataScope {
     // Convenience conversion for String -> StringView
     operator StringView() const requires (std::is_same_v<std::decay_t<T>, String>) { return data; }
 
-    const JSCell* owner;
-    T data;
+    const JSCell* owner { nullptr };
+    SUPPRESS_UNCOUNTED_MEMBER T data { };
 };
 
 }

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -102,12 +102,14 @@ CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
         dump(locker, WTF::dataFile());
         dataLog(": Enqueueing plan to optimize ", plan->key(), "\n");
     }
-    unsigned tier = static_cast<unsigned>(plan->tier());
+
+    auto tier = static_cast<unsigned>(plan->tier());
+
     ASSERT(m_plans.find(plan->key()) == m_plans.end());
     m_plans.add(plan->key(), plan.copyRef());
     m_queues[tier].append(WTFMove(plan));
 
-    if (m_numberOfActiveThreads < Options::numberOfWorklistThreads()
+    if (m_numberOfActiveThreads < m_threads.size()
         && m_ongoingCompilationsPerTier[tier] < m_maximumNumberOfConcurrentCompilationsPerTier[tier]) {
         m_planEnqueued->notifyOne(locker);
         m_numberOfActiveThreads++;

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1197,8 +1197,8 @@ static ALWAYS_INLINE JSValue getByVal(VM& vm, JSGlobalObject* globalObject, Code
         if (JSCell::canUseFastGetOwnProperty(structure)) {
             auto existingAtomString = asString(subscript)->toExistingAtomString(globalObject);
             RETURN_IF_EXCEPTION(scope, JSValue());
-            if (!existingAtomString.isNull()) {
-                if (JSValue result = baseValue.asCell()->fastGetOwnProperty(vm, structure, existingAtomString.impl()))
+            if (existingAtomString) {
+                if (JSValue result = baseValue.asCell()->fastGetOwnProperty(vm, structure, existingAtomString.data))
                     return result;
             }
         }

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -315,7 +315,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
 
     VariableEnvironment& varDeclarations = scope->declaredVariables();
     for (auto& entry : capturedVariables)
-        varDeclarations.markVariableAsCaptured(entry);
+        varDeclarations.markVariableAsCaptured(entry.get());
     scope->finalizeLexicalEnvironment();
 
     if (isGeneratorWrapperParseMode(parseMode) || isAsyncFunctionOrAsyncGeneratorWrapperParseMode(parseMode)) {
@@ -503,13 +503,13 @@ end:
 
     for (const auto& pair : m_moduleScopeData->exportedBindings()) {
         const auto& uid = pair.key;
-        if (currentScope()->hasDeclaredVariable(uid)) {
-            currentScope()->declaredVariables().markVariableAsExported(uid);
+        if (currentScope()->hasDeclaredVariable(uid.get())) {
+            currentScope()->declaredVariables().markVariableAsExported(uid.get());
             continue;
         }
 
-        if (currentScope()->hasLexicallyDeclaredVariable(uid)) {
-            currentScope()->lexicalVariables().markVariableAsExported(uid);
+        if (currentScope()->hasLexicallyDeclaredVariable(uid.get())) {
+            currentScope()->lexicalVariables().markVariableAsExported(uid.get());
             continue;
         }
 

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -484,9 +484,9 @@ public:
         return hasDeclaredVariable(ident.impl());
     }
 
-    bool hasDeclaredVariable(const RefPtr<UniquedStringImpl>& ident)
+    bool hasDeclaredVariable(const UniquedStringImpl* ident)
     {
-        auto iter = m_declaredVariables.find(ident.get());
+        auto iter = m_declaredVariables.find(ident);
         if (iter == m_declaredVariables.end())
             return false;
         VariableEnvironmentEntry entry = iter->value;
@@ -498,9 +498,9 @@ public:
         return hasLexicallyDeclaredVariable(ident.impl());
     }
 
-    bool hasLexicallyDeclaredVariable(const RefPtr<UniquedStringImpl>& ident) const
+    bool hasLexicallyDeclaredVariable(const UniquedStringImpl* ident) const
     {
-        return m_lexicalVariables.contains(ident.get());
+        return m_lexicalVariables.contains(ident);
     }
 
     bool hasPrivateName(const Identifier& ident)
@@ -569,9 +569,9 @@ public:
         return hasDeclaredParameter(ident.impl());
     }
 
-    bool hasDeclaredParameter(const RefPtr<UniquedStringImpl>& ident)
+    bool hasDeclaredParameter(UniquedStringImpl* ident)
     {
-        return m_declaredParameters.contains(ident.get()) || hasDeclaredVariable(ident);
+        return m_declaredParameters.contains(ident) || hasDeclaredVariable(ident);
     }
     
     void preventAllVariableDeclarations()

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -48,14 +48,14 @@ VariableEnvironment& VariableEnvironment::operator=(const VariableEnvironment& o
     return *this;
 }
 
-void VariableEnvironment::markVariableAsCapturedIfDefined(const RefPtr<UniquedStringImpl>& identifier)
+void VariableEnvironment::markVariableAsCapturedIfDefined(const UniquedStringImpl* identifier)
 {
     auto findResult = m_map.find(identifier);
     if (findResult != m_map.end())
         findResult->value.setIsCaptured();
 }
 
-void VariableEnvironment::markVariableAsCaptured(const RefPtr<UniquedStringImpl>& identifier)
+void VariableEnvironment::markVariableAsCaptured(const UniquedStringImpl* identifier)
 {
     auto findResult = m_map.find(identifier);
     RELEASE_ASSERT(findResult != m_map.end());
@@ -102,14 +102,14 @@ void VariableEnvironment::swap(VariableEnvironment& other)
     m_rareData.swap(other.m_rareData);
 }
 
-void VariableEnvironment::markVariableAsImported(const RefPtr<UniquedStringImpl>& identifier)
+void VariableEnvironment::markVariableAsImported(const UniquedStringImpl* identifier)
 {
     auto findResult = m_map.find(identifier);
     RELEASE_ASSERT(findResult != m_map.end());
     findResult->value.setIsImported();
 }
 
-void VariableEnvironment::markVariableAsExported(const RefPtr<UniquedStringImpl>& identifier)
+void VariableEnvironment::markVariableAsExported(const UniquedStringImpl* identifier)
 {
     auto findResult = m_map.find(identifier);
     RELEASE_ASSERT(findResult != m_map.end());

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -179,18 +179,18 @@ public:
 
     ALWAYS_INLINE unsigned size() const { return m_map.size() + privateNamesSize(); }
     ALWAYS_INLINE unsigned mapSize() const { return m_map.size(); }
-    ALWAYS_INLINE bool contains(const RefPtr<UniquedStringImpl>& identifier) const { return m_map.contains(identifier); }
-    ALWAYS_INLINE bool remove(const RefPtr<UniquedStringImpl>& identifier) { return m_map.remove(identifier); }
-    ALWAYS_INLINE Map::iterator find(const RefPtr<UniquedStringImpl>& identifier) { return m_map.find(identifier); }
-    ALWAYS_INLINE Map::const_iterator find(const RefPtr<UniquedStringImpl>& identifier) const { return m_map.find(identifier); }
+    ALWAYS_INLINE bool contains(const UniquedStringImpl* identifier) const { return m_map.contains(identifier); }
+    ALWAYS_INLINE bool remove(const UniquedStringImpl* identifier) { return m_map.remove(identifier); }
+    ALWAYS_INLINE Map::iterator find(const UniquedStringImpl* identifier) { return m_map.find(identifier); }
+    ALWAYS_INLINE Map::const_iterator find(const UniquedStringImpl* identifier) const { return m_map.find(identifier); }
     void swap(VariableEnvironment& other);
-    void markVariableAsCapturedIfDefined(const RefPtr<UniquedStringImpl>& identifier);
-    void markVariableAsCaptured(const RefPtr<UniquedStringImpl>& identifier);
+    void markVariableAsCapturedIfDefined(const UniquedStringImpl* identifier);
+    void markVariableAsCaptured(const UniquedStringImpl* identifier);
     void markAllVariablesAsCaptured();
     bool hasCapturedVariables() const;
     bool captures(UniquedStringImpl* identifier) const;
-    void markVariableAsImported(const RefPtr<UniquedStringImpl>& identifier);
-    void markVariableAsExported(const RefPtr<UniquedStringImpl>& identifier);
+    void markVariableAsImported(const UniquedStringImpl* identifier);
+    void markVariableAsExported(const UniquedStringImpl* identifier);
 
     bool isEverythingCaptured() const { return m_isEverythingCaptured; }
     bool isEmpty() const { return !m_map.size() && !privateNamesSize(); }

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -139,6 +139,9 @@ public:
         }
     }
 
+    EncodedJSValue* begin() { return m_buffer; }
+    EncodedJSValue* end() { return m_buffer + m_size; }
+
     auto at(unsigned i) const -> decltype(auto)
     {
         if constexpr (std::is_same_v<T, JSValue>) {

--- a/Source/JavaScriptCore/runtime/CacheableIdentifier.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GCOwnedDataScope.h"
 #include "JSCJSValue.h"
 #include <wtf/text/SymbolImpl.h>
 
@@ -78,6 +79,9 @@ public:
 
     static inline bool isCacheableIdentifierCell(JSCell*);
     static inline bool isCacheableIdentifierCell(JSValue);
+
+    static inline GCOwnedDataScope<const UniquedStringImpl*> getCacheableIdentifier(JSCell*);
+    static inline GCOwnedDataScope<const UniquedStringImpl*> getCacheableIdentifier(JSValue);
 
     uintptr_t rawBits() const { return m_bits; }
 

--- a/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
@@ -112,6 +112,25 @@ inline bool CacheableIdentifier::isCacheableIdentifierCell(JSValue value)
     return isCacheableIdentifierCell(value.asCell());
 }
 
+inline GCOwnedDataScope<const UniquedStringImpl*> CacheableIdentifier::getCacheableIdentifier(JSCell* cell)
+{
+    if (cell->isSymbol())
+        return { cell, &asSymbol(cell)->uid() };
+    if (!cell->isString())
+        return { };
+    JSString* string = jsCast<JSString*>(cell);
+    if (const StringImpl* impl = string->tryGetValueImpl(); impl && impl->isAtom())
+        return { cell, static_cast<const AtomStringImpl*>(impl) };
+    return { };
+}
+
+inline GCOwnedDataScope<const UniquedStringImpl*> CacheableIdentifier::getCacheableIdentifier(JSValue value)
+{
+    if (!value.isCell())
+        return { };
+    return getCacheableIdentifier(value.asCell());
+}
+
 inline bool CacheableIdentifier::isSymbolCell() const
 {
     return isCell() && cell()->isSymbol();

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1164,8 +1164,8 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_get_by_val_with_this)
         if (JSCell::canUseFastGetOwnProperty(structure)) {
             auto existingAtomString = asString(subscript)->toExistingAtomString(globalObject);
             CHECK_EXCEPTION();
-            if (!existingAtomString.isNull()) {
-                if (JSValue result = baseValue.asCell()->fastGetOwnProperty(vm, structure, existingAtomString.impl()))
+            if (existingAtomString) {
+                if (JSValue result = baseValue.asCell()->fastGetOwnProperty(vm, structure, existingAtomString.data))
                     RETURN_PROFILED(result);
             }
         }

--- a/Source/JavaScriptCore/runtime/EnsureStillAliveHere.h
+++ b/Source/JavaScriptCore/runtime/EnsureStillAliveHere.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 namespace JSC {
 
 ALWAYS_INLINE void ensureStillAliveHere(uint64_t value)

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -79,7 +79,7 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(std::span<const CharType> chara
     return value;
 }
 
-ALWAYS_INLINE std::optional<uint32_t> parseIndex(StringImpl& impl)
+ALWAYS_INLINE std::optional<uint32_t> parseIndex(const StringImpl& impl)
 {
     return impl.is8Bit() ? parseIndex(impl.span8()) : parseIndex(impl.span16());
 }
@@ -93,7 +93,8 @@ public:
 
     const AtomString& string() const { return m_string; }
 
-    UniquedStringImpl* impl() const { return static_cast<UniquedStringImpl*>(m_string.impl()); }
+    UniquedStringImpl* impl() const { return m_string.impl(); }
+    RefPtr<AtomStringImpl> releaseImpl() { return m_string.releaseImpl(); }
 
     int length() const { return m_string.length(); }
 

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -46,10 +46,10 @@ public:
     using Cache = std::array<Slot, capacity>;
 
     template<typename CharacterType>
-    ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(std::span<const CharacterType> characters)
-    {
-        return make(characters);
-    }
+    ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(std::span<const CharacterType> characters);
+
+    template<typename CharacterType>
+    ALWAYS_INLINE AtomStringImpl* existingIdentifier(std::span<const CharacterType> characters);
 
     ALWAYS_INLINE void clear()
     {
@@ -59,9 +59,6 @@ public:
     VM& vm() const;
 
 private:
-    template<typename CharacterType>
-    Ref<AtomStringImpl> make(std::span<const CharacterType>);
-
     ALWAYS_INLINE Slot& cacheSlot(UChar firstCharacter, UChar lastCharacter, UChar length)
     {
         unsigned hash = (firstCharacter << 6) ^ ((lastCharacter << 14) ^ firstCharacter);

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -32,12 +32,11 @@
 
 namespace JSC {
 
-// FIXME: This should take in a std::span.
 template<typename CharacterType>
-ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(std::span<const CharacterType> characters)
+ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::makeIdentifier(std::span<const CharacterType> characters)
 {
     if (characters.empty())
-        return *static_cast<AtomStringImpl*>(StringImpl::empty());
+        return *emptyAtom().impl();
 
     auto firstCharacter = characters.front();
     if (characters.size() == 1) {
@@ -57,6 +56,27 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(std::span<const Char
     }
 
     return *slot.m_impl;
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE AtomStringImpl* JSONAtomStringCache::existingIdentifier(std::span<const CharacterType> characters)
+{
+    if (characters.empty())
+        return emptyAtom().impl();
+
+    auto firstCharacter = characters.front();
+    if (characters.size() == 1) {
+        if (firstCharacter <= maxSingleCharacterString)
+            return vm().smallStrings.existingSingleCharacterStringRep(firstCharacter);
+    } else if (UNLIKELY(characters.size() > maxStringLengthForCache))
+        return nullptr;
+
+    auto lastCharacter = characters.back();
+    auto& slot = cacheSlot(firstCharacter, lastCharacter, characters.size());
+    if (UNLIKELY(slot.m_length != characters.size() || !equal(slot.m_buffer, characters)))
+        return nullptr;
+
+    return slot.m_impl.get();
 }
 
 ALWAYS_INLINE VM& JSONAtomStringCache::vm() const

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -220,8 +220,7 @@ inline PropertyNameForFunctionCall::PropertyNameForFunctionCall(PropertyName pro
 }
 
 inline PropertyNameForFunctionCall::PropertyNameForFunctionCall(unsigned number)
-    : m_propertyName(nullptr)
-    , m_number(number)
+    : m_number(number)
 {
 }
 
@@ -604,7 +603,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
         stringifyResult = stringifier.appendStringifiedValue(builder, value, *this, index);
         ASSERT(stringifyResult != StringifyFailedDueToUndefinedOrSymbolValue);
     } else {
-        PropertyName propertyName { nullptr };
+        PropertyName propertyName;
         JSValue value;
         if (m_hasFastObjectProperties) {
             propertyName = std::get<0>(m_propertiesAndOffsets[index]);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4170,13 +4170,13 @@ TransitionKind JSObject::suggestedArrayStorageTransition() const
     return TransitionKind::AllocateArrayStorage;
 }
 
-void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl>* properties, const EncodedJSValue* values, unsigned size)
+void JSObject::putOwnDataPropertyBatching(VM& vm, UniquedStringImpl** properties, const EncodedJSValue* values, unsigned size)
 {
     unsigned i = 0;
     Structure* structure = this->structure();
     if (!(structure->isDictionary() || (structure->transitionCountEstimate() + size) > Structure::s_maxTransitionLength || !structure->canPerformFastPropertyEnumerationCommon())) {
         Vector<PropertyOffset, 16> offsets(size, [&](size_t index) -> std::optional<PropertyOffset> {
-            PropertyName propertyName(properties[index].get());
+            PropertyName propertyName(properties[index]);
 
             PropertyOffset offset;
             if (Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(structure, propertyName, 0, offset)) {
@@ -4233,7 +4233,7 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
 
     for (; i < size; ++i) {
         PutPropertySlot putPropertySlot(this, true);
-        putOwnDataProperty(vm, properties[i].get(), JSValue::decode(values[i]), putPropertySlot);
+        putOwnDataProperty(vm, properties[i], JSValue::decode(values[i]), putPropertySlot);
     }
 }
 
@@ -4257,12 +4257,6 @@ ASCIILiteral JSObject::putDirectToDictionaryWithoutExtensibility(VM& vm, Propert
     }
 
     return NonExtensibleObjectPropertyDefineError;
-}
-
-NEVER_INLINE void JSObject::putDirectForJSONSlow(VM& vm, PropertyName propertyName, JSValue value)
-{
-    PutPropertySlot slot(this);
-    putDirectInternal<PutModeDefineOwnPropertyForJSONSlow>(vm, propertyName, value, 0, slot);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -105,7 +105,6 @@ class JSObject : public JSCell {
     enum PutMode : uint8_t {
         PutModePut,
         PutModeDefineOwnProperty,
-        PutModeDefineOwnPropertyForJSONSlow,
     };
 
 public:
@@ -738,7 +737,6 @@ public:
     bool putDirect(VM&, PropertyName, JSValue, unsigned attributes = 0);
     bool putDirect(VM&, PropertyName, JSValue, unsigned attributes, PutPropertySlot&);
     bool putDirect(VM&, PropertyName, JSValue, PutPropertySlot&);
-    void putDirectForJSONSlow(VM&, PropertyName, JSValue);
     void putDirectWithoutTransition(VM&, PropertyName, JSValue, unsigned attributes = 0);
     bool putDirectNonIndexAccessor(VM&, PropertyName, GetterSetter*, unsigned attributes);
     void putDirectNonIndexAccessorWithoutTransition(VM&, PropertyName, GetterSetter*, unsigned attributes);
@@ -878,7 +876,7 @@ public:
     bool putOwnDataProperty(VM&, PropertyName, JSValue, PutPropertySlot&);
     bool putOwnDataPropertyMayBeIndex(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
-    void putOwnDataPropertyBatching(VM&, const RefPtr<UniquedStringImpl>*, const EncodedJSValue*, unsigned size);
+    void putOwnDataPropertyBatching(VM&, UniquedStringImpl**, const EncodedJSValue*, unsigned size);
 private:
     void validatePutOwnDataProperty(VM&, PropertyName, JSValue);
 public:

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -408,7 +408,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
 
             // FIXME: Check attributes against PropertyAttribute::CustomAccessorOrValue. Changing GetterSetter should work w/o transition.
             // https://bugs.webkit.org/show_bug.cgi?id=214342
-            if ((mode == PutModeDefineOwnProperty || mode == PutModeDefineOwnPropertyForJSONSlow) && (newAttributes != attributes || (newAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
+            if ((mode == PutModeDefineOwnProperty) && (newAttributes != attributes || (newAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
                 DeferredStructureTransitionWatchpointFire deferred(vm, structure);
                 setStructure(vm, Structure::attributeChangeTransition(vm, structure, propertyName, newAttributes, &deferred));
                 if (UNLIKELY(mayBePrototype()))
@@ -430,8 +430,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
         return { };
     }
 
-    // In PutModeDefineOwnPropertyForJSONSlow, this is already checked.
-    if constexpr (mode != PutModeDefineOwnPropertyForJSONSlow) {
+    {
         PropertyOffset offset;
         Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(structure, propertyName, newAttributes, offset);
         if (newStructure) {
@@ -468,7 +467,7 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
 
         // FIXME: Check attributes against PropertyAttribute::CustomAccessorOrValue. Changing GetterSetter should work w/o transition.
         // https://bugs.webkit.org/show_bug.cgi?id=214342
-        if ((mode == PutModeDefineOwnProperty || mode == PutModeDefineOwnPropertyForJSONSlow) && (newAttributes != currentAttributes || (newAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
+        if ((mode == PutModeDefineOwnProperty) && (newAttributes != currentAttributes || (newAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
             // We want the structure transition watchpoint to fire after this object has switched structure.
             // This allows adaptive watchpoints to observe if the new structure is the one we want.
             DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, structure);

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
@@ -181,7 +181,7 @@ JSString* JSPropertyNameEnumerator::computeNext(JSGlobalObject* globalObject, JS
         scope.assertNoException();
 
         if (index < indexedLength())
-            return shouldAllocateIndexedNameString ? jsString(vm, Identifier::from(vm, index).string()) : nullptr;
+            return shouldAllocateIndexedNameString ? jsString(vm, Identifier::from(vm, index).releaseImpl()) : nullptr;
 
         if (!sizeOfPropertyNames())
             return nullptr;
@@ -202,9 +202,9 @@ JSString* JSPropertyNameEnumerator::computeNext(JSGlobalObject* globalObject, JS
                 break;
             if (index < endStructurePropertyIndex() && base->structureID() == cachedStructureID())
                 break;
-            auto id = name->toIdentifier(globalObject);
+            auto id = name->toAtomString(globalObject);
             RETURN_IF_EXCEPTION(scope, nullptr);
-            if (base->hasEnumerableProperty(globalObject, id))
+            if (base->hasEnumerableProperty(globalObject, id.data))
                 break;
             RETURN_IF_EXCEPTION(scope, nullptr);
             name = nullptr;

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -210,6 +210,31 @@ inline void JSRopeString::convertToNonRope(String&& string) const
     notifyNeedsDestruction();
 }
 
+inline StringImpl* JSRopeString::tryGetLHS(ASCIILiteral rhs) const
+{
+    if (isSubstring())
+        return nullptr;
+
+    JSString* fiber2 = this->fiber2();
+    if (fiber2)
+        return nullptr;
+
+    JSString* fiber1 = this->fiber1();
+    ASSERT(fiber1);
+    if (fiber1->isRope())
+        return nullptr;
+
+    JSString* fiber0 = this->fiber0();
+    ASSERT(fiber0);
+    if (fiber0->isRope())
+        return nullptr;
+
+    if (fiber1->valueInternal() != rhs)
+        return nullptr;
+
+    return fiber0->valueInternal().impl();
+}
+
 // Overview: These functions convert a JSString from holding a string in rope form
 // down to a simple String representation. It does so by building up the string
 // backwards, since we want to avoid recursion, we expect that the tree structure

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -291,8 +291,10 @@ private:
 
     JSValue parsePrimitiveValue(VM&);
 
-    ALWAYS_INLINE Identifier makeIdentifier(VM&, typename Lexer::LiteralParserTokenPtr);
-    ALWAYS_INLINE JSString* makeJSString(VM&, typename Lexer::LiteralParserTokenPtr);
+    static ALWAYS_INLINE bool equalIdentifier(UniquedStringImpl*, typename Lexer::LiteralParserTokenPtr);
+    static ALWAYS_INLINE AtomStringImpl* existingIdentifier(VM&, typename Lexer::LiteralParserTokenPtr);
+    static ALWAYS_INLINE Identifier makeIdentifier(VM&, typename Lexer::LiteralParserTokenPtr);
+    static ALWAYS_INLINE JSString* makeJSString(VM&, typename Lexer::LiteralParserTokenPtr);
 
     void setErrorMessageForToken(TokenType);
 

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -36,7 +36,7 @@ class SmallStrings;
 
 class NumericStrings {
 public:
-    static const size_t cacheSize = 256;
+    static const size_t cacheSize = 1024;
 
     template<typename T>
     struct CacheEntry {

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -281,7 +281,7 @@ ALWAYS_INLINE JSObject* tryCreateObjectViaCloning(VM& vm, JSGlobalObject* global
     return target;
 }
 
-ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
+ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject* target, JSObject* source, Vector<UniquedStringImpl*, 8>& properties, MarkedArgumentBuffer& values)
 {
     // |source| Structure does not have any getters. And target can perform fast put.
     // So enumerating properties and putting properties are non observable.
@@ -315,6 +315,7 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject*
     if (source->canHaveExistingOwnIndexedGetterSetterProperties())
         return false;
 
+    EnsureStillAliveScope sourceStructureScope(sourceStructure);
     sourceStructure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
         if (entry.attributes() & PropertyAttribute::DontEnum)
             return true;
@@ -323,7 +324,7 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject*
         if (propertyName.isPrivateName())
             return true;
 
-        properties.append(entry.key());
+        properties.append(entry.key()); // sourceStructure ensures the lifetimes of these strings.
         values.appendWithCrashOnOverflow(source->getDirect(entry.offset()));
 
         return true;
@@ -337,6 +338,7 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject*
     // Actually, assigning with empty object (option for example) is common. (`Object.assign(defaultOptions, passedOptions)` where `passedOptions` is empty object.)
     if (properties.size())
         target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
+
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.h
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.h
@@ -49,6 +49,6 @@ private:
 
 JS_EXPORT_PRIVATE JSC_DECLARE_HOST_FUNCTION(objectProtoFuncToString);
 JSString* objectPrototypeToString(JSGlobalObject*, JSValue thisValue);
-bool objectPrototypeHasOwnProperty(JSGlobalObject*, JSObject* base, const Identifier& property);
+bool objectPrototypeHasOwnProperty(JSGlobalObject*, JSObject* base, PropertyName);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -37,6 +37,17 @@ namespace JSC {
 
 class PropertyName {
 public:
+    PropertyName()
+        : m_impl(nullptr)
+    {
+    }
+
+    // FIXME: Make PropertyName const-correct.
+    PropertyName(const UniquedStringImpl* propertyName)
+        : m_impl(const_cast<UniquedStringImpl*>(propertyName))
+    {
+    }
+
     PropertyName(UniquedStringImpl* propertyName)
         : m_impl(propertyName)
     {

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -122,6 +122,13 @@ Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char charact
     return AtomStringImpl::add(string).releaseNonNull();
 }
 
+AtomStringImpl* SmallStrings::existingSingleCharacterStringRep(unsigned char character)
+{
+    if (UNLIKELY(!m_isInitialized))
+        return nullptr;
+    return static_cast<AtomStringImpl*>(const_cast<StringImpl*>(m_singleCharacterStrings[character]->tryGetValueImpl()));
+}
+
 void SmallStrings::initialize(VM* vm, JSString*& string, ASCIILiteral value)
 {
     string = JSString::create(*vm, AtomStringImpl::add(value));

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -75,6 +75,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     JS_EXPORT_PRIVATE Ref<AtomStringImpl> singleCharacterStringRep(unsigned char character);
+    JS_EXPORT_PRIVATE AtomStringImpl* existingSingleCharacterStringRep(unsigned char character);
 
     void setIsInitialized(bool isInitialized) { m_isInitialized = isInitialized; }
 

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -82,7 +82,7 @@ void StructureTransitionTable::add(VM& vm, JSCell* owner, Structure* structure)
     }
 
     // Add the structure to the map.
-    map()->set(StructureTransitionTable::Hash::createFromStructure(structure), structure);
+    map()->set(StructureTransitionTable::Hash::createKeyFromStructure(structure), structure);
 }
 
 void Structure::dumpStatistics()

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -301,6 +301,8 @@ public:
         return false;
     }
 
+    Structure* trySingleTransition() { return m_transitionTable.trySingleTransition(); }
+
     JS_EXPORT_PRIVATE static Structure* addPropertyTransition(VM&, Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* addNewPropertyTransition(VM&, Structure*, PropertyName, unsigned attributes, PropertyOffset&, PutPropertySlot::Context = PutPropertySlot::UnknownContext, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* addPropertyTransitionToExistingStructureConcurrently(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -817,7 +817,7 @@ ALWAYS_INLINE Structure* Structure::addPropertyTransitionToExistingStructureConc
     return addPropertyTransitionToExistingStructureImpl(structure, uid, attributes, offset);
 }
 
-ALWAYS_INLINE StructureTransitionTable::Hash::Key StructureTransitionTable::Hash::createFromStructure(Structure* structure)
+ALWAYS_INLINE StructureTransitionTable::Hash::Key StructureTransitionTable::Hash::createKeyFromStructure(Structure* structure)
 {
     switch (structure->transitionKind()) {
     case TransitionKind::ChangePrototype:
@@ -839,7 +839,11 @@ inline Structure* StructureTransitionTable::get(PointerKey rep, unsigned attribu
 {
     if (isUsingSingleSlot()) {
         auto* transition = trySingleTransition();
-        return (transition && Hash::createFromStructure(transition) == Hash::createKey(rep, attributes, transitionKind)) ? transition : nullptr;
+        if (!transition)
+            return nullptr;
+        if (Hash::createKeyFromStructure(transition) != Hash::createKey(rep, attributes, transitionKind))
+            return nullptr;
+        return transition;
     }
     return map()->get(StructureTransitionTable::Hash::createKey(rep, attributes, transitionKind));
 }

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -231,7 +231,7 @@ class StructureTransitionTable {
             return a == b;
         }
 
-        static Key createFromStructure(Structure*);
+        static Key createKeyFromStructure(Structure*);
         static Key createKey(PointerKey impl, unsigned attributes, TransitionKind transitionKind)
         {
             return Key { impl, attributes, transitionKind };
@@ -254,7 +254,7 @@ class StructureTransitionTable {
             return a == b;
         }
 
-        static Key createFromStructure(Structure*);
+        static Key createKeyFromStructure(Structure*);
         static Key createKey(PointerKey impl, unsigned attributes, TransitionKind transitionKind)
         {
             return Key { impl.pointer(), attributes, transitionKind };

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		143A90BA2CC2F08D002D3E27 /* IndexedRange.h in Headers */ = {isa = PBXBuildFile; fileRef = 143A90B92CC2F08D002D3E27 /* IndexedRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		143DDE9620C8BC37007F76FA /* Entitlements.mm in Sources */ = {isa = PBXBuildFile; fileRef = 143DDE9520C8BC37007F76FA /* Entitlements.mm */; };
 		143F611F1565F0F900DB514A /* RAMSize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 143F611D1565F0F900DB514A /* RAMSize.cpp */; };
+		144177D62D89B7C100F5099E /* ValueOrReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 144177D52D89B7C100F5099E /* ValueOrReference.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 144EB7452CBC94B100926E1B /* AbstractRefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		145DE2882CE95CE700F9F1D2 /* ZippedRange.h in Headers */ = {isa = PBXBuildFile; fileRef = 145DE2872CE95CE700F9F1D2 /* ZippedRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1469419D16EAB10A0024E146 /* AutodrainedPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */; };
@@ -1168,6 +1169,7 @@
 		143DDE9720C8BE99007F76FA /* Entitlements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Entitlements.h; sourceTree = "<group>"; };
 		143F611D1565F0F900DB514A /* RAMSize.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RAMSize.cpp; sourceTree = "<group>"; };
 		143F611E1565F0F900DB514A /* RAMSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RAMSize.h; sourceTree = "<group>"; };
+		144177D52D89B7C100F5099E /* ValueOrReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ValueOrReference.h; sourceTree = "<group>"; };
 		1447AEC518FCE57700B3D7FF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		1447AECA18FCE5B900B3D7FF /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = /usr/lib/libicucore.dylib; sourceTree = "<absolute>"; };
 		144EB7452CBC94B100926E1B /* AbstractRefCounted.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractRefCounted.h; sourceTree = "<group>"; };
@@ -2676,6 +2678,7 @@
 				A8A47311151A825B004123FG /* ValidatedReinterpretCast.h */,
 				A8A4736F151A825B004123FF /* ValueCheck.h */,
 				FA864D5F2DA9809F006820D3 /* Variant.h */,
+				144177D52D89B7C100F5099E /* ValueOrReference.h */,
 				BCE0DFAA2D18670B003F0349 /* VariantExtras.h */,
 				BCEA08032CCFDB33000AC148 /* VariantList.h */,
 				BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */,
@@ -3817,6 +3820,7 @@
 				DD3DC98127A4BF8E007E5B62 /* ValidatedReinterpretCast.h in Headers */,
 				DD3DC86D27A4BF8E007E5B61 /* ValueCheck.h in Headers */,
 				FA864D602DA9809F006820D3 /* Variant.h in Headers */,
+				144177D62D89B7C100F5099E /* ValueOrReference.h in Headers */,
 				BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */,
 				BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */,
 				BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -368,6 +368,7 @@ set(WTF_PUBLIC_HEADERS
     VMTags.h
     ValidatedReinterpretCast.h
     ValueCheck.h
+    ValueOrReference.h
     Variant.h
     VariantExtras.h
     VariantList.h

--- a/Source/WTF/wtf/RefCountedFixedVector.h
+++ b/Source/WTF/wtf/RefCountedFixedVector.h
@@ -70,17 +70,6 @@ public:
         return create(Base::begin(), Base::end());
     }
 
-    bool operator==(const RefCountedFixedVectorBase& other) const
-    {
-        if (Base::size() != other.size())
-            return false;
-        for (unsigned i = 0; i < Base::size(); ++i) {
-            if (Base::at(i) != other.at(i))
-                return false;
-        }
-        return true;
-    }
-
 private:
     explicit RefCountedFixedVectorBase(unsigned size)
         : Base(size)
@@ -93,6 +82,18 @@ private:
     {
     }
 };
+
+template<typename T, bool isThreadSafe, typename U>
+inline bool operator==(const RefCountedFixedVectorBase<T, isThreadSafe>& a, const U& b)
+{
+    if (a.size() != b.size())
+        return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a.at(i) != b.at(i))
+            return false;
+    }
+    return true;
+}
 
 template<typename T>
 using RefCountedFixedVector = RefCountedFixedVectorBase<T, false>;

--- a/Source/WTF/wtf/ValueOrReference.h
+++ b/Source/WTF/wtf/ValueOrReference.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+// ValueOrReference<T> is just like const T&, except that it can also optionally hold T.
+
+// ValueOrReference<T> is an optimization when you need to return a value that is
+// usually an existing reference, but sometimes a temporary, e.g.:
+//
+// ValueOrReference<String> append(const String& string LIFETIME_BOUND, std::optional<String&> suffix)
+// {
+//     if (LIKELY(!suffix))
+//         return string; // existing reference -- ValueOrReference<T> avoids a copy
+//     return makeString(string, suffix.value()); // temporary -- ValueOrReference<T> holds T
+// }
+template<typename T> class ValueOrReference {
+public:
+    ValueOrReference()
+        : m_reference(m_value)
+    {
+    }
+
+    ValueOrReference(ValueOrReference&& other)
+        : m_value(WTFMove(other.m_value))
+        , m_reference(&other.m_reference == &other.m_value ? m_value : other.m_reference)
+    {
+    }
+
+    ValueOrReference(const T& reference LIFETIME_BOUND)
+        : m_reference(reference)
+    {
+    }
+
+    ValueOrReference(T&& temporary)
+        : m_value(WTFMove(temporary))
+        , m_reference(m_value)
+    {
+    }
+
+    operator const T&() const LIFETIME_BOUND { return m_reference; }
+    const T& get() const LIFETIME_BOUND { return m_reference; }
+    const T* operator->() const LIFETIME_BOUND { return &m_reference; }
+
+private:
+    T m_value;
+    const T& m_reference;
+};
+
+} // namespace WTF
+
+using WTF::ValueOrReference;

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -2105,6 +2105,15 @@ inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> moveToVector(
     return moveToVectorOf<typename CopyOrMoveToVectorResult<Collection>::Type>(collection);
 }
 
+template<typename T, size_t inlineCapacity = 0> static bool insertInUniquedSortedVector(Vector<T, inlineCapacity>& vector, const T& value)
+{
+    auto it = std::lower_bound(vector.begin(), vector.end(), value);
+    if (UNLIKELY(it != vector.end() && *it == value))
+        return false;
+    vector.insert(it - vector.begin(), value);
+    return true;
+}
+
 template<typename T> Vector(const T*, size_t) -> Vector<T>;
 template<typename T, size_t Extent> Vector(std::span<const T, Extent>) -> Vector<T>;
 
@@ -2117,6 +2126,7 @@ using WTF::copyToVectorOf;
 using WTF::copyToVectorSpecialization;
 using WTF::compactMap;
 using WTF::flatMap;
+using WTF::insertInUniquedSortedVector;
 using WTF::removeRepeatedElements;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include <wtf/text/StringImpl.h>
 
+#include <atomic>
 #include <wtf/Algorithms.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/AtomString.h>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1745,7 +1745,7 @@ VisiblePosition AccessibilityRenderObject::visiblePositionForIndex(int index) co
     if (m_renderer) {
         if (isNativeTextControl()) {
             auto& textControl = uncheckedDowncast<RenderTextControl>(*m_renderer).textFormControlElement();
-            return textControl.visiblePositionForIndex(std::clamp(index, 0, static_cast<int>(textControl.value().length())));
+            return textControl.visiblePositionForIndex(std::clamp(index, 0, static_cast<int>(textControl.value()->length())));
         }
 
         if (!allowsTextRanges() && !is<RenderText>(*m_renderer))
@@ -1840,13 +1840,13 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
                 auto innerRange = makeVisiblePositionRange(AXObjectCache::rangeForNodeContents(*innerText));
 
                 if (range.start.equals(textControlRange.end))
-                    start = textControl->value().length();
+                    start = textControl->value()->length();
                 else if (range.start <= innerRange.start)
                     start = 0;
 
                 if (range.end >= innerRange.end
                     || range.end.equals(textControlRange.end))
-                    end = textControl->value().length();
+                    end = textControl->value()->length();
             }
         }
 

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -114,7 +114,7 @@ AccessibilityObject* AccessibilitySlider::elementAccessibilityHitTest(const IntP
 float AccessibilitySlider::valueForRange() const
 {
     if (auto* input = inputElement())
-        return input->value().toFloat();
+        return input->value()->toFloat();
     return 0;
 }
 

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -112,7 +112,7 @@ unsigned AccessibilityObject::accessibilitySecureFieldLength()
         return 0;
 
     auto* inputElement = dynamicDowncast<HTMLInputElement>(renderer->node());
-    return inputElement ? inputElement->value().length() : 0;
+    return inputElement ? inputElement->value()->length() : 0;
 }
 
 bool AccessibilityObject::accessibilityIgnoreAttachment() const

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
@@ -84,7 +84,7 @@ ConversionResult<IDLAtomStringAdaptor<IDLByteString>> valueToByteAtomString(JSC:
     VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto string = value.toString(&lexicalGlobalObject)->toAtomString(&lexicalGlobalObject);
+    AtomString string = value.toString(&lexicalGlobalObject)->toAtomString(&lexicalGlobalObject).data;
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLAtomStringAdaptor<IDLByteString>>::exception());
 
     if (UNLIKELY(throwIfInvalidByteString(lexicalGlobalObject, scope, string.string())))
@@ -117,7 +117,7 @@ ConversionResult<IDLAtomStringAdaptor<IDLUSVString>> valueToUSVAtomString(JSGlob
     auto string = value.toString(&lexicalGlobalObject)->toAtomString(&lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLAtomStringAdaptor<IDLUSVString>>::exception());
 
-    return replaceUnpairedSurrogatesWithReplacementCharacter(WTFMove(string));
+    return replaceUnpairedSurrogatesWithReplacementCharacter(AtomString(string));
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string-algorithm

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.h
@@ -271,7 +271,7 @@ template<typename T> struct Converter<IDLAtomStringAdaptor<T>> : DefaultConverte
 
         RETURN_IF_EXCEPTION(scope, Result::exception());
 
-        return Result { WTFMove(string) };
+        return Result { string.data };
     }
 };
 
@@ -348,7 +348,7 @@ template<typename IDL> struct Converter<IDLRequiresExistingAtomStringAdaptor<IDL
     {
         static_assert(std::is_same<IDL, IDLDOMString>::value, "This adaptor is only supported for IDLDOMString at the moment.");
 
-        return value.toString(&lexicalGlobalObject)->toExistingAtomString(&lexicalGlobalObject);
+        return value.toString(&lexicalGlobalObject)->toExistingAtomString(&lexicalGlobalObject).data;
     }
 };
 

--- a/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
@@ -52,7 +52,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSHTMLAllCollection, (JSGlobalObject* lexicalGlobal
     if (callFrame->argument(0).isUndefined())
         return JSValue::encode(jsNull());
 
-    AtomString nameOrIndex = callFrame->uncheckedArgument(0).toString(lexicalGlobalObject)->toAtomString(lexicalGlobalObject);
+    AtomString nameOrIndex = callFrame->uncheckedArgument(0).toString(lexicalGlobalObject)->toAtomString(lexicalGlobalObject).data;
     RETURN_IF_EXCEPTION(scope, { });
     RELEASE_AND_RETURN(scope, JSValue::encode(toJS<IDLNullable<IDLUnion<IDLInterface<HTMLCollection>, IDLInterface<Element>>>>(*lexicalGlobalObject, *castedThis->globalObject(), impl.namedOrIndexedItemOrItems(WTFMove(nameOrIndex)))));
 }

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -62,7 +62,7 @@ void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vect
     
     if (element.hasAttributesWithoutUpdate()) {
         for (auto& attribute : element.attributes()) {
-            auto attributeName = element.isHTMLElement() ? attribute.localName() : attribute.localNameLowercase();
+            auto& attributeName = element.isHTMLElement() ? attribute.localName() : attribute.localNameLowercase();
             if (isExcludedAttribute(attributeName))
                 continue;
             identifierHashes.append(attributeName.impl()->existingHash() * AttributeSalt);

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -82,11 +82,13 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
         auto defaultStyle = RenderStyle::create();
-        auto fontDescription = defaultStyle.fontDescription();
         auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *document);
-        fontDescription.setComputedSize(size);
-        fontDescription.setSpecifiedSize(size);
-        defaultStyle.setFontDescription(WTFMove(fontDescription));
+        if (size != defaultStyle.fontDescription().specifiedSize()) {
+            auto fontDescription = defaultStyle.fontDescription();
+            fontDescription.setSpecifiedSize(size);
+            fontDescription.setComputedSize(size);
+            defaultStyle.setFontDescription(WTFMove(fontDescription));
+        }
 
         FeatureEvaluationContext context { *document, { *m_rootElementStyle, &defaultStyle, nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3933,20 +3933,14 @@ class GenerateStyleBuilderGenerated:
     # Font property setters.
 
     def _generate_font_property_initial_value_setter(self, to, property):
-        to.write(f"auto fontDescription = builderState.fontDescription();")
-        to.write(f"fontDescription.{property.codegen_properties.font_description_setter}(FontCascadeDescription::{property.codegen_properties.font_description_initial}());")
-        to.write(f"builderState.setFontDescription(WTFMove(fontDescription));")
+        to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(FontCascadeDescription::{property.codegen_properties.font_description_initial}());")
 
     def _generate_font_property_inherit_value_setter(self, to, property):
-        to.write(f"auto fontDescription = builderState.fontDescription();")
         to.write(f"auto inheritedValue = builderState.parentFontDescription().{property.codegen_properties.font_description_getter}();")
-        to.write(f"fontDescription.{property.codegen_properties.font_description_setter}(WTFMove(inheritedValue));")
-        to.write(f"builderState.setFontDescription(WTFMove(fontDescription));")
+        to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(WTFMove(inheritedValue));")
 
     def _generate_font_property_value_setter(self, to, property, value):
-        to.write(f"auto fontDescription = builderState.fontDescription();")
-        to.write(f"fontDescription.{property.codegen_properties.font_description_setter}({value});")
-        to.write(f"builderState.setFontDescription(WTFMove(fontDescription));")
+        to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}({value});")
 
     # Fill Layer property setters.
 

--- a/Source/WebCore/dom/Attribute.h
+++ b/Source/WebCore/dom/Attribute.h
@@ -41,6 +41,12 @@ public:
     {
     }
 
+    Attribute(QualifiedName&& name, AtomString&& value)
+        : m_name(WTFMove(name))
+        , m_value(WTFMove(value))
+    {
+    }
+
     // NOTE: The references returned by these functions are only valid for as long
     // as the Attribute stays in place. For example, calling a function that mutates
     // an Element's internal attribute storage may invalidate them.

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -49,8 +49,11 @@ public:
 protected:
     CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = { })
         : Node(document, type, typeFlags | TypeFlag::IsCharacterData)
-        , m_data(!text.isNull() ? WTFMove(text) : emptyString())
+        , m_data(WTFMove(text))
     {
+        if (m_data.isNull())
+            m_data = emptyString();
+
         ASSERT(isCharacterDataNode());
         ASSERT(!isContainerNode());
     }

--- a/Source/WebCore/dom/ElementTextDirection.cpp
+++ b/Source/WebCore/dom/ElementTextDirection.cpp
@@ -231,7 +231,7 @@ std::optional<TextDirection> computeAutoDirectionality(const Element& element)
         // Specs: The directionality of the auto-directionality form-associated
         // element is calculated from its value() text.
         // Specs: If element's value is not the empty string, then return 'ltr'.
-        if (auto value = textFormControl->value(); !value.isEmpty())
+        if (auto value = textFormControl->value(); !value->isEmpty())
             return computeTextDirectionFromText(value).value_or(TextDirection::LTR);
         return std::nullopt;
     }

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -44,11 +44,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Text);
 
-Ref<Text> Text::create(Document& document, String&& data)
-{
-    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { }));
-}
-
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
     auto node = adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { }));

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -35,7 +35,10 @@ class Text : public CharacterData {
 public:
     static const unsigned defaultLengthLimit = 1 << 16;
 
-    static Ref<Text> create(Document&, String&&);
+    static Ref<Text> create(Document& document, String&& data)
+    {
+        return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { }));
+    }
     static Ref<Text> createEditingText(Document&, String&&);
 
     virtual ~Text();

--- a/Source/WebCore/domjit/DOMJITIDLConvert.h
+++ b/Source/WebCore/domjit/DOMJITIDLConvert.h
@@ -44,7 +44,7 @@ template<>
 struct DirectConverter<IDLAtomStringAdaptor<IDLDOMString>> {
     static AtomString directConvert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSString* string)
     {
-        return string->toAtomString(&lexicalGlobalObject);
+        return string->toAtomString(&lexicalGlobalObject).data;
     }
 };
 
@@ -52,7 +52,7 @@ template<>
 struct DirectConverter<IDLRequiresExistingAtomStringAdaptor<IDLDOMString>> {
     static AtomString directConvert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSString* string)
     {
-        return string->toExistingAtomString(&lexicalGlobalObject);
+        return string->toExistingAtomString(&lexicalGlobalObject).data;
     }
 };
 

--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -89,7 +89,7 @@ std::optional<AutofillElements> AutofillElements::computeAutofillElements(Ref<HT
         auto nextElement = nextAutofillableElement(start.ptr(), focusController);
 
         bool previousFieldIsTextField = previousElement && !previousElement->isPasswordField();
-        bool hasSecondPasswordFieldToFill = nextElement && nextElement->isPasswordField() && nextElement->value().isEmpty();
+        bool hasSecondPasswordFieldToFill = nextElement && nextElement->isPasswordField() && nextElement->value()->isEmpty();
 
         // Always allow AutoFill in a password field, even if we fill information only into it.
         return {{ previousFieldIsTextField ? WTFMove(previousElement) : nullptr, WTFMove(start), hasSecondPasswordFieldToFill ? WTFMove(nextElement) : nullptr }};
@@ -98,7 +98,7 @@ std::optional<AutofillElements> AutofillElements::computeAutofillElements(Ref<HT
         if (nextElement && is<HTMLInputElement>(*nextElement)) {
             if (nextElement->isPasswordField()) {
                 auto elementAfterNextElement = nextAutofillableElement(nextElement.get(), focusController);
-                bool hasSecondPasswordFieldToFill = elementAfterNextElement && elementAfterNextElement->isPasswordField() && elementAfterNextElement->value().isEmpty();
+                bool hasSecondPasswordFieldToFill = elementAfterNextElement && elementAfterNextElement->isPasswordField() && elementAfterNextElement->value()->isEmpty();
 
                 return {{ WTFMove(start), WTFMove(nextElement), hasSecondPasswordFieldToFill ? WTFMove(elementAfterNextElement) : nullptr }};
             }

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1874,14 +1874,14 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
     } else if (element.hasTagName(inputTag)) {
         if (RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element)) {
             if (inputElement->type() == textAtom()) {
-                RetainPtr value = inputElement->value().createNSString();
+                RetainPtr value = inputElement->value()->createNSString();
                 if (value && [value length] > 0)
                     _addValue(value.get(), element);
             }
         }
     } else if (element.hasTagName(textareaTag)) {
         if (RefPtr textAreaElement = dynamicDowncast<HTMLTextAreaElement>(element)) {
-            RetainPtr value = textAreaElement->value().createNSString();
+            RetainPtr value = textAreaElement->value()->createNSString();
             if (value && [value length] > 0)
                 _addValue(value.get(), element);
         }

--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -101,9 +101,9 @@ bool BaseCheckableInputType::accessKeyAction(bool sendMouseEvents)
     return InputType::accessKeyAction(sendMouseEvents) || protectedElement()->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents);
 }
 
-String BaseCheckableInputType::fallbackValue() const
+ValueOrReference<String> BaseCheckableInputType::fallbackValue() const
 {
-    return onAtom();
+    return onAtom().string();
 }
 
 bool BaseCheckableInputType::storesValueSeparateFromAttribute()

--- a/Source/WebCore/html/BaseCheckableInputType.h
+++ b/Source/WebCore/html/BaseCheckableInputType.h
@@ -56,7 +56,7 @@ private:
     bool appendFormData(DOMFormData&) const final;
     void handleKeypressEvent(KeyboardEvent&) final;
     bool accessKeyAction(bool sendMouseEvents) final;
-    String fallbackValue() const final;
+    ValueOrReference<String> fallbackValue() const final;
     bool storesValueSeparateFromAttribute() final;
     void setValue(const String&, bool, TextFieldEventBehavior, TextControlSetValueSelection) final;
 };

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -196,7 +196,7 @@ bool BaseDateAndTimeInputType::typeMismatch() const
 bool BaseDateAndTimeInputType::hasBadInput() const
 {
     ASSERT(element());
-    return protectedElement()->value().isEmpty() && m_dateTimeEditElement && protectedDateTimeEditElement()->editableFieldsHaveValues();
+    return protectedElement()->value()->isEmpty() && m_dateTimeEditElement && protectedDateTimeEditElement()->editableFieldsHaveValues();
 }
 
 Decimal BaseDateAndTimeInputType::defaultValueForStepUp() const
@@ -259,9 +259,11 @@ String BaseDateAndTimeInputType::visibleValue() const
     return localizeValue(protectedElement()->value());
 }
 
-String BaseDateAndTimeInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> BaseDateAndTimeInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
-    return typeMismatchFor(proposedValue) ? emptyString() : proposedValue;
+    if (typeMismatchFor(proposedValue))
+        return emptyString();
+    return proposedValue;
 }
 
 bool BaseDateAndTimeInputType::supportsReadOnly() const
@@ -403,7 +405,7 @@ void BaseDateAndTimeInputType::updateInnerTextValue()
 
     DateTimeEditElement::LayoutParameters layoutParameters(input->locale());
 
-    auto date = parseToDateComponents(input->value());
+    auto date = parseToDateComponents(input->value().get());
     if (date)
         setupLayoutParameters(layoutParameters, *date);
     else {
@@ -620,7 +622,7 @@ bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserPar
     auto* computedStyle = element->computedStyle();
     parameters.isAnchorElementRTL = computedStyle->writingMode().computedTextDirection() == TextDirection::RTL;
     parameters.useDarkAppearance = document->useDarkAppearance(computedStyle);
-    auto date = valueOrDefault(parseToDateComponents(element->value()));
+    auto date = valueOrDefault(parseToDateComponents(element->value().get()));
     parameters.hasSecondField = shouldHaveSecondField(date);
     parameters.hasMillisecondField = shouldHaveMillisecondField(date);
 

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -104,7 +104,7 @@ private:
 
     // InputType functions:
     String visibleValue() const final;
-    String sanitizeValue(const String&) const override;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const override;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;
     WallTime valueAsDate() const override;
     ExceptionOr<void> setValueAsDate(WallTime) const override;

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -178,13 +178,13 @@ bool ColorInputType::supportsRequired() const
     return false;
 }
 
-String ColorInputType::fallbackValue() const
+ValueOrReference<String> ColorInputType::fallbackValue() const
 {
     ASSERT(element());
     return serializeColorValue(Color::black, *protectedElement());
 }
 
-String ColorInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> ColorInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     ASSERT(element());
     Ref input = *element();
@@ -200,7 +200,7 @@ Color ColorInputType::valueAsColor() const
 {
     ASSERT(element());
     Ref input = *element();
-    auto color = parseColorValue(input->value(), input);
+    auto color = parseColorValue(input->value().get(), input);
     ASSERT(!!color);
     // FIXME: This is a speculative fix for rdar://144872437.
     if (!color)

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -73,8 +73,8 @@ private:
     bool isPresentingAttachedView() const final;
     const AtomString& formControlType() const final;
     bool supportsRequired() const final;
-    String fallbackValue() const final;
-    String sanitizeValue(const String&) const final;
+    ValueOrReference<String> fallbackValue() const final;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const final;
     void createShadowSubtree() final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;
     void attributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -101,13 +101,15 @@ bool DateTimeLocalInputType::isValidFormat(OptionSet<DateTimeFormatValidationRes
     return results.containsAll({ DateTimeFormatValidationResults::HasYear, DateTimeFormatValidationResults::HasMonth, DateTimeFormatValidationResults::HasDay, DateTimeFormatValidationResults::HasHour, DateTimeFormatValidationResults::HasMinute, DateTimeFormatValidationResults::HasMeridiem });
 }
 
-String DateTimeLocalInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> DateTimeLocalInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     if (proposedValue.isEmpty())
         return proposedValue;
 
-    auto components = DateComponents::fromParsingDateTimeLocal(proposedValue);
-    return components ? components->toString() : emptyString();
+    if (auto components = DateComponents::fromParsingDateTimeLocal(proposedValue))
+        return components->toString();
+
+    return emptyString();
 }
 
 String DateTimeLocalInputType::formatDateTimeFieldsState(const DateTimeFieldsState& state) const

--- a/Source/WebCore/html/DateTimeLocalInputType.h
+++ b/Source/WebCore/html/DateTimeLocalInputType.h
@@ -57,7 +57,7 @@ private:
     StepRange createStepRange(AnyStepHandling) const final;
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;
-    String sanitizeValue(const String&) const final;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const final;
 
     bool isValidFormat(OptionSet<DateTimeFormatValidationResults>) const final;
     String formatDateTimeFieldsState(const DateTimeFieldsState&) const final;

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -102,7 +102,7 @@ void EmailInputType::attributeChanged(const QualifiedName& name)
     BaseTextInputType::attributeChanged(name);
 }
 
-String EmailInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.
     String noLineBreakValue = proposedValue;

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -55,7 +55,7 @@ private:
     const AtomString& formControlType() const final;
     String typeMismatchText() const final;
     bool supportsSelectionAPI() const final;
-    String sanitizeValue(const String&) const final;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const final;
     void attributeChanged(const QualifiedName&) final;
 };
 

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -26,6 +26,7 @@
 
 #include "HTMLTextFormControlElement.h"
 #include <memory>
+#include <wtf/ValueOrReference.h>
 
 namespace WebCore {
 
@@ -84,7 +85,7 @@ public:
     WEBCORE_EXPORT const AtomString& defaultValue() const;
     WEBCORE_EXPORT void setDefaultValue(const AtomString&);
     WEBCORE_EXPORT void setType(const AtomString&);
-    WEBCORE_EXPORT String value() const final;
+    WEBCORE_EXPORT ValueOrReference<String> value() const final;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
     void setValueForUser(const String& value) { setValue(value, DispatchInputAndChangeEvent); }
     WEBCORE_EXPORT WallTime valueAsDate() const;
@@ -206,7 +207,7 @@ public:
 
     String placeholder() const;
 
-    String sanitizeValue(const String&) const;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const;
 
     String localizeValue(const String&) const;
 

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -45,9 +45,9 @@ public:
     WEBCORE_EXPORT void setCols(unsigned);
     WEBCORE_EXPORT String defaultValue() const;
     WEBCORE_EXPORT void setDefaultValue(String&&);
-    WEBCORE_EXPORT String value() const final;
+    WEBCORE_EXPORT ValueOrReference<String> value() const final;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
-    unsigned textLength() const { return value().length(); }
+    unsigned textLength() const { return value()->length(); }
     String validationMessage() const final;
 
     void setSelectionRangeForBindings(unsigned start, unsigned end, const String& direction);
@@ -77,7 +77,7 @@ private:
     HTMLElement* placeholderElement() const final { return m_placeholder.get(); }
     RefPtr<HTMLElement> protectedPlaceholderElement() const;
     void updatePlaceholderText() final;
-    bool isEmptyValue() const final { return value().isEmpty(); }
+    bool isEmptyValue() const final { return value()->isEmpty(); }
 
     bool isOptionalFormControl() const final { return !isRequiredFormControl(); }
     bool isRequiredFormControl() const final { return isRequired(); }

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -98,7 +98,7 @@ Node::InsertedIntoAncestorResult HTMLTextFormControlElement::insertedIntoAncesto
     InsertedIntoAncestorResult InsertedIntoAncestorResult = HTMLFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         String initialValue = value();
-        setTextAsOfLastFormControlChangeEvent(initialValue.isNull() ? emptyString() : initialValue);
+        setTextAsOfLastFormControlChangeEvent(initialValue.isNull() ? String(emptyString()) : WTFMove(initialValue));
     }
     return InsertedIntoAncestorResult;
 }
@@ -227,13 +227,14 @@ String HTMLTextFormControlElement::selectedText() const
 {
     if (!isTextField())
         return String();
-    return value().substring(selectionStart(), selectionEnd() - selectionStart());
+    return value()->substring(selectionStart(), selectionEnd() - selectionStart());
 }
 
 void HTMLTextFormControlElement::dispatchFormControlChangeEvent()
 {
-    if (m_textAsOfLastFormControlChangeEvent != value()) {
-        setTextAsOfLastFormControlChangeEvent(value());
+    auto value = this->value();
+    if (m_textAsOfLastFormControlChangeEvent != value.get()) {
+        setTextAsOfLastFormControlChangeEvent(String { value });
         dispatchChangeEvent();
     }
     setChangedSinceLastFormControlChangeEvent(false);

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -26,6 +26,7 @@
 
 #include "HTMLFormControlElement.h"
 #include "PointerEventTypeNames.h"
+#include <wtf/ValueOrReference.h>
 
 namespace WebCore {
 
@@ -94,7 +95,7 @@ public:
     void dispatchFormControlChangeEvent() final;
     void scheduleSelectEvent();
 
-    virtual String value() const = 0;
+    virtual ValueOrReference<String> value() const = 0;
 
     virtual ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) = 0;
     virtual RefPtr<TextControlInnerTextElement> innerTextElement() const = 0;
@@ -110,7 +111,7 @@ public:
 
     String directionForFormData() const;
 
-    void setTextAsOfLastFormControlChangeEvent(const String& text) { m_textAsOfLastFormControlChangeEvent = text; }
+    void setTextAsOfLastFormControlChangeEvent(String&& text) { m_textAsOfLastFormControlChangeEvent = WTFMove(text); }
 
     WEBCORE_EXPORT virtual bool isInnerTextElementEditable() const;
 

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -736,7 +736,7 @@ bool InputType::rendererIsNeeded()
     return true;
 }
 
-String InputType::fallbackValue() const
+ValueOrReference<String> InputType::fallbackValue() const
 {
     return String();
 }
@@ -811,7 +811,7 @@ bool InputType::isEmptyValue() const
     return true;
 }
 
-String InputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> InputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     return proposedValue;
 }

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -40,6 +40,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ValueOrReference.h>
 
 namespace WebCore {
 
@@ -224,7 +225,7 @@ public:
 
     // DOM property functions.
 
-    virtual String fallbackValue() const; // Checked last, if both internal storage and value attribute are missing.
+    virtual ValueOrReference<String> fallbackValue() const; // Checked last, if both internal storage and value attribute are missing.
     virtual String defaultValue() const; // Checked after even fallbackValue, only when the valueWithDefault function is called.
     virtual WallTime valueAsDate() const;
     virtual ExceptionOr<void> setValueAsDate(WallTime) const;
@@ -267,9 +268,8 @@ public:
     // though typeMismatchFor() does something for them because of value sanitization.
     virtual bool typeMismatch() const { return false; }
 
-    // Return value of null string means "use the default value".
     // This function must be called only by HTMLInputElement::sanitizeValue().
-    virtual String sanitizeValue(const String&) const;
+    virtual ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const;
 
     // Event handlers.
 

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -70,7 +70,7 @@ DateComponentsType MonthInputType::dateType() const
 WallTime MonthInputType::valueAsDate() const
 {
     ASSERT(element());
-    auto date = parseToDateComponents(protectedElement()->value());
+    auto date = parseToDateComponents(protectedElement()->value().get());
     if (!date)
         return WallTime::nan();
     double msec = date->millisecondsSinceEpoch();

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -110,7 +110,7 @@ void NumberInputType::setValue(const String& sanitizedValue, bool valueChanged, 
 double NumberInputType::valueAsDouble() const
 {
     ASSERT(element());
-    return parseToDoubleForNumberType(element()->value());
+    return parseToDoubleForNumberType(element()->value().get());
 }
 
 ExceptionOr<void> NumberInputType::setValueAsDouble(double newValue, TextFieldEventBehavior eventBehavior) const
@@ -261,11 +261,13 @@ String NumberInputType::convertFromVisibleValue(const String& visibleValue) cons
     return element()->locale().convertFromLocalizedNumber(visibleValue);
 }
 
-String NumberInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     if (proposedValue.isEmpty())
         return proposedValue;
-    return std::isfinite(parseToDoubleForNumberType(proposedValue)) ? proposedValue : emptyString();
+    if (std::isfinite(parseToDoubleForNumberType(proposedValue)))
+        return proposedValue;
+    return emptyString();
 }
 
 bool NumberInputType::hasBadInput() const

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -68,7 +68,7 @@ private:
     String localizeValue(const String&) const final;
     String visibleValue() const final;
     String convertFromVisibleValue(const String&) const final;
-    String sanitizeValue(const String&) const final;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const final;
     String badInputText() const final;
     bool supportsPlaceholder() const final;
     void attributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -63,7 +63,7 @@ static RefPtr<HTMLInputElement> nonEmptyRadioButton(Node& node)
     if (!inputElement)
         return nullptr;
 
-    if (!inputElement->isRadioButton() || inputElement->value().isEmpty())
+    if (!inputElement->isRadioButton() || inputElement->value()->isEmpty())
         return nullptr;
     return inputElement;
 }

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -96,7 +96,7 @@ const AtomString& RangeInputType::formControlType() const
 double RangeInputType::valueAsDouble() const
 {
     ASSERT(element());
-    return parseToDoubleForNumberType(element()->value());
+    return parseToDoubleForNumberType(element()->value().get());
 }
 
 ExceptionOr<void> RangeInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
@@ -347,19 +347,19 @@ void RangeInputType::setValue(const String& value, bool valueChanged, TextFieldE
 
     if (eventBehavior == DispatchNoEvent) {
         ASSERT(element());
-        element()->setTextAsOfLastFormControlChangeEvent(value);
+        element()->setTextAsOfLastFormControlChangeEvent(String(value));
     }
 
     if (hasCreatedShadowSubtree())
         typedSliderThumbElement().setPositionFromValue();
 }
 
-String RangeInputType::fallbackValue() const
+ValueOrReference<String> RangeInputType::fallbackValue() const
 {
     return serializeForNumberType(createStepRange(AnyStepHandling::Reject).defaultValue());
 }
 
-String RangeInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> RangeInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     StepRange stepRange(createStepRange(AnyStepHandling::Reject));
     const Decimal proposedNumericValue = parseToNumber(proposedValue, stepRange.defaultValue());

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -65,8 +65,8 @@ private:
     bool accessKeyAction(bool sendMouseEvents) final;
     void attributeChanged(const QualifiedName&) final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;
-    String fallbackValue() const final;
-    String sanitizeValue(const String& proposedValue) const final;
+    ValueOrReference<String> fallbackValue() const final;
+    ValueOrReference<String> sanitizeValue(const String& proposedValue LIFETIME_BOUND) const final;
     bool shouldRespectListAttribute() final;
     HTMLElement* sliderThumbElement() const final;
     HTMLElement* sliderTrackElement() const final;

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -202,7 +202,7 @@ float SearchInputType::decorationWidth() const
 
 void SearchInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
 {
-    bool emptinessChanged = valueChanged && sanitizedValue.isEmpty() != protectedElement()->value().isEmpty();
+    bool emptinessChanged = valueChanged && sanitizedValue.isEmpty() != protectedElement()->value()->isEmpty();
 
     BaseTextInputType::setValue(sanitizedValue, valueChanged, eventBehavior, selection);
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -174,7 +174,7 @@ void TextFieldInputType::setValue(const String& sanitizedValue, bool valueChange
     }
 
     if (!input->focused())
-        input->setTextAsOfLastFormControlChangeEvent(sanitizedValue);
+        input->setTextAsOfLastFormControlChangeEvent(String(sanitizedValue));
 
     if (UserTypingGestureIndicator::processingUserTypingGesture())
         didSetValueByUserEdit();
@@ -469,7 +469,7 @@ void TextFieldInputType::createDataListDropdownIndicator()
     m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone, IsImportant::Yes);
 }
 
-static String limitLength(const String& string, unsigned maxLength)
+static ValueOrReference<String> limitLength(const String& string LIFETIME_BOUND, unsigned maxLength)
 {
     if (LIKELY(string.length() <= maxLength))
         return string;
@@ -555,7 +555,7 @@ static bool isAutoFillButtonTypeChanged(const AtomString& attribute, AutoFillBut
     return false;
 }
 
-String TextFieldInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> TextFieldInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
     if (LIKELY(!containsHTMLLineBreak(proposedValue)))
         return limitLength(proposedValue, HTMLInputElement::maxEffectiveLength);
@@ -564,7 +564,7 @@ String TextFieldInputType::sanitizeValue(const String& proposedValue) const
     auto proposedValueWithoutLineBreaks = proposedValue.removeCharacters([](auto character) {
         return isHTMLLineBreak(character);
     });
-    return limitLength(WTFMove(proposedValueWithoutLineBreaks), HTMLInputElement::maxEffectiveLength);
+    return String(limitLength(proposedValueWithoutLineBreaks, HTMLInputElement::maxEffectiveLength));
 }
 
 void TextFieldInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& event)

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -79,7 +79,7 @@ protected:
     void handleBlurEvent() final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) override;
     void updateInnerTextValue() final;
-    String sanitizeValue(const String&) const override;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const override;
 
     virtual String convertFromVisibleValue(const String&) const;
     virtual void didSetValueByUserEdit();

--- a/Source/WebCore/html/URLInputType.cpp
+++ b/Source/WebCore/html/URLInputType.cpp
@@ -63,9 +63,9 @@ String URLInputType::typeMismatchText() const
     return validationMessageTypeMismatchForURLText();
 }
 
-String URLInputType::sanitizeValue(const String& proposedValue) const
+ValueOrReference<String> URLInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
 {
-    return BaseTextInputType::sanitizeValue(proposedValue).trim(isASCIIWhitespace);
+    return BaseTextInputType::sanitizeValue(proposedValue)->trim(isASCIIWhitespace);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -54,7 +54,7 @@ private:
 
     const AtomString& formControlType() const final;
     String typeMismatchText() const final;
-    String sanitizeValue(const String&) const final;
+    ValueOrReference<String> sanitizeValue(const String& value LIFETIME_BOUND) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -125,15 +125,6 @@ template<typename CharacterType> static inline bool isCharAfterUnquotedAttribute
     return character == ' ' || character == '>' || isASCIIWhitespace(character);
 }
 
-template<typename T> static bool insertInUniquedSortedVector(Vector<T>& vector, const T& value)
-{
-    auto it = std::lower_bound(vector.begin(), vector.end(), value);
-    if (UNLIKELY(it != vector.end() && *it == value))
-        return false;
-    vector.insert(it - vector.begin(), value);
-    return true;
-}
-
 #define FOR_EACH_SUPPORTED_TAG(APPLY) \
     APPLY(a, A)                       \
     APPLY(b, B)                       \
@@ -815,11 +806,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 return didFail(HTMLFastPathResult::FailedParsingAttributes);
             }
             skipWhile<isASCIIWhitespace>(m_parsingBuffer);
-            AtomString attributeValue { emptyAtom() };
+            AtomString attributeValue;
             if (skipExactly(m_parsingBuffer, '=')) {
                 attributeValue = scanAttributeValue();
                 skipWhile<isASCIIWhitespace>(m_parsingBuffer);
-            }
+            } else
+                attributeValue = emptyAtom();
             if (UNLIKELY(!insertInUniquedSortedVector(m_attributeNames, attributeName.localName().impl()))) {
                 hasDuplicateAttributes = true;
                 continue;

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -184,7 +184,9 @@ AtomString DateTimeFieldElement::localeIdentifier() const
 
 String DateTimeFieldElement::visibleValue() const
 {
-    return hasValue() ? value() : placeholderValue();
+    if (hasValue())
+        return value();
+    return placeholderValue();
 }
 
 void DateTimeFieldElement::updateVisibleValue(EventBehavior eventBehavior)

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -29,6 +29,7 @@
 #include "HTMLDivElement.h"
 
 #include <wtf/GregorianDateTime.h>
+#include <wtf/ValueOrReference.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -82,7 +83,7 @@ public:
     virtual void setValueAsInteger(int, EventBehavior = DispatchNoEvent) = 0;
     virtual void stepDown() = 0;
     virtual void stepUp() = 0;
-    virtual String value() const = 0;
+    virtual ValueOrReference<String> value() const = 0;
     virtual String placeholderValue() const = 0;
 
 protected:

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -152,9 +152,11 @@ void DateTimeNumericFieldElement::stepUp()
     setValueAsIntegerByStepping(newValue);
 }
 
-String DateTimeNumericFieldElement::value() const
+ValueOrReference<String> DateTimeNumericFieldElement::value() const
 {
-    return m_hasValue ? formatValue(m_value) : emptyString();
+    if (m_hasValue)
+        return formatValue(m_value);
+    return emptyString();
 }
 
 String DateTimeNumericFieldElement::placeholderValue() const

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -63,7 +63,7 @@ protected:
 private:
     // DateTimeFieldElement functions:
     void adjustMinInlineSize(RenderStyle&) const final;
-    String value() const final;
+    ValueOrReference<String> value() const final;
     String placeholderValue() const final;
     void handleKeyboardEvent(KeyboardEvent&) final;
     void handleBlurEvent(Event&) final;

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -97,9 +97,11 @@ void DateTimeSymbolicFieldElement::stepUp()
     setValueAsInteger(newValue, DispatchInputAndChangeEvents);
 }
 
-String DateTimeSymbolicFieldElement::value() const
+ValueOrReference<String> DateTimeSymbolicFieldElement::value() const
 {
-    return hasValue() ? m_symbols[m_selectedIndex] : emptyString();
+    if (hasValue())
+        return m_symbols[m_selectedIndex];
+    return emptyString();
 }
 
 String DateTimeSymbolicFieldElement::placeholderValue() const

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
@@ -49,7 +49,7 @@ private:
     void adjustMinInlineSize(RenderStyle&) const final;
     void stepDown() final;
     void stepUp() final;
-    String value() const final;
+    ValueOrReference<String> value() const final;
     String placeholderValue() const final;
     void handleKeyboardEvent(KeyboardEvent&) final;
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -72,7 +72,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(SliderContainerElement);
 inline static Decimal sliderPosition(HTMLInputElement& element)
 {
     const StepRange stepRange(element.createStepRange(AnyStepHandling::Reject));
-    const Decimal oldValue = parseToDecimalForNumberType(element.value(), stepRange.defaultValue());
+    const Decimal oldValue = parseToDecimalForNumberType(element.value().get(), stepRange.defaultValue());
     return stepRange.proportionFromValue(stepRange.clampValue(oldValue));
 }
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -343,7 +343,7 @@ std::optional<Style::ResolvedStyle> SearchFieldCancelButtonElement::resolveCusto
 {
     auto elementStyle = resolveStyle(resolutionContext);
     Ref inputElement = downcast<HTMLInputElement>(*shadowHost());
-    elementStyle.style->setVisibility(elementStyle.style->usedVisibility() == Visibility::Hidden || inputElement->value().isEmpty() ? Visibility::Hidden : Visibility::Visible);
+    elementStyle.style->setVisibility(elementStyle.style->usedVisibility() == Visibility::Hidden || inputElement->value()->isEmpty() ? Visibility::Hidden : Visibility::Visible);
 
     if (shadowHostStyle && searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(*shadowHostStyle))
         elementStyle.style->setDisplay(DisplayType::None);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -816,7 +816,7 @@ InlineContentCache::InlineItems::ContentAttributes InlineItemsBuilder::computeCo
 
 bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(const InlineTextBox& inlineTextBox, InlineItemList& inlineItemList)
 {
-    auto text = inlineTextBox.content();
+    auto& text = inlineTextBox.content();
     auto* breakingPositions = TextBreakingPositionCache::singleton().get({ text, { inlineTextBox.style() }, m_securityOrigin.data() });
     if (!breakingPositions)
         return false;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -63,7 +63,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
     if (inlineTextBox.isCombined())
         return fontCascade.size();
 
-    auto text = inlineTextBox.content();
+    auto& text = inlineTextBox.content();
     ASSERT(to <= text.length());
     auto hasKerningOrLigatures = fontCascade.enableKerning() || fontCascade.requiresShaping();
     // The "non-whitespace" + "whitespace" pattern is very common for inline content and since most of the "non-whitespace" runs end up with
@@ -127,9 +127,8 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
 
 InlineLayoutUnit TextUtil::trailingWhitespaceWidth(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, size_t startPosition, size_t endPosition)
 {
-    auto text = inlineTextBox.content();
     ASSERT(endPosition > startPosition + 1);
-    ASSERT(text[endPosition - 1] == space);
+    ASSERT(inlineTextBox.content()[endPosition - 1] == space);
     return width(inlineTextBox, fontCascade, startPosition, endPosition, { }, UseTrailingWhitespaceMeasuringOptimization::Yes) - 
         width(inlineTextBox, fontCascade, startPosition, endPosition - 1, { }, UseTrailingWhitespaceMeasuringOptimization::No);
 }
@@ -172,7 +171,7 @@ TextUtil::FallbackFontList TextUtil::fallbackFontsForText(StringView textContent
 {
     TextUtil::FallbackFontList fallbackFonts;
 
-    auto collectFallbackFonts = [&](const auto& textRun) {
+    auto collectFallbackFonts = [&](auto&& textRun) {
         if (textRun.text().isEmpty())
             return;
 
@@ -248,7 +247,7 @@ TextUtil::WordBreakLeft TextUtil::breakWord(const InlineTextBox& inlineTextBox, 
 {
     ASSERT(availableWidth >= 0);
     ASSERT(length);
-    auto text = inlineTextBox.content();
+    auto& text = inlineTextBox.content();
 
     if (UNLIKELY(!textWidth)) {
         ASSERT_NOT_REACHED();
@@ -582,7 +581,7 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
 
 size_t TextUtil::firstUserPerceivedCharacterLength(const InlineTextBox& inlineTextBox, size_t startPosition, size_t length)
 {
-    auto textContent = inlineTextBox.content();
+    auto& textContent = inlineTextBox.content();
     RELEASE_ASSERT(!textContent.isEmpty());
 
     if (textContent.is8Bit())

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -163,7 +163,7 @@ static bool shouldAllowNonInteractiveCursorForElement(const Element& element)
 #endif
 
     if (RefPtr textElement = dynamicDowncast<HTMLTextFormControlElement>(element))
-        return !textElement->focused() || !textElement->lastChangeWasUserEdit() || textElement->value().isEmpty();
+        return !textElement->focused() || !textElement->lastChangeWasUserEdit() || textElement->value()->isEmpty();
 
     if (is<HTMLFormControlElement>(element))
         return true;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -66,7 +66,7 @@ FontCascade::FontCascade()
 FontCascade::FontCascade(FontCascadeDescription&& description)
     : m_fontDescription(WTFMove(description))
     , m_generation(++lastFontCascadeGeneration)
-    , m_useBackslashAsYenSymbol(FontCache::forCurrentThread().useBackslashAsYenSignForFamily(m_fontDescription.firstFamily()))
+    , m_useBackslashAsYenSymbol(computeUseBackslashAsYenSymbol())
     , m_enableKerning(computeEnableKerning())
     , m_requiresShaping(computeRequiresShaping())
 {
@@ -77,7 +77,7 @@ FontCascade::FontCascade(FontCascadeDescription&& description, const FontCascade
     : m_fontDescription(WTFMove(description))
     , m_spacing(other.m_spacing)
     , m_generation(++lastFontCascadeGeneration)
-    , m_useBackslashAsYenSymbol(FontCache::forCurrentThread().useBackslashAsYenSignForFamily(m_fontDescription.firstFamily()))
+    , m_useBackslashAsYenSymbol(computeUseBackslashAsYenSymbol())
     , m_enableKerning(computeEnableKerning())
     , m_requiresShaping(computeRequiresShaping())
 {
@@ -1300,6 +1300,11 @@ bool FontCascade::isLoadingCustomFonts() const
 {
     RefPtr fonts = m_fonts;
     return fonts && fonts->isLoadingCustomFonts();
+}
+
+bool FontCascade::computeUseBackslashAsYenSymbol() const
+{
+    return FontCache::forCurrentThread().useBackslashAsYenSignForFamily(m_fontDescription.firstFamily());
 }
 
 enum class GlyphUnderlineType : uint8_t {

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -133,6 +133,7 @@ public:
     WEBCORE_EXPORT bool operator==(const FontCascade& other) const;
 
     const FontCascadeDescription& fontDescription() const { return m_fontDescription; }
+    FontCascadeDescription& mutableFontDescription() const { return m_fontDescription; }
 
     float size() const { return fontDescription().computedSize(); }
 
@@ -341,7 +342,13 @@ public:
 
     static ResolvedEmojiPolicy resolveEmojiPolicy(FontVariantEmoji, char32_t);
 
+    void updateUseBackslashAsYenSymbol() { m_useBackslashAsYenSymbol = computeUseBackslashAsYenSymbol(); }
+    void updateEnableKerning() { m_enableKerning = computeEnableKerning(); }
+    void updateRequiresShaping() { m_requiresShaping = computeRequiresShaping(); }
+
 private:
+
+    bool computeUseBackslashAsYenSymbol() const;
 
     bool advancedTextRenderingMode() const
     {

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -110,7 +110,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
         });
         if (iterator == charactersTreatedAsSpace.end() || iterator->stringOffset != characterIndex)
             continue;
-        const auto& originalAdvances = *iterator;
+        auto& originalAdvances = *iterator;
         setWidth(glyphBuffer.advanceAt(i), originalAdvances.advance);
     }
     charactersTreatedAsSpace.clear();
@@ -378,7 +378,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
 {
     // The core logic here needs to match FontCascade::widthForTextUsingSimplifiedMeasuring()
     FloatRect bounds;
-    auto fontDescription = m_fontCascade->fontDescription();
+    auto& fontDescription = m_fontCascade->fontDescription();
     Ref primaryFont = m_fontCascade->primaryFont();
     AdvanceInternalState advanceInternalState(glyphBuffer, primaryFont, textIterator.currentIndex());
     SmallCapsState smallCapsState(fontDescription);
@@ -632,7 +632,7 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
 
     auto previousCharacterClass = m_run->textSpacingState().lastCharacterClassFromPreviousRun;
     float position = m_run->xPos() + startingRunWidth;
-    const auto& textAutospace = m_fontCascade->textAutospace();
+    auto textAutospace = m_fontCascade->textAutospace();
     for (auto i = characterStartIndex; i < characterDestinationIndex; ++i) {
         auto& glyphIndexRange = characterIndexToGlyphIndexRange[i];
         if (!glyphIndexRange)

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -210,7 +210,7 @@ void RenderSearchField::updateCancelButtonVisibility() const
 
 Visibility RenderSearchField::visibilityForCancelButton() const
 {
-    return (style().usedVisibility() == Visibility::Hidden || inputElement().value().isEmpty()) ? Visibility::Hidden : Visibility::Visible;
+    return (style().usedVisibility() == Visibility::Hidden || inputElement().value()->isEmpty()) ? Visibility::Hidden : Visibility::Visible;
 }
 
 const AtomString& RenderSearchField::autosaveName() const

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2747,6 +2747,17 @@ const FontCascadeDescription& RenderStyle::fontDescription() const
     return m_inheritedData->fontData->fontCascade.fontDescription();
 }
 
+FontCascadeDescription& RenderStyle::mutableFontDescriptionWithoutUpdate()
+{
+    auto& cascade = m_inheritedData.access().fontData.access().fontCascade;
+    return cascade.mutableFontDescription();
+}
+
+FontCascade& RenderStyle::mutableFontCascadeWithoutUpdate()
+{
+    return m_inheritedData.access().fontData.access().fontCascade;
+}
+
 float RenderStyle::specifiedFontSize() const
 {
     return fontDescription().specifiedSize();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -595,6 +595,9 @@ public:
     WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const;
     WEBCORE_EXPORT const FontCascadeDescription& fontDescription() const;
 
+    WEBCORE_EXPORT FontCascade& mutableFontCascadeWithoutUpdate();
+    WEBCORE_EXPORT FontCascadeDescription& mutableFontDescriptionWithoutUpdate();
+
     inline bool fontCascadeEqual(const RenderStyle&) const;
 
     float specifiedFontSize() const;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -981,7 +981,7 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
     if (m_document->quirks().needsWeChatScrollingQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> class1("tree-select"_s);
         static MainThreadNeverDestroyed<const AtomString> class2("v-tree-select"_s);
-        const auto& flexBasis = style.flexBasis();
+        auto& flexBasis = style.flexBasis();
         if (style.minHeight().isAuto()
             && style.display() == DisplayType::Flex
             && style.flexGrow() == 1
@@ -1180,7 +1180,7 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
         adjustmentForTextAutosizing.newLineHeight = minimumLineHeight;
     };
 
-    auto fontDescription = style.fontDescription();
+    auto& fontDescription = style.fontDescription();
     auto initialComputedFontSize = fontDescription.computedSize();
     auto specifiedFontSize = fontDescription.specifiedSize();
     bool isCandidate = style.isIdempotentTextAutosizingCandidate(newStatus);

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -249,9 +249,9 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
     SetForScope scopedLinkMatchMutation(m_state.m_linkMatch, SelectorChecker::MatchDefault);
     applyProperty(CSSPropertyCustom, *resolvedValue, SelectorChecker::MatchDefault, property.cascadeLevel);
 
-    m_state.m_inProgressCustomProperties.remove(name);
-    m_state.m_appliedCustomProperties.add(name);
-    m_state.m_inCycleCustomProperties.formUnion(WTFMove(savedInCycleProperties));
+    AtomString takenName = m_state.m_inProgressCustomProperties.take(name);
+    m_state.m_appliedCustomProperties.add(WTFMove(takenName));
+    m_state.m_inCycleCustomProperties.formUnion(savedInCycleProperties);
 }
 
 inline void Builder::applyCascadeProperty(const PropertyCascade::Property& property)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -640,12 +640,10 @@ inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CS
     if (!primitiveValue)
         return;
 
-    FontCascadeDescription fontDescription = builderState.fontDescription();
     if (primitiveValue->valueID() == CSSValueAuto)
-        fontDescription.setSpecifiedLocale(nullAtom());
+        builderState.setFontDescriptionSpecifiedLocale(nullAtom());
     else
-        fontDescription.setSpecifiedLocale(AtomString { primitiveValue->stringValue() });
-    builderState.setFontDescription(WTFMove(fontDescription));
+        builderState.setFontDescriptionSpecifiedLocale(AtomString { primitiveValue->stringValue() });
 }
 
 inline void BuilderCustom::applyValueWritingMode(BuilderState& builderState, CSSValue& value)
@@ -772,33 +770,29 @@ inline void BuilderCustom::applyValueBoxShadow(BuilderState& builderState, CSSVa
 
 inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
+    auto& fontDescription = builderState.fontDescription();
     auto initialDesc = FontCascadeDescription();
 
     // We need to adjust the size to account for the generic family change from monospace to non-monospace.
     if (fontDescription.useFixedDefaultSize()) {
         if (CSSValueID sizeIdentifier = fontDescription.keywordSizeAsIdentifier())
-            builderState.setFontSize(fontDescription, Style::fontSizeForKeyword(sizeIdentifier, false, builderState.document()));
+            builderState.setFontDescriptionFontSize(Style::fontSizeForKeyword(sizeIdentifier, false, builderState.document()));
     }
     if (!initialDesc.firstFamily().isEmpty())
-        fontDescription.setFamilies(initialDesc.families());
-
-    builderState.setFontDescription(WTFMove(fontDescription));
+        builderState.setFontDescriptionFamilies(initialDesc.families());
 }
 
 inline void BuilderCustom::applyInheritFontFamily(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
     auto parentFontDescription = builderState.parentStyle().fontDescription();
 
-    fontDescription.setFamilies(parentFontDescription.families());
-    fontDescription.setIsSpecifiedFont(parentFontDescription.isSpecifiedFont());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionFamilies(parentFontDescription.families());
+    builderState.setFontDescriptionIsSpecifiedFont(parentFontDescription.isSpecifiedFont());
 }
 
 inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSValue& value)
 {
-    auto fontDescription = builderState.fontDescription();
+    auto& fontDescription = builderState.fontDescription();
     // Before mapping in a new font-family property, we should reset the generic family.
     bool oldFamilyUsedFixedDefaultSize = fontDescription.useFixedDefaultSize();
 
@@ -812,7 +806,7 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
         }
         AtomString family = SystemFontDatabase::singleton().systemFontShorthandFamily(CSSPropertyParserHelpers::lowerFontShorthand(valueID));
         ASSERT(!family.isEmpty());
-        fontDescription.setIsSpecifiedFont(false);
+        builderState.setFontDescriptionIsSpecifiedFont(false);
         families = Vector<AtomString>::from(WTFMove(family));
     } else {
         auto valueList = BuilderConverter::requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
@@ -835,7 +829,7 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
             if (family.isNull())
                 return std::nullopt;
             if (isFirstFont) {
-                fontDescription.setIsSpecifiedFont(!isGenericFamily);
+                builderState.setFontDescriptionIsSpecifiedFont(!isGenericFamily);
                 isFirstFont = false;
             }
             return family;
@@ -844,14 +838,12 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
             return;
     }
 
-    fontDescription.setFamilies(families);
+    builderState.setFontDescriptionFamilies(families);
 
     if (fontDescription.useFixedDefaultSize() != oldFamilyUsedFixedDefaultSize) {
         if (CSSValueID sizeIdentifier = fontDescription.keywordSizeAsIdentifier())
-            builderState.setFontSize(fontDescription, Style::fontSizeForKeyword(sizeIdentifier, !oldFamilyUsedFixedDefaultSize, builderState.document()));
+            builderState.setFontDescriptionFontSize(Style::fontSizeForKeyword(sizeIdentifier, !oldFamilyUsedFixedDefaultSize, builderState.document()));
     }
-
-    builderState.setFontDescription(WTFMove(fontDescription));
 }
 
 inline void BuilderCustom::applyInitialBorderBottomLeftRadius(BuilderState& builderState)
@@ -1400,22 +1392,18 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
 
 inline void BuilderCustom::applyInheritFontVariantLigatures(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantCommonLigatures(builderState.parentFontDescription().variantCommonLigatures());
-    fontDescription.setVariantDiscretionaryLigatures(builderState.parentFontDescription().variantDiscretionaryLigatures());
-    fontDescription.setVariantHistoricalLigatures(builderState.parentFontDescription().variantHistoricalLigatures());
-    fontDescription.setVariantContextualAlternates(builderState.parentFontDescription().variantContextualAlternates());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantCommonLigatures(builderState.parentFontDescription().variantCommonLigatures());
+    builderState.setFontDescriptionVariantDiscretionaryLigatures(builderState.parentFontDescription().variantDiscretionaryLigatures());
+    builderState.setFontDescriptionVariantHistoricalLigatures(builderState.parentFontDescription().variantHistoricalLigatures());
+    builderState.setFontDescriptionVariantContextualAlternates(builderState.parentFontDescription().variantContextualAlternates());
 }
 
 inline void BuilderCustom::applyInitialFontVariantLigatures(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantCommonLigatures(FontVariantLigatures::Normal);
-    fontDescription.setVariantDiscretionaryLigatures(FontVariantLigatures::Normal);
-    fontDescription.setVariantHistoricalLigatures(FontVariantLigatures::Normal);
-    fontDescription.setVariantContextualAlternates(FontVariantLigatures::Normal);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantCommonLigatures(FontVariantLigatures::Normal);
+    builderState.setFontDescriptionVariantDiscretionaryLigatures(FontVariantLigatures::Normal);
+    builderState.setFontDescriptionVariantHistoricalLigatures(FontVariantLigatures::Normal);
+    builderState.setFontDescriptionVariantContextualAlternates(FontVariantLigatures::Normal);
 }
 
 inline void BuilderCustom::applyValueFontVariantLigatures(BuilderState& builderState, CSSValue& value)
@@ -1424,35 +1412,29 @@ inline void BuilderCustom::applyValueFontVariantLigatures(BuilderState& builderS
         applyInitialFontVariantLigatures(builderState);
         return;
     }
-    auto fontDescription = builderState.fontDescription();
     auto variantLigatures = extractFontVariantLigatures(value);
-    fontDescription.setVariantCommonLigatures(variantLigatures.commonLigatures);
-    fontDescription.setVariantDiscretionaryLigatures(variantLigatures.discretionaryLigatures);
-    fontDescription.setVariantHistoricalLigatures(variantLigatures.historicalLigatures);
-    fontDescription.setVariantContextualAlternates(variantLigatures.contextualAlternates);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantCommonLigatures(variantLigatures.commonLigatures);
+    builderState.setFontDescriptionVariantDiscretionaryLigatures(variantLigatures.discretionaryLigatures);
+    builderState.setFontDescriptionVariantHistoricalLigatures(variantLigatures.historicalLigatures);
+    builderState.setFontDescriptionVariantContextualAlternates(variantLigatures.contextualAlternates);
 }
 
 inline void BuilderCustom::applyInheritFontVariantNumeric(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantNumericFigure(builderState.parentFontDescription().variantNumericFigure());
-    fontDescription.setVariantNumericSpacing(builderState.parentFontDescription().variantNumericSpacing());
-    fontDescription.setVariantNumericFraction(builderState.parentFontDescription().variantNumericFraction());
-    fontDescription.setVariantNumericOrdinal(builderState.parentFontDescription().variantNumericOrdinal());
-    fontDescription.setVariantNumericSlashedZero(builderState.parentFontDescription().variantNumericSlashedZero());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantNumericFigure(builderState.parentFontDescription().variantNumericFigure());
+    builderState.setFontDescriptionVariantNumericSpacing(builderState.parentFontDescription().variantNumericSpacing());
+    builderState.setFontDescriptionVariantNumericFraction(builderState.parentFontDescription().variantNumericFraction());
+    builderState.setFontDescriptionVariantNumericOrdinal(builderState.parentFontDescription().variantNumericOrdinal());
+    builderState.setFontDescriptionVariantNumericSlashedZero(builderState.parentFontDescription().variantNumericSlashedZero());
 }
 
 inline void BuilderCustom::applyInitialFontVariantNumeric(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantNumericFigure(FontVariantNumericFigure::Normal);
-    fontDescription.setVariantNumericSpacing(FontVariantNumericSpacing::Normal);
-    fontDescription.setVariantNumericFraction(FontVariantNumericFraction::Normal);
-    fontDescription.setVariantNumericOrdinal(FontVariantNumericOrdinal::Normal);
-    fontDescription.setVariantNumericSlashedZero(FontVariantNumericSlashedZero::Normal);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantNumericFigure(FontVariantNumericFigure::Normal);
+    builderState.setFontDescriptionVariantNumericSpacing(FontVariantNumericSpacing::Normal);
+    builderState.setFontDescriptionVariantNumericFraction(FontVariantNumericFraction::Normal);
+    builderState.setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal::Normal);
+    builderState.setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero::Normal);
 }
 
 inline void BuilderCustom::applyValueFontVariantNumeric(BuilderState& builderState, CSSValue& value)
@@ -1461,32 +1443,26 @@ inline void BuilderCustom::applyValueFontVariantNumeric(BuilderState& builderSta
         applyInitialFontVariantNumeric(builderState);
         return;
     }
-    auto fontDescription = builderState.fontDescription();
     auto variantNumeric = extractFontVariantNumeric(value);
-    fontDescription.setVariantNumericFigure(variantNumeric.figure);
-    fontDescription.setVariantNumericSpacing(variantNumeric.spacing);
-    fontDescription.setVariantNumericFraction(variantNumeric.fraction);
-    fontDescription.setVariantNumericOrdinal(variantNumeric.ordinal);
-    fontDescription.setVariantNumericSlashedZero(variantNumeric.slashedZero);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantNumericFigure(variantNumeric.figure);
+    builderState.setFontDescriptionVariantNumericSpacing(variantNumeric.spacing);
+    builderState.setFontDescriptionVariantNumericFraction(variantNumeric.fraction);
+    builderState.setFontDescriptionVariantNumericOrdinal(variantNumeric.ordinal);
+    builderState.setFontDescriptionVariantNumericSlashedZero(variantNumeric.slashedZero);
 }
 
 inline void BuilderCustom::applyInheritFontVariantEastAsian(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantEastAsianVariant(builderState.parentFontDescription().variantEastAsianVariant());
-    fontDescription.setVariantEastAsianWidth(builderState.parentFontDescription().variantEastAsianWidth());
-    fontDescription.setVariantEastAsianRuby(builderState.parentFontDescription().variantEastAsianRuby());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantEastAsianVariant(builderState.parentFontDescription().variantEastAsianVariant());
+    builderState.setFontDescriptionVariantEastAsianWidth(builderState.parentFontDescription().variantEastAsianWidth());
+    builderState.setFontDescriptionVariantEastAsianRuby(builderState.parentFontDescription().variantEastAsianRuby());
 }
 
 inline void BuilderCustom::applyInitialFontVariantEastAsian(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantEastAsianVariant(FontVariantEastAsianVariant::Normal);
-    fontDescription.setVariantEastAsianWidth(FontVariantEastAsianWidth::Normal);
-    fontDescription.setVariantEastAsianRuby(FontVariantEastAsianRuby::Normal);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantEastAsianVariant(FontVariantEastAsianVariant::Normal);
+    builderState.setFontDescriptionVariantEastAsianWidth(FontVariantEastAsianWidth::Normal);
+    builderState.setFontDescriptionVariantEastAsianRuby(FontVariantEastAsianRuby::Normal);
 }
 
 inline void BuilderCustom::applyValueFontVariantEastAsian(BuilderState& builderState, CSSValue& value)
@@ -1495,26 +1471,20 @@ inline void BuilderCustom::applyValueFontVariantEastAsian(BuilderState& builderS
         applyInitialFontVariantEastAsian(builderState);
         return;
     }
-    auto fontDescription = builderState.fontDescription();
     auto variantEastAsian = extractFontVariantEastAsian(value);
-    fontDescription.setVariantEastAsianVariant(variantEastAsian.variant);
-    fontDescription.setVariantEastAsianWidth(variantEastAsian.width);
-    fontDescription.setVariantEastAsianRuby(variantEastAsian.ruby);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantEastAsianVariant(variantEastAsian.variant);
+    builderState.setFontDescriptionVariantEastAsianWidth(variantEastAsian.width);
+    builderState.setFontDescriptionVariantEastAsianRuby(variantEastAsian.ruby);
 }
 
 inline void BuilderCustom::applyInheritFontVariantAlternates(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantAlternates(builderState.parentFontDescription().variantAlternates());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantAlternates(builderState.parentFontDescription().variantAlternates());
 }
 
 inline void BuilderCustom::applyInitialFontVariantAlternates(BuilderState& builderState)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setVariantAlternates(FontVariantAlternates::Normal());
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionVariantAlternates(FontVariantAlternates::Normal());
 }
 
 inline void BuilderCustom::applyValueFontVariantAlternates(BuilderState& builderState, CSSValue& value)
@@ -1549,10 +1519,8 @@ inline void BuilderCustom::applyInheritFontSize(BuilderState& builderState)
     if (size < 0)
         return;
 
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setKeywordSize(parentFontDescription.keywordSize());
-    builderState.setFontSize(fontDescription, size);
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionKeywordSize(parentFontDescription.keywordSize());
+    builderState.setFontDescriptionFontSize(size);
 }
 
 // When the CSS keyword "larger" is used, this function will attempt to match within the keyword
@@ -1632,8 +1600,8 @@ inline void BuilderCustom::applyValueFontStyle(BuilderState& state, CSSValue& va
 
 inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSValue& value)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setKeywordSizeFromIdentifier(CSSValueInvalid);
+    auto& fontDescription = builderState.fontDescription();
+    builderState.setFontDescriptionKeywordSizeFromIdentifier(CSSValueInvalid);
 
     float parentSize = builderState.parentStyle().fontDescription().specifiedSize();
     bool parentIsAbsoluteSize = builderState.parentStyle().fontDescription().isAbsoluteSize();
@@ -1644,7 +1612,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
 
     float size = 0;
     if (CSSValueID ident = primitiveValue->valueID()) {
-        fontDescription.setIsAbsoluteSize((parentIsAbsoluteSize && (ident == CSSValueLarger || ident == CSSValueSmaller || ident == CSSValueWebkitRubyText)) || CSSPropertyParserHelpers::isSystemFontShorthand(ident));
+        builderState.setFontDescriptionIsAbsoluteSize((parentIsAbsoluteSize && (ident == CSSValueLarger || ident == CSSValueSmaller || ident == CSSValueWebkitRubyText)) || CSSPropertyParserHelpers::isSystemFontShorthand(ident));
 
         if (CSSPropertyParserHelpers::isSystemFontShorthand(ident))
             size = SystemFontDatabase::singleton().systemFontShorthandSize(CSSPropertyParserHelpers::lowerFontShorthand(ident));
@@ -1659,7 +1627,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
         case CSSValueXxLarge:
         case CSSValueXxxLarge:
             size = Style::fontSizeForKeyword(ident, fontDescription.useFixedDefaultSize(), builderState.document());
-            fontDescription.setKeywordSizeFromIdentifier(ident);
+            builderState.setFontDescriptionKeywordSizeFromIdentifier(ident);
             break;
         case CSSValueLarger:
             size = largerFontSize(parentSize);
@@ -1674,7 +1642,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
             break;
         }
     } else {
-        fontDescription.setIsAbsoluteSize(parentIsAbsoluteSize || !primitiveValue->isParentFontRelativeLength());
+        builderState.setFontDescriptionIsAbsoluteSize(parentIsAbsoluteSize || !primitiveValue->isParentFontRelativeLength());
         auto conversionData = builderState.cssToLengthConversionData().copyForFontSize();
         if (primitiveValue->isLength())
             size = primitiveValue->resolveAsLength<float>(conversionData);
@@ -1689,15 +1657,12 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
     if (size < 0)
         return;
 
-    builderState.setFontSize(fontDescription, std::min(maximumAllowedFontSize, size));
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionFontSize(std::min(maximumAllowedFontSize, size));
 }
 
 inline void BuilderCustom::applyValueFontSizeAdjust(BuilderState& builderState, CSSValue& value)
 {
-    auto fontDescription = builderState.fontDescription();
-    fontDescription.setFontSizeAdjust(BuilderConverter::convertFontSizeAdjust(builderState, value));
-    builderState.setFontDescription(WTFMove(fontDescription));
+    builderState.setFontDescriptionFontSizeAdjust(BuilderConverter::convertFontSizeAdjust(builderState, value));
 }
 
 inline void BuilderCustom::applyInitialGridTemplateAreas(BuilderState& builderState)

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -237,11 +237,7 @@ void BuilderState::updateFontForZoomChange()
     if (m_style.usedZoom() == parentStyle().usedZoom() && m_style.textZoom() == parentStyle().textZoom())
         return;
 
-    const auto& childFont = m_style.fontDescription();
-    auto newFontDescription = childFont;
-    setFontSize(newFontDescription, childFont.specifiedSize());
-
-    m_style.setFontDescriptionWithoutUpdate(WTFMove(newFontDescription));
+    setFontDescriptionFontSize(m_style.fontDescription().specifiedSize());
 }
 
 void BuilderState::updateFontForGenericFamilyChange()

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -29,6 +29,7 @@
 #include "CSSToStyleMap.h"
 #include "CascadeLevel.h"
 #include "Document.h"
+#include "FontTaggedSettings.h"
 #include "PositionArea.h"
 #include "PositionTryFallback.h"
 #include "PropertyCascade.h"
@@ -36,15 +37,23 @@
 #include "SelectorChecker.h"
 #include "StyleForVisitedLink.h"
 #include "TreeResolutionState.h"
+#include "platform/text/TextFlags.h"
 #include <wtf/BitSet.h>
+#include <wtf/RefCountedFixedVector.h>
 
 namespace WebCore {
 
 class FilterOperations;
 class FontCascadeDescription;
+class FontSelectionValue;
 class RenderStyle;
 class StyleImage;
 class StyleResolver;
+class TextAutospace;
+class TextSpacingTrim;
+
+struct FontPalette;
+struct FontSizeAdjust;
 
 namespace CSSCalc {
 struct RandomCachingKey;
@@ -71,7 +80,7 @@ struct BuilderPositionTryFallback {
 };
 
 struct BuilderContext {
-    Ref<const Document> document;
+    const Ref<const Document> document;
     const RenderStyle& parentStyle;
     const RenderStyle* rootElementStyle = nullptr;
     RefPtr<const Element> element = nullptr;
@@ -95,8 +104,6 @@ public:
     Ref<const Document> protectedDocument() const { return m_context.document; }
     const Element* element() const { return m_context.element.get(); }
 
-    inline void setFontDescription(FontCascadeDescription&&);
-    void setFontSize(FontCascadeDescription&, float size);
     inline void setZoom(float);
     inline void setUsedZoom(float);
     inline void setWritingMode(StyleWritingMode);
@@ -151,6 +158,51 @@ public:
 
     AnchorPositionedStates* anchorPositionedStates() { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }
     const std::optional<BuilderPositionTryFallback>& positionTryFallback() const { return m_context.positionTryFallback; }
+
+    // FIXME: Copying a FontCascadeDescription is really inefficient. Migrate all callers to
+    // setFontDescriptionXXX() variants below, then remove these functions.
+    inline void setFontDescription(FontCascadeDescription&&);
+    void setFontSize(FontCascadeDescription&, float size);
+
+    void setFontDescriptionKeywordSizeFromIdentifier(CSSValueID);
+    void setFontDescriptionIsAbsoluteSize(bool);
+    void setFontDescriptionFontSize(float);
+    void setFontDescriptionFamilies(RefCountedFixedVector<AtomString>&);
+    void setFontDescriptionFamilies(Vector<AtomString>&);
+    void setFontDescriptionIsSpecifiedFont(bool);
+    void setFontDescriptionFeatureSettings(FontFeatureSettings&&);
+    void setFontDescriptionFontPalette(const FontPalette&);
+    void setFontDescriptionFontSizeAdjust(FontSizeAdjust);
+    void setFontDescriptionFontSmoothing(FontSmoothingMode);
+    void setFontDescriptionFontSynthesisSmallCaps(FontSynthesisLonghandValue);
+    void setFontDescriptionFontSynthesisStyle(FontSynthesisLonghandValue);
+    void setFontDescriptionFontSynthesisWeight(FontSynthesisLonghandValue);
+    void setFontDescriptionKerning(Kerning);
+    void setFontDescriptionOpticalSizing(FontOpticalSizing);
+    void setFontDescriptionSpecifiedLocale(const AtomString&);
+    void setFontDescriptionTextAutospace(TextAutospace);
+    void setFontDescriptionTextRenderingMode(TextRenderingMode);
+    void setFontDescriptionTextSpacingTrim(TextSpacingTrim);
+    void setFontDescriptionVariantCaps(FontVariantCaps);
+    void setFontDescriptionVariantEmoji(FontVariantEmoji);
+    void setFontDescriptionVariantPosition(FontVariantPosition);
+    void setFontDescriptionVariationSettings(FontVariationSettings&&);
+    void setFontDescriptionWeight(FontSelectionValue);
+    void setFontDescriptionWidth(FontSelectionValue);
+    void setFontDescriptionVariantAlternates(const FontVariantAlternates&);
+    void setFontDescriptionVariantEastAsianVariant(FontVariantEastAsianVariant);
+    void setFontDescriptionVariantEastAsianWidth(FontVariantEastAsianWidth);
+    void setFontDescriptionVariantEastAsianRuby(FontVariantEastAsianRuby);
+    void setFontDescriptionKeywordSize(unsigned);
+    void setFontDescriptionVariantCommonLigatures(FontVariantLigatures);
+    void setFontDescriptionVariantDiscretionaryLigatures(FontVariantLigatures);
+    void setFontDescriptionVariantHistoricalLigatures(FontVariantLigatures);
+    void setFontDescriptionVariantContextualAlternates(FontVariantLigatures);
+    void setFontDescriptionVariantNumericFigure(FontVariantNumericFigure);
+    void setFontDescriptionVariantNumericSpacing(FontVariantNumericSpacing);
+    void setFontDescriptionVariantNumericFraction(FontVariantNumericFraction);
+    void setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal);
+    void setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero);
 
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -25,19 +25,421 @@
 
 #pragma once
 
+#include "RenderStyle.h"
 #include "RenderStyleSetters.h"
 #include "StyleBuilderState.h"
+#include "StyleFontSizeFunctions.h"
 
 namespace WebCore {
 namespace Style {
 
 inline const FontCascadeDescription& BuilderState::fontDescription() { return m_style.fontDescription(); }
+inline void BuilderState::setFontDescription(FontCascadeDescription&& description) { m_fontDirty |= m_style.setFontDescriptionWithoutUpdate(WTFMove(description)); }
+
 inline const FontCascadeDescription& BuilderState::parentFontDescription() { return parentStyle().fontDescription(); }
 inline void BuilderState::setUsedZoom(float zoom) { m_fontDirty |= m_style.setUsedZoom(zoom); }
-inline void BuilderState::setFontDescription(FontCascadeDescription&& description) { m_fontDirty |= m_style.setFontDescriptionWithoutUpdate(WTFMove(description)); }
 inline void BuilderState::setTextOrientation(TextOrientation orientation) { m_fontDirty |= m_style.setTextOrientation(orientation); }
 inline void BuilderState::setWritingMode(StyleWritingMode mode) { m_fontDirty |= m_style.setWritingMode(mode); }
 inline void BuilderState::setZoom(float zoom) { m_fontDirty |= m_style.setZoom(zoom); }
+
+inline void BuilderState::setFontDescriptionKeywordSizeFromIdentifier(CSSValueID identifier)
+{
+    if (m_style.fontDescription().keywordSizeAsIdentifier() == identifier)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setKeywordSizeFromIdentifier(identifier);
+}
+
+inline void BuilderState::setFontDescriptionIsAbsoluteSize(bool isAbsoluteSize)
+{
+    if (m_style.fontDescription().isAbsoluteSize() == isAbsoluteSize)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setIsAbsoluteSize(isAbsoluteSize);
+}
+
+inline void BuilderState::setFontDescriptionFontSize(float fontSize)
+{
+    if (m_style.fontDescription().specifiedSize() != fontSize) {
+        m_fontDirty = true;
+        m_style.mutableFontDescriptionWithoutUpdate().setSpecifiedSize(fontSize);
+    }
+
+    SUPPRESS_UNCOUNTED_ARG auto computedSize = Style::computedFontSizeFromSpecifiedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), &style(), document());
+    if (m_style.fontDescription().computedSize() != computedSize) {
+        m_fontDirty = true;
+        m_style.mutableFontDescriptionWithoutUpdate().setComputedSize(computedSize);
+    }
+}
+
+inline void BuilderState::setFontDescriptionFamilies(RefCountedFixedVector<AtomString>& families)
+{
+    if (m_style.fontDescription().families() == families)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setFamilies(families);
+    fontCascade.updateUseBackslashAsYenSymbol();
+}
+
+inline void BuilderState::setFontDescriptionFamilies(Vector<AtomString>& families)
+{
+    if (m_style.fontDescription().families() == families)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setFamilies(families);
+    fontCascade.updateUseBackslashAsYenSymbol();
+}
+
+inline void BuilderState::setFontDescriptionIsSpecifiedFont(bool isSpecifiedFont)
+{
+    if (m_style.fontDescription().isSpecifiedFont() == isSpecifiedFont)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setIsSpecifiedFont(isSpecifiedFont);
+}
+
+inline void BuilderState::setFontDescriptionFeatureSettings(FontFeatureSettings&& featureSettings)
+{
+    if (m_style.fontDescription().featureSettings() == featureSettings)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setFeatureSettings(WTFMove(featureSettings));
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionFontPalette(const FontPalette& fontPalette)
+{
+    if (m_style.fontDescription().fontPalette() == fontPalette)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontPalette(fontPalette);
+}
+
+inline void BuilderState::setFontDescriptionFontSizeAdjust(FontSizeAdjust fontSizeAdjust)
+{
+    if (m_style.fontDescription().fontSizeAdjust() == fontSizeAdjust)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSizeAdjust(WTFMove(fontSizeAdjust));
+}
+
+inline void BuilderState::setFontDescriptionFontSmoothing(FontSmoothingMode fontSmoothing)
+{
+    if (m_style.fontDescription().fontSmoothing() == fontSmoothing)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSmoothing(WTFMove(fontSmoothing));
+}
+
+inline void BuilderState::setFontDescriptionFontSynthesisSmallCaps(FontSynthesisLonghandValue fontSynthesisSmallCaps)
+{
+    if (m_style.fontDescription().fontSynthesisSmallCaps() == fontSynthesisSmallCaps)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSynthesisSmallCaps(WTFMove(fontSynthesisSmallCaps));
+}
+
+inline void BuilderState::setFontDescriptionFontSynthesisStyle(FontSynthesisLonghandValue fontSynthesisStyle)
+{
+    if (m_style.fontDescription().fontSynthesisStyle() == fontSynthesisStyle)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSynthesisStyle(fontSynthesisStyle);
+}
+
+inline void BuilderState::setFontDescriptionFontSynthesisWeight(FontSynthesisLonghandValue fontSynthesisWeight)
+{
+    if (m_style.fontDescription().fontSynthesisWeight() == fontSynthesisWeight)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSynthesisWeight(fontSynthesisWeight);
+}
+
+inline void BuilderState::setFontDescriptionKerning(Kerning kerning)
+{
+    if (m_style.fontDescription().kerning() == kerning)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setKerning(kerning);
+    fontCascade.updateEnableKerning();
+}
+
+inline void BuilderState::setFontDescriptionOpticalSizing(FontOpticalSizing opticalSizing)
+{
+    if (m_style.fontDescription().opticalSizing() == opticalSizing)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setOpticalSizing(opticalSizing);
+}
+
+inline void BuilderState::setFontDescriptionSpecifiedLocale(const AtomString& specifiedLocale)
+{
+    if (m_style.fontDescription().specifiedLocale() == specifiedLocale)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setSpecifiedLocale(specifiedLocale);
+}
+
+inline void BuilderState::setFontDescriptionTextAutospace(TextAutospace textAutospace)
+{
+    if (m_style.fontDescription().textAutospace() == textAutospace)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setTextAutospace(textAutospace);
+}
+
+inline void BuilderState::setFontDescriptionTextRenderingMode(TextRenderingMode textRenderingMode)
+{
+    if (m_style.fontDescription().textRenderingMode() == textRenderingMode)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setTextRenderingMode(textRenderingMode);
+    fontCascade.updateEnableKerning();
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionTextSpacingTrim(TextSpacingTrim textSpacingTrim)
+{
+    if (m_style.fontDescription().textSpacingTrim() == textSpacingTrim)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setTextSpacingTrim(textSpacingTrim);
+}
+
+inline void BuilderState::setFontDescriptionVariantCaps(FontVariantCaps variantCaps)
+{
+    if (m_style.fontDescription().variantCaps() == variantCaps)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantCaps(variantCaps);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantEmoji(FontVariantEmoji variantEmoji)
+{
+    if (m_style.fontDescription().variantEmoji() == variantEmoji)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantEmoji(variantEmoji);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantPosition(FontVariantPosition variantPosition)
+{
+    if (m_style.fontDescription().variantPosition() == variantPosition)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantPosition(variantPosition);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariationSettings(FontVariationSettings&& variationSettings)
+{
+    if (m_style.fontDescription().variationSettings() == variationSettings)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setVariationSettings(WTFMove(variationSettings));
+}
+
+inline void BuilderState::setFontDescriptionWeight(FontSelectionValue weight)
+{
+    if (m_style.fontDescription().weight() == weight)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setWeight(weight);
+}
+
+inline void BuilderState::setFontDescriptionWidth(FontSelectionValue width)
+{
+    if (m_style.fontDescription().width() == width)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setWidth(width);
+}
+
+inline void BuilderState::setFontDescriptionVariantAlternates(const FontVariantAlternates& variantAlternates)
+{
+    if (m_style.fontDescription().variantAlternates() == variantAlternates)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantAlternates(variantAlternates);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantEastAsianVariant(FontVariantEastAsianVariant variantEastAsianVariant)
+{
+    if (m_style.fontDescription().variantEastAsianVariant() == variantEastAsianVariant)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantEastAsianVariant(variantEastAsianVariant);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantEastAsianWidth(FontVariantEastAsianWidth variantEastAsianWidth)
+{
+    if (m_style.fontDescription().variantEastAsianWidth() == variantEastAsianWidth)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantEastAsianWidth(variantEastAsianWidth);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantEastAsianRuby(FontVariantEastAsianRuby variantEastAsianRuby)
+{
+    if (m_style.fontDescription().variantEastAsianRuby() == variantEastAsianRuby)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantEastAsianRuby(variantEastAsianRuby);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionKeywordSize(unsigned keywordSize)
+{
+    if (m_style.fontDescription().keywordSize() == keywordSize)
+        return;
+
+    m_fontDirty = true;
+    m_style.mutableFontDescriptionWithoutUpdate().setKeywordSize(keywordSize);
+}
+
+inline void BuilderState::setFontDescriptionVariantCommonLigatures(FontVariantLigatures variantCommonLigatures)
+{
+    if (m_style.fontDescription().variantCommonLigatures() == variantCommonLigatures)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantCommonLigatures(variantCommonLigatures);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantDiscretionaryLigatures(FontVariantLigatures variantDiscretionaryLigatures)
+{
+    if (m_style.fontDescription().variantDiscretionaryLigatures() == variantDiscretionaryLigatures)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantDiscretionaryLigatures(variantDiscretionaryLigatures);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantHistoricalLigatures(FontVariantLigatures variantHistoricalLigatures)
+{
+    if (m_style.fontDescription().variantHistoricalLigatures() == variantHistoricalLigatures)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantHistoricalLigatures(variantHistoricalLigatures);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantContextualAlternates(FontVariantLigatures variantContextualAlternates)
+{
+    if (m_style.fontDescription().variantContextualAlternates() == variantContextualAlternates)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantContextualAlternates(variantContextualAlternates);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantNumericFigure(FontVariantNumericFigure variantNumericFigure)
+{
+    if (m_style.fontDescription().variantNumericFigure() == variantNumericFigure)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantNumericFigure(variantNumericFigure);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantNumericSpacing(FontVariantNumericSpacing variantNumericSpacing)
+{
+    if (m_style.fontDescription().variantNumericSpacing() == variantNumericSpacing)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantNumericSpacing(variantNumericSpacing);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantNumericFraction(FontVariantNumericFraction variantNumericFraction)
+{
+    if (m_style.fontDescription().variantNumericFraction() == variantNumericFraction)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantNumericFraction(variantNumericFraction);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal variantNumericOrdinal)
+{
+    if (m_style.fontDescription().variantNumericOrdinal() == variantNumericOrdinal)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantNumericOrdinal(variantNumericOrdinal);
+    fontCascade.updateRequiresShaping();
+}
+
+inline void BuilderState::setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero variantNumericSlashedZero)
+{
+    if (m_style.fontDescription().variantNumericSlashedZero() == variantNumericSlashedZero)
+        return;
+
+    m_fontDirty = true;
+    auto& fontCascade = m_style.mutableFontCascadeWithoutUpdate();
+    fontCascade.mutableFontDescription().setVariantNumericSlashedZero(variantNumericSlashedZero);
+    fontCascade.updateRequiresShaping();
+}
 
 }
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5579,7 +5579,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
             rangeOfInterest.end = closestEditablePositionInElementForAbsolutePoint(*element, roundedIntPoint(request.rect.maxXMaxYCorner()));
         } else if (RefPtr textFormControlElement = dynamicDowncast<HTMLTextFormControlElement>(element)) {
             rangeOfInterest.start = textFormControlElement->visiblePositionForIndex(0);
-            rangeOfInterest.end = textFormControlElement->visiblePositionForIndex(textFormControlElement->value().length());
+            rangeOfInterest.end = textFormControlElement->visiblePositionForIndex(textFormControlElement->value()->length());
         } else {
             rangeOfInterest.start = firstPositionInOrBeforeNode(element.get());
             rangeOfInterest.end = lastPositionInOrAfterNode(element.get());

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
@@ -535,7 +535,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
         return [super endPosition];
     
     RenderTextControl& textControl = downcast<RenderTextControl>(*object);
-    VisiblePosition visiblePosition = textControl.textFormControlElement().visiblePositionForIndex(textControl.textFormControlElement().value().length());
+    VisiblePosition visiblePosition = textControl.textFormControlElement().visiblePositionForIndex(textControl.textFormControlElement().value()->length());
     return [WebVisiblePosition _wrapVisiblePosition:visiblePosition];
 }
 
@@ -562,7 +562,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
         return [super endPosition];
     
     RenderTextControl& textControl = downcast<RenderTextControl>(*object);
-    VisiblePosition visiblePosition = textControl.textFormControlElement().visiblePositionForIndex(textControl.textFormControlElement().value().length());
+    VisiblePosition visiblePosition = textControl.textFormControlElement().visiblePositionForIndex(textControl.textFormControlElement().value()->length());
     return [WebVisiblePosition _wrapVisiblePosition:visiblePosition];
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -449,7 +449,7 @@
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->value().createNSString().autorelease();
+    return IMPL->value()->createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
@@ -213,7 +213,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (NSString *)value
 {
     WebCore::JSMainThreadNullState state;
-    return unwrap(*self).value().createNSString().autorelease();
+    return unwrap(*self).value()->createNSString().autorelease();
 }
 
 - (void)setValue:(NSString *)newValue


### PR DESCRIPTION
#### 5caae6b082d7b5b47e6250c3b8189869abcc4574
<pre>
StringImpl refcounting should be atomic
<a href="https://bugs.webkit.org/show_bug.cgi?id=289962">https://bugs.webkit.org/show_bug.cgi?id=289962</a>
<a href="https://rdar.apple.com/147313174">rdar://147313174</a>

Reviewed by Antti Koivisto, Yusuke Suzuki, Chris Dumez, and Keith Miller.

This patch takes the first step to making WTF::String thread-safe: Making
m_refcount increment and decrement atomic. (Hash, flags, and the AtomString
table are not yet atomic. I plan to address those in my next patch.)

The direct code change is pretty small, but it measured as a performance
regression. So most of this code is optimization. I got rid of about 1/3 of
WTF::StringImpl refcounts on Speedometer and about 1/2 on JetStream.

ARM has a special ldadd instruction for fast atomics. Net net, it measures as
about 1.5X slower than just add. That&apos;s pretty good! But it still required
some optimizations to be affordable. Intel atomics are much slower, so it took
far more optimizations to get Intel across the finish line.

A/B testers suggest that we might still have a &lt; 0.5% JetStream regression on
Intel. I checked in with Yusuke, Keith, and Maciej, and we can move forward
because we have a large total JetStream speedup on Intel this year, so customers
on older hardware will still see a net speedup when they get new software.

* Source/JavaScriptCore/bytecode/DirectEvalCodeCache.cpp:
(JSC::DirectEvalCodeCache::setSlow):
* Source/JavaScriptCore/bytecode/DirectEvalCodeCache.h:
(JSC::DirectEvalCodeCache::CacheKey::CacheKey):
(JSC::DirectEvalCodeCache::CacheKey::hash const):
(JSC::DirectEvalCodeCache::CacheKey::operator== const):
(JSC::DirectEvalCodeCache::CacheLookupKey::CacheLookupKey):
(JSC::DirectEvalCodeCache::CacheLookupKey::hash const):
(JSC::DirectEvalCodeCache::CacheLookupKey::operator== const):
(JSC::DirectEvalCodeCache::CacheLookupKey::operator CacheKey const):
(JSC::DirectEvalCodeCache::CacheLookupKeyHashTranslator::hash):
(JSC::DirectEvalCodeCache::CacheLookupKeyHashTranslator::equal):
(JSC::DirectEvalCodeCache::get):
(JSC::DirectEvalCodeCache::set):
(JSC::DirectEvalCodeCache::tryGet): Deleted.
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::directEvalCacheKey):
(JSC::eval): Added a fast path for looking up a rope string without resolving
the rope when the right hand side of the rope is trivial.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION): No need to ref StringImpls here because
the Structure they came from ensures their lifetime in this scope.

* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::putByVal):
(JSC::putByValOptimize):
(JSC::getByVal):
(JSC::JSC_DEFINE_JIT_OPERATION):
(JSC::getByValWithThis):
(JSC::getByValMegamorphic): Refactored fast paths not to ref strings.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::enqueue): Dan and I collided here on
<a href="https://commits.webkit.org/293052@main">https://commits.webkit.org/293052@main</a>, but this version measured as a speedup
so I&apos;m keeping the slight change in how we load this value in case it matters.

* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseModuleSourceElements):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::hasDeclaredVariable):
(JSC::Scope::hasLexicallyDeclaredVariable const):
(JSC::Scope::hasDeclaredParameter):
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
(JSC::VariableEnvironment::markVariableAsCapturedIfDefined):
(JSC::VariableEnvironment::markVariableAsCaptured):
(JSC::VariableEnvironment::markVariableAsImported):
(JSC::VariableEnvironment::markVariableAsExported):
* Source/JavaScriptCore/parser/VariableEnvironment.h:
(JSC::VariableEnvironment::contains const):
(JSC::VariableEnvironment::remove):
(JSC::VariableEnvironment::find):
(JSC::VariableEnvironment::find const):
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::MarkedVector::begin):
(JSC::MarkedVector::end): Removed some unnecessary conversions from StringImpl*
to RefPtr&lt;StringImpl&gt; for lookup.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastJoin):
(JSC::JSC_DEFINE_HOST_FUNCTION): Added a fast path for joins that are all
strings.

* Source/JavaScriptCore/runtime/CacheableIdentifier.h:
* Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h: Added a fast path
for grabbing a cacheable identifier without first asking if it exists.

* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION): No need for refcount churn if our StringImpl*
is owned by our structure.

* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
(JSC::JSONAtomStringCache::makeIdentifier): Deleted.
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::makeIdentifier):
(JSC::JSONAtomStringCache::existingIdentifier):
(JSC::JSONAtomStringCache::make): Deleted. Added a fast path for grabbing a
StringImpl* without refcount churn.

* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
(JSC::JSObject::putDirectForJSONSlow): Deleted.
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::putDirectInternal): Our fast path doesn&apos;t deterministically rule
out a hit anymore, so we can&apos;t skip that check on the slow path anymore.

* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC:: const):
(JSC::JSRopeString::resolveRopeToAtomString const): Deleted.
(JSC::JSRopeString::resolveRopeToExistingAtomString const): Deleted.
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::getValueImpl const):
(JSC::JSString::tryGetValueImpl const):
(JSC:: const):
(JSC::JSString::toAtomString const): Deleted.
(JSC::JSString::toExistingAtomString const): Deleted.
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::tryGetLHS const): Use GCOwnedDataScope for more return values, to avoid
refcount churn.

* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::joinStrings):
(JSC::JSOnlyStringsJoiner::joinSlow):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSOnlyStringsJoiner::JSOnlyStringsJoiner):
(JSC::JSOnlyStringsJoiner::tryJoin): Helper class for the fast path for joining
only strings.

* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::equalIdentifier):
(JSC::reviverMode&gt;::existingIdentifier):
(JSC::reviverMode&gt;::makeJSString):
(JSC::requires):
* Source/JavaScriptCore/runtime/LiteralParser.h: Added a fast path for following
a property transition without looking up and/or ref&apos;ing an Identifier.

* Source/JavaScriptCore/runtime/NumericStrings.h: Made the cache bigger because
it made a ~20% difference on hit rate, reducing string churn.

* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast): No need to ref strings owned by our structure.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::substituteBackreferences):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::jsSpliceSubstringsWithSeparator):
(JSC::jsSpliceSubstrings):
(JSC::removeAllUsingRegExpSearch):
(JSC::addToRegExpSearchCache):
(JSC::replaceAllWithCacheUsingRegExpSearchThreeArguments):
(JSC::replaceAllWithCacheUsingRegExpSearch):
(JSC::replaceAllWithStringUsingRegExpSearchNoBackreferences):
(JSC::replaceAllWithStringUsingRegExpSearch):
(JSC::replaceOneWithStringUsingRegExpSearch):
(JSC::replaceUsingRegExpSearch):
(JSC::removeUsingRegExpSearch): Deleted.
(JSC::replaceUsingRegExpSearchWithCache): Deleted.
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::StructureTransitionTable::add): Streamlined the fast paths and added
a new fast path for a single separator join.

* Source/WTF/wtf/ValueOrReference.h: Made a new type to encapsulate a pattern
where we usually return an existing reference, but sometimes need to allocate
a temporary. This avoids a copy in the case where we return an existing reference.
Mostly deployed this in form controls code.

* Source/WTF/wtf/Vector.h:
(WTF::insertInUniquedSortedVector): Factored out a helper function for use in
HTML attributes.

* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::ref):
(WTF::StringImpl::deref): Aha! The actual refcounting change. (Note that memory order
is relaxed because we have no data dependencies yet. That will come next.)

* Source/WebCore/dom/Attribute.h:
(WebCore::Attribute::Attribute): Don&apos;t copy strings when moving.

* Source/WebCore/dom/CharacterData.h: Don&apos;t copy the empty string unless you&apos;re
actually going to use it.

* Source/WebCore/dom/ElementTextDirection.cpp:
(WebCore::computeAutoDirectionality):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::create): Deleted.
* Source/WebCore/dom/Text.h:
(WebCore::Text::create):
* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::AutofillElements::computeAutofillElements):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processElement):
* Source/WebCore/html/BaseCheckableInputType.cpp:
(WebCore::BaseCheckableInputType::fallbackValue const):
* Source/WebCore/html/BaseCheckableInputType.h:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::hasBadInput const):
(WebCore::BaseDateAndTimeInputType::sanitizeValue const):
(WebCore::BaseDateAndTimeInputType::updateInnerTextValue):
(WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::fallbackValue const):
(WebCore::ColorInputType::sanitizeValue const):
(WebCore::ColorInputType::valueAsColor const):
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/DateTimeLocalInputType.cpp:
(WebCore::DateTimeLocalInputType::sanitizeValue const):
* Source/WebCore/html/DateTimeLocalInputType.h:
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::tooShort const):
(WebCore::HTMLInputElement::tooLong const):
(WebCore::HTMLInputElement::computeValidity const):
(WebCore::HTMLInputElement::listOptionValueAsDouble):
(WebCore::HTMLInputElement::value const):
(WebCore::HTMLInputElement::valueWithDefault const):
(WebCore::HTMLInputElement::setValue):
(WebCore::HTMLInputElement::sanitizeValue const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::childrenChanged):
(WebCore::HTMLTextAreaElement::appendFormData):
(WebCore::HTMLTextAreaElement::value const):
(WebCore::HTMLTextAreaElement::setValueCommon):
(WebCore::HTMLTextAreaElement::validationMessage const):
(WebCore::HTMLTextAreaElement::valueMissing const):
(WebCore::HTMLTextAreaElement::tooShort const):
(WebCore::HTMLTextAreaElement::tooLong const):
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::insertedIntoAncestor):
(WebCore::HTMLTextFormControlElement::selectedText const):
(WebCore::HTMLTextFormControlElement::dispatchFormControlChangeEvent):
* Source/WebCore/html/HTMLTextFormControlElement.h:
(WebCore::HTMLTextFormControlElement::setTextAsOfLastFormControlChangeEvent):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::fallbackValue const):
(WebCore::InputType::sanitizeValue const):
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/MonthInputType.cpp:
(WebCore::MonthInputType::valueAsDate const):
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::valueAsDouble const):
(WebCore::NumberInputType::sanitizeValue const):
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/RadioNodeList.cpp:
(WebCore::nonEmptyRadioButton):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::valueAsDouble const):
(WebCore::RangeInputType::setValue):
(WebCore::RangeInputType::fallbackValue const):
(WebCore::RangeInputType::sanitizeValue const):
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::setValue):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::setValue):
(WebCore::limitLength):
(WebCore::TextFieldInputType::sanitizeValue const):
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/URLInputType.cpp:
(WebCore::URLInputType::sanitizeValue const):
* Source/WebCore/html/URLInputType.h:

* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::initializeAttributes): Use raw pointers for unique-ing
because we&apos;re retaining them elsewhere and anyway we never dereference them.
Use a Vector instead of a hash table because number of elements is usually
small, so a Vector is faster.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseAttributes): Don&apos;t copy the empty string
unless you have to.
(WebCore::insertInUniquedSortedVector): Deleted.

* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::visibleValue const):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::value const):
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
(WebCore::DateTimeSymbolicFieldElement::value const):
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h:
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::sliderPosition):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldCancelButtonElement::resolveCustomStyle):

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::width):
(WebCore::Layout::TextUtil::trailingWhitespaceWidth):
(WebCore::Layout::TextUtil::fallbackFontsForText):
(WebCore::Layout::TextUtil::breakWord):
(WebCore::Layout::TextUtil::firstUserPerceivedCharacterLength):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowNonInteractiveCursorForElement):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyFontTransforms):
(WebCore::WidthIterator::advanceInternal):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::visibilityForCancelButton const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
(WebCore::Style::Adjuster::adjustmentForTextAutosizing): Don&apos;t copy for no reason.
Conversely, don&apos;t declare const auto&amp; when it has no meaning.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::mutableFontDescriptionWithoutUpdate):
(WebCore::RenderStyle::mutableFontCascadeWithoutUpdate):
* Source/WebCore/rendering/style/RenderStyle.h: Helper functions for the setters
below.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
(WebCore::Style::Adjuster::adjustmentForTextAutosizing):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyImpl): Avoid refcount churn.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueWebkitLocale):
(WebCore::Style::BuilderCustom::applyInitialFontFamily):
(WebCore::Style::BuilderCustom::applyInheritFontFamily):
(WebCore::Style::BuilderCustom::applyValueFontFamily):
(WebCore::Style::BuilderCustom::applyInheritFontVariantLigatures):
(WebCore::Style::BuilderCustom::applyInitialFontVariantLigatures):
(WebCore::Style::BuilderCustom::applyValueFontVariantLigatures):
(WebCore::Style::BuilderCustom::applyInheritFontVariantNumeric):
(WebCore::Style::BuilderCustom::applyInitialFontVariantNumeric):
(WebCore::Style::BuilderCustom::applyValueFontVariantNumeric):
(WebCore::Style::BuilderCustom::applyInheritFontVariantEastAsian):
(WebCore::Style::BuilderCustom::applyInitialFontVariantEastAsian):
(WebCore::Style::BuilderCustom::applyValueFontVariantEastAsian):
(WebCore::Style::BuilderCustom::applyInheritFontVariantAlternates):
(WebCore::Style::BuilderCustom::applyInitialFontVariantAlternates):
(WebCore::Style::BuilderCustom::applyInheritFontSize):
(WebCore::Style::BuilderCustom::applyValueFontSize):
(WebCore::Style::BuilderCustom::applyValueFontSizeAdjust):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::updateFontForZoomChange):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
(WebCore::Style::BuilderState::setFontDescription):
(WebCore::Style::BuilderState::setUsedZoom):
(WebCore::Style::BuilderState::setFontDescriptionKeywordSizeFromIdentifier):
(WebCore::Style::BuilderState::setFontDescriptionIsAbsoluteSize):
(WebCore::Style::BuilderState::setFontDescriptionFontSize):
(WebCore::Style::BuilderState::setFontDescriptionFamilies):
(WebCore::Style::BuilderState::setFontDescriptionIsSpecifiedFont):
(WebCore::Style::BuilderState::setFontDescriptionFeatureSettings):
(WebCore::Style::BuilderState::setFontDescriptionFontPalette):
(WebCore::Style::BuilderState::setFontDescriptionFontSizeAdjust):
(WebCore::Style::BuilderState::setFontDescriptionFontSmoothing):
(WebCore::Style::BuilderState::setFontDescriptionFontSynthesisSmallCaps):
(WebCore::Style::BuilderState::setFontDescriptionFontSynthesisStyle):
(WebCore::Style::BuilderState::setFontDescriptionFontSynthesisWeight):
(WebCore::Style::BuilderState::setFontDescriptionKerning):
(WebCore::Style::BuilderState::setFontDescriptionOpticalSizing):
(WebCore::Style::BuilderState::setFontDescriptionSpecifiedLocale):
(WebCore::Style::BuilderState::setFontDescriptionTextAutospace):
(WebCore::Style::BuilderState::setFontDescriptionTextRenderingMode):
(WebCore::Style::BuilderState::setFontDescriptionTextSpacingTrim):
(WebCore::Style::BuilderState::setFontDescriptionVariantCaps):
(WebCore::Style::BuilderState::setFontDescriptionVariantEmoji):
(WebCore::Style::BuilderState::setFontDescriptionVariantPosition):
(WebCore::Style::BuilderState::setFontDescriptionVariationSettings):
(WebCore::Style::BuilderState::setFontDescriptionWeight):
(WebCore::Style::BuilderState::setFontDescriptionWidth):
(WebCore::Style::BuilderState::setFontDescriptionVariantAlternates):
(WebCore::Style::BuilderState::setFontDescriptionVariantEastAsianVariant):
(WebCore::Style::BuilderState::setFontDescriptionVariantEastAsianWidth):
(WebCore::Style::BuilderState::setFontDescriptionVariantEastAsianRuby):
(WebCore::Style::BuilderState::setFontDescriptionKeywordSize):
(WebCore::Style::BuilderState::setFontDescriptionVariantCommonLigatures):
(WebCore::Style::BuilderState::setFontDescriptionVariantDiscretionaryLigatures):
(WebCore::Style::BuilderState::setFontDescriptionVariantHistoricalLigatures):
(WebCore::Style::BuilderState::setFontDescriptionVariantContextualAlternates):
(WebCore::Style::BuilderState::setFontDescriptionVariantNumericFigure):
(WebCore::Style::BuilderState::setFontDescriptionVariantNumericSpacing):
(WebCore::Style::BuilderState::setFontDescriptionVariantNumericFraction):
(WebCore::Style::BuilderState::setFontDescriptionVariantNumericOrdinal):
(WebCore::Style::BuilderState::setFontDescriptionVariantNumericSlashedZero): Added
efficient setters that avoid copying FontCascadeDescription. FontCascadeDescription
is 192 bytes, plus some out of line Vector storage, plus some String refcounts.
Copying a FontCascadeDescription just to change a bool is expensive. Copying
a FontCascadeDescription when nothing has changed is just funny.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm:
(-[DOMHTMLInputElement endPosition]):
(-[DOMHTMLTextAreaElement endPosition]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
(-[DOMHTMLInputElement value]):
* Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm:
(-[DOMHTMLTextAreaElement value]):

Canonical link: <a href="https://commits.webkit.org/293816@main">https://commits.webkit.org/293816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75eb823f5780f7f84ff7b5545679544664572e88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100009 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103016 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90324 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/56504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49959 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92667 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107497 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98616 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86529 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/84629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20958 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16272 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32287 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122242 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26870 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34126 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->