### PR TITLE
[web-animations] REGRESSION(289928@main): Crash in Style::TreeResolver::createAnimatedElementUpdate on auth.w3.org

### DIFF
--- a/LayoutTests/webanimations/very-short-transition-crash-expected.txt
+++ b/LayoutTests/webanimations/very-short-transition-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webanimations/very-short-transition-crash.html
+++ b/LayoutTests/webanimations/very-short-transition-crash.html
@@ -1,0 +1,33 @@
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    transition-duration: 0.001ms;
+}
+
+div.transition {
+    width: 200px;
+}
+
+</style>
+
+<div>This test passes if it does not crash.</div>
+
+<script>
+
+if (window.testRunner) {
+    window.testRunner.dumpAsText();
+    window.testRunner.waitUntilDone();
+}
+
+(async function() {
+    await new Promise(requestAnimationFrame);
+    document.querySelector("div").classList.add("transition");
+    await new Promise(requestAnimationFrame);
+    if (window.testRunner)
+        window.testRunner.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -71,9 +71,12 @@ void AnimationTimeline::removeAnimation(WebAnimation& animation)
 {
     ASSERT(!animation.timeline() || animation.timeline() == this);
     m_animations.remove(animation);
-    if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
-        if (auto styleable = keyframeEffect->targetStyleable())
+    if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
+        if (auto styleable = keyframeEffect->targetStyleable()) {
             styleable->animationWasRemoved(animation);
+            if (auto* effectStack = styleable->keyframeEffectStack())
+                effectStack->removeEffect(*keyframeEffect);
+        }
     }
 }
 


### PR DESCRIPTION
#### c7df234e8e3024e0bba88b9c78313b08877c4a74
<pre>
[web-animations] REGRESSION(289928@main): Crash in Style::TreeResolver::createAnimatedElementUpdate on auth.w3.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=289980">https://bugs.webkit.org/show_bug.cgi?id=289980</a>
<a href="https://rdar.apple.com/146866523">rdar://146866523</a>

Reviewed by Tim Nguyen.

We must make sure to remove effects from the keyframe effect stack that they&apos;re a member of
or we may end up in situations where an effect stack has null values in its effect list.

* LayoutTests/webanimations/very-short-transition-crash-expected.txt: Added.
* LayoutTests/webanimations/very-short-transition-crash.html: Added.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::removeAnimation):

Canonical link: <a href="https://commits.webkit.org/292328@main">https://commits.webkit.org/292328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b51e4bf2461fc4ae91d474250c65ea8e4c3dea0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95622 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15224 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102706 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81969 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81319 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16017 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15394 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22640 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->