### PR TITLE
grid fast path wip

### DIFF
--- a/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
@@ -5,7 +5,6 @@ Tests invalidation on align-self style change (just overflow). Passes if there i
   (rect 0 2 200 200)
   (rect 0 52 200 200)
   (rect 0 252 200 100)
-  (rect 0 2 200 50)
   (rect 0 2 800 14)
 )
 

--- a/LayoutTests/fast/repaint/align-self-overflow-change.html
+++ b/LayoutTests/fast/repaint/align-self-overflow-change.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML>
-<script src="resources/text-based-repaint.js"></script>
+<!DOCTYPE HTML> <script src="resources/text-based-repaint.js"></script>
 <script>
 function repaintTest() {
   document.getElementsByClassName('item1')[0].style.alignSelf = 'safe end';

--- a/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
@@ -5,7 +5,6 @@ Tests invalidation on justify-self style change. Passes if there is no red.
   (rect -50 52 150 300)
   (rect 0 52 150 300)
   (rect 150 52 50 300)
-  (rect -50 52 50 300)
   (rect -50 16 50 336)
   (rect -50 0 50 352)
 )

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3133,6 +3133,8 @@ void LocalFrameView::addTrackedRepaintRect(const FloatRect& r)
     if (!m_isTrackingRepaints || r.isEmpty())
         return;
 
+    WTFReportBacktrace();
+
     FloatRect repaintRect = r;
     repaintRect.moveBy(-scrollPosition());
     m_trackedRepaintRects.append(repaintRect);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -341,10 +341,121 @@ static void clearGridItemOverridingSizesBeforeLayout(RenderGrid& renderGrid)
     }
 }
 
+bool RenderGrid::isEligibleForExtrinsicTrackSizesFastPath() const
+{
+    if (m_gridAreaLogicalSizesCache.isEmpty())
+        return false;
+
+    auto& gridStyle = style();
+
+    auto participatesInBlockLayout = [&] {
+        if (isInline())
+            return false;
+        if (auto* containingBlock = this->containingBlock())
+            return containingBlock->isBlockContainer();
+        return false;
+    };
+
+    auto allTracksAreExtrinsicallySized = [&] {
+        for (auto& column : gridStyle.gridTrackSizes(GridTrackSizingDirection::ForColumns)) {
+            if (column.isContentSized())
+                return false;
+        }
+
+
+        for (auto& row : gridStyle.gridTrackSizes(GridTrackSizingDirection::ForRows)) {
+            if (row.isContentSized())
+                return false;
+        }
+        return true;
+    };
+
+    auto& currentGrid = this->currentGrid();
+    if (selfNeedsLayout()
+        || gridStyle.logicalWidth().isIntrinsic()
+        || !gridStyle.logicalHeight().isFixed()
+        || !participatesInBlockLayout()
+        || currentGrid.needsItemsPlacement()
+        || !allTracksAreExtrinsicallySized()
+        || currentGrid.autoRepeatTracks(GridTrackSizingDirection::ForColumns)
+        || currentGrid.autoRepeatTracks(GridTrackSizingDirection::ForRows)
+        || isSubgrid()
+        || isMasonry()
+        || gridStyle.hasAspectRatio()
+        || hasNonVisibleOverflow()
+        || isOutOfFlowPositioned()
+        || hasPositionedObjects()
+        || isFieldset()
+        || !firstChildBox()) {
+        return false;
+    }
+
+    for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
+        auto& gridItemStyle = gridItem.style();
+
+        auto isSubgridOrMasonry = [&] {
+            if (auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem))
+                return renderGrid->isSubgrid() || renderGrid->isMasonry();
+            return false;
+        };
+
+        auto isReplaced = [&] {
+            if (auto* gridItemElement = gridItem.element())
+                return gridItemElement->isReplaced(gridItem.style());
+            return false;
+        };
+
+        if (gridItem.isOutOfFlowPositioned()
+            || hasAutoMarginsInColumnAxis(gridItem)
+            || hasAutoMarginsInRowAxis(gridItem)
+            || isBaselineAlignmentForGridItem(gridItem)
+            || GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem)
+            || isSubgridOrMasonry()
+            || gridItemStyle.hasAspectRatio()
+            || isReplaced()) {
+
+            return false;
+        }
+    }
+    return true;
+}
+
+void RenderGrid::performExtrinsicTrackSizesFastPath(GridLayoutState& gridLayoutState)
+{
+    ASSERT(isEligibleForExtrinsicTrackSizesFastPath());
+
+    for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
+        auto [gridAreaLogicalWidth, gridAreaLogicalHeight] = m_gridAreaLogicalSizesCache.get(gridItem);
+        gridItem.setGridAreaContentLogicalWidth(gridAreaLogicalWidth);
+        gridItem.setGridAreaContentLogicalHeight(gridAreaLogicalHeight);
+
+        auto oldGridItemRect = gridItem.frameRect();
+
+        applyStretchAlignmentToGridItemIfNeeded(gridItem, gridLayoutState);
+        gridItem.layoutIfNeeded();
+
+        setLogicalPositionForGridItem(gridItem);
+        if (gridItem.checkForRepaintDuringLayout())
+            gridItem.repaintDuringLayoutIfMoved(oldGridItemRect);
+
+    }
+
+    updateLogicalHeight();
+
+    endAndCommitUpdateScrollInfoAfterLayoutTransaction();
+
+    computeOverflow(layoutOverflowLogicalBottom(*this));
+
+    updateDescendantTransformsAfterLayout();
+
+
+    updateLayerTransform();
+
+    clearNeedsLayout();
+}
+
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
-    m_gridAreaLogicalSizesCache.clear();
-
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -369,7 +480,12 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         resetLogicalHeightBeforeLayoutIfNeeded();
 
-        updateLogicalWidth();
+        if (!recomputeLogicalWidth() && isEligibleForExtrinsicTrackSizesFastPath()) {
+            performExtrinsicTrackSizesFastPath(gridLayoutState);
+            return;
+        }
+
+        m_gridAreaLogicalSizesCache.clear();
 
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.
@@ -1458,7 +1574,7 @@ void RenderGrid::layoutGridItems(GridLayoutState& gridLayoutState)
         auto gridAreaLogicalHeight = gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, GridTrackSizingDirection::ForRows);
         m_gridAreaLogicalSizesCache.set(gridItem, GridAreaLogicalSize { gridAreaLogicalWidth, gridAreaLogicalHeight });
 
-        updateGridAreaLogicalSize(*gridItem, gridAreaLogicalWidth, gridAreaLogicalHeight);
+        updateGridAreaLogicalSize(gridItem, gridAreaLogicalWidth, gridAreaLogicalHeight);
 
         LayoutRect oldGridItemRect = gridItem.frameRect();
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -89,6 +89,8 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         return;
 
     m_intrinsicLogicalHeightsForRowSizingFirstPass.reset();
+    m_gridAreaLogicalSizesCache.clear();
+
     const RenderStyle& newStyle = this->style();
 
     auto hasDifferentTrackSizes = [&newStyle, &oldStyle](GridTrackSizingDirection direction) {
@@ -341,6 +343,8 @@ static void clearGridItemOverridingSizesBeforeLayout(RenderGrid& renderGrid)
 
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -478,6 +482,8 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
 void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -1326,6 +1332,8 @@ void RenderGrid::setNeedsItemPlacement(SubgridDidChange subgridDidChange)
     if (currentGrid().needsItemsPlacement())
         return;
 
+    m_gridAreaLogicalSizesCache.clear();
+
     currentGrid().setNeedsItemsPlacement(true);
 
     auto currentChild = this;
@@ -1446,7 +1454,11 @@ void RenderGrid::layoutGridItems(GridLayoutState& gridLayoutState)
         // Setting the definite grid area's sizes. It may imply that the
         // item must perform a layout if its area differs from the one
         // used during the track sizing algorithm.
-        updateGridAreaLogicalSize(gridItem, gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, GridTrackSizingDirection::ForColumns), gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, GridTrackSizingDirection::ForRows));
+        auto gridAreaLogicalWidth = gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, GridTrackSizingDirection::ForColumns);
+        auto gridAreaLogicalHeight = gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, GridTrackSizingDirection::ForRows);
+        m_gridAreaLogicalSizesCache.set(gridItem, GridAreaLogicalSize { gridAreaLogicalWidth, gridAreaLogicalHeight });
+
+        updateGridAreaLogicalSize(*gridItem, gridAreaLogicalWidth, gridAreaLogicalHeight);
 
         LayoutRect oldGridItemRect = gridItem.frameRect();
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -308,6 +308,10 @@ private:
     bool m_hasAnyBaselineAlignmentItem { false };
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
+
+    using GridAreaLogicalSize = std::pair<LayoutUnit, LayoutUnit>;
+    UncheckedKeyHashMap<SingleThreadWeakRef<const RenderBox>, GridAreaLogicalSize> m_gridAreaLogicalSizesCache;
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -280,6 +280,8 @@ private:
     AutoRepeatType autoRepeatRowsType() const;
 
     bool canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() const;
+    bool isEligibleForExtrinsicTrackSizesFastPath() const;
+    void performExtrinsicTrackSizesFastPath(GridLayoutState&);
 
     class GridWrapper {
         Grid m_layoutGrid;


### PR DESCRIPTION
#### 45202404035fb9c55339c743c4e0376e00ab0c91
<pre>
grid fast path wip
</pre>
----------------------------------------------------------------------
#### c4fd592e27377ca48bda30cb207c329317958323
<pre>
[Grid] Introduce grid area logical sizes cache.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289004">https://bugs.webkit.org/show_bug.cgi?id=289004</a>
<a href="https://rdar.apple.com/problem/146051830">rdar://problem/146051830</a>

Reviewed by NOBODY (OOPS!).

This patch introduces a cache that stores the logical size of each grid
item&apos;s grid area. The grid area of an item is computed during the track
sizing algorithm and is used during layoutGridItems to set the item&apos;s
grid area logical width/height before calling layout on it as this
represents the item&apos;s containing block. We can use this as an
opportunity to cache these computed values to potentially use in a
subsequent layout in certain conditions which will be determined in a
future patch.

With the introduction of this cache we will want to invalidate it
basically whenever the grid experiences any sort of style mutation that
requires layout or whenever the content of the grid changes. The former
is done in a straightforward manner via RenderGrid::styleDidChange. The
latter is done inside of dirtyGrid, which is called at different points
in time when we need to perform item placement again including when:

1. A renderer is attached or detached from the RenderGrid
2.) A grid item&apos;s style changes such that it requires it to be placed
again

We will also aggressively invalidate this cache at the beginning of
RenderGrid::layoutGrid since we have no use for it yet. With respect to
the scenarios described above, this would represent another case where
a grid item&apos;s content/styling would have been mutated and could possibly
influence the sizes of the tracks and the sizes of the grid areas as a
result. I plan to add a fast path in which we would not invalidate this
cache during layout and instead use the sizes in scenarios where the
grid content does not influence the sizes of the tracks.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::dirtyGrid):
(WebCore::RenderGrid::layoutGridItems):
* Source/WebCore/rendering/RenderGrid.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45202404035fb9c55339c743c4e0376e00ab0c91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73144 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22994 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16762 "Found 4 new test failures: fast/css/relative-positioned-block-crash.html fast/repaint/hidpi-transform-on-subpixel-repaintrect.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html svg/hixie/perf/004.xml (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82183 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81545 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26132 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3585 "Found 2 new test failures: fast/repaint/hidpi-transform-on-subpixel-repaintrect.html svg/hixie/perf/004.xml (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22957 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28112 "Found 1 new failure in rendering/RenderGrid.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->