### PR TITLE
[WebGPU] minBindingSize could have static_assert against its corresponding type

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -295,10 +295,10 @@ String Type::toString() const
 }
 
 // https://gpuweb.github.io/gpuweb/wgsl/#alignment-and-size
-unsigned Type::size() const
+std::optional<unsigned> Type::maybeSize() const
 {
     return WTF::switchOn(*this,
-        [&](const Primitive& primitive) -> unsigned {
+        [&](const Primitive& primitive) -> std::optional<unsigned> {
             switch (primitive.kind) {
             case Types::Primitive::F16:
                 return 2;
@@ -317,13 +317,13 @@ unsigned Type::size() const
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:
             case Types::Primitive::AddressSpace:
-                RELEASE_ASSERT_NOT_REACHED();
+                return std::nullopt;
             }
         },
-        [&](const Vector& vector) -> unsigned {
+        [&](const Vector& vector) -> std::optional<unsigned> {
             return vector.element->size() * vector.size;
         },
-        [&](const Matrix& matrix) -> unsigned {
+        [&](const Matrix& matrix) -> std::optional<unsigned> {
             // The size of the matrix is computed as: sizeof(array<vecR<T>, C>)
             // sizeof(vecR<T>)
             auto rowSize = matrix.rows * matrix.element->size();
@@ -331,7 +331,7 @@ unsigned Type::size() const
             auto rowAlignment = (matrix.rows == 2 ? 2 : 4) * matrix.element->alignment();
             return matrix.columns * WTF::roundUpToMultipleOf(rowAlignment, rowSize);
         },
-        [&](const Array& array) -> unsigned {
+        [&](const Array& array) -> std::optional<unsigned> {
             CheckedUint32 size = 1;
             if (auto* constantSize = std::get_if<unsigned>(&array.size))
                 size = *constantSize;
@@ -348,43 +348,48 @@ unsigned Type::size() const
                 return std::numeric_limits<unsigned>::max();
             return size.value();
         },
-        [&](const Struct& structure) -> unsigned {
+        [&](const Struct& structure) -> std::optional<unsigned> {
             return structure.structure.size();
         },
-        [&](const PrimitiveStruct& structure) -> unsigned {
+        [&](const PrimitiveStruct& structure) -> std::optional<unsigned> {
             unsigned size = 0;
             for (auto* type : structure.values)
                 size += type->size();
             return size;
         },
-        [&](const Function&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Function&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const Texture&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Texture&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const TextureStorage&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const TextureStorage&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const TextureDepth&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const TextureDepth&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const Reference&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Reference&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const Pointer&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Pointer&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const Atomic& a) -> unsigned {
+        [&](const Atomic& a) -> std::optional<unsigned> {
             RELEASE_ASSERT(a.element);
             return a.element->size();
         },
-        [&](const TypeConstructor&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const TypeConstructor&) -> std::optional<unsigned> {
+            return std::nullopt;
         },
-        [&](const Bottom&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Bottom&) -> std::optional<unsigned> {
+            return std::nullopt;
         });
+}
+
+unsigned Type::size() const
+{
+    return *maybeSize();
 }
 
 unsigned Type::alignment() const

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -286,6 +286,7 @@ struct Type : public std::variant<
     void dump(PrintStream&) const;
     String toString() const;
     unsigned size() const;
+    std::optional<unsigned> maybeSize() const;
     unsigned alignment() const;
     Packing packing() const;
     bool isConstructible() const;


### PR DESCRIPTION
#### 72d5055eb82599aaeb71eb9eef88d8e970863579
<pre>
[WebGPU] minBindingSize could have static_assert against its corresponding type
<a href="https://bugs.webkit.org/show_bug.cgi?id=288654">https://bugs.webkit.org/show_bug.cgi?id=288654</a>
&lt;<a href="https://rdar.apple.com/145694247">rdar://145694247</a>&gt;

Reviewed by Mike Wyrzykowski.

Add static_assert&apos;s for each bind group entry to verify that the size we
computed for the type matches the size of the generated Metal type. Not
every type has a size, so we introduce a new function `Type::maybeSize`
to determine which types we can safely assert.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::maybeSize const):
(WGSL::Type::size const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/292376@main">https://commits.webkit.org/292376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11a449aff32c3a2537d2f9bad52c0717524c016c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46313 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73065 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11499 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22872 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82102 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81465 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3497 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22837 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->