### PR TITLE
Web Inspector: Allow ServiceWorkerDebuggableProxy to be auto-inspected in the same process as the host browser

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -60,6 +60,7 @@ public:
     virtual void setIndicating(bool) { } // Default is to do nothing.
 
     virtual bool automaticInspectionAllowed() const { return false; }
+    virtual bool automaticInspectionAllowedInSameProcess() const { return false; }
     JS_EXPORT_PRIVATE virtual void pauseWaitingForAutomaticInspection();
     JS_EXPORT_PRIVATE virtual void unpauseForResolvedAutomaticInspection();
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
@@ -91,6 +91,8 @@
 #define WIRPingMessage                          @"WIRPingMessage"
 #define WIRPingSuccessMessage                   @"WIRPingSuccessMessage"
 
+#define WIRTargetAllowsAutomaticInspectionInSameProcessKey  @"WIRTargetAllowsAutomaticInspectionInSameProcess"
+
 // Allowed values for WIRMessageDataTypeKey.
 #define WIRMessageDataTypeFull                  @"WIRMessageDataTypeFull"
 #define WIRMessageDataTypeChunk                 @"WIRMessageDataTypeChunk"

--- a/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.h
+++ b/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.h
@@ -55,6 +55,7 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
 #if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
     bool automaticInspectionAllowed() const final { return true; }
+    bool automaticInspectionAllowedInSameProcess() const final { return true; }
     void pauseWaitingForAutomaticInspection() final;
     void unpauseForResolvedAutomaticInspection() final;
 
@@ -70,5 +71,7 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_CONTROLLABLE_TARGET(WebKit::ServiceWorkerDebuggableProxy, ServiceWorker);
 
 #endif // ENABLE(REMOTE_INSPECTOR)


### PR DESCRIPTION
#### a33dcd8b653d273281052582b3a65f01acc750a2
<pre>
Web Inspector: Allow ServiceWorkerDebuggableProxy to be auto-inspected in the same process as the host browser
<a href="https://rdar.apple.com/147007512">rdar://147007512</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289762">https://bugs.webkit.org/show_bug.cgi?id=289762</a>

Reviewed by BJ Burg.

Let ServiceWorkerDebuggableProxy advertise itself as permitted to be
auto-inspected in the same process as the inspector host, using the
new key WIRTargetAllowsAutomaticInspectionInSameProcessKey.
ServiceWorkerDebuggableProxy is able to do so because it does not rely
on the RemoteInspector&apos;s process being blocked to achieve pausing
waiting for the reply of the automatic inspection policy.

* Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
(Inspector::RemoteInspectionTarget::automaticInspectionAllowedInSameProcess const):
* Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::sendAutomaticInspectionCandidateMessage):
   - When reporting a new automatic inspection candidate, also report
     whether this candidate supports being auto-inspected in the same
     process, which ServiceWorkerDebuggableProxy does.

(Inspector::RemoteInspector::receivedAutomaticInspectionRejectMessage):
   - It&apos;s more correct to not assume the target still exists in
     m_targetMap, similar to inside sendAutomaticInspectionCandidateMessage.

Canonical link: <a href="https://commits.webkit.org/292775@main">https://commits.webkit.org/292775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de9b6c1516ab90b63a618aec2b5eb12896b385be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47430 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99912 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12673 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46757 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89582 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82524 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5569 "Found 1 new test failure: fast/scrolling/mac/momentum-animator-end-event-stops.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104006 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95530 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4497 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17480 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29094 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119157 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23598 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->