### PR TITLE
Correct performance regression caused by additional bounds check

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -436,10 +436,10 @@ ALWAYS_INLINE FloatRect Font::boundsForGlyph(Glyph glyph) const
 ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGlyphs(std::span<const Glyph> glyphs) const
 {
     const auto glyphCount = glyphs.size();
-    if (!glyphCount)
+    if (UNLIKELY(!glyphCount))
         return { };
 
-    if (glyphCount == 1)
+    if (UNLIKELY(glyphCount == 1))
         return { boundsForGlyph(glyphs[0]) };
 
     Vector<Glyph, inlineGlyphRunCapacity> glyphsNeedingMeasurement;


### PR DESCRIPTION
#### 75e9f6372cbf1b0e384a46130bf757021e3c5959
<pre>
Correct performance regression caused by additional bounds check
<a href="https://bugs.webkit.org/show_bug.cgi?id=289969">https://bugs.webkit.org/show_bug.cgi?id=289969</a>
<a href="https://rdar.apple.com/147325714">rdar://147325714</a>

Reviewed by Matthieu Dubet and Vitor Roriz.

When I landed PR-41576 (292198@main) I added an additional zero-length check on a
Glyph buffer. That branch slowed the patch enough to make it a performance-neutral change.

This patch hints to the branch predictor that the null buffer is unexpected, which
restores the 0.18% performance improvement.

* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::boundsForGlyphs const):

Canonical link: <a href="https://commits.webkit.org/292325@main">https://commits.webkit.org/292325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2760c21712d4c04a345bfdd1013b4a9293aee724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72922 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102697 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81315 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25900 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3370 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16008 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22631 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->