### PR TITLE
[Regression@292296@main] textureDimensions is broken for 1D textures

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_275624-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275624-expected.txt
@@ -1,22 +1,4 @@
-CONSOLE MESSAGE: validation error
-CONSOLE MESSAGE: Failed to compile the shader source, generated metal:
-#include <metal_stdlib>
-#include <metal_types>
-
-using namespace metal;
-
-struct __ArgumentBufferT_0 {
-    texture1d<float, access::sample> global0 [[id(0)]];
-};
-
-[[fragment]] vec<float, 4> function1(constant __ArgumentBufferT_0& __ArgumentBuffer_0 [[buffer(0)]])
-{
-    texture1d<float, access::sample> global0 = __ArgumentBuffer_0.global0;
-    (void)(global0.get_width(min(global0.get_num_mip_levels(), uint(1))));
-    return vec<float, 4>(0., 0., 0., 0.);
-}
-
-
+CONSOLE MESSAGE: no validation error
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1318,10 +1318,11 @@ static void visitArguments(FunctionDefinitionWriter* writer, AST::CallExpression
 
 static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
+    const auto* vector = std::get_if<Types::Vector>(call.inferredType());
     const auto& get = [&](ASCIILiteral property) {
         writer->visit(call.arguments()[0]);
         writer->stringBuilder().append(".get_"_s, property, '(');
-        if (call.arguments().size() > 1) {
+        if (vector && call.arguments().size() > 1) {
             writer->stringBuilder().append("min("_s);
             writer->visit(call.arguments()[0]);
             writer->stringBuilder().append(".get_num_mip_levels(), uint("_s);
@@ -1332,7 +1333,6 @@ static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExp
         writer->stringBuilder().append(')');
     };
 
-    const auto* vector = std::get_if<Types::Vector>(call.inferredType());
     if (!vector) {
         get("width"_s);
         return;


### PR DESCRIPTION
#### 41c2531885689f1396affaf45a8c702a19f2287d
<pre>
[Regression@292296@main] textureDimensions is broken for 1D textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=289971">https://bugs.webkit.org/show_bug.cgi?id=289971</a>
<a href="https://rdar.apple.com/147325897">rdar://147325897</a>

Reviewed by Tadeu Zagallo.

292296@main clamps the lod to the max mip level, but for 1D textures which
require constant levels we shouldn&apos;t do this. 1D textures don&apos;t support
mip levels in WebGPU, so the level is always zero.

Testing: existing wgslc tests caught this

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureDimensions):

Canonical link: <a href="https://commits.webkit.org/292319@main">https://commits.webkit.org/292319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5d66c1d5b9ba23c9d7e729de3783756ddf665b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23668 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30194 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11627 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11338 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/4095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22678 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25909 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22646 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->