### PR TITLE
Rename several helper methods in iOS selection code after 291696@main

### DIFF
--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2664,7 +2664,7 @@ static void adjustTextDirectionForCoalescedGeometries(const SelectionEndpointDir
     }
 }
 
-static bool currentNodeRequiresToSeparateLines(const RenderObject* currentRenderer)
+static bool shouldRenderSelectionOnSeparateLine(const RenderObject* currentRenderer)
 {
     if (!currentRenderer)
         return false;
@@ -2678,7 +2678,7 @@ static bool currentNodeRequiresToSeparateLines(const RenderObject* currentRender
     return false;
 }
 
-static bool hasAncestorRequiresToSeparateLines(RenderObject* descendant, const RenderObject* stayWithin)
+static bool hasAncestorWithSelectionOnSeparateLine(RenderObject* descendant, const RenderObject* stayWithin)
 {
     for (CheckedPtr current = descendant; current; current = current->parent()) {
         if (current->isOutOfFlowPositioned())
@@ -2691,11 +2691,11 @@ static bool hasAncestorRequiresToSeparateLines(RenderObject* descendant, const R
     return false;
 }
 
-static bool previousNodeRequiresToSeparateLines(RenderObject* previousRenderer, const RenderObject* stayWithin)
+static bool shouldRenderPreviousSelectionOnSeparateLine(RenderObject* previousRenderer, const RenderObject* stayWithin)
 {
     if (!previousRenderer || !stayWithin)
         return false;
-    return hasAncestorRequiresToSeparateLines(previousRenderer, stayWithin);
+    return hasAncestorWithSelectionOnSeparateLine(previousRenderer, stayWithin);
 }
 
 auto RenderObject::collectSelectionGeometriesInternal(const SimpleRange& range) -> SelectionGeometries
@@ -2714,7 +2714,7 @@ auto RenderObject::collectSelectionGeometriesInternal(const SimpleRange& range) 
             continue;
 
         if (!separateFromPreviousLine)
-            separateFromPreviousLine = currentNodeRequiresToSeparateLines(renderer.get()) || previousNodeRequiresToSeparateLines(previousRenderer.get(), renderer->previousSibling());
+            separateFromPreviousLine = shouldRenderSelectionOnSeparateLine(renderer.get()) || shouldRenderPreviousSelectionOnSeparateLine(previousRenderer.get(), renderer->previousSibling());
         previousRenderer = renderer.get();
 
         // Only ask leaf render objects for their line box rects.


### PR DESCRIPTION
#### bacd813bd34a82d93fb689dd9f4d34371d7277bc
<pre>
Rename several helper methods in iOS selection code after 291696@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=289968">https://bugs.webkit.org/show_bug.cgi?id=289968</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Rename several helper methods that are grammatically incorrect:

- `currentNodeRequiresToSeparateLines` → `shouldRenderSelectionOnSeparateLine`
- `previousNodeRequiresToSeparateLines` → `shouldRenderPreviousSelectionOnSeparateLine`
- `hasAncestorRequiresToSeparateLines` → `hasAncestorWithSelectionOnSeparateLine`

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::shouldRenderSelectionOnSeparateLine):
(WebCore::hasAncestorWithSelectionOnSeparateLine):
(WebCore::shouldRenderPreviousSelectionOnSeparateLine):
(WebCore::RenderObject::collectSelectionGeometriesInternal):
(WebCore::currentNodeRequiresToSeparateLines): Deleted.
(WebCore::hasAncestorRequiresToSeparateLines): Deleted.
(WebCore::previousNodeRequiresToSeparateLines): Deleted.

Canonical link: <a href="https://commits.webkit.org/292317@main">https://commits.webkit.org/292317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3515528c43ea7fc0dbee776705dc1c0054bc998d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15212 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5124 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86362 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Running checkout-pull-request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4075 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45451 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81310 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25897 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16005 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22628 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->