### PR TITLE
Allow doubles for ProgressEvent loaded and total

### DIFF
--- a/LayoutTests/fast/events/constructors/progress-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/progress-event-constructor-expected.txt
@@ -18,43 +18,43 @@ PASS new ProgressEvent('eventType', { loaded: 0 }).loaded is 0
 PASS new ProgressEvent('eventType', { loaded: 1 }).loaded is 1
 PASS new ProgressEvent('eventType', { loaded: 9007199254740990 }).loaded is 9007199254740990
 PASS new ProgressEvent('eventType', { loaded: 9007199254740991 }).loaded is 9007199254740991
-PASS new ProgressEvent('eventType', { loaded: 18446744073709551615 }).loaded is 0
+PASS new ProgressEvent('eventType', { loaded: 18446744073709551615 }).loaded is 18446744073709552000
 PASS new ProgressEvent('eventType', { loaded: 12345678901234567890 }).loaded is 12345678901234567890
-PASS new ProgressEvent('eventType', { loaded: -1 }).loaded is 18446744073709551615
-PASS new ProgressEvent('eventType', { loaded: NaN }).loaded is 0
-PASS new ProgressEvent('eventType', { loaded: 123.45 }).loaded is 123
+PASS new ProgressEvent('eventType', { loaded: -1 }).loaded is -1
+PASS new ProgressEvent('eventType', { loaded: NaN }).loaded threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { loaded: 123.45 }).loaded is 123.45
 PASS new ProgressEvent('eventType', { loaded: undefined }).loaded is 0
 PASS new ProgressEvent('eventType', { loaded: null }).loaded is 0
 PASS new ProgressEvent('eventType', { loaded: '' }).loaded is 0
 PASS new ProgressEvent('eventType', { loaded: '12345' }).loaded is 12345
-PASS new ProgressEvent('eventType', { loaded: '12345a' }).loaded is 0
-PASS new ProgressEvent('eventType', { loaded: 'abc' }).loaded is 0
+PASS new ProgressEvent('eventType', { loaded: '12345a' }).loaded threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { loaded: 'abc' }).loaded threw exception TypeError: The provided value is non-finite.
 PASS new ProgressEvent('eventType', { loaded: [] }).loaded is 0
 PASS new ProgressEvent('eventType', { loaded: [12345] }).loaded is 12345
-PASS new ProgressEvent('eventType', { loaded: [12345, 67890] }).loaded is 0
-PASS new ProgressEvent('eventType', { loaded: {} }).loaded is 0
-PASS new ProgressEvent('eventType', { loaded: {moe: 12345} }).loaded is 0
+PASS new ProgressEvent('eventType', { loaded: [12345, 67890] }).loaded threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { loaded: {} }).loaded threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { loaded: {moe: 12345} }).loaded threw exception TypeError: The provided value is non-finite.
 PASS new ProgressEvent('eventType', { loaded: {valueOf: function () { return 12345; }} }).loaded is 12345
 PASS new ProgressEvent('eventType', { total: 0 }).total is 0
 PASS new ProgressEvent('eventType', { total: 1 }).total is 1
 PASS new ProgressEvent('eventType', { total: 9007199254740990 }).total is 9007199254740990
 PASS new ProgressEvent('eventType', { total: 9007199254740991 }).total is 9007199254740991
-PASS new ProgressEvent('eventType', { total: 18446744073709551615 }).total is 0
+PASS new ProgressEvent('eventType', { total: 18446744073709551615 }).total is 18446744073709552000
 PASS new ProgressEvent('eventType', { total: 12345678901234567890 }).total is 12345678901234567890
-PASS new ProgressEvent('eventType', { total: -1 }).total is 18446744073709551615
-PASS new ProgressEvent('eventType', { total: NaN }).total is 0
-PASS new ProgressEvent('eventType', { total: 123.45 }).total is 123
+PASS new ProgressEvent('eventType', { total: -1 }).total is -1
+PASS new ProgressEvent('eventType', { total: NaN }).total threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { total: 123.45 }).total is 123.45
 PASS new ProgressEvent('eventType', { total: undefined }).total is 0
 PASS new ProgressEvent('eventType', { total: null }).total is 0
 PASS new ProgressEvent('eventType', { total: '' }).total is 0
 PASS new ProgressEvent('eventType', { total: '12345' }).total is 12345
-PASS new ProgressEvent('eventType', { total: '12345a' }).total is 0
-PASS new ProgressEvent('eventType', { total: 'abc' }).total is 0
+PASS new ProgressEvent('eventType', { total: '12345a' }).total threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { total: 'abc' }).total threw exception TypeError: The provided value is non-finite.
 PASS new ProgressEvent('eventType', { total: [] }).total is 0
 PASS new ProgressEvent('eventType', { total: [12345] }).total is 12345
-PASS new ProgressEvent('eventType', { total: [12345, 67890] }).total is 0
-PASS new ProgressEvent('eventType', { total: {} }).total is 0
-PASS new ProgressEvent('eventType', { total: {moe: 12345} }).total is 0
+PASS new ProgressEvent('eventType', { total: [12345, 67890] }).total threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { total: {} }).total threw exception TypeError: The provided value is non-finite.
+PASS new ProgressEvent('eventType', { total: {moe: 12345} }).total threw exception TypeError: The provided value is non-finite.
 PASS new ProgressEvent('eventType', { total: {valueOf: function () { return 12345; }} }).total is 12345
 PASS new ProgressEvent('eventType', { bubbles: true, cancelable: true, lengthComputable: true, loaded: 12345, total: 12345 }).bubbles is true
 PASS new ProgressEvent('eventType', { bubbles: true, cancelable: true, lengthComputable: true, loaded: 12345, total: 12345 }).cancelable is true

--- a/LayoutTests/fast/events/constructors/progress-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/progress-event-constructor.html
@@ -37,30 +37,30 @@ shouldBe("new ProgressEvent('eventType', { lengthComputable: true }).lengthCompu
 
     // [2^53, 2^64 - 1]. A value that is in the unsigned long long range but cannot be represented as a double.
     // Spec: http://www.w3.org/TR/WebIDL/#es-unsigned-long-long
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": 18446744073709551615 })." + attr, "0");
+    shouldBe("new ProgressEvent('eventType', { " + attr + ": 18446744073709551615 })." + attr, "18446744073709552000");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": 12345678901234567890 })." + attr, "12345678901234567890");
 
     // A negative number.
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": -1 })." + attr, "18446744073709551615");
+    shouldBe("new ProgressEvent('eventType', { " + attr + ": -1 })." + attr, "-1");
 
     // NaN.
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": NaN })." + attr, "0");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": NaN })." + attr, "TypeError");
 
     // A double.
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": 123.45 })." + attr, "123");
+    shouldBe("new ProgressEvent('eventType', { " + attr + ": 123.45 })." + attr, "123.45");
 
     // Non-numeric values.
     shouldBe("new ProgressEvent('eventType', { " + attr + ": undefined })." + attr, "0");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": null })." + attr, "0");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": '' })." + attr, "0");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": '12345' })." + attr, "12345");
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": '12345a' })." + attr, "0");
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": 'abc' })." + attr, "0");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": '12345a' })." + attr, "TypeError");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": 'abc' })." + attr, "TypeError");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": [] })." + attr, "0");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": [12345] })." + attr, "12345");
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": [12345, 67890] })." + attr, "0");
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": {} })." + attr, "0");
-    shouldBe("new ProgressEvent('eventType', { " + attr + ": {moe: 12345} })." + attr, "0");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": [12345, 67890] })." + attr, "TypeError");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": {} })." + attr, "TypeError");
+    shouldThrowErrorName("new ProgressEvent('eventType', { " + attr + ": {moe: 12345} })." + attr, "TypeError");
     shouldBe("new ProgressEvent('eventType', { " + attr + ": {valueOf: function () { return 12345; }} })." + attr, "12345");
 });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/progressevent-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/progressevent-constructor-expected.txt
@@ -5,8 +5,8 @@ PASS Basic test.
 PASS ECMAScript value conversion test.
 PASS Positive integer number test.
 PASS Zero test.
-FAIL Decimal number test. assert_equals: expected 1.5 but got 1
-FAIL Mixed integer and decimal number test. assert_equals: expected 1.5 but got 1
-FAIL Negative number. assert_equals: expected -1 but got 18446744073709552000
+PASS Decimal number test.
+PASS Mixed integer and decimal number test.
+PASS Negative number.
 PASS ProgressEventInit members must be matched case-sensitively.
 

--- a/Source/WebCore/dom/ProgressEvent.cpp
+++ b/Source/WebCore/dom/ProgressEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@ ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomS
 {
 }
 
-ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
+ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomString& type, bool lengthComputable, double loaded, double total)
     : Event(eventInterface, type, CanBubble::No, IsCancelable::No)
     , m_lengthComputable(lengthComputable)
     , m_loaded(loaded)

--- a/Source/WebCore/dom/ProgressEvent.h
+++ b/Source/WebCore/dom/ProgressEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,15 +32,15 @@ namespace WebCore {
 class ProgressEvent : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ProgressEvent);
 public:
-    static Ref<ProgressEvent> create(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
+    static Ref<ProgressEvent> create(const AtomString& type, bool lengthComputable, double loaded, double total)
     {
         return adoptRef(*new ProgressEvent(EventInterfaceType::ProgressEvent, type, lengthComputable, loaded, total));
     }
 
     struct Init : EventInit {
         bool lengthComputable { false };
-        unsigned long long loaded { 0 };
-        unsigned long long total { 0 };
+        double loaded { 0 };
+        double total { 0 };
     };
 
     static Ref<ProgressEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
@@ -49,17 +49,17 @@ public:
     }
 
     bool lengthComputable() const { return m_lengthComputable; }
-    unsigned long long loaded() const { return m_loaded; }
-    unsigned long long total() const { return m_total; }
+    double loaded() const { return m_loaded; }
+    double total() const { return m_total; }
 
 protected:
-    ProgressEvent(enum EventInterfaceType, const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total);
+    ProgressEvent(enum EventInterfaceType, const AtomString& type, bool lengthComputable, double loaded, double total);
     ProgressEvent(enum EventInterfaceType, const AtomString&, const Init&, IsTrusted);
 
 private:
     bool m_lengthComputable;
-    unsigned long long m_loaded;
-    unsigned long long m_total;
+    double m_loaded;
+    double m_total;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ProgressEvent.idl
+++ b/Source/WebCore/dom/ProgressEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,12 @@
     constructor([AtomString] DOMString type, optional ProgressEventInit eventInitDict);
 
     readonly attribute boolean lengthComputable;
-    readonly attribute unsigned long long loaded;
-    readonly attribute unsigned long long total;
+    readonly attribute double loaded;
+    readonly attribute double total;
 };
 
 dictionary ProgressEventInit : EventInit {
     boolean lengthComputable = false;
-    unsigned long long loaded = 0;
-    unsigned long long total = 0;
+    double loaded = 0;
+    double total = 0;
 };


### PR DESCRIPTION
#### 85ad05a1e4a88daaed6106eaeb0895f8452f9507
<pre>
Allow doubles for ProgressEvent loaded and total
<a href="https://bugs.webkit.org/show_bug.cgi?id=288688">https://bugs.webkit.org/show_bug.cgi?id=288688</a>
<a href="https://rdar.apple.com/146356214">rdar://146356214</a>

Reviewed by Youenn Fablet.

Match the recently changed specification, as well as Chrome and
Firefox. This change will allow the ProgressEvent class to be used for
more use cases, without really impacting what kind of values it can
represent, as integers and floats are the same thing in JavaScript.

* LayoutTests/fast/events/constructors/progress-event-constructor-expected.txt:
* LayoutTests/fast/events/constructors/progress-event-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/xhr/progressevent-constructor-expected.txt:
* Source/WebCore/dom/ProgressEvent.cpp:
(WebCore::ProgressEvent::ProgressEvent):
* Source/WebCore/dom/ProgressEvent.h:
(WebCore::ProgressEvent::create):
(WebCore::ProgressEvent::loaded const):
(WebCore::ProgressEvent::total const):
* Source/WebCore/dom/ProgressEvent.idl:

Canonical link: <a href="https://commits.webkit.org/292359@main">https://commits.webkit.org/292359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42ca4ff0ee0cf1d676f490f4840119de19198806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73023 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30267 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102848 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82057 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81421 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16158 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15413 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22789 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27938 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->