### PR TITLE
Move webpushd state to container

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -300,6 +300,13 @@ function mac_process_webpushd_entitlements()
     plistbuddy Add :com.apple.private.aps-connection-initiate bool YES
     plistbuddy Add :com.apple.private.launchservices.entitledtoaccessothersessions bool YES
     plistbuddy Add :com.apple.usernotification.notificationschedulerproxy bool YES
+
+    if [[ "${WK_RELOCATABLE_WEBPUSHD}" == NO ]]; then
+        plistbuddy Add :com.apple.security.application-groups array
+        plistbuddy Add :com.apple.security.application-groups:0 string group.com.apple.webkit.webpushd
+        plistbuddy Add :com.apple.private.security.restricted-application-groups array
+        plistbuddy Add :com.apple.private.security.restricted-application-groups:0 string group.com.apple.webkit.webpushd
+    fi
 }
 
 # ========================================

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
@@ -298,3 +298,9 @@
 ;;; Allow interfacing with UNUserNotificationCenter
 (allow mach-lookup
     (global-name "com.apple.usernotifications.listener"))
+
+;;; Allow looking up container paths
+(allow file-read* file-write*
+    (extension "com.apple.sandbox.application-group"))
+
+(allow mach-lookup (global-name "com.apple.containermanagerd"))


### PR DESCRIPTION
#### 8237aaf69a3ffed7d5969214385fa99cfeb71ded
<pre>
Move webpushd state to container
<a href="https://bugs.webkit.org/show_bug.cgi?id=289557">https://bugs.webkit.org/show_bug.cgi?id=289557</a>
<a href="https://rdar.apple.com/110714823">rdar://110714823</a>

Reviewed by Brady Eidson.

The data in ~/Library/WebKit/WebPush contains state that only webpushd needs to access. To enforce
this, move that state in to a container. We do this at process launch time. If we detect state in
the old location and no state in the new location, then we initiate a one-time migration.

* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::getWebPushDirectoryPathWithMigrationIfNecessary):
(WebKit::WebPushDaemonMain):
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in:

Canonical link: <a href="https://commits.webkit.org/292327@main">https://commits.webkit.org/292327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1962966398c2ef13cc3d0ea1e4231d86a1b30e3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46132 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72930 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30193 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53263 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/95115 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11342 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22677 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81972 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25912 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16022 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22645 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->