### PR TITLE
SVGLengthValue.cpp should support rem (probably other) units for width and height attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Error: Invalid value for <rect> attribute x="25rem"
 
-FAIL rem unit in SVGLength assert_equals: expected 0 but got 1
-FAIL Convert back to rem from new user unit value assert_equals: expected 50 but got 450
+PASS rem unit in SVGLength
+PASS Convert back to rem from new user unit value
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8270,10 +8270,11 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
+                "animation-wrapper": "DiscreteSVGWrapper",
                 "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
                 "render-style-initial": "zeroLength",
-                "style-builder-converter": "Length",
+                "style-builder-converter": "SVGLength",
+                "svg": true,
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -93,6 +93,7 @@ public:
     static String initialMarkerEndResource() { return String(); }
     static MaskType initialMaskType() { return MaskType::Luminance; }
     static SVGLengthValue initialBaselineShiftValue() { return SVGLengthValue(0, SVGLengthType::Number); }
+    static SVGLengthValue zeroLength() { return SVGLengthValue(0, SVGLengthType::Number); }
 
     // SVG CSS Property setters
     void setAlignmentBaseline(AlignmentBaseline val) { m_nonInheritedFlags.flagBits.alignmentBaseline = static_cast<unsigned>(val); }
@@ -115,6 +116,7 @@ public:
     void setRx(const Length&);
     void setRy(const Length&);
     void setX(const Length&);
+    void setX(const SVGLengthValue&);
     void setY(const Length&);
     void setD(RefPtr<StylePathData>&&);
     void setFillOpacity(float);
@@ -343,6 +345,13 @@ inline void SVGRenderStyle::setX(const Length& length)
 {
     if (!(m_layoutData->x == length))
         m_layoutData.access().x = length;
+}
+
+inline void SVGRenderStyle::setX(const SVGLengthValue& length) {
+    Length newLength = Length(length.valueInSpecifiedUnits(), LengthType::Fixed, false);
+
+    if (!(m_layoutData->x == newLength))
+        m_layoutData.access().x = newLength;
 }
 
 inline void SVGRenderStyle::setY(const Length& length)

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -347,8 +347,9 @@ inline void SVGRenderStyle::setX(const Length& length)
         m_layoutData.access().x = length;
 }
 
-inline void SVGRenderStyle::setX(const SVGLengthValue& length) {
-    Length newLength = Length(length.valueInSpecifiedUnits(), LengthType::Fixed, false);
+inline void SVGRenderStyle::setX(const SVGLengthValue& length)
+{
+    Length newLength = Length(length.valueInSpecifiedUnits(), length.toCoreLengthType(), false);
 
     if (!(m_layoutData->x == newLength))
         m_layoutData.access().x = newLength;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -388,6 +388,10 @@ inline WebCore::Length BuilderConverter::convertLength(BuilderState& builderStat
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
         : builderState.cssToLengthConversionData();
 
+    if (primitiveValue->isFontRelativeLength()) {
+        conversionData = conversionData.copyForFontSize();
+    }
+
     if (primitiveValue->isLength()) {
         auto length = primitiveValue->resolveAsLength<WebCore::Length>(conversionData);
         length.setHasQuirk(primitiveValue->primitiveType() == CSSUnitType::CSS_QUIRKY_EM);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -98,6 +98,7 @@
 #include "TransformOperationsBuilder.h"
 #include "ViewTimeline.h"
 #include "WillChangeData.h"
+#include "svg/SVGLengthValue.h"
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -109,6 +110,7 @@ namespace Style {
 class BuilderConverter {
 public:
     static WebCore::Length convertLength(BuilderState&, const CSSValue&);
+    static SVGLengthValue convertSVGLength(BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthOrAuto(BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthOrAutoOrContent(BuilderState&, const CSSValue&);
     static WebCore::Length convertLengthSizing(BuilderState&, const CSSValue&);
@@ -400,6 +402,17 @@ inline WebCore::Length BuilderConverter::convertLength(BuilderState& builderStat
 
     ASSERT_NOT_REACHED();
     return WebCore::Length(0, LengthType::Fixed);
+}
+
+inline SVGLengthValue BuilderConverter::convertSVGLength(BuilderState& builderState, const CSSValue& value)
+{
+    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return { };
+
+    CSSToLengthConversionData conversionData = builderState.cssToLengthConversionData().copyForFontSize();
+
+    return SVGLengthValue::fromCSSPrimitiveValue(*primitiveValue, conversionData);
 }
 
 inline WebCore::Length BuilderConverter::convertLengthAllowingNumber(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -135,6 +135,8 @@ ExceptionOr<float> SVGLengthContext::convertValueToUserUnits(float value, SVGLen
         return convertValueFromPercentageToUserUnits(value / 100, lengthMode);
     case SVGLengthType::Ems:
         return convertValueFromEMSToUserUnits(value);
+    case SVGLengthType::Rems:
+        return convertValueFromREMSToUserUnits(value);
     case SVGLengthType::Exs:
         return convertValueFromEXSToUserUnits(value);
     case SVGLengthType::Lh:
@@ -168,6 +170,8 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnits(float value, SVGL
         return convertValueFromUserUnitsToPercentage(value * 100, lengthMode);
     case SVGLengthType::Ems:
         return convertValueFromUserUnitsToEMS(value);
+    case SVGLengthType::Rems:
+        return convertValueFromUserUnitsToREMS(value);
     case SVGLengthType::Exs:
         return convertValueFromUserUnitsToEXS(value);
     case SVGLengthType::Lh:
@@ -233,6 +237,23 @@ static inline const RenderStyle* renderStyleForLengthResolving(const SVGElement*
     return nullptr;
 }
 
+static inline const RenderStyle* rootRenderStyleForLength(const SVGElement* svgElement)
+{
+    if (!svgElement)
+        return nullptr;
+
+    Ref svgDocument = svgElement->document();
+    RefPtr rootElement = svgDocument->documentElement();
+
+    const RenderStyle* style = nullptr;
+    if (svgElement != rootElement)
+        style = rootElement->computedStyle();
+    else
+        style = svgDocument->computedStyle();
+
+    return style;
+}
+
 RefPtr<const SVGElement> SVGLengthContext::protectedContext() const
 {
     return m_context.get();
@@ -258,6 +279,28 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEMSToUserUnits(float value)
         return Exception { ExceptionCode::NotSupportedError };
 
     return value * style->computedFontSize();
+}
+
+ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToREMS(float value) const
+{
+    auto* rootStyle = rootRenderStyleForLength(protectedContext().get());
+    if (!rootStyle)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    float fontSize = rootStyle->computedFontSize();
+    if (!fontSize)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    return value / fontSize;
+}
+
+ExceptionOr<float> SVGLengthContext::convertValueFromREMSToUserUnits(float value) const
+{
+    auto* rootStyle = rootRenderStyleForLength(protectedContext().get());
+    if (!rootStyle)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    return value * rootStyle->computedFontSize();
 }
 
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -300,7 +300,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromREMSToUserUnits(float value
     if (!rootStyle)
         return Exception { ExceptionCode::NotSupportedError };
 
-    return value * rootStyle->computedFontSize();
+    return value * rootStyle->specifiedFontSize();
 }
 
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -61,6 +61,9 @@ private:
     ExceptionOr<float> convertValueFromUserUnitsToEMS(float) const;
     ExceptionOr<float> convertValueFromEMSToUserUnits(float) const;
 
+    ExceptionOr<float> convertValueFromUserUnitsToREMS(float) const;
+    ExceptionOr<float> convertValueFromREMSToUserUnits(float) const;
+
     ExceptionOr<float> convertValueFromUserUnitsToEXS(float) const;
     ExceptionOr<float> convertValueFromEXSToUserUnits(float) const;
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -64,6 +64,8 @@ static inline ASCIILiteral lengthTypeToString(SVGLengthType lengthType)
         return "lh"_s;
     case SVGLengthType::Ch:
         return "ch"_s;
+    case SVGLengthType::Rems:
+        return "rem"_s;
     }
 
     ASSERT_NOT_REACHED();
@@ -83,8 +85,16 @@ template<typename CharacterType> static inline SVGLengthType parseLengthType(Str
 
     buffer.advance();
 
+    bool hasThirdChar = !buffer.atEnd();
+
+    if (hasThirdChar)
+        buffer.advance();
+
     if (!buffer.atEnd())
         return SVGLengthType::Unknown;
+
+    if (hasThirdChar && compareCharacters(firstCharacterPosition, 'r', 'e', 'm'))
+        return SVGLengthType::Rems;
 
     if (compareCharacters(firstCharacterPosition, 'e', 'm'))
         return SVGLengthType::Ems;
@@ -139,6 +149,8 @@ static inline SVGLengthType primitiveTypeToLengthType(CSSUnitType primitiveType)
         return SVGLengthType::Lh;
     case CSSUnitType::CSS_CH:
         return SVGLengthType::Ch;
+    case WebCore::CSSUnitType::CSS_REM:
+        return SVGLengthType::Rems;
     default:
         return SVGLengthType::Unknown;
     }
@@ -175,6 +187,8 @@ static inline CSSUnitType lengthTypeToPrimitiveType(SVGLengthType lengthType)
         return CSSUnitType::CSS_LH;
     case SVGLengthType::Ch:
         return CSSUnitType::CSS_CH;
+    case SVGLengthType::Rems:
+        return CSSUnitType::CSS_REM;
     }
 
     ASSERT_NOT_REACHED();
@@ -229,7 +243,7 @@ SVGLengthValue SVGLengthValue::blend(const SVGLengthValue& from, const SVGLength
         || to.lengthType() == SVGLengthType::Unknown
         || (!from.isZero() && from.lengthType() != SVGLengthType::Percentage && to.lengthType() == SVGLengthType::Percentage)
         || (!to.isZero() && from.lengthType() == SVGLengthType::Percentage && to.lengthType() != SVGLengthType::Percentage)
-        || (!from.isZero() && !to.isZero() && (from.lengthType() == SVGLengthType::Ems || from.lengthType() == SVGLengthType::Exs) && from.lengthType() != to.lengthType()))
+        || (!from.isZero() && !to.isZero() && (from.lengthType() == SVGLengthType::Ems || from.lengthType() == SVGLengthType::Exs || from.lengthType() == SVGLengthType::Rems) && from.lengthType() != to.lengthType()))
         return to;
 
     if (from.lengthType() == SVGLengthType::Percentage || to.lengthType() == SVGLengthType::Percentage) {

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -271,6 +271,31 @@ SVGLengthValue SVGLengthValue::blend(const SVGLengthValue& from, const SVGLength
     return { WebCore::blend(fromValue.releaseReturnValue(), toValue, { progress }), to.lengthType() };
 }
 
+WebCore::LengthType SVGLengthValue::toCoreLengthType() const {
+    switch (m_lengthType) {
+        case SVGLengthType::Unknown:
+            return LengthType::Undefined;
+        case SVGLengthType::Number:
+        case SVGLengthType::Ems:
+        case SVGLengthType::Exs:
+        case SVGLengthType::Pixels:
+        case SVGLengthType::Rems:
+        case SVGLengthType::Ch:
+        case SVGLengthType::Inches:
+        case SVGLengthType::Lh:
+        case SVGLengthType::Centimeters:
+        case SVGLengthType::Millimeters:
+        case SVGLengthType::Picas:
+        case SVGLengthType::Points:
+            return LengthType::Fixed;
+        case SVGLengthType::Percentage:
+            return LengthType::Percent;
+    }
+
+    ASSERT_NOT_REACHED();
+    return LengthType::Undefined;
+}
+
 SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& value, const CSSToLengthConversionData& conversionData, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
     auto primitiveType = value.primitiveType();

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -284,6 +284,8 @@ SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& va
         return { value.resolveAsNumber<float>(conversionData), SVGLengthType::Number };
     case SVGLengthType::Percentage:
         return { value.resolveAsPercentage<float>(conversionData), SVGLengthType::Percentage };
+    case SVGLengthType::Rems:
+        return { value.resolveAsLength<float>(conversionData), SVGLengthType::Rems };
     default:
         return { value.resolveAsLength<float>(conversionData), SVGLengthType::Pixels };
     }

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -45,7 +45,8 @@ enum class SVGLengthType : uint8_t {
     Points,
     Picas,
     Lh,
-    Ch
+    Ch,
+    Rems
 };
 
 enum class SVGLengthMode : uint8_t {
@@ -79,7 +80,7 @@ public:
     SVGLengthMode lengthMode() const { return m_lengthMode; }
 
     bool isZero() const { return !m_valueInSpecifiedUnits;  }
-    bool isRelative() const { return m_lengthType == SVGLengthType::Percentage || m_lengthType == SVGLengthType::Ems || m_lengthType == SVGLengthType::Exs || m_lengthType == SVGLengthType::Ch; }
+    bool isRelative() const { return m_lengthType == SVGLengthType::Percentage || m_lengthType == SVGLengthType::Ems || m_lengthType == SVGLengthType::Exs || m_lengthType == SVGLengthType::Ch || m_lengthType == SVGLengthType::Rems; }
 
     float value(const SVGLengthContext&) const;
     float valueAsPercentage() const { return m_lengthType == SVGLengthType::Percentage ? m_valueInSpecifiedUnits / 100 : m_valueInSpecifiedUnits; }

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -78,6 +78,7 @@ public:
 
     SVGLengthType lengthType() const { return m_lengthType; }
     SVGLengthMode lengthMode() const { return m_lengthMode; }
+    WebCore::LengthType toCoreLengthType() const;
 
     bool isZero() const { return !m_valueInSpecifiedUnits;  }
     bool isRelative() const { return m_lengthType == SVGLengthType::Percentage || m_lengthType == SVGLengthType::Ems || m_lengthType == SVGLengthType::Exs || m_lengthType == SVGLengthType::Ch || m_lengthType == SVGLengthType::Rems; }


### PR DESCRIPTION
#### 5e29e18f12fb9dc7245a7f03867364eb9fa5f9d6
<pre>
SVGLengthValue.cpp should support rem (probably other) units for width and height attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=258003">https://bugs.webkit.org/show_bug.cgi?id=258003</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/svg/SVGLength.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnitsToREMS const):
(WebCore::SVGLengthContext::convertValueFromREMSToUserUnits const):
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::lengthTypeToString):
(WebCore::parseLengthType):
(WebCore::primitiveTypeToLengthType):
(WebCore::lengthTypeToPrimitiveType):
* Source/WebCore/svg/SVGLengthValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c4dc51c807c5473c5d92ea4b93a35b54e8b8da8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96846 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24905 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73798 "Failure limit exceed. At least found 470 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/aria-roles.html accessibility/css-content-attribute.html accessibility/heading-title-includes-links.html accessibility/image-link.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31007 "Found 60 new test failures: animations/animation-controller-drt-api.html css3/flexbox/csswg/flexbox_direction-row-reverse.html css3/masking/clip-path-on-inline.html css3/unicode-bidi-float-crash.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/execCommand/5700414-1.html editing/execCommand/5700414-2.html editing/execCommand/format-block-with-trailing-br.html editing/execCommand/move-up-down-should-skip-hidden-elements.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99849 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12619 "Found 60 new test failures: accessibility/display-contents/search-traversal.html accessibility/ios-simulator/focus-change-notifications.html accessibility/ios-simulator/heading-text-updates.html accessibility/ios-simulator/ios-search-predicate.html accessibility/ios-simulator/textfield-in-axvalue.html accessibility/search-traversal-after-role-change.html animations/animation-controller-drt-api.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54132 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12379 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/accname/basic.html imported/w3c/web-platform-tests/accname/name/comp_host_language_label.html imported/w3c/web-platform-tests/accname/name/comp_label.html imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative.html imported/w3c/web-platform-tests/accname/name/comp_text_node.html imported/w3c/web-platform-tests/content-security-policy/base-uri/base-uri_iframe_sandbox.sub.html imported/w3c/web-platform-tests/content-security-policy/generic/generic-0_1-img-src.html imported/w3c/web-platform-tests/content-security-policy/generic/generic-0_1-script-src.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5430 "Found 60 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-updates-alldescendants.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/display-contents/search-traversal.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46694 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82473 "Found 7 new API test failures: TestWebKitAPI.DocumentEditingContext.SpatialRequestInTextField, TestWebKitAPI.DragAndDropTests.BackgroundImageLinkToInput, TestWebKitAPI.DragAndDropTests.TextAreaToInput, TestWebKitAPI.DragAndDropTests.ImageInLinkToInput, TestWebKitAPI.DragAndDropTests.LinkToInput, TestWebKitAPI.DragAndDropTests.ContentEditableToTextarea, TestWebKitAPI.KeyboardInputTests.SelectionClipRectsWhenPresentingInputView (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5511 "Found 60 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-updates-alldescendants.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/aria-roles.html accessibility/display-contents/search-traversal.html accessibility/mac/clipped-text-under-element.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23914 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17449 "Found 60 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-updates-alldescendants.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/display-contents/search-traversal.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82846 "Failure limit exceed. At least found 465 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/aria-roles.html accessibility/css-content-attribute.html accessibility/gtk/object-attributes.html accessibility/heading-title-includes-links.html accessibility/image-link.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83683 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82236 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26898 "Found 9 new test failures: interaction-region/consolidated-nested-regions.html interaction-region/full-page-overlay.html interaction-region/region-area-overflow-does-not-crash.html interaction-region/svg.html interaction-region/text-controls.html interaction-region/text-input-focused-edited-empty.html interaction-region/text-input-focused.html interaction-region/textarea-focused-edited-empty.html interaction-region/textarea-focused.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4448 "Found 60 new test failures: accessibility/aria-hidden-subtree.html accessibility/aria-hidden-updates-alldescendants.html accessibility/aria-hidden-with-elements.html accessibility/aria-hidden.html accessibility/aria-roles.html accessibility/display-contents/search-traversal.html animations/animation-controller-drt-api.html compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17408 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->