### PR TITLE
tabs.sendMessage() also sends the message to the tab's opener.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h
@@ -34,6 +34,7 @@
 namespace WebKit {
 
 struct WebExtensionMessageTargetParameters {
+    std::optional<WebPageProxyIdentifier> pageProxyIdentifier;
     std::optional<WebExtensionFrameIdentifier> frameIdentifier;
     Markable<WTF::UUID> documentIdentifier;
 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in
@@ -23,6 +23,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 struct WebKit::WebExtensionMessageTargetParameters {
+    std::optional<WebKit::WebPageProxyIdentifier> pageProxyIdentifier;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;
     Markable<WTF::UUID> documentIdentifier;
 };

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -45,6 +45,7 @@
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
+#import "WebPageProxy.h"
 #import <WebCore/ImageBufferUtilitiesCG.h>
 #import <wtf/CallbackAggregator.h>
 
@@ -468,6 +469,12 @@ void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifie
         return;
     }
 
+    auto *webView = tab->webView();
+    if (!webView) {
+        completionHandler({ });
+        return;
+    }
+
     auto targetContentWorldType = isURLForAnyExtension(tab->url()) ? WebExtensionContentWorldType::Main : WebExtensionContentWorldType::ContentScript;
 
     auto processes = tab->processes(WebExtensionEventListenerType::RuntimeOnMessage, targetContentWorldType);
@@ -477,9 +484,12 @@ void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifie
     }
 
     ASSERT(processes.size() == 1);
-    auto process = processes.takeAny();
+    RefPtr process = processes.takeAny();
 
-    process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeMessageEvent(targetContentWorldType, messageJSON, targetParameters, senderParameters), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](String&& replyJSON) mutable {
+    auto targetParametersCopy = targetParameters;
+    targetParametersCopy.pageProxyIdentifier = webView._protectedPage->identifier();
+
+    process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeMessageEvent(targetContentWorldType, messageJSON, targetParametersCopy, senderParameters), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](String&& replyJSON) mutable {
         completionHandler(WTFMove(replyJSON));
     }, identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -599,7 +599,11 @@ static bool matches(WebFrame& frame, const std::optional<WebExtensionMessageTarg
     if (!targetParameters)
         return true;
 
-    // Skip all frames / documents that don't match the target parameters.
+    // Skip all pages / frames / documents that don't match the target parameters.
+    auto& pageProxyIdentifier = targetParameters.value().pageProxyIdentifier;
+    if (pageProxyIdentifier && pageProxyIdentifier != frame.protectedPage()->webPageProxyIdentifier())
+        return false;
+
     auto& frameIdentifier = targetParameters.value().frameIdentifier;
     if (frameIdentifier && !matchesFrame(frameIdentifier.value(), frame))
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -827,6 +827,91 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
     [manager run];
 }
 
+TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>window.open('/window.html', '_blank');</script>"_s } },
+        { "/window.html"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    static auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Tabs Test",
+        @"description": @"Tabs Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"content_scripts": @[
+            @{ @"js": @[ @"main-script.js" ], @"matches": @[ @"*://localhost/" ], @"all_frames": @NO },
+            @{ @"js": @[ @"window-script.js" ], @"matches": @[ @"*://localhost/window.html" ], @"all_frames": @NO }
+        ],
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener(async (message, sender) => {",
+        @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
+
+        @"  const tabId = sender?.tab?.id",
+        @"  browser.test.assertTrue(typeof tabId === 'number', 'tabId should be a valid number')",
+
+        @"  const response = await browser.tabs.sendMessage(tabId, 'Hello, window!')",
+        @"  browser.test.assertEq(response, 'Message received', 'Should receive response from window script')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')",
+    ]);
+
+    auto *mainScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener(() => {",
+        @"  browser.test.fail('Main page should not receive messages intended for opened window')",
+        @"})",
+    ]);
+
+    auto *windowScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message, 'Hello, window!', 'Message should be received in the opened window')",
+        @"  sendResponse('Message received')",
+        @"})",
+
+        @"browser.runtime.sendMessage('Begin Test')",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"main-script.js": mainScript,
+        @"window-script.js": windowScript,
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:@"*" host:@"localhost" path:@"/*"];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    __block RetainPtr<TestWebExtensionWindow> testWindow;
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        testWindow = [manager openNewWindowUsingPrivateBrowsing:NO];
+        testWindow.get().activeTab.webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]).get();
+        return testWindow.get().activeTab.webView;
+    };
+
+    auto *webView = manager.get().defaultTab.webView;
+    webView.UIDelegate = uiDelegate.get();
+    [webView loadRequest:server.requestWithLocalhost()];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)
 {
     TestWebKitAPI::HTTPServer server({

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -121,7 +121,7 @@ using CocoaColor = UIColor;
 - (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
-@property (nonatomic, strong) TestWebExtensionTab * activeTab;
+@property (nonatomic, strong) TestWebExtensionTab *activeTab;
 
 - (TestWebExtensionTab *)openNewTab;
 - (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;


### PR DESCRIPTION
#### 8b48418aa2dc2810ca2401510c09d4ce1a3fb2f4
<pre>
tabs.sendMessage() also sends the message to the tab&apos;s opener.
<a href="https://webkit.org/b/289640">https://webkit.org/b/289640</a>
<a href="https://rdar.apple.com/problem/146886179">rdar://problem/146886179</a>

Reviewed by NOBODY (OOPS!).

Since window.open() web views share the same web process, tabs.sendMessage must include the target
web page’s identifier to ensure messages are delivered only to that specific page, avoiding
unintended delivery to other pages within the same process.

* Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h: Add web page identifier.
* Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in: Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage): Add the web page identifier for the tab
to a copy of the target parameters.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::matches): Check the web page identifier if it is supplied.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)): Added.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h: Removed a stray space.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b48418aa2dc2810ca2401510c09d4ce1a3fb2f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46144 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72938 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45482 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81533 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPITabs.SendMessageFromBackgroundToOpenedWindow (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22689 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16568 "Found 3 new test failures: fast/scrolling/iframe-scrollable-after-back.html html5lib/generated/run-entities01-data.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81333 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25919 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16034 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27814 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->