### PR TITLE
REGRESSION(292206@main): [macOS iOS wk2]ASSERTION and text diff in imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (flaky in EWS)

### DIFF
--- a/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.cpp
@@ -34,10 +34,9 @@
 
 namespace WebKit {
 
-AboutSchemeHandler& AboutSchemeHandler::singleton()
+Ref<AboutSchemeHandler> AboutSchemeHandler::create()
 {
-    static MainThreadNeverDestroyed<AboutSchemeHandler> globalHandler;
-    return globalHandler;
+    return adoptRef(*new AboutSchemeHandler());
 }
 
 AboutSchemeHandler::AboutSchemeHandler()

--- a/Source/WebKit/UIProcess/AboutSchemeHandler.h
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.h
@@ -40,7 +40,7 @@ public:
         virtual void loadContent(URL, CompletionHandler<void(WebCore::ResourceResponse&&, Ref<WebCore::SharedBuffer>&&)>&&) = 0;
     };
 
-    static AboutSchemeHandler& singleton();
+    static Ref<AboutSchemeHandler> create();
 
     void registerHandler(const String& opaquePath, std::unique_ptr<OpaquePathHandler>&&);
     bool canHandleURL(const URL&) const;
@@ -49,8 +49,6 @@ public:
     static constexpr auto blank = "blank"_s;
 
 private:
-    friend MainThreadNeverDestroyed<AboutSchemeHandler>;
-
     class EmptyPathHandler final : public OpaquePathHandler {
         WTF_MAKE_FAST_ALLOCATED;
     public:

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -424,6 +424,7 @@ using ElementIdentifier = ObjectIdentifier<ElementIdentifierType>;
 
 namespace WebKit {
 
+class AboutSchemeHandler;
 class AudioSessionRoutingArbitratorProxy;
 class AuthenticationChallengeProxy;
 class BrowsingContextGroup;
@@ -2720,6 +2721,8 @@ public:
     bool hasAccessibilityActivityForTesting();
 #endif
 
+    Ref<AboutSchemeHandler> protectedAboutSchemeHandler();
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -3371,7 +3374,7 @@ private:
     bool hasValidOpeningAppLinkActivity() const;
 #endif
 
-RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
+    RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
 
 #if PLATFORM(COCOA)
     String presentingApplicationBundleIdentifier() const;
@@ -3895,6 +3898,7 @@ RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionM
     std::optional<audit_token_t> m_presentingApplicationAuditToken;
 #endif
 
+    Ref<AboutSchemeHandler> m_aboutSchemeHandler;
     RefPtr<WebPageProxyTesting> m_pageForTesting;
 };
 


### PR DESCRIPTION
#### 326bf0916c6eb4044d5e51b76735aa6104277499
<pre>
REGRESSION(292206@main): [macOS iOS wk2]ASSERTION and text diff in imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=289986">https://bugs.webkit.org/show_bug.cgi?id=289986</a>
<a href="https://rdar.apple.com/147337748">rdar://147337748</a>

Reviewed by Alex Christensen.

292206@main introduced new AboutSchemeHandler registered in WebPageProxy creation timing.
On iOS, process is just created but might not be ready to accept message.
Postponing the registration after attached to WebProcess.

* Source/WebKit/UIProcess/AboutSchemeHandler.cpp:
(WebKit::AboutSchemeHandler::create):
(WebKit::AboutSchemeHandler::singleton): Deleted.
* Source/WebKit/UIProcess/AboutSchemeHandler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::protectedAboutSchemeHandler):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/292419@main">https://commits.webkit.org/292419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8baf5a873834ce890e12020f369d75b5108338

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46427 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11579 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22985 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16754 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28103 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->