### PR TITLE
Fix Windows drive letter after file:/// when parsing URLs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_include=file-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_include=file-expected.txt
@@ -26,7 +26,7 @@ PASS Parsing: <test> against <file:///tmp/mock/path>
 PASS Parsing: <file:test> against <file:///tmp/mock/path>
 PASS Parsing: <file:///w|m> against <about:blank>
 PASS Parsing: <file:///w||m> against <about:blank>
-FAIL Parsing: <file:///w|/m> against <about:blank> assert_equals: href expected "file:///w:/m" but got "file:///w|/m"
+PASS Parsing: <file:///w|/m> against <about:blank>
 PASS Parsing: <file:C|/m/> against <about:blank>
 PASS Parsing: <file:C||/m/> against <about:blank>
 PASS Parsing: <file:/example.com/> against <about:blank>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element_include=file-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element_include=file-expected.txt
@@ -27,7 +27,7 @@ PASS Parsing: <test> against <file:///tmp/mock/path>
 PASS Parsing: <file:test> against <file:///tmp/mock/path>
 PASS Parsing: <file:///w|m> against <about:blank>
 PASS Parsing: <file:///w||m> against <about:blank>
-FAIL Parsing: <file:///w|/m> against <about:blank> assert_equals: href expected "file:///w:/m" but got "file:///w|/m"
+PASS Parsing: <file:///w|/m> against <about:blank>
 PASS Parsing: <file:C|/m/> against <about:blank>
 PASS Parsing: <file:C||/m/> against <about:blank>
 PASS Parsing: <file:/example.com/> against <about:blank>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_include=file-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_include=file-expected.txt
@@ -26,7 +26,7 @@ PASS Parsing: <test> against <file:///tmp/mock/path>
 PASS Parsing: <file:test> against <file:///tmp/mock/path>
 PASS Parsing: <file:///w|m> without base
 PASS Parsing: <file:///w||m> without base
-FAIL Parsing: <file:///w|/m> without base assert_equals: href expected "file:///w:/m" but got "file:///w|/m"
+PASS Parsing: <file:///w|/m> without base
 PASS Parsing: <file:C|/m/> without base
 PASS Parsing: <file:C||/m/> without base
 PASS Parsing: <file:/example.com/> without base

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_include=file-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_include=file-expected.txt
@@ -26,7 +26,7 @@ PASS Parsing: <test> against <file:///tmp/mock/path>
 PASS Parsing: <file:test> against <file:///tmp/mock/path>
 PASS Parsing: <file:///w|m> without base
 PASS Parsing: <file:///w||m> without base
-FAIL Parsing: <file:///w|/m> without base assert_equals: href expected "file:///w:/m" but got "file:///w|/m"
+PASS Parsing: <file:///w|/m> without base
 PASS Parsing: <file:C|/m/> without base
 PASS Parsing: <file:C||/m/> without base
 PASS Parsing: <file:/example.com/> without base

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1167,6 +1167,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
         File,
         FileSlash,
         FileHost,
+        FilePathStart,
         PathStart,
         Path,
         OpaquePath,
@@ -1683,7 +1684,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                             state = State::Fragment;
                             break;
                         }
-                        state = State::Path;
+                        state = authorityOrHostBegin == c ? State::FilePathStart : State::Path;
                         break;
                     }
                     if (parseHostAndPort(CodePointIterator<CharacterType>(authorityOrHostBegin, c)) == HostParsingResult::InvalidHost) {
@@ -1704,6 +1705,20 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     m_hostHasPercentOrNonASCII = true;
                 ++c;
             } while (!c.atEnd());
+            break;
+        case State::FilePathStart:
+            LOG_STATE("FilePathStart");
+            if (*c == '/' || *c != '\\') {
+                if (UNLIKELY(m_urlIsSpecial && *c == '\\'))
+                    syntaxViolation(c);
+                appendToASCIIBuffer('/');
+                advance(c);
+                m_url.m_pathAfterLastSlash = currentPosition(c);
+                if (isWindowsDriveLetter(c)
+                    && currentPosition(c) == m_url.m_hostEnd + 1)
+                    appendWindowsDriveLetter(c);
+            }
+            state = State::Path;
             break;
         case State::PathStart:
             LOG_STATE("PathStart");
@@ -2013,6 +2028,8 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
     case State::PathStart:
         LOG_FINAL_STATE("PathStart");
         RELEASE_ASSERT_NOT_REACHED();
+    case State::FilePathStart:
+        FALLTHROUGH;
     case State::Path:
         LOG_FINAL_STATE("Path");
         m_url.m_pathEnd = currentPosition(c);


### PR DESCRIPTION
#### ada7fdc9501dcb376b0179c6833dce41aad797e4
<pre>
Fix Windows drive letter after file:/// when parsing URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=290029">https://bugs.webkit.org/show_bug.cgi?id=290029</a>
<a href="https://rdar.apple.com/147381130">rdar://147381130</a>

Reviewed by Anne van Kesteren.

<a href="https://url.spec.whatwg.org/#path-state">https://url.spec.whatwg.org/#path-state</a> step 1.4.1. has a windows drive letter check that is implemented
in Firefox.  This adds it, but rather than add another branch in State::Path (which is often run on
thousands or even millions of code points for a single URL) I add a new state, State::FilePathStart.

* LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_include=file-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element_include=file-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_include=file-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_include=file-expected.txt:
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::parse):

Canonical link: <a href="https://commits.webkit.org/292396@main">https://commits.webkit.org/292396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac5b340dd8a6eb8726d72605505e32d53ff64bd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30350 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45743 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88572 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102987 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94520 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22966 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82163 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81522 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16303 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22929 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/117997 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22588 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->