### PR TITLE
Web Inspector: Heap: allow filtering by the text of the preview

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGridNode.js
@@ -339,7 +339,7 @@ WI.DataGridNode = class DataGridNode extends WI.Object
             this._scheduledRefreshIdentifier = undefined;
         }
 
-        this._cachedFilterableData = null;
+        this.clearCachedFilterableData();
         this._needsRefresh = false;
 
         this._element.removeChildren();
@@ -746,6 +746,13 @@ WI.DataGridNode = class DataGridNode extends WI.Object
     {
         let value = this.data[columnIdentifier];
         return typeof value === "string" ? value : null;
+    }
+
+    clearCachedFilterableData()
+    {
+        this._cachedFilterableData = null;
+
+        this.dataGrid?._applyFiltersToNodeAndDispatchEvent(this);
     }
 
     didResizeColumn(columnIdentifier)

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js
@@ -42,6 +42,8 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
         this._edge = edge || null;
         this._base = base || null;
 
+        this._classNameElementTextContent = null;
+
         if (hasChildren)
             this.addEventListener(WI.DataGridNode.Event.Populate, this._populate, this);
     }
@@ -199,6 +201,22 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
         }
     }
 
+    // Protected
+
+    filterableDataForColumn(columnIdentifier)
+    {
+        switch (columnIdentifier) {
+        case "className": {
+            let data = [this._node.className];
+            if (this._classNameElementTextContent)
+                data.push(this._classNameElementTextContent);
+            return data;
+        }
+        }
+
+        return super.filterableDataForColumn(columnIdentifier);
+    }
+
     // Private
 
     _isDominatedByBase()
@@ -294,12 +312,12 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
             remoteObject.callFunctionJSON(inspectedPage_window_getLocationHref, args, (href) => {
                 remoteObject.release();
 
-                if (!href)
+                if (!href) {
                     this._populateError(containerElement);
-                else {
-                    let primitiveRemoteObject = WI.RemoteObject.fromPrimitiveValue(href);
-                    containerElement.appendChild(WI.FormattedValue.createElementForRemoteObject(primitiveRemoteObject));
+                    return;
                 }
+
+                this._populateRemoteObject(WI.RemoteObject.fromPrimitiveValue(href));
             });
         });
     }
@@ -313,24 +331,25 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
             }
 
             if (string) {
-                if (this._node.className === "BigInt") {
-                    let bigIntRemoteObject = WI.RemoteObject.createBigIntFromDescriptionString(string + "n");
-                    containerElement.appendChild(WI.FormattedValue.createElementForRemoteObject(bigIntRemoteObject));
-                } else {
-                    let primitiveRemoteObject = WI.RemoteObject.fromPrimitiveValue(string);
-                    containerElement.appendChild(WI.FormattedValue.createElementForRemoteObject(primitiveRemoteObject));
-                }
+                if (this._node.className === "BigInt")
+                    this._populateRemoteObject(WI.RemoteObject.createBigIntFromDescriptionString(string + "n"));
+                else
+                    this._populateRemoteObject(WI.RemoteObject.fromPrimitiveValue(string));
                 return;
             }
 
             if (functionDetails) {
                 let {location, name, displayName} = functionDetails;
-                let functionNameElement = containerElement.appendChild(document.createElement("span"));
+
+                let fragment = document.createDocumentFragment();
+
+                let functionNameElement = fragment.appendChild(document.createElement("span"));
                 functionNameElement.classList.add("function-name");
                 functionNameElement.textContent = name || displayName || WI.UIString("(anonymous function)");
+
                 let sourceCode = WI.debuggerManager.scriptForIdentifier(location.scriptId, this._node.target);
                 if (sourceCode) {
-                    let locationElement = containerElement.appendChild(document.createElement("span"));
+                    let locationElement = fragment.appendChild(document.createElement("span"));
                     locationElement.classList.add("location");
                     let sourceCodeLocation = sourceCode.createSourceCodeLocation(location.lineNumber, location.columnNumber);
                     sourceCodeLocation.populateLiveDisplayLocationString(locationElement, "textContent", WI.SourceCodeLocation.ColumnStyle.Hidden, WI.SourceCodeLocation.NameStyle.Short);
@@ -342,14 +361,19 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
                         ignoreSearchTab: true,
                     };
                     let goToArrowButtonLink = WI.createSourceCodeLocationLink(sourceCodeLocation, options);
-                    containerElement.appendChild(goToArrowButtonLink);
+                    fragment.appendChild(goToArrowButtonLink);
                 }
+
+                this._classNameElementTextContent = fragment.textContent;
+                this.clearCachedFilterableData();
+
+                containerElement.appendChild(fragment);
                 return;
             }
 
             if (objectPreviewPayload) {
                 let objectPreview = WI.ObjectPreview.fromPayload(objectPreviewPayload);
-                let previewElement = WI.FormattedValue.createObjectPreviewOrFormattedValueForObjectPreview(objectPreview, {
+                let objectPreviewElement = WI.FormattedValue.createObjectPreviewOrFormattedValueForObjectPreview(objectPreview, {
                     remoteObjectAccessor: (callback) => {
                         this._getRemoteObject((remoteObject) => {
                             if (remoteObject)
@@ -357,10 +381,24 @@ WI.HeapSnapshotInstanceDataGridNode = class HeapSnapshotInstanceDataGridNode ext
                         });
                     },
                 });
-                containerElement.appendChild(previewElement);
+
+                this._classNameElementTextContent = objectPreviewElement.textContent;
+                this.clearCachedFilterableData();
+
+                containerElement.appendChild(objectPreviewElement);
                 return;
             }
         });
+    }
+
+    _populateRemoteObject(containerElement, remoteObject)
+    {
+        let remoteObjectElement = WI.FormattedValue.createElementForRemoteObject(primitiveRemoteObject);
+
+        this._classNameElementTextContent = remoteObjectElement.textContent;
+        this.clearCachedFilterableData();
+
+        containerElement.appendChild(remoteObjectElement);
     }
 
     _mouseoverHandler(event)


### PR DESCRIPTION
#### 81f430414c0a0507ff086a354a893ab28934c39c
<pre>
Web Inspector: Heap: allow filtering by the text of the preview
<a href="https://bugs.webkit.org/show_bug.cgi?id=290025">https://bugs.webkit.org/show_bug.cgi?id=290025</a>

Reviewed by BJ Burg.

Previously, the filter would only look at the category (i.e. `className`), meaning that specific instance details (e.g. the `foo` of `&lt;div id=&quot;foo&quot;&gt;`) would not be searchable as the preview is retrieved and displayed asynchronously.

Being able to filter by specific instance details will help developers narrow down what objects exist in the entire JS heap snapshot (e.g. only nodes with `id=&quot;foo&quot;` vs also ones with `id=&quot;bar&quot;`).

* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js:
(WI.HeapSnapshotInstanceDataGridNode):
(WI.HeapSnapshotInstanceDataGridNode.prototype.filterableDataForColumn): Added.
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateWindowPreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populatePreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateRemoteObject): Added.
Include a text representation of the preview inside the filterable data (if it&apos;s ready when the filter is applied).

* Source/WebInspectorUI/UserInterface/Views/DataGridNode.js:
(WI.DataGridNode.prototype.refresh):
(WI.DataGridNode.prototype.clearCachedFilterableData): Added.
Introduce a way to clear any cached filterable data so that the `WI.DataGrid` can re-filter when the preview is ready.

Canonical link: <a href="https://commits.webkit.org/292458@main">https://commits.webkit.org/292458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/367750b8d8f587647454e19f13ac807c65e7df0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99143 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45984 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88813 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4701 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 21 flakes 1 failures; Uploaded test results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103230 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81700 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26316 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16563 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23170 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->