### PR TITLE
Move API for file mapping to the new FileHandle class

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -95,6 +95,7 @@
 #include <wtf/CPUTime.h>
 #include <wtf/CommaPrinter.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/MemoryPressureHandler.h>
@@ -1379,13 +1380,11 @@ private:
         if (!handle)
             return;
 
-        bool success;
-        FileSystem::MappedFileData mappedFileData(handle, FileSystem::MappedFileMode::Private, success);
-
-        if (!success)
+        auto mappedFileData = handle.map(FileSystem::MappedFileMode::Private);
+        if (!mappedFileData)
             return;
 
-        m_cachedBytecode = CachedBytecode::create(WTFMove(mappedFileData));
+        m_cachedBytecode = CachedBytecode::create(WTFMove(*mappedFileData));
     }
 
     ShellSourceProvider(const String& source, const SourceOrigin& sourceOrigin, String&& sourceURL, const TextPosition& startPosition, SourceProviderSourceType sourceType)

--- a/Source/JavaScriptCore/runtime/CachePayload.h
+++ b/Source/JavaScriptCore/runtime/CachePayload.h
@@ -27,8 +27,8 @@
 
 #include "VM.h"
 #include <variant>
-#include <wtf/FileSystem.h>
 #include <wtf/MallocSpan.h>
+#include <wtf/MappedFileData.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -42,6 +42,7 @@
 #include "UnlinkedMetadataTableInlines.h"
 #include "UnlinkedModuleProgramCodeBlock.h"
 #include "UnlinkedProgramCodeBlock.h"
+#include <wtf/FileHandle.h>
 #include <wtf/MallocPtr.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Packed.h>
@@ -195,14 +196,13 @@ private:
             }
         }
 
-        bool success;
-        FileSystem::MappedFileData mappedFileData(m_fileHandle, FileSystem::MappedFileMode::Private, success);
-        if (!success) {
+        auto mappedFileData = m_fileHandle.map(FileSystem::MappedFileMode::Private);
+        if (!mappedFileData) {
             error = BytecodeCacheError::StandardError(errno);
             return nullptr;
         }
 
-        return CachedBytecode::create(WTFMove(mappedFileData), WTFMove(m_leafExecutables));
+        return CachedBytecode::create(WTFMove(*mappedFileData), WTFMove(m_leafExecutables));
     }
 
     class Page {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -292,6 +292,7 @@
 #include "WrapForValidIteratorPrototypeInlines.h"
 #include "runtime/VM.h"
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FixedVector.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/WeakHashSet.h>

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -33,6 +33,7 @@
 #include "WasmParser.h"
 #include "WasmSectionParser.h"
 #include "WasmTypeDefinitionInlines.h"
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/UnalignedAccess.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -99,11 +99,14 @@
 		468742F12D7F8A0100F4BE74 /* FileHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = 468742EF2D7F8A0100F4BE74 /* FileHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		468742F22D7F8A0100F4BE74 /* FileHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 468742F02D7F8A0100F4BE74 /* FileHandle.cpp */; };
 		468EAFD42D5B1E37005069CF /* SocketPOSIX.h in Headers */ = {isa = PBXBuildFile; fileRef = 468EAFD32D5B1E37005069CF /* SocketPOSIX.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46A6D0D62D8A166D00FC76C8 /* MappedFileDataPOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46A6D0D52D8A166D00FC76C8 /* MappedFileDataPOSIX.cpp */; };
+		46A6D0DA2D8A168400FC76C8 /* MappedFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A6D0D72D8A168400FC76C8 /* MappedFileData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B4C53C2D4F2D0A00BAA3FE /* NSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46BEB6EB22FFE24900269868 /* RefTrackerMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */; };
 		46CA183A2D83C17A00B68573 /* FileHandlePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46CA18392D83C17A00B68573 /* FileHandlePOSIX.cpp */; };
+		46CE0CB62D8BD18500B8A1DD /* FileLockMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 46CE0CB52D8BD18500B8A1DD /* FileLockMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46CEA3FA2CC2D39B00FE325C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */; };
 		46E915222CD2E26C00C437B7 /* UnicodeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46E915212CD2E26C00C437B7 /* UnicodeExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46E93049271F1205005BA6E5 /* SafeStrerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E43647271F10AA00C88C90 /* SafeStrerror.cpp */; };
@@ -1265,6 +1268,8 @@
 		468742EF2D7F8A0100F4BE74 /* FileHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandle.h; sourceTree = "<group>"; };
 		468742F02D7F8A0100F4BE74 /* FileHandle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileHandle.cpp; sourceTree = "<group>"; };
 		468EAFD32D5B1E37005069CF /* SocketPOSIX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SocketPOSIX.h; sourceTree = "<group>"; };
+		46A6D0D52D8A166D00FC76C8 /* MappedFileDataPOSIX.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MappedFileDataPOSIX.cpp; sourceTree = "<group>"; };
+		46A6D0D72D8A168400FC76C8 /* MappedFileData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MappedFileData.h; sourceTree = "<group>"; };
 		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
 		46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSStringExtras.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
@@ -1272,6 +1277,7 @@
 		46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefTrackerMixin.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD50026DEAD /* RefTrackerMixin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RefTrackerMixin.h; sourceTree = "<group>"; };
 		46CA18392D83C17A00B68573 /* FileHandlePOSIX.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileHandlePOSIX.cpp; sourceTree = "<group>"; };
+		46CE0CB52D8BD18500B8A1DD /* FileLockMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileLockMode.h; sourceTree = "<group>"; };
 		46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SpanCocoa.mm; sourceTree = "<group>"; };
 		46E43646271F10AA00C88C90 /* SafeStrerror.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SafeStrerror.h; sourceTree = "<group>"; };
 		46E43647271F10AA00C88C90 /* SafeStrerror.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SafeStrerror.cpp; sourceTree = "<group>"; };
@@ -2126,6 +2132,7 @@
 				EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */,
 				46CA18392D83C17A00B68573 /* FileHandlePOSIX.cpp */,
 				A331D96621F24ABD009F02AA /* FileSystemPOSIX.cpp */,
+				46A6D0D52D8A166D00FC76C8 /* MappedFileDataPOSIX.cpp */,
 				A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */,
 				468EAFD32D5B1E37005069CF /* SocketPOSIX.h */,
 				A32D8FA421FFFAB400780662 /* ThreadingPOSIX.cpp */,
@@ -2304,6 +2311,7 @@
 				0F79C7C31E73511800EB34D1 /* FastTLS.h */,
 				468742F02D7F8A0100F4BE74 /* FileHandle.cpp */,
 				468742EF2D7F8A0100F4BE74 /* FileHandle.h */,
+				46CE0CB52D8BD18500B8A1DD /* FileLockMode.h */,
 				0F9D335B165DBA73005AD387 /* FilePrintStream.cpp */,
 				0F9D335C165DBA73005AD387 /* FilePrintStream.h */,
 				A331D95A21F24992009F02AA /* FileSystem.cpp */,
@@ -2408,6 +2416,7 @@
 				BBEA08032CCFDB33000AC148 /* MallocCommon.h */,
 				1A233C7C17DAA6E300A93ACF /* MallocPtr.h */,
 				465005D72CD2840A00950C5F /* MallocSpan.h */,
+				46A6D0D72D8A168400FC76C8 /* MappedFileData.h */,
 				304CA4E41375437EBE931D03 /* Markable.h */,
 				A8A472C9151A825B004123FF /* MathExtras.h */,
 				CD5497AA15857D0300B5BC30 /* MediaTime.cpp */,
@@ -3421,6 +3430,7 @@
 				DD3DC8A727A4BF8E007E5B61 /* FastMalloc.h in Headers */,
 				DD3DC8AF27A4BF8E007E5B61 /* FastTLS.h in Headers */,
 				468742F12D7F8A0100F4BE74 /* FileHandle.h in Headers */,
+				46CE0CB62D8BD18500B8A1DD /* FileLockMode.h in Headers */,
 				DD3DC96E27A4BF8E007E5B61 /* FilePrintStream.h in Headers */,
 				DD3DC8F827A4BF8E007E5B61 /* FileSystem.h in Headers */,
 				DDF306FB27C086CC006A526F /* fixed-dtoa.h in Headers */,
@@ -3521,6 +3531,7 @@
 				BBEA08042CCFDB33000AC148 /* MallocCommon.h in Headers */,
 				DD3DC8D427A4BF8E007E5B61 /* MallocPtr.h in Headers */,
 				465005D82CD2840A00950C5F /* MallocSpan.h in Headers */,
+				46A6D0DA2D8A168400FC76C8 /* MappedFileData.h in Headers */,
 				DD3DC89727A4BF8E007E5B61 /* Markable.h in Headers */,
 				DD3DC89427A4BF8E007E5B61 /* MathExtras.h in Headers */,
 				DD3DC96A27A4BF8E007E5B61 /* MediaTime.h in Headers */,
@@ -4289,6 +4300,7 @@
 				A8A473E4151A825B004123FF /* MainThreadCocoa.mm in Sources */,
 				5187AC952C08570600549EFE /* MainThreadDispatcher.cpp in Sources */,
 				BBFA08042CCFDB33000AC148 /* MallocCommon.cpp in Sources */,
+				46A6D0D62D8A166D00FC76C8 /* MappedFileDataPOSIX.cpp in Sources */,
 				CD5497AC15857D0300B5BC30 /* MediaTime.cpp in Sources */,
 				ADF2CE671E39F106006889DB /* MemoryFootprintCocoa.cpp in Sources */,
 				AD89B6B71E6415080090707F /* MemoryPressureHandler.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -90,6 +90,7 @@ set(WTF_PUBLIC_HEADERS
     FastMalloc.h
     FastTLS.h
     FileHandle.h
+    FileLockMode.h
     FilePrintStream.h
     FileSystem.h
     FixedBitVector.h
@@ -173,6 +174,7 @@ set(WTF_PUBLIC_HEADERS
     MallocCommon.h
     MallocPtr.h
     MallocSpan.h
+    MappedFileData.h
     Markable.h
     MathExtras.h
     MediaTime.h

--- a/Source/WTF/wtf/FileHandle.cpp
+++ b/Source/WTF/wtf/FileHandle.cpp
@@ -27,6 +27,7 @@
 #include "FileHandle.h"
 
 #include <wtf/FileSystem.h>
+#include <wtf/MappedFileData.h>
 
 namespace WTF::FileSystemImpl {
 
@@ -109,6 +110,11 @@ bool FileHandle::appendFileContents(const String& path)
     } while (true);
 
     ASSERT_NOT_REACHED();
+}
+
+std::optional<MappedFileData> FileHandle::map(MappedFileMode fileMode)
+{
+    return map(fileMode, FileOpenMode::Read);
 }
 
 } // namespace WTF::FileSystemImpl

--- a/Source/WTF/wtf/FileHandle.h
+++ b/Source/WTF/wtf/FileHandle.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/FileLockMode.h>
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
 #include <wtf/OptionSet.h>
@@ -39,6 +40,11 @@
 namespace WTF {
 
 namespace FileSystemImpl {
+
+class MappedFileData;
+
+enum class FileOpenMode : uint8_t;
+enum class MappedFileMode : bool;
 
 #if OS(WINDOWS)
 typedef HANDLE PlatformFileHandle;
@@ -61,12 +67,6 @@ enum class FileSeekOrigin {
     Beginning,
     Current,
     End,
-};
-
-enum class FileLockMode {
-    Shared = 1 << 0,
-    Exclusive = 1 << 1,
-    Nonblocking = 1 << 2,
 };
 
 class FileHandle {
@@ -101,6 +101,9 @@ public:
     // Appends the contents of the file found at 'path' to the FileHandle.
     // Returns true if the write was successful, false if it was not.
     WTF_EXPORT_PRIVATE bool appendFileContents(const String& path);
+
+    WTF_EXPORT_PRIVATE std::optional<MappedFileData> map(MappedFileMode);
+    WTF_EXPORT_PRIVATE std::optional<MappedFileData> map(MappedFileMode, FileOpenMode);
 
 private:
     WTF_EXPORT_PRIVATE FileHandle(PlatformFileHandle, OptionSet<FileLockMode>);

--- a/Source/WTF/wtf/FileLockMode.h
+++ b/Source/WTF/wtf/FileLockMode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,16 @@
 
 #pragma once
 
-#include <fcntl.h>
-#include <wtf/FileHandle.h>
+namespace WTF {
 
-namespace IPC {
+namespace FileSystemImpl {
 
-class Decoder;
-class Encoder;
-
-class SharedFileHandle {
-public:
-    static std::optional<SharedFileHandle> create(FileSystem::FileHandle&&);
-
-#if PLATFORM(COCOA)
-    explicit SharedFileHandle(MachSendRight&&);
-    MachSendRight toMachSendRight() const;
-#endif
-
-    SharedFileHandle() = default;
-    FileSystem::FileHandle release() { return std::exchange(m_handle, { }); }
-
-private:
-    explicit SharedFileHandle(FileSystem::FileHandle&& handle)
-        : m_handle(WTFMove(handle))
-    {
-    }
-
-    FileSystem::FileHandle m_handle;
+enum class FileLockMode {
+    Shared = 1 << 0,
+    Exclusive = 1 << 1,
+    Nonblocking = 1 << 2,
 };
 
-} // namespace IPC
+} // namespace FileSystemImpl
 
-
+} // namespace WTF

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <wtf/Forward.h>
+
+#if HAVE(MMAP)
+#include <wtf/MallocSpan.h>
+#include <wtf/Mmap.h>
+#endif
+
+#if OS(WINDOWS)
+#include <wtf/win/Win32Handle.h>
+#endif
+
+namespace WTF {
+
+namespace FileSystemImpl {
+
+enum class MappedFileMode : bool {
+    Shared,
+    Private,
+};
+
+class MappedFileData {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    MappedFileData() = default;
+    WTF_EXPORT_PRIVATE ~MappedFileData();
+
+    MappedFileData(MappedFileData&&) = default;
+    MappedFileData& operator=(MappedFileData&&) = default;
+
+#if HAVE(MMAP)
+    explicit MappedFileData(MallocSpan<uint8_t, Mmap>&&);
+
+    std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
+    explicit operator bool() const { return !!m_fileData; }
+    size_t size() const { return m_fileData.span().size(); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }
+    std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData.mutableSpan(); }
+#elif OS(WINDOWS)
+    MappedFileData(std::span<uint8_t>, Win32Handle&&);
+
+    const Win32Handle& fileMapping() const { return m_fileMapping; }
+    explicit operator bool() const { return !!m_fileData.data(); }
+    size_t size() const { return m_fileData.size(); }
+    std::span<const uint8_t> span() const { return m_fileData; }
+    std::span<uint8_t> mutableSpan() { return m_fileData; }
+#endif
+
+private:
+#if HAVE(MMAP)
+    MallocSpan<uint8_t, Mmap> m_fileData;
+#elif OS(WINDOWS)
+    std::span<uint8_t> m_fileData;
+    Win32Handle m_fileMapping;
+#endif
+};
+
+} // namespace FileSystemImpl
+
+} // namespace WTF
+
+namespace FileSystem = WTF::FileSystemImpl;

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -18,6 +18,7 @@ list(APPEND WTF_SOURCES
     posix/CPUTimePOSIX.cpp
     posix/FileHandlePOSIX.cpp
     posix/FileSystemPOSIX.cpp
+    posix/MappedFileDataPOSIX.cpp
     posix/OSAllocatorPOSIX.cpp
     posix/ThreadingPOSIX.cpp
 

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -14,6 +14,7 @@ if (WIN32)
         win/LanguageWin.cpp
         win/LoggingWin.cpp
         win/MainThreadWin.cpp
+        win/MappedFileDataWin.cpp
         win/OSAllocatorWin.cpp
         win/PathWalker.cpp
         win/SignalsWin.cpp
@@ -57,6 +58,7 @@ else ()
     list(APPEND WTF_SOURCES
         posix/FileHandlePOSIX.cpp
         posix/FileSystemPOSIX.cpp
+        posix/MappedFileDataPOSIX.cpp
 
         unix/UniStdExtrasUnix.cpp
     )

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -46,6 +46,7 @@ list(APPEND WTF_SOURCES
     posix/CPUTimePOSIX.cpp
     posix/FileHandlePOSIX.cpp
     posix/FileSystemPOSIX.cpp
+    posix/MappedFileDataPOSIX.cpp
     posix/OSAllocatorPOSIX.cpp
     posix/ThreadingPOSIX.cpp
 

--- a/Source/WTF/wtf/PlatformPlayStation.cmake
+++ b/Source/WTF/wtf/PlatformPlayStation.cmake
@@ -12,6 +12,7 @@ list(APPEND WTF_SOURCES
     posix/CPUTimePOSIX.cpp
     posix/FileHandlePOSIX.cpp
     posix/FileSystemPOSIX.cpp
+    posix/MappedFileDataPOSIX.cpp
     posix/ThreadingPOSIX.cpp
 
     text/unix/TextBreakIteratorInternalICUUnix.cpp

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -20,6 +20,7 @@ list(APPEND WTF_SOURCES
     posix/CPUTimePOSIX.cpp
     posix/FileHandlePOSIX.cpp
     posix/FileSystemPOSIX.cpp
+    posix/MappedFileDataPOSIX.cpp
     posix/OSAllocatorPOSIX.cpp
     posix/ThreadingPOSIX.cpp
 

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -11,6 +11,7 @@ list(APPEND WTF_SOURCES
     win/LanguageWin.cpp
     win/LoggingWin.cpp
     win/MainThreadWin.cpp
+    win/MappedFileDataWin.cpp
     win/MemoryFootprintWin.cpp
     win/MemoryPressureHandlerWin.cpp
     win/OSAllocatorWin.cpp

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -30,6 +30,7 @@
 #import <wtf/FileSystem.h>
 
 #import <sys/resource.h>
+#import <wtf/FileHandle.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -41,7 +41,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/FileHandle.h>
 #include <wtf/MallocSpan.h>
+#include <wtf/MappedFileData.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,37 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "MappedFileData.h"
 
-#include <fcntl.h>
-#include <wtf/FileHandle.h>
+namespace WTF::FileSystemImpl {
 
-namespace IPC {
+#if HAVE(MMAP)
+MappedFileData::MappedFileData(MallocSpan<uint8_t, Mmap>&& fileData)
+    : m_fileData(WTFMove(fileData))
+{ }
 
-class Decoder;
-class Encoder;
-
-class SharedFileHandle {
-public:
-    static std::optional<SharedFileHandle> create(FileSystem::FileHandle&&);
-
-#if PLATFORM(COCOA)
-    explicit SharedFileHandle(MachSendRight&&);
-    MachSendRight toMachSendRight() const;
+MappedFileData::~MappedFileData() = default;
 #endif
 
-    SharedFileHandle() = default;
-    FileSystem::FileHandle release() { return std::exchange(m_handle, { }); }
-
-private:
-    explicit SharedFileHandle(FileSystem::FileHandle&& handle)
-        : m_handle(WTFMove(handle))
-    {
-    }
-
-    FileSystem::FileHandle m_handle;
-};
-
-} // namespace IPC
-
-
+} // namespace WTF::FileSystemImpl

--- a/Source/WTF/wtf/win/MappedFileDataWin.cpp
+++ b/Source/WTF/wtf/win/MappedFileDataWin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,37 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "MappedFileData.h"
 
-#include <fcntl.h>
-#include <wtf/FileHandle.h>
+#include <windows.h>
 
-namespace IPC {
+namespace WTF::FileSystemImpl {
 
-class Decoder;
-class Encoder;
+MappedFileData::MappedFileData(std::span<uint8_t> fileData, Win32Handle&& fileMapping)
+    : m_fileData(fileData)
+    , m_fileMapping(WTFMove(fileMapping))
+{
+}
 
-class SharedFileHandle {
-public:
-    static std::optional<SharedFileHandle> create(FileSystem::FileHandle&&);
+MappedFileData::~MappedFileData()
+{
+    if (m_fileData.data())
+        UnmapViewOfFile(m_fileData.data());
+}
 
-#if PLATFORM(COCOA)
-    explicit SharedFileHandle(MachSendRight&&);
-    MachSendRight toMachSendRight() const;
-#endif
-
-    SharedFileHandle() = default;
-    FileSystem::FileHandle release() { return std::exchange(m_handle, { }); }
-
-private:
-    explicit SharedFileHandle(FileSystem::FileHandle&& handle)
-        : m_handle(WTFMove(handle))
-    {
-    }
-
-    FileSystem::FileHandle m_handle;
-};
-
-} // namespace IPC
-
-
+} // namespace WTF::FileSystemImpl

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -35,6 +35,7 @@
 #import "SceneKitModelLoader.h"
 #import "SceneKitModelLoaderClient.h"
 #import <pal/spi/cocoa/SceneKitSPI.h>
+#import <wtf/FileHandle.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webdatabase/OriginLock.cpp
+++ b/Source/WebCore/Modules/webdatabase/OriginLock.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "OriginLock.h"
 
+#include <wtf/FileSystem.h>
+
 namespace WebCore {
 
 static String lockFileNameForPath(const String& originPath)

--- a/Source/WebCore/Modules/webdatabase/OriginLock.h
+++ b/Source/WebCore/Modules/webdatabase/OriginLock.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/FileSystem.h>
+#include <wtf/FileHandle.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/VM.h>
 #include <pal/Logging.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/contentextensions/SerializedNFA.h
+++ b/Source/WebCore/contentextensions/SerializedNFA.h
@@ -28,7 +28,7 @@
 #if ENABLE(CONTENT_EXTENSIONS)
 
 #include "ImmutableNFA.h"
-#include <wtf/FileSystem.h>
+#include <wtf/MappedFileData.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -46,6 +46,7 @@
 #include "ShadowRoot.h"
 #include "UserAgentParts.h"
 #include "UserGestureIndicator.h"
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -35,6 +35,7 @@
 #include "SQLiteTransaction.h"
 #include "SecurityOrigin.h"
 #include "SecurityOriginData.h"
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>

--- a/Source/WebCore/platform/FileStream.cpp
+++ b/Source/WebCore/platform/FileStream.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "FileStream.h"
 
+#include <wtf/FileHandle.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/FileStream.h
+++ b/Source/WebCore/platform/FileStream.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -546,10 +546,8 @@ SharedBuffer::SharedBuffer(FileSystem::MappedFileData&& data)
 RefPtr<SharedBuffer> SharedBuffer::createWithContentsOfFile(const String& filePath, FileSystem::MappedFileMode mappedFileMode, MayUseFileMapping mayUseFileMapping)
 {
     if (mayUseFileMapping == MayUseFileMapping::Yes) {
-        bool mappingSuccess;
-        FileSystem::MappedFileData mappedFileData(filePath, mappedFileMode, mappingSuccess);
-        if (mappingSuccess)
-            return adoptRef(new SharedBuffer(WTFMove(mappedFileData)));
+        if (auto mappedFileData = FileSystem::mapFile(filePath, mappedFileMode))
+            return adoptRef(new SharedBuffer(WTFMove(*mappedFileData)));
     }
 
     auto buffer = FileSystem::readEntireFile(filePath);

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -33,6 +33,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/MappedFileData.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/platform/cocoa/FileMonitorCocoa.mm
+++ b/Source/WebCore/platform/cocoa/FileMonitorCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "Logging.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -34,6 +34,7 @@
 #include "LayoutRect.h"
 #include "MediaPlayerEnums.h"
 #include "RotateTransformOperation.h"
+#include <wtf/FileHandle.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -39,6 +39,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <ImageIO/ImageIO.h>
 #include <WebCore/ShareableBitmap.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/cf/VectorCF.h>
 #include <wtf/text/CString.h>

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -44,6 +44,7 @@
 #include "ResourceResponse.h"
 #include "SecurityOriginData.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -32,6 +32,7 @@
 #include "RegistrableDomain.h"
 #include "SQLiteFileSystem.h"
 #include <wtf/DateMath.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.h
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "FormData.h"
-#include <wtf/FileSystem.h>
+#include <wtf/FileHandle.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -29,6 +29,7 @@
 #include "ClientOrigin.h"
 #include "WebCorePersistentCoders.h"
 #include <pal/crypto/CryptoDigest.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Scope.h>
 #include <wtf/persistence/PersistentCoders.h>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -258,6 +258,7 @@
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/HexNumber.h>
 #include <wtf/JSONValues.h>

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -30,6 +30,7 @@
 #include "ScriptBuffer.h"
 #include "ServiceWorkerRegistrationKey.h"
 #include <pal/crypto/CryptoDigest.h>
+#include <wtf/FileHandle.h>
 #include <wtf/MainThread.h>
 #include <wtf/PageBlock.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -33,7 +33,7 @@
 
 #include "NetworkDataTask.h"
 #include <WebCore/FileStreamClient.h>
-#include <wtf/FileSystem.h>
+#include <wtf/FileHandle.h>
 
 namespace WebCore {
 class AsyncFileStream;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -30,7 +30,7 @@
 #include "NetworkConnectionToWebProcess.h"
 #include "NetworkDataTask.h"
 #include <WebCore/FetchIdentifier.h>
-#include <wtf/FileSystem.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -69,12 +69,11 @@ Data adoptAndMapFile(FileSystem::FileHandle&& handle, size_t offset, size_t size
     if (!size)
         return Data::empty();
 
-    bool success;
-    FileSystem::MappedFileData mappedFile(handle, FileSystem::FileOpenMode::Read, FileSystem::MappedFileMode::Private, success);
-    if (!success)
+    auto mappedFile = handle.map(FileSystem::MappedFileMode::Private);
+    if (!mappedFile)
         return { };
 
-    return Data::adoptMap(WTFMove(mappedFile), WTFMove(handle));
+    return Data::adoptMap(WTFMove(*mappedFile), WTFMove(handle));
 }
 
 SHA1::Digest computeSHA1(const Data& data, const Salt& salt)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -27,7 +27,9 @@
 
 #include <span>
 #include <wtf/Box.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
+#include <wtf/MappedFileData.h>
 #include <wtf/SHA1.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -30,6 +30,7 @@
 #import <dispatch/dispatch.h>
 #import <sys/mman.h>
 #import <sys/stat.h>
+#import <wtf/FileHandle.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
@@ -33,7 +33,7 @@
 #include <WebCore/ProtectionSpace.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
-#include <wtf/FileSystem.h>
+#include <wtf/FileHandle.h>
 #include <wtf/MonotonicTime.h>
 
 namespace WebCore {

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/CrossThreadCopier.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/PageBlock.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -359,7 +359,7 @@ void CacheStorageDiskStore::readAllRecordInfosInternal(ReadAllRecordInfosCallbac
                     continue;
 
                 auto recordFile = FileSystem::pathByAppendingComponent(cacheDirectory, recordName);
-                auto fileData = FileSystem::MappedFileData::create(recordFile, FileSystem::MappedFileMode::Private);
+                auto fileData = FileSystem::mapFile(recordFile, FileSystem::MappedFileMode::Private);
                 if (!fileData)
                     continue;
 
@@ -384,8 +384,8 @@ void CacheStorageDiskStore::readRecordsInternal(const Vector<CacheStorageRecordI
         Vector<std::optional<CacheStorageRecord>> records;
         for (auto& recordInfo : recordInfos) {
             auto recordFile = recordFilePathWithDirectory(directory, recordInfo.key());
-            auto fileData = valueOrDefault(FileSystem::MappedFileData::create(recordFile, FileSystem::MappedFileMode::Private));
-            auto blobData = !fileData.size() ? FileSystem::MappedFileData { } : valueOrDefault(FileSystem::MappedFileData::create(recordBlobFilePath(recordFile), FileSystem::MappedFileMode::Private));
+            auto fileData = valueOrDefault(FileSystem::mapFile(recordFile, FileSystem::MappedFileMode::Private));
+            auto blobData = !fileData.size() ? FileSystem::MappedFileData { } : valueOrDefault(FileSystem::mapFile(recordBlobFilePath(recordFile), FileSystem::MappedFileMode::Private));
             auto record = readRecordFromFileData(fileData.span(), WTFMove(blobData));
             if (!record) {
                 RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readRecordsInternal fails to decode record from file", this);

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -28,6 +28,7 @@
 
 #include "Logging.h"
 #include <WebCore/SharedBuffer.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/RunLoop.h>
 

--- a/Source/WebKit/Shared/WebMemorySampler.h
+++ b/Source/WebKit/Shared/WebMemorySampler.h
@@ -53,6 +53,7 @@
 
 #include "SandboxExtension.h"
 #include <WebCore/Timer.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -47,6 +47,7 @@
 #import <sys/sysctl.h>
 #import <sysexits.h>
 #import <wtf/DataLog.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/SafeStrerror.h>
 #import <wtf/Scope.h>

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -44,6 +44,7 @@
 #include <string>
 #include <wtf/CompletionHandler.h>
 #include <wtf/CrossThreadCopier.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -45,6 +45,7 @@
 #import <pal/spi/cocoa/FoundationSPI.h>
 #import <pal/spi/ios/QuickLookSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/FileHandle.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/SpanCocoa.h>
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/LocalizedStrings.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/TextResourceDecoder.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
@@ -48,17 +48,16 @@ void InspectorResourceURLSchemeHandler::platformStartTask(WebPageProxy&, WebURLS
     if (requestPath.startsWith("\\"_s))
         requestPath = requestPath.substring(1);
     auto path = WebCore::webKitBundlePath({ "WebInspectorUI"_s, requestPath });
-    bool success;
-    FileSystem::MappedFileData file(path, FileSystem::MappedFileMode::Private, success);
-    if (!success) {
+    auto file = FileSystem::mapFile(path, FileSystem::MappedFileMode::Private);
+    if (!file) {
         task.didComplete(WebCore::ResourceError(CURLE_READ_ERROR, requestURL));
         return;
     }
     auto contentType = WebCore::File::contentTypeForFile(path);
     if (contentType.isEmpty())
         contentType = "application/octet-stream"_s;
-    WebCore::ResourceResponse response(requestURL, contentType, file.size(), "UTF-8"_s);
-    auto data = WebCore::SharedBuffer::create(file.span());
+    WebCore::ResourceResponse response(requestURL, contentType, file->size(), "UTF-8"_s);
+    auto data = WebCore::SharedBuffer::create(file->span());
 
     task.didReceiveResponse(response);
     task.didReceiveData(WTFMove(data));

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/WebCoreBundleWin.h>
 #include <WebCore/WindowMessageBroadcaster.h>
 #include <WebKit/WKPage.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -37,6 +37,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/ios/SystemPreviewSPI.h>
 #import <wtf/Assertions.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -69,6 +69,7 @@
 #import <mach-o/dyld.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSMenuSPI.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -36,6 +36,7 @@
 #import <WebCore/Model.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/SystemPreviewSPI.h>
+#import <wtf/FileHandle.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/UUID.h>

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -66,6 +66,7 @@
 #import <WebCore/SimpleRange.h>
 #import <WebCore/WebNSAttributedStringExtras.h>
 #import <wtf/Assertions.h>
+#import <wtf/FileHandle.h>
 #import <wtf/FileSystem.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/URL.h>

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -28,8 +28,10 @@
 
 #include "Test.h"
 #include "Utilities.h"
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
+#include <wtf/MappedFileData.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/StringExtras.h>
 #include <wtf/text/MakeString.h>
@@ -112,28 +114,23 @@ private:
 
 TEST_F(FileSystemTest, MappingMissingFile)
 {
-    bool success;
-    FileSystem::MappedFileData mappedFileData(String("not_existing_file"_s), FileSystem::MappedFileMode::Shared, success);
-    EXPECT_FALSE(success);
-    EXPECT_TRUE(!mappedFileData);
+    auto mappedFileData = FileSystem::mapFile(String("not_existing_file"_s), FileSystem::MappedFileMode::Shared);
+    EXPECT_FALSE(!!mappedFileData);
 }
 
 TEST_F(FileSystemTest, MappingExistingFile)
 {
-    bool success;
-    FileSystem::MappedFileData mappedFileData(tempFilePath(), FileSystem::MappedFileMode::Shared, success);
-    EXPECT_TRUE(success);
+    auto mappedFileData = FileSystem::mapFile(tempFilePath(), FileSystem::MappedFileMode::Shared);
     EXPECT_TRUE(!!mappedFileData);
-    EXPECT_TRUE(mappedFileData.size() == strlen(FileSystemTestData));
-    EXPECT_TRUE(contains(FileSystemTestData.span(), mappedFileData.span()));
+    EXPECT_TRUE(mappedFileData->size() == strlen(FileSystemTestData));
+    EXPECT_TRUE(contains(FileSystemTestData.span(), mappedFileData->span()));
 }
 
 TEST_F(FileSystemTest, MappingExistingEmptyFile)
 {
-    bool success;
-    FileSystem::MappedFileData mappedFileData(tempEmptyFilePath(), FileSystem::MappedFileMode::Shared, success);
-    EXPECT_TRUE(success);
-    EXPECT_TRUE(!mappedFileData);
+    auto mappedFileData = FileSystem::mapFile(tempEmptyFilePath(), FileSystem::MappedFileMode::Shared);
+    EXPECT_TRUE(!!mappedFileData);
+    EXPECT_TRUE(!*mappedFileData);
 }
 
 TEST_F(FileSystemTest, FilesHaveSameVolume)

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -28,6 +28,7 @@
 #include "Test.h"
 #include "Utilities.h"
 #include <WebCore/FileMonitor.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SharedBufferTest.h"
 
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -31,6 +31,7 @@
 #include "Test.h"
 #include <WebCore/GStreamerCommon.h>
 #include <WebCore/GStreamerElementHarness.h>
+#include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 
 using namespace WebCore;


### PR DESCRIPTION
#### d8d038849797ffa70e6614b51dba9e6ca42b7c6c
<pre>
Move API for file mapping to the new FileHandle class
<a href="https://bugs.webkit.org/show_bug.cgi?id=290022">https://bugs.webkit.org/show_bug.cgi?id=290022</a>

Reviewed by Darin Adler.

Move API for file mapping to the new FileHandle class since the new main entry point
to deal with file descriptors.

It used to be constructors and create() functions on the MappedFileData class, taking
a FileHandle as parameter. It&apos;s easier to just call `map()` on the FileHandle directly
and is more consistent with how other FileSystem APIs currently work.

* Source/JavaScriptCore/API/JSScript.mm:
(+[JSScript scriptOfType:memoryMappedFromASCIIFile:withSourceURL:andBytecodeCache:inVirtualMachine:error:]):
(-[JSScript readCache]):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::releaseMapped):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/FileHandle.h:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::mapFile):
(WTF::FileSystemImpl::createMappedFileData):
(WTF::FileSystemImpl::MappedFileData::MappedFileData): Deleted.
(WTF::FileSystemImpl::MappedFileData::mapFileHandle): Deleted.
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::leakHandle): Deleted.
(WTF::FileSystemImpl::MappedFileData::operator bool const): Deleted.
(WTF::FileSystemImpl::MappedFileData::size const): Deleted.
(): Deleted.
(WTF::FileSystemImpl::MappedFileData::fileMapping const): Deleted.
(WTF::FileSystemImpl::MappedFileData::span const): Deleted.
(WTF::FileSystemImpl::MappedFileData::mutableSpan): Deleted.
(WTF::FileSystemImpl::MappedFileData::create): Deleted.
(WTF::FileSystemImpl::MappedFileData::MappedFileData): Deleted.
(WTF::FileSystemImpl::m_fileMapping): Deleted.
(WTF::FileSystemImpl::MappedFileData::operator=): Deleted.
* Source/WTF/wtf/MappedFileData.h: Added.
(WTF::FileSystemImpl::MappedFileData::leakHandle):
(WTF::FileSystemImpl::MappedFileData::operator bool const):
(WTF::FileSystemImpl::MappedFileData::size const):
(WTF::FileSystemImpl::MappedFileData::fileMapping const):
(WTF::FileSystemImpl::MappedFileData::span const):
(WTF::FileSystemImpl::MappedFileData::mutableSpan):
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::lock):
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp: Added.
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::MappedFileData::~MappedFileData): Deleted.
(WTF::FileSystemImpl::MappedFileData::mapFileHandle): Deleted.
* Source/WTF/wtf/win/MappedFileDataWin.cpp: Added.
(WTF::FileSystemImpl::MappedFileData):
(WTF::FileSystemImpl::MappedFileData::~MappedFileData):
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::SerializedNFA::serialize):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::SharedBuffer::createWithContentsOfFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp:
(WebKit::NetworkCache::adoptAndMapFile):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::readAllRecordInfosInternal):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, MappingMissingFile)):
(TestWebKitAPI::TEST_F(FileSystemTest, MappingExistingFile)):
(TestWebKitAPI::TEST_F(FileSystemTest, MappingExistingEmptyFile)):

Canonical link: <a href="https://commits.webkit.org/292461@main">https://commits.webkit.org/292461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/814efcdff23e17295ec3576450a4fc26f529ee8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98180 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16044 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73287 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45979 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88808 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103225 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94756 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23202 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26311 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23165 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118233 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22824 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->