### PR TITLE
AX: [AX Thread Text APIs] Estimated range bounds aren't accurate

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1137,6 +1137,7 @@ public:
     bool emitsNewline() const;
     virtual AXTextRunLineID listMarkerLineID() const = 0;
     virtual String listMarkerText() const = 0;
+    virtual FontOrientation fontOrientation() const = 0;
 #endif
 
     // Methods for determining accessibility text.

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -758,6 +758,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::Font:
         stream << "Font";
         break;
+    case AXProperty::FontOrientation:
+        stream << "FontOrientation";
+        break;
 #endif // PLATFORM(COCOA)
     case AXProperty::TextColor:
         stream << "TextColor";

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -841,11 +841,16 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
     }
 
     float estimatedLineHeight = relativeFrame.height() / runs->size();
-    auto runsLocalRect = runs->localRect(start, end, estimatedLineHeight);
-    // The rect we got above is a "local" rect, relative to nothing else. Move it to be
-    // anchored at this object's relative frame.
-    runsLocalRect.move(relativeFrame.x(), relativeFrame.y());
-    return runsLocalRect;
+    if (auto fontRef = object->font()) {
+        auto runsLocalRect = runs->localRect(start, end, estimatedLineHeight, relativeFrame, fontRef.get(), object->fontOrientation());
+        // The rect we got above is a "local" rect, relative to nothing else. Move it to be
+        // anchored at this object's relative frame.
+        runsLocalRect.move(relativeFrame.x(), relativeFrame.y());
+        return runsLocalRect;
+    }
+
+    // This means we had no font information, so fallback to the object's relative frame.
+    return relativeFrame;
 }
 
 static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, unsigned offset)

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -28,6 +28,8 @@
 #if ENABLE(AX_THREAD_TEXT_APIS)
 
 #include "FloatRect.h"
+#include "TextFlags.h"
+#include <CoreText/CTFont.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -100,19 +102,11 @@ struct AXTextRuns {
     void* containingBlock { nullptr };
     Vector<AXTextRun> runs;
     bool containsOnlyASCII { true };
-    // A rough estimate of the size of the characters in these runs. This is per-AXTextRuns because
-    // AXTextRuns are associated with a single RenderText, which has the same style for all its runs.
-    // This is still an estimate, as characters can have vastly different sizes. We use this to serve
-    // APIs like AXBoundsForTextMarkerRangeAttribute quickly off the main-thread, and get more accurate
-    // sizes on-demand for runs that assistive technologies are actually requesting these APIs from.
-    static constexpr uint8_t defaultEstimatedCharacterWidth = 12;
-    uint8_t estimatedCharacterWidth { defaultEstimatedCharacterWidth };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, uint8_t estimatedCharacterWidth)
+    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns)
         : containingBlock(containingBlock)
         , runs(WTFMove(textRuns))
-        , estimatedCharacterWidth(estimatedCharacterWidth)
     {
         for (const auto& run : runs) {
             if (!run.text.containsOnlyASCII()) {
@@ -172,7 +166,7 @@ struct AXTextRuns {
     //   b|bb|b
     // The local rect would be:
     //   {x: width_of_single_b, y: |lineHeight| * 1, width: width_of_two_b, height: |lineHeight * 1|}
-    FloatRect localRect(unsigned start, unsigned end, float lineHeight) const;
+    FloatRect localRect(unsigned start, unsigned end, float lineHeight, FloatRect, CTFontRef, FontOrientation) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -396,6 +396,7 @@ public:
     TextEmissionBehavior textEmissionBehavior() const override { return TextEmissionBehavior::None; }
     AXTextRunLineID listMarkerLineID() const override { return { }; }
     String listMarkerText() const override { return { }; }
+    FontOrientation fontOrientation() const final;
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 #if PLATFORM(COCOA)
     // Returns an array of strings and AXObject wrappers corresponding to the

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -203,6 +203,15 @@ RetainPtr<CTFontRef> AccessibilityObject::font() const
     return style ? fontFrom(*style) : nil;
 }
 
+#if ENABLE(AX_THREAD_TEXT_APIS)
+FontOrientation AccessibilityObject::fontOrientation() const
+{
+    if (CheckedPtr style = this->style())
+        return const_cast<RenderStyle*>(style.get())->fontAndGlyphOrientation().first;
+    return FontOrientation::Horizontal;
+}
+#endif
+
 Color AccessibilityObject::textColor() const
 {
     const auto* style = this->style();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -630,6 +630,7 @@ void AXIsolatedObject::setProperty(AXProperty propertyName, AXPropertyValueVaria
 #if ENABLE(AX_THREAD_TEXT_APIS)
         [](AXTextRuns& runs) { return !runs.size(); },
         [](RetainPtr<CTFontRef>& typedValue) { return !typedValue; },
+        [](FontOrientation typedValue) { return typedValue == FontOrientation::Horizontal; },
         [](TextEmissionBehavior typedValue) { return typedValue == TextEmissionBehavior::None; },
         [](AXTextRunLineID typedValue) { return !typedValue; },
 #endif // ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -92,6 +92,7 @@ public:
     TextEmissionBehavior textEmissionBehavior() const final { return propertyValue<TextEmissionBehavior>(AXProperty::TextEmissionBehavior); }
     AXTextRunLineID listMarkerLineID() const final { return propertyValue<AXTextRunLineID>(AXProperty::ListMarkerLineID); };
     String listMarkerText() const final { return stringAttributeValue(AXProperty::ListMarkerText); }
+    FontOrientation fontOrientation() const final { return propertyValue<FontOrientation>(AXProperty::FontOrientation); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -103,6 +104,10 @@ public:
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 
     AXTextMarkerRange textMarkerRange() const final;
+
+#if PLATFORM(COCOA)
+    RetainPtr<CTFontRef> font() const final { return propertyValue<RetainPtr<CTFontRef>>(AXProperty::Font); }
+#endif
 
 private:
     constexpr ProcessID processID() const final { return tree()->processID(); }
@@ -505,7 +510,6 @@ private:
     unsigned textLength() const final;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
-    RetainPtr<CTFontRef> font() const final { return propertyValue<RetainPtr<CTFontRef>>(AXProperty::Font); }
 #endif
     AXObjectCache* axObjectCache() const final;
     Element* actionElement() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -131,6 +131,7 @@ enum class AXProperty : uint16_t {
     ExtendedDescription,
 #if PLATFORM(COCOA)
     Font,
+    FontOrientation,
 #endif
     TextColor,
     HasApplePDFAnnotationAttribute,
@@ -305,6 +306,7 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
 #endif // PLATFORM(COCOA)
 #if ENABLE(AX_THREAD_TEXT_APIS)
     , RetainPtr<CTFontRef>
+    , FontOrientation
     , AXTextRuns
     , TextEmissionBehavior
     , AXTextRunLineID

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -61,6 +61,8 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
         // Resolve this FIXME before shipping AX_THREAD_TEXT_APIS.
         setProperty(AXProperty::TextColor, WTFMove(style.textColor));
         setProperty(AXProperty::UnderlineColor, style.underlineColor());
+
+        setProperty(AXProperty::FontOrientation, object->fontOrientation());
     }
     // FIXME: Can we compute this off the main-thread with our cached text runs?
     setProperty(AXProperty::StringValue, object->stringValue().isolatedCopy());


### PR DESCRIPTION
#### 9343d8ff722ecfe6379cf2668fc1c0d13bd902ce
<pre>
AX: [AX Thread Text APIs] Estimated range bounds aren&apos;t accurate
<a href="https://bugs.webkit.org/show_bug.cgi?id=290015">https://bugs.webkit.org/show_bug.cgi?id=290015</a>
<a href="https://rdar.apple.com/147365717">rdar://147365717</a>

Reviewed by Tyler Wilcock.

Our old approach of computing text marker range bounds off of the main thread,
using a fixed, estimated character width, would lead to frames that were
inaccurate and didn&apos;t properly highlight the range. To account for variable
character widths, we can instead reference the CTFont&apos;s properties, which
we already cache on isolated objects. The `advance` of a series of the glyphs
provides an accurate horizontal width of a text range.

Follow up PRs will be necessary to address geometry and character manipulation
like transforms and letter-spacing.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::viewportRelativeFrameFromRuns):
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::AXTextRuns):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::AccessibilityObject::fontOrientation const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::setProperty):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::initializePlatformProperties):

Canonical link: <a href="https://commits.webkit.org/292392@main">https://commits.webkit.org/292392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52534d5ec5cf4e18bf46846cd193f8945c582f60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98855 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11803 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22919 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82142 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16256 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->