### PR TITLE
Remove unused font-variant-* consuming code from @font-face code path

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12270,7 +12270,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family"
                 }
             },
             "font-display": {
@@ -12287,7 +12287,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#font-display-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-display"
                 }
             },
             "font-feature-settings": {
@@ -12300,7 +12300,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-feature-settings"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-feature-settings"
                 }
             },
             "font-width": {
@@ -12337,7 +12337,7 @@
                 ],
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-stretch"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-width"
                 }
             },
             "font-style": {
@@ -12365,126 +12365,7 @@
                 ],
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-style"
-                }
-            },
-            "font-variant": {
-                "codegen-properties": {
-                    "longhands": [
-                        "font-variant-ligatures",
-                        "font-variant-caps",
-                        "font-variant-alternates",
-                        "font-variant-numeric",
-                        "font-variant-east-asian",
-                        "font-variant-position"
-                    ]
-                },
-                "specification": {
-                    "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#propdef-font-variant"
-                }
-            },
-            "font-variant-alternates": {
-                "codegen-properties": {
-                    "parser-grammar": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]@(no-single-item-opt)"
-                },
-                "specification": {
-                    "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-alternates-prop"
-                }
-            },
-            "font-variant-caps": {
-                "values": [
-                    "normal",
-                    "small-caps",
-                    "all-small-caps",
-                    "petite-caps",
-                    "all-petite-caps",
-                    "unicase",
-                    "titling-caps"
-                ],
-                "codegen-properties": {
-                    "parser-grammar": "<<values>>"
-                },
-                "specification": {
-                    "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-caps-prop"
-                }
-            },
-            "font-variant-east-asian": {
-                "values": [
-                    "normal",
-                    "jis78",
-                    "jis83",
-                    "jis90",
-                    "jis04",
-                    "simplified",
-                    "traditional",
-                    "full-width",
-                    "proportional-width",
-                    "ruby"
-                ],
-                "codegen-properties": {
-                    "parser-grammar": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]@(no-single-item-opt)"
-                },
-                "specification": {
-                    "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-east-asian-prop"
-                }
-            },
-            "font-variant-ligatures": {
-                "values": [
-                    "normal",
-                    "none",
-                    "common-ligatures",
-                    "no-common-ligatures",
-                    "discretionary-ligatures",
-                    "no-discretionary-ligatures",
-                    "historical-ligatures",
-                    "no-historical-ligatures",
-                    "contextual",
-                    "no-contextual"
-                ],
-                "codegen-properties": {
-                    "parser-grammar": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]@(no-single-item-opt)"
-                },
-                "specification": {
-                    "category": "css-fonts-4",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#font-variant-ligatures-prop"
-                }
-            },
-            "font-variant-numeric": {
-                "values": [
-                    "normal",
-                    "lining-nums",
-                    "oldstyle-nums",
-                    "proportional-nums",
-                    "tabular-nums",
-                    "diagonal-fractions",
-                    "stacked-fractions",
-                    "ordinal",
-                    "slashed-zero"
-                ],
-                "codegen-properties": {
-                    "parser-grammar": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]@(no-single-item-opt)"
-                },
-                "specification": {
-                    "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-numeric-prop"
-                }
-            },
-            "font-variant-position": {
-                "values": [
-                    "normal",
-                    "sub",
-                    "super"
-                ],
-                "codegen-properties": {
-                    "parser-grammar": "<<values>>"
-                },
-                "specification": {
-                    "category": "css-fonts-4",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-style"
                 }
             },
             "font-weight": {
@@ -12512,7 +12393,7 @@
                 ],
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-weight"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-weight"
                 }
             },
             "src": {
@@ -12523,7 +12404,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#src-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-src"
                 }
             },
             "size-adjust": {
@@ -12534,7 +12415,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-5",
-                    "url": "https://www.w3.org/TR/css-fonts-5/#size-adjust-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-5/#descdef-font-face-size-adjust"
                 }
             },
             "unicode-range": {
@@ -12544,7 +12425,7 @@
                 },
                 "specification": {
                     "category": "css-fonts",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-unicode-range"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-unicode-range"
                 }
             }
         },
@@ -12555,7 +12436,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://drafts.csswg.org/css-fonts-4/#font-family-2-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-palette-values-font-family"
                 }
             },
             "base-palette": {
@@ -12564,7 +12445,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-2-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-palette-values-base-palette"
                 }
             },
             "override-colors": {
@@ -12573,7 +12454,7 @@
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#override-color"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-palette-values-override-colors"
                 }
             }
         },

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -615,27 +615,12 @@ bool CSSPropertyParser::parsePositionTryDescriptor(CSSPropertyID property, bool 
 
 bool CSSPropertyParser::parseFontFaceDescriptor(CSSPropertyID property)
 {
-    if (isShorthand(property))
-        return parseFontFaceDescriptorShorthand(property);
-
     RefPtr parsedValue = CSSPropertyParsing::parseFontFaceDescriptor(m_range, property, m_context);
     if (!parsedValue || !m_range.atEnd())
         return false;
 
     addProperty(property, CSSPropertyInvalid, WTFMove(parsedValue), false);
     return true;
-}
-
-bool CSSPropertyParser::parseFontFaceDescriptorShorthand(CSSPropertyID property)
-{
-    ASSERT(isExposed(property, m_context.propertySettings));
-
-    switch (property) {
-    case CSSPropertyFontVariant:
-        return consumeFontVariantShorthand(false);
-    default:
-        return false;
-    }
 }
 
 bool CSSPropertyParser::parseKeyframeDescriptor(CSSPropertyID propertyID, bool important)

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -72,7 +72,6 @@ private:
 
     // @font-face descriptors.
     bool parseFontFaceDescriptor(CSSPropertyID);
-    bool parseFontFaceDescriptorShorthand(CSSPropertyID);
 
     // @font-palette-values descriptors.
     bool parseFontPaletteValuesDescriptor(CSSPropertyID);


### PR DESCRIPTION
#### 27b8f9f7c638eafb5c21bcc1e8c5938aa2ff30e7
<pre>
Remove unused font-variant-* consuming code from @font-face code path
<a href="https://bugs.webkit.org/show_bug.cgi?id=290017">https://bugs.webkit.org/show_bug.cgi?id=290017</a>

Reviewed by Tim Nguyen.

Remove unused font-variant-* consuming code from @font-face code paths. Nothing ever consumes
these. It seems these have been here since the tokenizer was imported from blink.

Also updates the URLs for a few descriptors to point to their @rule specific definitions.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.h:

Canonical link: <a href="https://commits.webkit.org/292362@main">https://commits.webkit.org/292362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3b408dd0bf2ed870650d9812f5ce36fcc225ec7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45572 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22787 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16620 "Found 2 new test failures: html5lib/generated/run-entities01-write.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27904 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22414 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->