### PR TITLE
ASAN_TRAP | WebCore::RenderObject::repaintRectangle

### DIFF
--- a/LayoutTests/editing/selection/selection-update-repaint-expected.txt
+++ b/LayoutTests/editing/selection/selection-update-repaint-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not crash.
+PASS.

--- a/LayoutTests/editing/selection/selection-update-repaint.html
+++ b/LayoutTests/editing/selection/selection-update-repaint.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table { -webkit-column-count: 3; transform-origin: 81; column-span: all; }
+.multicol { -webkit-column-count: 7; }
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+function runTest() {
+    getSelection().deleteFromDocument();
+    setTimeout(() => {
+        let count = location.search ? +location.search.substring(1) : 1;
+        if (count >= 20) {
+            document.open();
+            document.write('This test passes if WebKit does not crash.<br>PASS.');
+            document.close();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        } else
+            location.href = '?' + (count + 1);
+    }, 10);
+}
+
+function selectAll() {
+    document.execCommand("selectAll", false);
+}
+
+</script>
+</head>
+<body onload=runTest()>
+<div class="multicol" tabindex="1" autofocus>
+    <table>
+        <th>
+            <table>a</table>
+        </th>
+        <tr>b</tr>
+    </table>
+</div>
+<li class="multicol">
+    <iframe allowfullscreen="true" srcdoc=")#&quot;~KVv8CRs" loopstart="1">c</iframe>
+</li>
+<details open="true" ontoggle="selectAll()">d</details>
+</body>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1020,11 +1020,6 @@ static void resetRendererStateOnDetach(RenderElement& parent, RenderObject& chil
 
     if (CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(child); listItemRenderer && isInternalMove == RenderTreeBuilder::IsInternalMove::No)
         listItemRenderer->updateListMarkerNumbers();
-
-    // If child is the start or end of the selection, then clear the selection to
-    // avoid problems of invalid pointers.
-    if (willBeDestroyed == RenderTreeBuilder::WillBeDestroyed::Yes && child.isSelectionBorder())
-        parent.frame().selection().setNeedsSelectionUpdate();
 }
 
 RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed willBeDestroyed)


### PR DESCRIPTION
#### 6e216e69281c511606d800818a1d83f7d888f5f2
<pre>
ASAN_TRAP | WebCore::RenderObject::repaintRectangle
<a href="https://bugs.webkit.org/show_bug.cgi?id=290013">https://bugs.webkit.org/show_bug.cgi?id=290013</a>
<a href="https://rdar.apple.com/146074591">rdar://146074591</a>

Reviewed by Alan Baradlay.

The issue was the the repaint rect was called in the middle of detach. In that state,
some of the memebers were detached and the others not, causing calls to detached
members. The fix was to call the repaint is called in the tree updater function.

* LayoutTests/editing/selection/selection-update-repaint-expected.txt: Added.
* LayoutTests/editing/selection/selection-update-repaint.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::resetRendererStateOnDetach):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::repaintAndMarkContainingBlockDirtyBeforeTearDown):

Canonical link: <a href="https://commits.webkit.org/293475@main">https://commits.webkit.org/293475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dece7e1e6656423ab48a2d7f74181da6865546d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32434 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101927 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14324 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7310 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83771 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6098 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19742 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31159 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->