### PR TITLE
[iOS] [Visual Bidi Selection] Selection highlight is sometimes missing on last line in multiline bidi text selection

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10-expected.txt
@@ -1,0 +1,19 @@
+Verifies that the selection remains visually stable when extending a selection handle into an inline-block container after a soft line break.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS visuallyContiguousBeforeEndingSelection is true
+PASS visuallyContiguousAfterEndingSelection is true
+PASS boundsBeforeEndingSelection.top is boundsAfterEndingSelection.top
+PASS boundsBeforeEndingSelection.left is boundsAfterEndingSelection.left
+PASS boundsBeforeEndingSelection.width is boundsAfterEndingSelection.width
+PASS boundsBeforeEndingSelection.height is boundsAfterEndingSelection.height
+PASS rectsBeforeEndingSelection.length is 3
+PASS rectsAfterEndingSelection.length is 3
+PASS selectionHighlightMaxXExtents[0] is selectionHighlightMaxXExtents[1]
+PASS selectionHighlightMaxXExtents[1] is selectionHighlightMaxXExtents[2]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    font-family: system-ui;
+    font-size: 16px;
+}
+
+div[dir='rtl'] {
+    width: 300px;
+    padding: 1em;
+    border: 1px solid tomato;
+    line-height: 2;
+}
+
+.red {
+    color: rgba(255, 10, 0);
+    display: inline-block;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection remains visually stable when extending a selection handle into an inline-block container after a soft line break.");
+
+    paragraph = document.querySelector("div[dir='rtl']");
+
+    const bounds = paragraph.getBoundingClientRect();
+    await UIHelper.longPressAtPoint(bounds.left + bounds.width - 25, bounds.top + 25);
+    await UIHelper.waitForSelectionToAppear();
+
+    const endHandlePoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(endHandlePoint.x, endHandlePoint.y)
+        .move(bounds.left + (bounds.width / 2), bounds.top + bounds.height - 10, 1)
+        .wait(0.2)
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    visuallyContiguousBeforeEndingSelection = await UIHelper.isSelectionVisuallyContiguous();
+    rectsBeforeEndingSelection = await UIHelper.getUISelectionViewRects();
+    boundsBeforeEndingSelection = await UIHelper.selectionBounds();
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    visuallyContiguousAfterEndingSelection = await UIHelper.isSelectionVisuallyContiguous();
+    rectsAfterEndingSelection = await UIHelper.getUISelectionViewRects();
+    boundsAfterEndingSelection = await UIHelper.selectionBounds();
+
+    shouldBeTrue("visuallyContiguousBeforeEndingSelection");
+    shouldBeTrue("visuallyContiguousAfterEndingSelection");
+    shouldBe("boundsBeforeEndingSelection.top", "boundsAfterEndingSelection.top");
+    shouldBe("boundsBeforeEndingSelection.left", "boundsAfterEndingSelection.left");
+    shouldBe("boundsBeforeEndingSelection.width", "boundsAfterEndingSelection.width");
+    shouldBe("boundsBeforeEndingSelection.height", "boundsAfterEndingSelection.height");
+    shouldBe("rectsBeforeEndingSelection.length", "3");
+    shouldBe("rectsAfterEndingSelection.length", "3");
+
+    selectionHighlightMaxXExtents = rectsBeforeEndingSelection.map(rect => Math.round(rect.width + rect.left));
+    shouldBe("selectionHighlightMaxXExtents[0]", "selectionHighlightMaxXExtents[1]");
+    shouldBe("selectionHighlightMaxXExtents[1]", "selectionHighlightMaxXExtents[2]");
+
+    paragraph.remove();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div dir="rtl">
+    يمكنك أن تقتبس منهم، أو تختلف معهم، أو تمجدهم، أو تشوه سمعتهم. ولكن الشيء الوحيد الذي لا يمكنك فعله هو تجاهلهم
+    <span class="red">012345678901234567890123456789</span>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/CaretRectComputation.h
+++ b/Source/WebCore/rendering/CaretRectComputation.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-enum class CaretRectMode {
+enum class CaretRectMode : bool {
     Normal,
     ExpandToEndOfLine
 };


### PR DESCRIPTION
#### f6bc4f7cc2fe6e6e5f32fb44c979ba685e88b7c1
<pre>
[iOS] [Visual Bidi Selection] Selection highlight is sometimes missing on last line in multiline bidi text selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=290014">https://bugs.webkit.org/show_bug.cgi?id=290014</a>
<a href="https://rdar.apple.com/146854735">rdar://146854735</a>

Reviewed by Abrar Rahman Protyasha.

Currently, `makeBidiSelectionVisuallyContiguousIfNeeded` handles multiline selections by adjusting
the selections in the first and last lines, such that they unite the caret rect of the corresponding
selection endpoint, with the rect of the position at the end or start of the line (depending on
whether we&apos;re computing the selection rect for the first or last line).

This mostly works, except for the case where `(right|left)BoundaryOfLine` returns a position that&apos;s
on the *previous* line, instead of the current line; in this case, we end up with a broken selection
handle, as the selection caret on the last line is joined with the caret rect of a position on the
previous line. The handle rect becomes too tall, and the highlight itself either faces the wrong
direction or disappears entirely.

To fix this, use `RenderedPosition`&apos;s helpers — `(right|left)BoundaryOfBidiRun` — instead of the
editing helpers `(right|left)BoundaryOfLine` when computing the caret rect of the extents on the
same line. Unlike the latter, the former correctly handles the case where a soft line wrap is
followed by an inline block container, by returning caret rects corresponding to the left and right
visual boundaries of the inline block container.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-10.html: Added.

Add a layout test to exercise this fix.

* Source/WebCore/rendering/CaretRectComputation.h:

Drive-by change — give this `enum class` a width of `bool`.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):

Canonical link: <a href="https://commits.webkit.org/292356@main">https://commits.webkit.org/292356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcf1624765f797d9703adab7fe6812902e6db88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30249 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98725 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53332 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45565 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22780 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16615 "Found 2 new test failures: html5lib/generated/run-entities01-write.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82036 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22748 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->