### PR TITLE
[Cocoa] Use mediaKeysHashSalt() in more places

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -40,14 +40,14 @@
 
 namespace WebCore {
 
-Ref<MediaKeySystemRequest> MediaKeySystemRequest::create(Document& document, const String& keySystem, Ref<DeferredPromise>&& promise)
+Ref<MediaKeySystemRequest> MediaKeySystemRequest::create(Document& document, const String& keySystem, RefPtr<DeferredPromise>&& promise)
 {
     auto result = adoptRef(*new MediaKeySystemRequest(document, keySystem, WTFMove(promise)));
     result->suspendIfNeeded();
     return result;
 }
 
-MediaKeySystemRequest::MediaKeySystemRequest(Document& document, const String& keySystem, Ref<DeferredPromise>&& promise)
+MediaKeySystemRequest::MediaKeySystemRequest(Document& document, const String& keySystem, RefPtr<DeferredPromise>&& promise)
     : ActiveDOMObject(document)
     , m_keySystem(keySystem)
     , m_promise(WTFMove(promise))
@@ -98,7 +98,7 @@ void MediaKeySystemRequest::allow(String&& mediaKeysHashSalt)
 
 void MediaKeySystemRequest::deny(const String& message)
 {
-    if (!scriptExecutionContext())
+    if (!scriptExecutionContext() || !m_promise)
         return;
 
     ExceptionCode code = ExceptionCode::NotSupportedError;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -48,10 +48,10 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    WEBCORE_EXPORT static Ref<MediaKeySystemRequest> create(Document&, const String& keySystem, Ref<DeferredPromise>&&);
+    WEBCORE_EXPORT static Ref<MediaKeySystemRequest> create(Document&, const String& keySystem, RefPtr<DeferredPromise>&&);
     virtual ~MediaKeySystemRequest();
 
-    void setAllowCallback(CompletionHandler<void(String&& mediaKeysHashSalt, Ref<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
+    void setAllowCallback(CompletionHandler<void(String&& mediaKeysHashSalt, RefPtr<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
     WEBCORE_EXPORT void start();
 
     WEBCORE_EXPORT void allow(String&& mediaKeysHashSalt);
@@ -63,15 +63,15 @@ public:
     const String keySystem() const { return m_keySystem; }
 
 private:
-    MediaKeySystemRequest(Document&, const String& keySystem, Ref<DeferredPromise>&&);
+    MediaKeySystemRequest(Document&, const String& keySystem, RefPtr<DeferredPromise>&&);
 
     // ActiveDOMObject.
     void stop() final;
 
     String m_keySystem;
-    Ref<DeferredPromise> m_promise;
+    RefPtr<DeferredPromise> m_promise;
 
-    CompletionHandler<void(String&&, Ref<DeferredPromise>&&)> m_allowCompletionHandler;
+    CompletionHandler<void(String&&, RefPtr<DeferredPromise>&&)> m_allowCompletionHandler;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -90,9 +90,10 @@ RefPtr<ArrayBuffer> WebKitMediaKeySession::cachedKeyForKeyId(const String& keyId
     return m_session ? m_session->cachedKeyForKeyID(keyId) : nullptr;
 }
 
-void WebKitMediaKeySession::generateKeyRequest(const String& mimeType, Ref<Uint8Array>&& initData)
+void WebKitMediaKeySession::generateKeyRequest(const String& mimeType, Ref<Uint8Array>&& initData, const String& mediaKeysHashSalt)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "mimeType: ", mimeType);
+    m_mediaKeysHashSalt = mediaKeysHashSalt;
     m_pendingKeyRequests.append({ mimeType, WTFMove(initData) });
     m_keyRequestTimer.startOneShot(0_s);
 }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -60,7 +60,7 @@ public:
 
     void detachKeys() { m_keys = nullptr; }
 
-    void generateKeyRequest(const String& mimeType, Ref<Uint8Array>&& initData);
+    void generateKeyRequest(const String& mimeType, Ref<Uint8Array>&& initData, const String& mediaKeysHashSalt);
     RefPtr<ArrayBuffer> cachedKeyForKeyId(const String& keyId) const;
 
 private:
@@ -71,6 +71,7 @@ private:
     void sendMessage(Uint8Array*, String destinationURL) final;
     void sendError(MediaKeyErrorCode, uint32_t systemCode) final;
     String mediaKeysStorageDirectory() const final;
+    String mediaKeysHashSalt() const final { return m_mediaKeysHashSalt; }
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
@@ -95,6 +96,7 @@ private:
     WebKitMediaKeys* m_keys;
     String m_keySystem;
     String m_sessionId;
+    String m_mediaKeysHashSalt;
     RefPtr<WebKitMediaKeyError> m_error;
     RefPtr<LegacyCDMSession> m_session;
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
@@ -29,6 +29,8 @@
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 #include "HTMLMediaElement.h"
+#include "JSDOMPromiseDeferred.h"
+#include "MediaKeySystemRequest.h"
 #include "WebKitMediaKeySession.h"
 #include <JavaScriptCore/Uint8Array.h>
 
@@ -103,7 +105,11 @@ ExceptionOr<Ref<WebKitMediaKeySession>> WebKitMediaKeys::createSession(Document&
     m_sessions.append(session.copyRef());
 
     // 5. Schedule a task to initialize the session, providing contentType, initData, and the new object.
-    session->generateKeyRequest(type, WTFMove(initData));
+    auto request = MediaKeySystemRequest::create(document, m_keySystem, { });
+    request->setAllowCallback([session = session.copyRef(), type = type, initData = WTFMove(initData)](String&& mediaKeysHashSalt, RefPtr<DeferredPromise>&&) mutable {
+        session->generateKeyRequest(type, WTFMove(initData), mediaKeysHashSalt);
+    });
+    request->start();
 
     // 6. Return the new object to the caller.
     return session;

--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -62,6 +62,7 @@ public:
     virtual void sendError(MediaKeyErrorCode, uint32_t systemCode) = 0;
 
     virtual String mediaKeysStorageDirectory() const = 0;
+    virtual String mediaKeysHashSalt() const = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -40,6 +40,7 @@ OBJC_CLASS AVContentKeyReportGroup;
 OBJC_CLASS AVContentKeyRequest;
 OBJC_CLASS AVContentKeySession;
 OBJC_CLASS NSData;
+OBJC_CLASS NSDictionary;
 OBJC_CLASS NSError;
 OBJC_CLASS NSURL;
 OBJC_CLASS WebCoreFPSContentKeySessionDelegate;
@@ -233,6 +234,8 @@ public:
     KeyStatusVector copyKeyStatuses() const;
 
     void attachContentKeyToSample(const MediaSampleAVFObjC&);
+
+    static RetainPtr<NSDictionary> optionsForKeyRequestWithHashSalt(const String&);
 
 private:
     bool ensureSessionOrGroup(KeyGroupingStrategy);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -91,7 +91,7 @@ void RemoteLegacyCDMSessionProxy::setPlayer(WeakPtr<RemoteMediaPlayerProxy> play
     m_player = WTFMove(player);
 }
 
-void RemoteLegacyCDMSessionProxy::generateKeyRequest(const String& mimeType, RefPtr<SharedBuffer>&& initData, GenerateKeyCallback&& completion)
+void RemoteLegacyCDMSessionProxy::generateKeyRequest(const String& mimeType, RefPtr<SharedBuffer>&& initData, const String& mediaKeysHashSalt, GenerateKeyCallback&& completion)
 {
     RefPtr session = m_session;
     if (!session) {
@@ -105,6 +105,7 @@ void RemoteLegacyCDMSessionProxy::generateKeyRequest(const String& mimeType, Ref
         return;
     }
 
+    m_mediaKeysHashSalt = mediaKeysHashSalt;
     String destinationURL;
     unsigned short errorCode { 0 };
     uint32_t systemCode { 0 };

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -80,6 +80,7 @@ private:
     void sendMessage(Uint8Array*, String destinationURL) final;
     void sendError(MediaKeyErrorCode, uint32_t systemCode) final;
     String mediaKeysStorageDirectory() const final;
+    String mediaKeysHashSalt() const final { return m_mediaKeysHashSalt; }
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
@@ -89,7 +90,7 @@ private:
 
     // Messages
     using GenerateKeyCallback = CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&, const String&, unsigned short, uint32_t)>;
-    void generateKeyRequest(const String& mimeType, RefPtr<WebCore::SharedBuffer>&& initData, GenerateKeyCallback&&);
+    void generateKeyRequest(const String& mimeType, RefPtr<WebCore::SharedBuffer>&& initData, const String& mediaKeysHashSalt, GenerateKeyCallback&&);
     void releaseKeys();
     using UpdateCallback = CompletionHandler<void(bool, RefPtr<WebCore::SharedBuffer>&&, unsigned short, uint32_t)>;
     void update(RefPtr<WebCore::SharedBuffer>&& update, UpdateCallback&&);
@@ -106,6 +107,7 @@ private:
     RemoteLegacyCDMSessionIdentifier m_identifier;
     RefPtr<WebCore::LegacyCDMSession> m_session;
     WeakPtr<RemoteMediaPlayerProxy> m_player;
+    String m_mediaKeysHashSalt;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in
@@ -29,7 +29,7 @@
     EnabledBy=LegacyEncryptedMediaAPIEnabled
 ]
 messages -> RemoteLegacyCDMSessionProxy {
-    GenerateKeyRequest(String mimeType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> nextMessage, String destinationURL, unsigned short errorCode, uint32_t systemCode) Synchronous
+    GenerateKeyRequest(String mimeType, RefPtr<WebCore::SharedBuffer> initData, String mediaKeysHashSalt) -> (RefPtr<WebCore::SharedBuffer> nextMessage, String destinationURL, unsigned short errorCode, uint32_t systemCode) Synchronous
     ReleaseKeys()
     Update(RefPtr<WebCore::SharedBuffer> update) -> (bool succeeded, RefPtr<WebCore::SharedBuffer> nextMessage, unsigned short errorCode, uint32_t systemCode) Synchronous
     CachedKeyForKeyID(String keyId) -> (RefPtr<WebCore::SharedBuffer> key) Synchronous

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -95,11 +95,11 @@ void RemoteLegacyCDMSession::invalidate()
 
 RefPtr<Uint8Array> RemoteLegacyCDMSession::generateKeyRequest(const String& mimeType, Uint8Array* initData, String& destinationURL, unsigned short& errorCode, uint32_t& systemCode)
 {
-    if (!m_factory || !initData)
+    if (!m_factory || !initData || !m_client)
         return nullptr;
 
     auto ipcInitData = convertToSharedBuffer(initData);
-    auto sendResult = m_factory->gpuProcessConnection().protectedConnection()->sendSync(Messages::RemoteLegacyCDMSessionProxy::GenerateKeyRequest(mimeType, ipcInitData), m_identifier);
+    auto sendResult = m_factory->gpuProcessConnection().protectedConnection()->sendSync(Messages::RemoteLegacyCDMSessionProxy::GenerateKeyRequest(mimeType, ipcInitData, m_client->mediaKeysHashSalt()), m_identifier);
 
     RefPtr<SharedBuffer> ipcNextMessage;
     if (sendResult.succeeded())


### PR DESCRIPTION
#### 0bba38cb4b4c8fd349eefdc8825821582dc5a965
<pre>
[Cocoa] Use mediaKeysHashSalt() in more places
<a href="https://rdar.apple.com/146422515">rdar://146422515</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289987">https://bugs.webkit.org/show_bug.cgi?id=289987</a>

Reviewed by Andy Estes.

Use mediaKeysHashSalt() in all the places where -[AVContentKeyRequest
makeStreamingContentKeyRequestDataForApp:contentIdentifier:options:completionHandler:]
is called, by adding a static method optionsForKeyRequestWithHashSalt() which can
be used in both CDMInstanceFairPlayStreamingAVFObjC as well as CDMSessionAVContentKeySession.

To make mediaKeyHashSalt() avalable in the LegacyCDMSession codepath, make legacy requests take the same
trip through MediaKeySystemRequest.

* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::create):
(WebCore::MediaKeySystemRequest::MediaKeySystemRequest):
(WebCore::MediaKeySystemRequest::deny):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
(WebCore::MediaKeySystemRequest::setAllowCallback):
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WebCore::NavigatorEME::requestMediaKeySystemAccess):
(WebCore::tryNextSupportedConfiguration):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
(WebCore::WebKitMediaKeySession::generateKeyRequest):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp:
(WebCore::WebKitMediaKeys::createSession):
* Source/WebCore/platform/graphics/LegacyCDMSession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::update):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::generateKeyRequest):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::generateKeyRequest):

Canonical link: <a href="https://commits.webkit.org/292370@main">https://commits.webkit.org/292370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d201d9c7cad2147df5420b548b540a3ca7bc42a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86415 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53289 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11376 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81354 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20428 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16062 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->