### PR TITLE
WebProcess crash from CheckedPtr assertion under styleForContainer

### DIFF
--- a/LayoutTests/fast/css/nested-shadow-dom-css-container-query-expected.txt
+++ b/LayoutTests/fast/css/nested-shadow-dom-css-container-query-expected.txt
@@ -1,0 +1,3 @@
+Tests CSS container queries don't break when using nested shadow DOM
+
+PASS if not crash

--- a/LayoutTests/fast/css/nested-shadow-dom-css-container-query.html
+++ b/LayoutTests/fast/css/nested-shadow-dom-css-container-query.html
@@ -1,0 +1,78 @@
+<!doctype html>
+  <html lang="en">
+  <body>
+    <outer-custom-el></outer-custom-el>
+    <p>Tests CSS container queries don't break when using nested shadow DOM</p>
+    <p>PASS if not crash</p>
+  </body>
+  <script>
+    var ShadowHostBase = class extends HTMLElement {
+      createRenderRoot() {
+        const renderRoot = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+        renderRoot.adoptedStyleSheets = this.constructor.styles;
+        return renderRoot;
+      }
+      connectedCallback() {
+        this.renderRoot ??= this.createRenderRoot();
+        this.update();
+      }
+      update() {
+        const htmlContent = this.render();
+        const template = document.createElement("template");
+        template.innerHTML = htmlContent;
+        this.renderRoot.appendChild(template.content.cloneNode(true));
+      }
+    };
+    ShadowHostBase.shadowRootOptions = { mode: "open" };
+    var SecondShadowHost = class extends ShadowHostBase {
+      render() {
+        return `
+        <div>
+          <span part="label">Nested span with label part</span>
+        </div>
+        `;
+      }
+    };
+    var secondShadowHostStyles = `div:hover span {
+    }`;
+    var prepareStyleSheets = (textStyle) => {
+      const style = new CSSStyleSheet();
+      style.replaceSync(textStyle);
+      return [style];
+    };
+    SecondShadowHost.styles = prepareStyleSheets(secondShadowHostStyles);
+    customElements.define("inner-custom-el", SecondShadowHost);
+    var firstShadowHostStyles = `* {
+      @container style(--foo: bar) {
+        ::part(baz) {}
+      }
+    }`;
+    var FirstShadowHost = class extends ShadowHostBase {
+      render() {
+        return `
+        <inner-custom-el>
+        </inner-custom-el>
+      `;
+      }
+    };
+    FirstShadowHost.styles = prepareStyleSheets(firstShadowHostStyles);
+    customElements.define("outer-custom-el", FirstShadowHost);
+
+    if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+    }
+    window.onload = async () => {
+      await customElements.whenDefined('outer-custom-el');
+      await customElements.whenDefined('inner-custom-el');
+      const button = document.querySelector('outer-custom-el').shadowRoot.querySelector('inner-custom-el');
+      const rect = button.getBoundingClientRect();
+      if (window.eventSender) {
+        // The action below triggers the hover behaviour. In combination with the styles defined earlier,
+        // this triggers styleForContainer and used to crash.
+        eventSender.mouseMoveTo(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      }
+      testRunner.notifyDone();
+    };
+  </script>
+</html>

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -61,7 +61,7 @@ static const RenderStyle* styleForContainer(const Element& container, OptionSet<
 {
     // Any element can be a style container and we haven't necessarily committed the style to render tree yet.
     // Look it up from the currently computed style update instead.
-    if (requiredAxes.isEmpty() && evaluationState)
+    if (requiredAxes.isEmpty() && evaluationState && evaluationState->styleUpdate)
         return evaluationState->styleUpdate->elementStyle(container);
 
     return container.existingComputedStyle();


### PR DESCRIPTION
#### f34f7f5c4f50fb52e9c87bdade1e59dadce9d455
<pre>
WebProcess crash from CheckedPtr assertion under styleForContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=289963">https://bugs.webkit.org/show_bug.cgi?id=289963</a>

Reviewed by Antti Koivisto.

Avoid dereferencing a styleUpdate if it is still uninitialised. Added
test triggering the crash.

* LayoutTests/fast/css/nested-shadow-dom-css-container-query-expected.txt: Added.
* LayoutTests/fast/css/nested-shadow-dom-css-container-query.html: Added.
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::styleForContainer):

Canonical link: <a href="https://commits.webkit.org/294104@main">https://commits.webkit.org/294104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22e672f31d5af64acd0031e4968a68b76fa8432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108202 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33016 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->