### PR TITLE
Address safer CPP failures in WebFoundTextRangeController.cpp

### DIFF
--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -304,9 +304,14 @@ void PageOverlay::clear()
         pageOverlayController->clearPageOverlay(*this);
 }
 
-GraphicsLayer& PageOverlay::layer()
+GraphicsLayer& PageOverlay::layer() const
 {
     return controller()->layerForOverlay(*this);
+}
+
+Ref<GraphicsLayer> PageOverlay::protectedLayer() const
+{
+    return layer();
 }
 
 } // namespace WebKit

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -121,7 +121,8 @@ public:
     void setShouldIgnoreMouseEventsOutsideBounds(bool flag) { m_shouldIgnoreMouseEventsOutsideBounds = flag; }
 
     // FIXME: PageOverlay should own its layer, instead of PageOverlayController.
-    WEBCORE_EXPORT GraphicsLayer& layer();
+    WEBCORE_EXPORT GraphicsLayer& layer() const;
+    WEBCORE_EXPORT Ref<GraphicsLayer> protectedLayer() const;
 
     bool needsSynchronousScrolling() const { return m_needsSynchronousScrolling; }
     void setNeedsSynchronousScrolling(bool needsSynchronousScrolling) { m_needsSynchronousScrolling = needsSynchronousScrolling; }

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -292,7 +292,7 @@ void PageOverlayController::clearPageOverlay(PageOverlay& overlay)
     m_overlayGraphicsLayers.get(overlay)->setDrawsContent(false);
 }
 
-GraphicsLayer& PageOverlayController::layerForOverlay(PageOverlay& overlay) const
+GraphicsLayer& PageOverlayController::layerForOverlay(const PageOverlay& overlay) const
 {
     ASSERT(m_pageOverlays.contains(&overlay));
     return *m_overlayGraphicsLayers.get(overlay);

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -61,7 +61,7 @@ public:
     void setPageOverlayNeedsDisplay(PageOverlay&, const IntRect&);
     void setPageOverlayOpacity(PageOverlay&, float);
     void clearPageOverlay(PageOverlay&);
-    GraphicsLayer& layerForOverlay(PageOverlay&) const;
+    GraphicsLayer& layerForOverlay(const PageOverlay&) const;
 
     void didChangeViewSize();
     void didChangeDocumentSize();

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -14,7 +14,6 @@ WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/FindController.cpp
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
-WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/cocoa/PlaybackSessionManager.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -238,7 +238,6 @@ WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/VisitedLinkTableController.cpp
 WebProcess/WebPage/WebContextMenu.cpp
 WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
-WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/WebOpenPanelResultListener.cpp
 WebProcess/WebPage/WebPage.cpp

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -96,6 +96,9 @@ private:
     WebCore::Document* documentForFoundTextRange(const WebFoundTextRange&) const;
     std::optional<WebCore::SimpleRange> simpleRangeFromFoundTextRange(WebFoundTextRange);
 
+    RefPtr<WebPage> protectedWebPage() const { return m_webPage.get(); }
+    RefPtr<WebCore::PageOverlay> protectedFindPageOverlay() const { return m_findPageOverlay; }
+
     WeakPtr<WebPage> m_webPage;
     RefPtr<WebCore::PageOverlay> m_findPageOverlay;
 


### PR DESCRIPTION
#### ae1342640d59b646fdf527543ff2ee038b95f68c
<pre>
Address safer CPP failures in WebFoundTextRangeController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290030">https://bugs.webkit.org/show_bug.cgi?id=290030</a>
<a href="https://rdar.apple.com/147385786">rdar://147385786</a>

Reviewed by Rupin Mittal.

* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::layer const):
(WebCore::PageOverlay::protectedLayer const):
(WebCore::PageOverlay::layer): Deleted.
* Source/WebCore/page/PageOverlay.h:

Drive-by: Make getters const.

* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::layerForOverlay const):
* Source/WebCore/page/PageOverlayController.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::replaceFoundTextRangeWithString):
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
(WebKit::WebFoundTextRangeController::didBeginTextSearchOperation):
(WebKit::WebFoundTextRangeController::addLayerForFindOverlay):
(WebKit::WebFoundTextRangeController::removeLayerForFindOverlay):
(WebKit::WebFoundTextRangeController::createTextIndicatorForRange):
(WebKit::WebFoundTextRangeController::flashTextIndicatorAndUpdateSelectionWithRange):
(WebKit::WebFoundTextRangeController::flashTextIndicatorAndUpdateSelectionWithPDFRange):
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):

Canonical link: <a href="https://commits.webkit.org/292430@main">https://commits.webkit.org/292430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69265b2773f9ad9e1f8d0adb4a9ea6484e9f711c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4392 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81554 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16324 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->