### PR TITLE
[JSC] Fix spec compliance and optimize `RegExp#@@search`

### DIFF
--- a/JSTests/microbenchmarks/regexp-prototype-search-anchor.js
+++ b/JSTests/microbenchmarks/regexp-prototype-search-anchor.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected} but got ${actual}`);
+  }
+}
+
+const str = ("X".repeat(50) + "the_end").repeat(2);
+
+const re1 = /the_end$/;
+const re2 = /^X{50}the_end$/;
+
+for (let i = 0; i < 1e6; i++) {
+  shouldBe(re1[Symbol.search](str), 107);
+  shouldBe(re2[Symbol.search](str), -1);
+  shouldBe(str.search(re1), 107);
+  shouldBe(str.search(re2), -1);
+}

--- a/JSTests/microbenchmarks/regexp-prototype-search-basic.js
+++ b/JSTests/microbenchmarks/regexp-prototype-search-basic.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const str = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoo";
+const re1 = /foo/;
+const re2 = /bar/;
+for (let i = 0; i < 1e6; i++) {
+    shouldBe(re1[Symbol.search](str), 78);
+    shouldBe(re2[Symbol.search](str), -1);
+    shouldBe(str.search(re1), 78);
+    shouldBe(str.search(re2), -1);
+}

--- a/JSTests/microbenchmarks/regexp-prototype-search-complex-pattern.js
+++ b/JSTests/microbenchmarks/regexp-prototype-search-complex-pattern.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected} but got ${actual}`);
+  }
+}
+
+const str = "abc123XYZ_foo_bar_baz_987654321".repeat(2);
+
+const re1 = /abc\d+XYZ_foo_bar_baz_\d+/;
+const re2 = /abc\d+(?=XXX)(?:_foo_)(?:bar_)(?:baz_)\d+/;
+
+for (let i = 0; i < 1e6; i++) {
+  shouldBe(re1[Symbol.search](str), 0);
+  shouldBe(re2[Symbol.search](str), -1);
+  shouldBe(str.search(re1), 0);
+  shouldBe(str.search(re2), -1);
+}

--- a/JSTests/microbenchmarks/regexp-prototype-search-short-string.js
+++ b/JSTests/microbenchmarks/regexp-prototype-search-short-string.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected} but got ${actual}`);
+  }
+}
+
+const str = "abc123XYZ";
+
+const re1 = /^([a-z]+)(\d+)([A-Z]+)$/;
+const re2 = /^([a-z]+)(\d+)([A-Z]+)foo$/;
+
+for (let i = 0; i < 1e6; i++) {
+  shouldBe(re1[Symbol.search](str), 0);
+  shouldBe(re2[Symbol.search](str), -1);
+  shouldBe(str.search(re1), 0);
+  shouldBe(str.search(re2), -1);
+}

--- a/JSTests/stress/regexp-prototype-search-fastpath-check.js
+++ b/JSTests/stress/regexp-prototype-search-fastpath-check.js
@@ -1,0 +1,76 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(run, errorType, message) {
+    let actual;
+    var hadError = false;
+
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Execute fast path and throw type error
+    shouldThrow(() => {
+        RegExp.prototype[Symbol.search].call({});
+    }, TypeError, "Builtin RegExp exec can only be called on a RegExp object");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Execute builtin exec
+    const re = /foo/;
+    let called = 0;
+    Object.defineProperty(re, "exec", {
+        get() {
+            called++;
+            return function () { return null };
+        }
+    });
+    shouldBe(re[Symbol.search]("foo"), -1);
+    shouldBe(re[Symbol.search]("bar"), -1);
+    shouldBe(called, 2);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Execute non-builtin exec (native function)
+    const re = /foo/;
+    let called = 0;
+    Object.defineProperty(re, "exec", {
+        get() {
+            called++;
+            return String.prototype.match;
+        }
+    });
+    shouldBe(re[Symbol.search]("foo"), 1);
+    shouldBe(re[Symbol.search]("bar"), -1);
+    shouldBe(called, 2);
+}
+
+// Invalidate watchpoint
+Object.defineProperty(RegExp.prototype, "global", { get() { return false }});
+for (let i = 0; i < testLoopCount; i++) {
+    // Execute builtin exec
+    const re = /foo/;
+    shouldBe(re[Symbol.search]("foo"), 0);
+    shouldBe(re[Symbol.search]("bar"), -1);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Execute builtin exec and throw type error
+    shouldThrow(() => {
+        RegExp.prototype[Symbol.search].call({})
+    }, TypeError, "Builtin RegExp exec can only be called on a RegExp object");
+}

--- a/JSTests/stress/regexp-prototype-search-lastIndex-writable.js
+++ b/JSTests/stress/regexp-prototype-search-lastIndex-writable.js
@@ -1,0 +1,40 @@
+function shouldThrow(run, errorType) {
+    let actual;
+    var hadError = false;
+
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const re = /abc/;
+    Object.defineProperty(re, "lastIndex", { value: -1, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const re = /abc/g;
+    Object.defineProperty(re, "lastIndex", { value: 0, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const re = /abc/y;
+    Object.defineProperty(re, "lastIndex", { value: 0, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}

--- a/JSTests/stress/regexp-prototype-search-typed-lastIndex.js
+++ b/JSTests/stress/regexp-prototype-search-typed-lastIndex.js
@@ -1,0 +1,24 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// `re` is RegExpObjectUse, `str` is StringUse
+function test(re, str) {
+    return re[Symbol.search](str);
+}
+noInline(test);
+
+let catchCount = 0;
+let expectedCatchCount = testLoopCount / 2;
+const re = /foo/g;
+for (let i = 0 ; i < testLoopCount; i++) {
+    if (i === expectedCatchCount)
+        Object.defineProperty(re, "lastIndex", { writable: false });
+    try {
+        test(re, " foo");
+    } catch {
+        catchCount++;
+    }
+}
+shouldBe(catchCount, expectedCatchCount);

--- a/JSTests/stress/regexp-prototype-search-typed.js
+++ b/JSTests/stress/regexp-prototype-search-typed.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(re, str) {
+    return re[Symbol.search](str);
+}
+noInline(test);
+
+// `re` is RegExpObjectUse, `str` is StringUse
+const re = /foo/;
+for (let i = 0 ; i < testLoopCount; i++) {
+    shouldBe(test(re, " foo"), 1);
+}

--- a/JSTests/stress/regexp-prototype-search-untyped-lastIndex.js
+++ b/JSTests/stress/regexp-prototype-search-untyped-lastIndex.js
@@ -1,0 +1,41 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+function shouldThrow(func, expected) {
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error('not thrown');
+    shouldBe(String(error), expected);
+}
+var errorKey = {
+    toString() {
+        throw new Error('out');
+    }
+};
+
+let catchCount = 0;
+let expectedCatchCount = testLoopCount / 2;
+
+var string = 'Cocoa, Cappuccino, Rize, Matcha, Kilimanjaro';
+const cocoaRe = /Cocoa/g;
+for (let i = 0; i < testLoopCount; i ++) {
+    if (i === expectedCatchCount)
+        Object.defineProperty(cocoaRe, "lastIndex", { writable: false });
+    shouldThrow(function () { string.search(errorKey); }, "Error: out");
+    shouldBe(string.search(/Rize/), 19);
+    shouldBe(string.search('Rize'), 19);
+    shouldBe(string.search(/Matcha/), 25);
+    try {
+        shouldBe('Cocoa'.search(cocoaRe), 0);
+    } catch {
+        catchCount++;
+    }
+}
+
+shouldBe(catchCount, expectedCatchCount);

--- a/JSTests/stress/regexp-prototype-search-untyped-str-lastIndex.js
+++ b/JSTests/stress/regexp-prototype-search-untyped-str-lastIndex.js
@@ -1,0 +1,24 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// `re` is RegExpObjectUse, but `str` is Untyped
+function test(re, str) {
+    return re[Symbol.search](str);
+}
+noInline(test);
+
+let catchCount = 0;
+let expectedCatchCount = testLoopCount / 2;
+const re = /foo/g;
+for (let i = 0 ; i < testLoopCount; i++) {
+    if (i === expectedCatchCount)
+        Object.defineProperty(re, "lastIndex", { writable: false });
+    try {
+        test(re, { toString() { return " foo" } });
+    } catch {
+        catchCount++;
+    }
+}
+shouldBe(catchCount, expectedCatchCount);

--- a/JSTests/stress/regexp-prototype-search-untyped-str.js
+++ b/JSTests/stress/regexp-prototype-search-untyped-str.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(re, str) {
+    return re[Symbol.search](str);
+}
+noInline(test);
+
+// `this` is RegExpObjectUse, but `str` is Untyped
+const re = /foo/;
+for (let i = 0 ; i < testLoopCount; i++) {
+    shouldBe(test(re, { toString() { return " foo" } }), 1);;
+}

--- a/JSTests/stress/regexp-prototype-search-untyped.js
+++ b/JSTests/stress/regexp-prototype-search-untyped.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(re, str) {
+    return RegExp.prototype[Symbol.search].call(re, str);
+}
+noInline(test);
+
+// `re` is Untyped
+for (let i = 0 ; i < testLoopCount; i++) {
+    try {
+        test({ toString() { throw new Error("error"); }}, " foo");
+    } catch {}
+    shouldBe(test(/foo/, " foo"), 1);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1391,8 +1391,6 @@ test/staging/sm/Function/function-toString-builtin-name.js:
   default: 'Test262Error: Incorrect match for undefined Expected SameValue(«"fn"», «undefined») to be true'
 test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js:
   default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
-test/staging/sm/RegExp/lastIndex-search.js:
-  default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
 test/staging/sm/RegExp/match-local-tolength-recompilation.js:
   default: 'Test262Error: Expected SameValue(«false», «true») to be true'
 test/staging/sm/RegExp/replace-local-tolength-recompilation.js:

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -393,53 +393,6 @@ function replace(strArg, replace)
     return accumulatedResult + @stringSubstring.@call(str, nextSourcePosition);
 }
 
-// 21.2.5.9 RegExp.prototype[@@search] (string)
-@overriddenName="[Symbol.search]"
-function search(strArg)
-{
-    "use strict";
-
-    var regexp = this;
-
-    // Check for observable side effects and call the fast path if there aren't any.
-    if (@isRegExpObject(regexp)
-        && @tryGetById(regexp, "exec") === @regExpBuiltinExec
-        && typeof regexp.lastIndex === "number")
-        return @regExpSearchFast.@call(regexp, strArg);
-
-    // 1. Let rx be the this value.
-    // 2. If Type(rx) is not Object, throw a TypeError exception.
-    if (!@isObject(this))
-        @throwTypeError("RegExp.prototype.@@search requires that |this| be an Object");
-
-    // 3. Let S be ? ToString(string).
-    var str = @toString(strArg)
-
-    // 4. Let previousLastIndex be ? Get(rx, "lastIndex").
-    var previousLastIndex = regexp.lastIndex;
-
-    // 5. If SameValue(previousLastIndex, 0) is false, then
-    // 5.a. Perform ? Set(rx, "lastIndex", 0, true).
-    if (!@sameValue(previousLastIndex, 0))
-        regexp.lastIndex = 0;
-
-    // 6. Let result be ? RegExpExec(rx, S).
-    var result = @regExpExec(regexp, str);
-
-    // 7. Let currentLastIndex be ? Get(rx, "lastIndex").
-    // 8. If SameValue(currentLastIndex, previousLastIndex) is false, then
-    // 8.a. Perform ? Set(rx, "lastIndex", previousLastIndex, true).
-    if (!@sameValue(regexp.lastIndex, previousLastIndex))
-        regexp.lastIndex = previousLastIndex;
-
-    // 9. If result is null, return -1.
-    if (result === null)
-        return -1;
-
-    // 10. Return ? Get(result, "index").
-    return result.index;
-}
-
 @linkTimeConstant
 function hasObservableSideEffectsForRegExpSplit(regexp)
 {

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3309,6 +3309,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setNonCellTypeForNode(node, SpecBoolean);
         break;
 
+    case RegExpSearch:
+        clobberWorld();
+        setNonCellTypeForNode(node, SpecInt32Only);
+        break;
+
     case RegExpMatchFast:
         ASSERT(node->child2().useKind() == RegExpObjectUse);
         ASSERT(node->child3().useKind() == StringUse || node->child3().useKind() == KnownStringUse);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3159,7 +3159,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             
             return CallOptimizationResult::Inlined;
         }
-            
+
         case RegExpTestIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
@@ -3203,6 +3203,60 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* regExpExec = addToGraph(RegExpTest, OpInfo(0), OpInfo(prediction), addToGraph(GetGlobalObject, callee), regExpObject, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
+            setResult(regExpExec);
+
+            return CallOptimizationResult::Inlined;
+        }
+
+        case RegExpSearchIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            // Don't inline intrinsic if we exited due to one of the primordial RegExp checks failing.
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, ExoticObjectMode))
+                return CallOptimizationResult::DidNothing;
+
+            JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
+            if (!globalObject->regExpPrimordialPropertiesWatchpointSet().isStillValid())
+                return CallOptimizationResult::DidNothing;
+
+            Structure* regExpStructure = globalObject->regExpStructure();
+            m_graph.registerStructure(regExpStructure);
+            ASSERT(regExpStructure->storedPrototype().isObject());
+            ASSERT(regExpStructure->storedPrototype().asCell()->classInfo() == RegExpPrototype::info());
+
+            FrozenValue* regExpPrototypeObjectValue = m_graph.freeze(regExpStructure->storedPrototype());
+            Structure* regExpPrototypeStructure = regExpPrototypeObjectValue->structure();
+
+            auto isRegExpPropertySame = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
+                JSValue currentProperty;
+                if (!m_graph.getRegExpPrototypeProperty(regExpStructure->storedPrototypeObject(), regExpPrototypeStructure, propertyUID, currentProperty))
+                    return false;
+
+                return currentProperty == primordialProperty;
+            };
+
+            // Check that RegExp.exec is still the primordial RegExp.prototype.exec
+            if (!isRegExpPropertySame(globalObject->regExpProtoExecFunction(), m_vm->propertyNames->exec.impl()))
+                return CallOptimizationResult::DidNothing;
+
+            // Check that regExpObject is actually a RegExp object.
+            Node* regExpObject = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            addToGraph(Check, Edge(regExpObject, RegExpObjectUse));
+
+            // Check that regExpObject's exec is actually the primodial RegExp.prototype.exec.
+            UniquedStringImpl* execPropertyID = m_vm->propertyNames->exec.impl();
+            m_graph.identifiers().ensure(execPropertyID);
+            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(execPropertyID), CacheType::GetByIdPrototype });
+            Node* actualProperty = addToGraph(TryGetById, OpInfo(data), OpInfo(SpecFunction), Edge(regExpObject, CellUse));
+            FrozenValue* regExpPrototypeExec = m_graph.freeze(globalObject->regExpProtoExecFunction());
+            addToGraph(CheckIsConstant, OpInfo(regExpPrototypeExec), Edge(actualProperty, CellUse));
+
+            insertChecks();
+            Node* regExpExec = addToGraph(RegExpSearch, OpInfo(0), OpInfo(prediction), addToGraph(GetGlobalObject, callee), regExpObject, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
             setResult(regExpExec);
             
             return CallOptimizationResult::Inlined;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2172,6 +2172,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(HeapObjectCount);
         return;
 
+    case RegExpSearch:
     case RegExpExec:
     case RegExpTest:
     case RegExpTestInline:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -368,6 +368,7 @@ bool doesGC(Graph& graph, Node* node)
     case RegExpMatchFastGlobal:
     case RegExpTest:
     case RegExpTestInline:
+    case RegExpSearch:
     case ResolveScope:
     case ResolveScopeForHoistingFuncDeclInEval:
     case Return:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2099,6 +2099,7 @@ public:
         case RegExpTestInline:
         case RegExpMatchFast:
         case RegExpMatchFastGlobal:
+        case RegExpSearch:
         case GetGlobalVar:
         case GetGlobalLexicalVariable:
         case StringReplace:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -349,6 +349,7 @@ namespace JSC { namespace DFG {
     macro(RegExpTestInline, NodeResultJS | NodeMustGenerate) \
     macro(RegExpMatchFast, NodeResultJS | NodeMustGenerate) \
     macro(RegExpMatchFastGlobal, NodeResultJS) \
+    macro(RegExpSearch, NodeResultInt32 | NodeMustGenerate) \
     macro(StringReplace, NodeResultJS | NodeMustGenerate) \
     macro(StringReplaceAll, NodeResultJS | NodeMustGenerate) \
     macro(StringReplaceRegExp, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -222,6 +222,8 @@ JSC_DECLARE_JIT_OPERATION(operationRegExpMatchFastString, EncodedJSValue, (JSGlo
 JSC_DECLARE_JIT_OPERATION(operationRegExpTestString, size_t, (JSGlobalObject*, RegExpObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationRegExpTest, size_t, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpTestGeneric, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationRegExpSearchString, UCPUStrictInt32, (JSGlobalObject*, RegExpObject*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationRegExpSearch, UCPUStrictInt32, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStrictEqCell, size_t, (JSGlobalObject*, JSCell* op1, JSCell* op2));
 JSC_DECLARE_JIT_OPERATION(operationSubHeapBigInt, EncodedJSValue, (JSGlobalObject*, JSCell* op1, JSCell* op2));
 JSC_DECLARE_JIT_OPERATION(operationMulHeapBigInt, EncodedJSValue, (JSGlobalObject*, JSCell* op1, JSCell* op2));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1146,7 +1146,8 @@ private:
             break;
 
         case GetRestLength:
-        case ArrayIndexOf: {
+        case ArrayIndexOf:
+        case RegExpSearch: {
             setPrediction(SpecInt32Only);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -627,6 +627,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case RegExpTestInline:
     case RegExpMatchFast:
     case RegExpMatchFastGlobal:
+    case RegExpSearch:
     case Call:
     case DirectCall:
     case TailCallInlinedCaller:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1692,6 +1692,7 @@ public:
     void compileRegExpMatchFastGlobal(Node*);
     void compileRegExpTest(Node*);
     void compileRegExpTestInline(Node*);
+    void compileRegExpSearch(Node*);
     void compileStringReplace(Node*);
     void compileStringReplaceAll(Node*);
     void compileStringReplaceString(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2777,6 +2777,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case RegExpSearch: {
+        compileRegExpSearch(node);
+        break;
+    }
+
     case StringReplace:
     case StringReplaceAll:
     case StringReplaceRegExp: {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4192,6 +4192,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case RegExpSearch: {
+        compileRegExpSearch(node);
+        break;
+    }
+
     case StringReplace:
     case StringReplaceAll:
     case StringReplaceRegExp: {

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -639,6 +639,7 @@ private:
             break;
         }
 
+        // FIXME: handle RegExpSearch here if possible.
         case RegExpExec:
         case RegExpTest:
         case RegExpMatchFast:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -389,6 +389,7 @@ inline CapabilityLevel canCompile(Node* node)
     case RegExpTestInline:
     case RegExpMatchFast:
     case RegExpMatchFastGlobal:
+    case RegExpSearch:
     case NewRegExp:
     case NewMap:
     case NewSet:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -101,6 +101,7 @@ namespace JSC {
     macro(RegExpExecIntrinsic) \
     macro(RegExpTestIntrinsic) \
     macro(RegExpMatchFastIntrinsic) \
+    macro(RegExpSearchIntrinsic) \
     macro(ObjectAssignIntrinsic) \
     macro(ObjectCreateIntrinsic) \
     macro(ObjectGetOwnPropertyNamesIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1809,9 +1809,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpMatchFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "regExpMatchFast"_s, regExpProtoFuncMatchFast, ImplementationVisibility::Private, RegExpMatchFastIntrinsic));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpSearchFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "regExpSearchFast"_s, regExpProtoFuncSearchFast, ImplementationVisibility::Private));
-        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpSplitFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "regExpSplitFast"_s, regExpProtoFuncSplitFast, ImplementationVisibility::Private));
         });

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -54,7 +54,6 @@ private:
 };
 
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncMatchFast);
-JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSearchFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSplitFast);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
@@ -25,7 +25,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE bool regExpTestWatchpointIsValid(VM& vm, JSObject* thisObject)
+ALWAYS_INLINE bool regExpExecWatchpointIsValid(VM& vm, JSObject* thisObject)
 {
     JSGlobalObject* globalObject = thisObject->globalObject();
     RegExpPrototype* regExpPrototype = globalObject->regExpPrototype();


### PR DESCRIPTION
#### 8657eef539f38caf5a8066aeeac5524832a35bed
<pre>
[JSC] Fix spec compliance and optimize `RegExp#@@search`
<a href="https://bugs.webkit.org/show_bug.cgi?id=288832">https://bugs.webkit.org/show_bug.cgi?id=288832</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], `RegExp#[Symbol.search]` writes to the `lastIndex`
property of `this` in the following cases:

- `lastIndex` is not 0
- The value of `lastIndex` changes before and after calling `RegExpExec`
  (which occurs when the `g` or `y` flag is enabled)

So, if `lastIndex` is not writable and the above conditions are met, a
`TypeError` should be thrown.

However, in the current JSC implementation, no error is thrown. So we
should change to execute the slow path when `lastIndex` is not writable,
ensuring that an error is thrown.

Furthermore, adding additional fast-path checks to the current JavaScript
implementation might lead to a performance regression[2].

Thus, this patch not only fixes the spec compliance issue but also implements
the behavior in C++ and applies optimizations in DFG/FTL.

Below are the microbenchmark results when DFG/FTL is enabled:

                                                  TipOfTree                  Patched

regexp-prototype-search-short-string           80.3555+-0.4927     ^     76.5456+-0.6090        ^ definitely 1.0498x faster
regexp-prototype-search-complex-pattern        93.2712+-0.3697     ^     89.3464+-0.7167        ^ definitely 1.0439x faster
regexp-prototype-search-basic                 123.5857+-3.7591          120.8217+-0.4638          might be 1.0229x faster
regexp-prototype-search-anchor                100.5400+-1.0777     ^     96.3188+-1.4436        ^ definitely 1.0438x faster

[1]: <a href="https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%">https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%</a>
[2]: <a href="https://github.com/WebKit/WebKit/pull/41631#discussion_r1982656344">https://github.com/WebKit/WebKit/pull/41631#discussion_r1982656344</a>

* JSTests/microbenchmarks/regexp-prototype-search-anchor.js: Added.
(shouldBe):
* JSTests/microbenchmarks/regexp-prototype-search-basic.js: Added.
(shouldBe):
* JSTests/microbenchmarks/regexp-prototype-search-complex-pattern.js: Added.
(shouldBe):
* JSTests/microbenchmarks/regexp-prototype-search-short-string.js: Added.
(shouldBe):
* JSTests/stress/regexp-prototype-search-fastpath-check.js: Added.
(shouldBe):
(shouldThrow):
(i.shouldThrow):
(i.get called):
(get return):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::addRegExpSearchPrimordialChecks):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasHeapPrediction):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::RegExpPrototype::finishCreation):
(JSC::regExpExec):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototype.h:
* Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h:
(JSC::regExpExecWatchpointIsValid):
(JSC::regExpTestWatchpointIsValid): Deleted.

Canonical link: <a href="https://commits.webkit.org/296443@main">https://commits.webkit.org/296443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/903b836a95a7a34fbd0ece3af82f05a2fa8c2c69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58951 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82446 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58476 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101109 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92304 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15967 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116882 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107111 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91472 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23251 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41043 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131393 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35220 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35645 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->