### PR TITLE
Remove 'masonry-auto-flow' now that it has been removed from the spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -230,7 +230,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -204,7 +204,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -222,7 +222,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -230,7 +230,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -220,7 +220,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -229,7 +229,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -203,7 +203,6 @@ PASS mask-origin
 PASS mask-repeat
 PASS mask-size
 PASS mask-type
-PASS masonry-auto-flow
 PASS math-style
 PASS max-block-size
 PASS max-height

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5782,28 +5782,6 @@
                 "url": "https://drafts.fxtf.org/css-masking-1/#propdef-mask-type"
             }
         },
-        "masonry-auto-flow": {
-            "animation-type": "not animatable (needs triage)",
-            "initial": "pack definite-first",
-            "values": [
-                "pack",
-                "next",
-                "definite-first",
-                "ordered"
-            ],
-            "codegen-properties": {
-                "style-builder-converter": "MasonryAutoFlow",
-                "settings-flag": "masonryEnabled",
-                "parser-function": "consumeMasonryAutoFlow",
-                "parser-grammar-unused": "[ pack | next ] || [ definite-first | ordered ]",
-                "parser-grammar-unused-reason": "Needs support for '||' groups."
-            },
-            "specification": {
-                "category": "css-grid",
-                "url": "https://drafts.csswg.org/css-grid-3/#masonry-auto-flow"
-            },
-            "status": "experimental"
-        },
         "math-style": {
             "animation-type": "not animatable",
             "inherited": true,

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1560,12 +1560,6 @@ minmax
 subgrid
 masonry
 
-// masonry-auto-flow
-pack
-next
-definite-first
-ordered
-
 // grid-auto-flow
 auto-flow
 dense

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4022,25 +4022,6 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
 
         return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
-    case CSSPropertyMasonryAutoFlow: {
-        CSSValueListBuilder list;
-        // MasonryAutoFlow information is stored in a struct that should always
-        // hold 2 pieces of information. It should contain both Pack/Next inside
-        // the MasonryAutoFlowPlacementAlgorithm enum class and DefiniteFirst/Ordered
-        // inside the MasonryAutoFlowPlacementOrder enum class
-        ASSERT((style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Pack || style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Next) && (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst || style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered));
-
-        if (style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Next)
-            list.append(CSSPrimitiveValue::create(CSSValueNext));
-        // Since we know that placementAlgorithm is not Next, it must be Packed. If the PlacementOrder
-        // is DefiniteFirst, then the canonical form of the computed style is just Pack (DefiniteFirst is implicit)
-        else if (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst)
-            list.append(CSSPrimitiveValue::create(CSSValuePack));
-
-        if (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
-            list.append(CSSPrimitiveValue::create(CSSValueOrdered));
-        return CSSValueList::createSpaceSeparated(WTFMove(list));
-    }
 
     // Specs mention that getComputedStyle() should return the used value of the property instead of the computed
     // one for grid-template-{rows|columns} but not for the grid-auto-{rows|columns} as things like

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -483,27 +483,5 @@ RefPtr<CSSValue> consumeGridAutoFlow(CSSParserTokenRange& range, const CSSParser
     return CSSValueList::createSpaceSeparated(WTFMove(parsedValues));
 }
 
-RefPtr<CSSValue> consumeMasonryAutoFlow(CSSParserTokenRange& range, const CSSParserContext&)
-{
-    auto packOrNextValue = consumeIdent<CSSValuePack, CSSValueNext>(range);
-    auto definiteFirstOrOrderedValue = consumeIdent<CSSValueDefiniteFirst, CSSValueOrdered>(range);
-
-    if (!packOrNextValue) {
-        packOrNextValue = consumeIdent<CSSValuePack, CSSValueNext>(range);
-        if (!packOrNextValue)
-            packOrNextValue = CSSPrimitiveValue::create(CSSValuePack);
-    }
-
-    CSSValueListBuilder parsedValues;
-    if (packOrNextValue) {
-        CSSValueID packOrNextValueID = packOrNextValue->valueID();
-        if (!definiteFirstOrOrderedValue || (definiteFirstOrOrderedValue && definiteFirstOrOrderedValue->valueID() == CSSValueDefiniteFirst) || packOrNextValueID == CSSValueNext)
-            parsedValues.append(packOrNextValue.releaseNonNull());
-    }
-    if (definiteFirstOrOrderedValue && definiteFirstOrOrderedValue->valueID() == CSSValueOrdered)
-        parsedValues.append(definiteFirstOrOrderedValue.releaseNonNull());
-    return CSSValueList::createSpaceSeparated(WTFMove(parsedValues));
-}
-
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
@@ -54,7 +54,6 @@ RefPtr<CSSValue> consumeGridTrackList(CSSParserTokenRange&, const CSSParserConte
 RefPtr<CSSValue> consumeGridTemplatesRowsOrColumns(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeGridTemplateAreas(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeGridAutoFlow(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSValue> consumeMasonryAutoFlow(CSSParserTokenRange&, const CSSParserContext&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -192,7 +192,7 @@ void GridMasonryLayout::updateItemOffset(const RenderBox& gridItem, LayoutUnit o
     m_itemOffsets.set(gridItem, offset);
 }
 
-GridSpan GridMasonryLayout::gridAxisPositionUsingPackAutoFlow(const RenderBox& item) const
+GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
 {
     auto itemSpanLength = GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection());
     LayoutUnit smallestMaxPos = LayoutUnit::max();
@@ -207,21 +207,7 @@ GridSpan GridMasonryLayout::gridAxisPositionUsingPackAutoFlow(const RenderBox& i
             smallestMaxPosLine = startingLine;
         } 
     }
-    return GridSpan::translatedDefiniteGridSpan(smallestMaxPosLine, smallestMaxPosLine + itemSpanLength);
-}
-
-GridSpan GridMasonryLayout::gridAxisPositionUsingNextAutoFlow(const RenderBox& item)
-{
-    auto itemSpanLength = GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection());
-    if (!hasEnoughSpaceAtPosition(m_autoFlowNextCursor, itemSpanLength))
-        m_autoFlowNextCursor = 0;
-    return GridSpan::translatedDefiniteGridSpan(m_autoFlowNextCursor, m_autoFlowNextCursor + itemSpanLength);
-}
-
-GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
-{
-    // Determine the logic to use for positioning based on the value of masonry-auto-flow
-    GridSpan gridAxisPosition = m_renderGrid.style().masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Pack ? gridAxisPositionUsingPackAutoFlow(item) : gridAxisPositionUsingNextAutoFlow(item);
+    auto gridAxisPosition = GridSpan::translatedDefiniteGridSpan(smallestMaxPosLine, smallestMaxPosLine + itemSpanLength);
     return masonryGridAreaFromGridAxisSpan(gridAxisPosition);
 }
 

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -55,8 +55,6 @@ public:
     LayoutUnit gridGap() const { return m_masonryAxisGridGap; };
 
 private:
-    GridSpan gridAxisPositionUsingPackAutoFlow(const RenderBox& item) const;
-    GridSpan gridAxisPositionUsingNextAutoFlow(const RenderBox& item);
     GridArea gridAreaForIndefiniteGridAxisItem(const RenderBox& item);
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -261,7 +261,6 @@ struct Length;
 struct LengthPoint;
 struct LengthSize;
 struct ListStyleType;
-struct MasonryAutoFlow;
 struct NamedGridAreaMap;
 struct NamedGridLinesMap;
 struct OrderedNamedGridLinesMap;
@@ -864,7 +863,6 @@ public:
     inline size_t namedGridAreaRowCount() const;
     inline size_t namedGridAreaColumnCount() const;
     inline GridAutoFlow gridAutoFlow() const;
-    inline MasonryAutoFlow masonryAutoFlow() const;
     inline bool gridSubgridRows() const;
     inline bool gridSubgridColumns() const;
     inline bool gridMasonryRows() const;
@@ -1521,8 +1519,6 @@ public:
     inline void setGridItemRowStart(const GridPosition&);
     inline void setGridItemRowEnd(const GridPosition&);
 
-    inline void setMasonryAutoFlow(MasonryAutoFlow);
-
     inline void setMarqueeIncrement(Length&&);
     inline void setMarqueeSpeed(int);
     inline void setMarqueeDirection(MarqueeDirection);
@@ -2161,7 +2157,6 @@ public:
     static constexpr AutoRepeatType initialGridAutoRepeatType();
 
     static constexpr GridAutoFlow initialGridAutoFlow();
-    static constexpr MasonryAutoFlow initialMasonryAutoFlow();
 
     static inline Vector<GridTrackSize> initialGridAutoColumns();
     static inline Vector<GridTrackSize> initialGridAutoRows();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1054,16 +1054,6 @@ enum GridAutoFlow : uint8_t {
     AutoFlowColumnDense = InternalAutoFlowAlgorithmDense | InternalAutoFlowDirectionColumn
 };
 
-enum class MasonryAutoFlowPlacementAlgorithm {
-    Pack,
-    Next
-};
-
-enum class MasonryAutoFlowPlacementOrder {
-    DefiniteFirst,
-    Ordered
-};
-
 enum class AutoRepeatType : uint8_t {
     None,
     Fill,

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -446,7 +446,6 @@ constexpr OptionSet<MarginTrimType> RenderStyle::initialMarginTrim() { return { 
 constexpr MarqueeBehavior RenderStyle::initialMarqueeBehavior() { return MarqueeBehavior::Scroll; }
 constexpr MarqueeDirection RenderStyle::initialMarqueeDirection() { return MarqueeDirection::Auto; }
 inline Length RenderStyle::initialMarqueeIncrement() { return { 6, LengthType::Fixed }; }
-constexpr MasonryAutoFlow RenderStyle::initialMasonryAutoFlow() { return { MasonryAutoFlowPlacementAlgorithm::Pack, MasonryAutoFlowPlacementOrder::DefiniteFirst }; }
 constexpr MathStyle RenderStyle::initialMathStyle() { return MathStyle::Normal; }
 inline Length RenderStyle::initialMaxSize() { return LengthType::Undefined; }
 inline Length RenderStyle::initialMinSize() { return LengthType::Auto; }
@@ -649,7 +648,6 @@ inline const LengthSize& RenderStyle::maskSizeLength() const { return maskLayers
 inline FillSizeType RenderStyle::maskSizeType() const { return maskLayers().sizeType(); }
 inline const Length& RenderStyle::maskXPosition() const { return maskLayers().xPosition(); }
 inline const Length& RenderStyle::maskYPosition() const { return maskLayers().yPosition(); }
-inline MasonryAutoFlow RenderStyle::masonryAutoFlow() const { return m_nonInheritedData->rareData->grid->masonryAutoFlow; }
 inline MathStyle RenderStyle::mathStyle() const { return static_cast<MathStyle>(m_rareInheritedData->mathStyle); }
 inline const Length& RenderStyle::maxHeight() const { return m_nonInheritedData->boxData->maxHeight(); }
 inline size_t RenderStyle::maxLines() const { return m_nonInheritedData->rareData->maxLines; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -232,7 +232,6 @@ inline void RenderStyle::setMaskRepeat(FillRepeatXY repeat) { SET_DOUBLY_NESTED_
 inline void RenderStyle::setMaskSize(LengthSize size) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, mask, m_sizeLength, WTFMove(size)); }
 inline void RenderStyle::setMaskXPosition(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, mask, m_xPosition, WTFMove(length)); }
 inline void RenderStyle::setMaskYPosition(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, mask, m_yPosition, WTFMove(length)); }
-inline void RenderStyle::setMasonryAutoFlow(MasonryAutoFlow flow) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, masonryAutoFlow, flow); }
 inline void RenderStyle::setMathStyle(const MathStyle& style) { SET(m_rareInheritedData, mathStyle, static_cast<unsigned>(style)); }
 inline void RenderStyle::setMaxHeight(Length&& length) { SET_NESTED(m_nonInheritedData, boxData, m_maxHeight, WTFMove(length)); }
 inline void RenderStyle::setMaxLines(size_t value) { SET_NESTED(m_nonInheritedData, rareData, maxLines, value); }

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -37,7 +37,6 @@ StyleGridData::StyleGridData()
     : implicitNamedGridColumnLines(RenderStyle::initialNamedGridColumnLines())
     , implicitNamedGridRowLines(RenderStyle::initialNamedGridRowLines())
     , gridAutoFlow(RenderStyle::initialGridAutoFlow())
-    , masonryAutoFlow(RenderStyle::initialMasonryAutoFlow())
     , gridAutoRows(RenderStyle::initialGridAutoRows())
     , gridAutoColumns(RenderStyle::initialGridAutoColumns())
     , namedGridArea(RenderStyle::initialNamedGridArea())
@@ -71,7 +70,6 @@ inline StyleGridData::StyleGridData(const StyleGridData& o)
     , implicitNamedGridColumnLines(o.implicitNamedGridColumnLines)
     , implicitNamedGridRowLines(o.implicitNamedGridRowLines)
     , gridAutoFlow(o.gridAutoFlow)
-    , masonryAutoFlow(o.masonryAutoFlow)
     , gridAutoRows(o.gridAutoRows)
     , gridAutoColumns(o.gridAutoColumns)
     , namedGridArea(o.namedGridArea)
@@ -115,8 +113,7 @@ bool StyleGridData::operator==(const StyleGridData& o) const
         && namedGridAreaRowCount == o.namedGridAreaRowCount
         && namedGridAreaColumnCount == o.namedGridAreaColumnCount
         && m_masonryRows == o.m_masonryRows
-        && m_masonryColumns == o.m_masonryColumns
-        && masonryAutoFlow == o.masonryAutoFlow;
+        && m_masonryColumns == o.m_masonryColumns;
 }
 
 void StyleGridData::setRows(const GridTrackList& list)

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -73,13 +73,6 @@ struct GridTrackEntryAutoRepeat {
     RepeatTrackList list;
 };
 
-struct MasonryAutoFlow {
-    friend bool operator==(const MasonryAutoFlow&, const MasonryAutoFlow&) = default;
-
-    MasonryAutoFlowPlacementAlgorithm placementAlgorithm;
-    MasonryAutoFlowPlacementOrder placementOrder;
-};
-
 using GridTrackEntry = std::variant<GridTrackSize, Vector<String>, GridTrackEntryRepeat, GridTrackEntryAutoRepeat, GridTrackEntrySubgrid, GridTrackEntryMasonry>;
 struct GridTrackList {
     Vector<GridTrackEntry> list;
@@ -142,7 +135,6 @@ public:
     NamedGridLinesMap implicitNamedGridRowLines;
 
     unsigned gridAutoFlow : GridAutoFlowBits;
-    MasonryAutoFlow masonryAutoFlow;
 
     Vector<GridTrackSize> gridAutoRows;
     Vector<GridTrackSize> gridAutoColumns;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -171,7 +171,6 @@ public:
     static GridPosition convertGridPosition(BuilderState&, const CSSValue&);
     static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
     static Vector<StyleContentAlignmentData> convertContentAlignmentDataList(BuilderState&, const CSSValue&);
-    static MasonryAutoFlow convertMasonryAutoFlow(BuilderState&, const CSSValue&);
     static std::optional<float> convertPerspective(BuilderState&, const CSSValue&);
     static std::optional<WebCore::Length> convertMarqueeIncrement(BuilderState&, const CSSValue&);
     static FilterOperations convertFilterOperations(BuilderState&, const CSSValue&);
@@ -1610,41 +1609,6 @@ inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignme
     return WTF::map(*list, [&](auto& value) {
         return convertContentAlignmentData(builderState, value);
     });
-}
-
-inline MasonryAutoFlow BuilderConverter::convertMasonryAutoFlow(BuilderState& builderState, const CSSValue& value)
-{
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    if (!(list->size() == 1 || list->size() == 2))
-        return RenderStyle::initialMasonryAutoFlow();
-
-    auto& firstValue = list->item(0);
-    auto* secondValue = list->size() == 2 ? &list->item(1) : nullptr;
-    MasonryAutoFlow masonryAutoFlow;
-    if (secondValue) {
-        ASSERT(firstValue.valueID() == CSSValueID::CSSValuePack || firstValue.valueID() == CSSValueID::CSSValueNext);
-        ASSERT(secondValue->valueID() == CSSValueID::CSSValueOrdered);
-        if (firstValue.valueID() == CSSValueID::CSSValuePack)
-            masonryAutoFlow = { MasonryAutoFlowPlacementAlgorithm::Pack, MasonryAutoFlowPlacementOrder::Ordered };
-        else
-            masonryAutoFlow = { MasonryAutoFlowPlacementAlgorithm::Next, MasonryAutoFlowPlacementOrder::Ordered };
-
-    } else  {
-        if (firstValue.valueID() == CSSValueID::CSSValuePack)
-            masonryAutoFlow = { MasonryAutoFlowPlacementAlgorithm::Pack, MasonryAutoFlowPlacementOrder::DefiniteFirst };
-        else if (firstValue.valueID() == CSSValueID::CSSValueNext)
-            masonryAutoFlow = { MasonryAutoFlowPlacementAlgorithm::Next, MasonryAutoFlowPlacementOrder::DefiniteFirst };
-        else if (firstValue.valueID() == CSSValueID::CSSValueOrdered)
-            masonryAutoFlow = { MasonryAutoFlowPlacementAlgorithm::Pack, MasonryAutoFlowPlacementOrder::Ordered };
-        else {
-            ASSERT_NOT_REACHED();
-            return RenderStyle::initialMasonryAutoFlow();
-        }
-    }
-    return masonryAutoFlow;
 }
 
 inline float zoomWithTextZoomFactor(BuilderState& builderState)


### PR DESCRIPTION
#### c135a89ebf07ef386b63afb2aeddc542e29fd9a2
<pre>
Remove &apos;masonry-auto-flow&apos; now that it has been removed from the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=290019">https://bugs.webkit.org/show_bug.cgi?id=290019</a>

Reviewed by Anne van Kesteren.

Removes support for the masonry-auto-flow CSS property now that
it is no longer part of CSS Grid.

In the one place it was queried in GridMasonryLayout. the default
behavior (as if you hadn&apos;t set the property) is now always used.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleGridData.cpp:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/style/StyleBuilderConverter.h:

Canonical link: <a href="https://commits.webkit.org/292367@main">https://commits.webkit.org/292367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a54589e871300cce11697aa6b619e8e4bebc41f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16133 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22764 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27913 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->