### PR TITLE
ASAN_TRAP | URLPatternUtilities::Tokenizer::tokenize

### DIFF
--- a/LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash-expected.txt
+++ b/LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+

--- a/LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash.html
+++ b/LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash.html
@@ -1,0 +1,34 @@
+<script>
+var feedback = [];
+
+function logFeedback(line, result) {
+    feedback.push([line, result]);
+}
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function runTest() {
+    let trackElement = document.getElementById('htmlvar00027').src;
+    logFeedback('trackElement.src', 'Valid');
+
+    let sourceUrl = trackElement;
+    logFeedback('sourceUrl', 'Valid');
+
+    let targetUrl = {};
+    logFeedback('targetUrl', 'Valid');
+
+    try {
+        let urlPattern = new URLPattern(sourceUrl, trackElement, targetUrl);
+        logFeedback('URLPattern(sourceUrl, trackElement, targetUrl)', 'Valid');
+    } catch(e) {
+        logFeedback('URLPattern(sourceUrl, trackElement, targetUrl)', e.name);
+    }
+    globalThis.testRunner?.notifyDone();
+}
+</script>
+
+<body onload="runTest()">
+    <p>This test passes if WebKit does not crash.</p>
+    <track id="htmlvar00027" src="Y(HQ(#a6d#" shouldfocus="true">
+</body>

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -45,6 +45,9 @@ bool Token::isNull() const
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point
 void Tokenizer::getNextCodePoint()
 {
+    if (m_nextIndex >= m_input.length())
+        return;
+
     m_codepoint = m_input[m_nextIndex++];
 
     if (m_input.is8Bit() || !U16_IS_LEAD(m_codepoint) || m_nextIndex >= m_input.length())


### PR DESCRIPTION
#### a6854d0fb17d8684cb8fa02fb7fdf812c7f010ab
<pre>
ASAN_TRAP | URLPatternUtilities::Tokenizer::tokenize
<a href="https://bugs.webkit.org/show_bug.cgi?id=289995">https://bugs.webkit.org/show_bug.cgi?id=289995</a>
<a href="https://rdar.apple.com/146075781">rdar://146075781</a>

Added a check for the index if it is out of bounds and returns early if so.

* LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash-expected.txt: Added.
* LayoutTests/fast/url/invalid-url-pattern-tokenizer-crash.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::getNextCodePoint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6854d0fb17d8684cb8fa02fb7fdf812c7f010ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53299 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11375 "Failed to checkout and rebase branch from PR 42649") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82008 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81363 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3408 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16071 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->