### PR TITLE
REGRESSION(274481@main): crash when trying to open web inspector, `RELEASE_ASSERT(!m_inStyleRecalc)` hit under `Document::resolveStyle()`

### DIFF
--- a/LayoutTests/inspector/animation/effectChanged-expected.txt
+++ b/LayoutTests/inspector/animation/effectChanged-expected.txt
@@ -3,8 +3,14 @@ Tests for the Animation.effectChanged event.
 
 == Running test suite: Animation.effectChanged
 -- Running test case: Animation.effectChanged.NewEffect
+PASS: Animation should not start with effect.
+Updating effect...
+
 PASS: Animation should have an effect.
 Changing effect...
+
+PASS: Animation should need to update effect.
+Updating effect...
 
 PASS: Animation should have an effect.
 PASS: Animation effect should have changed.
@@ -12,6 +18,9 @@ PASS: Animation effect should have changed.
 -- Running test case: Animation.effectChanged.NullEffect
 PASS: Animation should have an effect.
 Changing effect...
+
+PASS: Animation should need to update effect.
+Updating effect...
 
 PASS: Animation should not have an effect.
 PASS: Animation effect should have changed.

--- a/LayoutTests/inspector/animation/effectChanged.html
+++ b/LayoutTests/inspector/animation/effectChanged.html
@@ -28,6 +28,10 @@ function test()
 
             InspectorTest.assert(animation.animationType === WI.Animation.Type.WebAnimation, "Animation should be a web animation.");
 
+            InspectorTest.expectNull(animation._effect, "Animation should not start with effect.");
+            InspectorTest.log("Updating effect...\n");
+            await animation.ensureEffect();
+
             let oldKeyframes = animation.keyframes;
             InspectorTest.expectNotEmpty(oldKeyframes, "Animation should have an effect.");
 
@@ -36,6 +40,10 @@ function test()
                 animation.awaitEvent(WI.Animation.Event.EffectChanged),
                 InspectorTest.evaluateInPage(`window.animation.effect = new KeyframeEffect(window.animation.effect.target, [{opacity: 1}], {})`),
             ]);
+
+            InspectorTest.expectNull(animation._effect, "Animation should need to update effect.");
+            InspectorTest.log("Updating effect...\n");
+            await animation.ensureEffect();
 
             let newKeyframes = animation.keyframes;
             InspectorTest.expectNotEmpty(newKeyframes, "Animation should have an effect.");
@@ -59,6 +67,8 @@ function test()
 
             InspectorTest.assert(animation.animationType === WI.Animation.Type.WebAnimation, "Animation should be a web animation.");
 
+            // Effect will carry over from previous test case.
+
             let oldKeyframes = animation.keyframes;
             InspectorTest.expectNotEmpty(oldKeyframes, "Animation should have an effect.");
 
@@ -67,6 +77,10 @@ function test()
                 animation.awaitEvent(WI.Animation.Event.EffectChanged),
                 InspectorTest.evaluateInPage(`window.animation.effect = null`),
             ]);
+
+            InspectorTest.expectNull(animation._effect, "Animation should need to update effect.");
+            InspectorTest.log("Updating effect...\n");
+            await animation.ensureEffect();
 
             let newKeyframes = animation.keyframes;
             InspectorTest.expectEmpty(newKeyframes, "Animation should not have an effect.");

--- a/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
+++ b/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
@@ -87,6 +87,7 @@ TestPage.registerInitializer(() => {
 
         InspectorTest.expectEqual(animation.animationType, animationType, `Animation type should be ${WI.Animation.displayNameForAnimationType(animationType)}.`);
 
+        await animation.ensureEffect();
         if (animation.startDelay)
             InspectorTest.log("startDelay: " + JSON.stringify(animation.startDelay));
         if (animation.endDelay)

--- a/Source/JavaScriptCore/inspector/protocol/Animation.json
+++ b/Source/JavaScriptCore/inspector/protocol/Animation.json
@@ -32,7 +32,6 @@
                 { "name": "name", "type": "string", "optional": true, "description": "Equal to `Animation.prototype.get id`." },
                 { "name": "cssAnimationName", "type": "string", "optional": true, "description": "Equal to the corresponding `animation-name` CSS property. Should not be provided if `transitionProperty` is also provided." },
                 { "name": "cssTransitionProperty", "type": "string", "optional": true, "description": "Equal to the corresponding `transition-property` CSS property. Should not be provided if `animationName` is also provided." },
-                { "name": "effect", "$ref": "Effect", "optional": true },
                 { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Backtrace that was captured when this `WebAnimation` was created." }
             ]
         },
@@ -80,6 +79,16 @@
         {
             "name": "disable",
             "description": "Disables Canvas domain events."
+        },
+        {
+            "name": "requestEffect",
+            "description": "Gets the `Effect` for the animation with the given `AnimationId`.",
+            "parameters": [
+                { "name": "animationId", "$ref": "AnimationId" }
+            ],
+            "returns": [
+                { "name": "effect", "$ref": "Effect", "optional": true, "description": "This is omitted when there is no effect." }
+            ]
         },
         {
             "name": "requestEffectTarget",
@@ -131,8 +140,7 @@
             "name": "effectChanged",
             "description": "Dispatched whenever the effect of any animation is changed in any way.",
             "parameters": [
-                { "name": "animationId", "$ref": "AnimationId" },
-                { "name": "effect", "$ref": "Effect", "optional": true, "description": "This is omitted when the effect is removed without a replacement." }
+                { "name": "animationId", "$ref": "AnimationId" }
             ]
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -66,6 +66,7 @@ public:
     // AnimationBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<void> enable();
     Inspector::Protocol::ErrorStringOr<void> disable();
+    Inspector::Protocol::ErrorStringOr<RefPtr<Inspector::Protocol::Animation::Effect>> requestEffect(const Inspector::Protocol::Animation::AnimationId&);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Styleable>> requestEffectTarget(const Inspector::Protocol::Animation::AnimationId&);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveAnimation(const Inspector::Protocol::Animation::AnimationId&, const String& objectGroup);
     Inspector::Protocol::ErrorStringOr<void> startTracking();
@@ -98,20 +99,23 @@ private:
     Inspector::InjectedScriptManager& m_injectedScriptManager;
     WeakRef<Page> m_inspectedPage;
 
-    MemoryCompactRobinHoodHashMap<String, WebAnimation*> m_animationIdMap;
+    MemoryCompactRobinHoodHashMap<Inspector::Protocol::Animation::AnimationId, WebAnimation*> m_animationIdMap;
 
     WeakHashMap<WebAnimation, Ref<Inspector::Protocol::Console::StackTrace>, WeakPtrImplWithEventTargetData> m_animationsPendingBinding;
     Timer m_animationBindingTimer;
 
-    Vector<String> m_removedAnimationIds;
+    Vector<Inspector::Protocol::Animation::AnimationId> m_removedAnimationIds;
     Timer m_animationDestroyedTimer;
 
     struct TrackedStyleOriginatedAnimationData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
-        String trackingAnimationId;
+        Inspector::Protocol::Animation::AnimationId trackingAnimationId;
         ComputedEffectTiming lastComputedTiming;
     };
     HashMap<StyleOriginatedAnimation*, UniqueRef<TrackedStyleOriginatedAnimationData>> m_trackedStyleOriginatedAnimationData;
+
+    WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_animationsIgnoringEffectChanges;
+    WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_animationsIgnoringTargetChanges;
 };
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js
@@ -126,6 +126,7 @@ WI.AnimationManager = class AnimationManager
         if (!animation)
             return;
 
+        // COMPATIBILITY (iOS 18.X, macOS 15.X): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.
         animation.effectChanged(effect);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js
@@ -39,6 +39,7 @@ WI.AnimationObserver = class AnimationObserver extends InspectorBackend.Dispatch
 
     effectChanged(animationId, effect)
     {
+        // COMPATIBILITY (iOS 18.X, macOS 15.X): `Animation.effectChanged` removed the `effect` parameter in favor of `Animation.requestEffect`.`
         WI.animationManager.effectChanged(animationId, effect);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js
@@ -171,8 +171,10 @@ WI.AnimationContentView = class AnimationContentView extends WI.ContentView
         });
     }
 
-    _refreshPreview()
+    async _refreshPreview()
     {
+        await this.representedObject.ensureEffect();
+
         this._previewContainer.removeChildren();
 
         let keyframes = this.representedObject.keyframes;

--- a/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
@@ -137,17 +137,6 @@ WI.AnimationDetailsSidebarPanel = class AnimationDetailsSidebarPanel extends WI.
         this._refreshIdentitySection();
         this._refreshEffectSection();
         this._refreshBacktraceSection();
-
-        for (let codeMirror of this._codeMirrorSectionMap.values())
-            codeMirror.refresh();
-    }
-
-    attached()
-    {
-        super.attached();
-
-        for (let codeMirror of this._codeMirrorSectionMap.values())
-            codeMirror.refresh();
     }
 
     // Private
@@ -184,8 +173,10 @@ WI.AnimationDetailsSidebarPanel = class AnimationDetailsSidebarPanel extends WI.
         });
     }
 
-    _refreshEffectSection()
+    async _refreshEffectSection()
     {
+        await this._animation.ensureEffect();
+
         for (let section of this._codeMirrorSectionMap.keys())
             section.removeEventListener(WI.DetailsSection.Event.CollapsedStateChanged, this._handleDetailsSectionCollapsedStateChanged, this);
         this._codeMirrorSectionMap.clear();
@@ -265,6 +256,11 @@ WI.AnimationDetailsSidebarPanel = class AnimationDetailsSidebarPanel extends WI.
             keyframeSections.push(emptyRow);
         }
         this._keyframesGroup.rows = keyframeSections;
+
+        setTimeout(() => {
+            for (let codeMirror of this._codeMirrorSectionMap.values())
+                codeMirror.refresh();
+        });
     }
 
     _refreshBacktraceSection()


### PR DESCRIPTION
#### 0683db19e202d5882d533a6049780ceb51bb1e76
<pre>
REGRESSION(274481@main): crash when trying to open web inspector, `RELEASE_ASSERT(!m_inStyleRecalc)` hit under `Document::resolveStyle()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286534">https://bugs.webkit.org/show_bug.cgi?id=286534</a>
&lt;<a href="https://rdar.apple.com/problem/143769557">rdar://problem/143769557</a>&gt;

Reviewed by BJ Burg.

Instead of pushing animation effect changes to the frontend every time they happen, have the frontend request the new animation effect only when it needs it.

This avoids the unnecessary work of recalculating and redisplaying the animation effect data when the Graphics Tab is not visible (as well as fixing the bug by not doing work during layout).

For future reference, an alternative fix could&apos;ve been to modify `InspectorAnimationAgent::enable` such that it delays calling `InspectorAnimationAgent::bindAnimation` by at least `0_s` (similar to what `InspectorAnimationAgent::didCreateWebAnimation` already does) so that it can never happen during layout.

* Source/JavaScriptCore/inspector/protocol/Animation.json:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::requestEffect): Added.
(WebCore::InspectorAnimationAgent::requestEffectTarget):
(WebCore::InspectorAnimationAgent::didChangeWebAnimationEffectTiming):
(WebCore::InspectorAnimationAgent::didChangeWebAnimationEffectTarget):
(WebCore::InspectorAnimationAgent::bindAnimation):
* Source/WebInspectorUI/UserInterface/Protocol/AnimationObserver.js:
(WI.AnimationObserver.prototype.effectChanged):
* Source/WebInspectorUI/UserInterface/Controllers/AnimationManager.js:
(WI.AnimationManager.prototype.effectChanged):
* Source/WebInspectorUI/UserInterface/Models/Animation.js:
(WI.Animation):
(WI.Animation.fromPayload):
(WI.Animation.prototype.get startDelay):
(WI.Animation.prototype.get endDelay):
(WI.Animation.prototype.get iterationCount):
(WI.Animation.prototype.get iterationStart):
(WI.Animation.prototype.get iterationDuration):
(WI.Animation.prototype.get timingFunction):
(WI.Animation.prototype.get playbackDirection):
(WI.Animation.prototype.get fillMode):
(WI.Animation.prototype.get keyframes):
(WI.Animation.prototype.ensureEffect): Added.
(WI.Animation.prototype.effectChanged):
(WI.Animation.prototype._updateEffect):

* Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js:
(WI.AnimationContentView.prototype.async _refreshPreview):
* Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js:
(WI.AnimationDetailsSidebarPanel.prototype.layout):
(WI.AnimationDetailsSidebarPanel.prototype.async _refreshEffectSection):
(WI.AnimationDetailsSidebarPanel.prototype.attached): Deleted.
Ensure that the effect is updated before attempting to grab any values from it.
Drive-by: simplify how `CodeMirror.prototype.refresh` is called after updating the effect.

* LayoutTests/inspector/animation/resources/lifecycle-utilities.js:
* LayoutTests/inspector/animation/effectChanged.html:
* LayoutTests/inspector/animation/effectChanged-expected.txt:

Canonical link: <a href="https://commits.webkit.org/292391@main">https://commits.webkit.org/292391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0b84fb848674d2730d8b9d29350020d49929045

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5497 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23983 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/100998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98940 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86655 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4406 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88610 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103025 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94558 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26141 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22967 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118035 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/22626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/26106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->