### PR TITLE
Web Inspector: REGRESSION(289844@main): virtualized `WI.TreeOutline` can sometimes jump around

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css
@@ -104,6 +104,7 @@
 .open-resource-dialog > .scroll-container {
     display: flex;
     flex-direction: column;
+    position: relative;
     overflow-y: auto;
 
     border-bottom-left-radius: 4px;
@@ -112,6 +113,10 @@
 
 .open-resource-dialog.has-results .scroll-container {
     border-top: solid 1px var(--border-color);
+}
+
+.open-resource-dialog > .scroll-container > .virtualized-spacer {
+    flex-shrink: 0;
 }
 
 .open-resource-dialog .tree-outline .item {


### PR DESCRIPTION
#### 07b6563676a6e6c20485d3e3a875bf985178b560
<pre>
Web Inspector: REGRESSION(289844@main): virtualized `WI.TreeOutline` can sometimes jump around
<a href="https://bugs.webkit.org/show_bug.cgi?id=290031">https://bugs.webkit.org/show_bug.cgi?id=290031</a>

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css:
(.open-resource-dialog &gt; .scroll-container):
(.open-resource-dialog &gt; .scroll-container &gt; .virtualized-spacer): Added.
The `offsetParent` is not the same thing as `parentNode`.  Mark the parent as `position: relative` to make it qualify.
Ensure that the spacers before and after the `WI.TreeOutline` do not shrink since the `offsetParent` is `display: flex;`.

* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype.registerScrollVirtualizer):
(WI.TreeOutline.prototype._updateVirtualizedElements):
(WI.TreeOutline.prototype._updateVirtualizedElements.walk): Deleted.
Rework the math to calculate what `WI.TreeElement` should be attached to or removed from the DOM to lower the chance of errors by basing the spacer heights on what&apos;s actually in the DOM.

Drive-by: leverage `WI.TreeElement.prototype.traverseNextTreeElement` instead of having custom tree walking logic.
Canonical link: <a href="https://commits.webkit.org/292455@main">https://commits.webkit.org/292455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fb87890de47e1b20f237064df9e326983c866e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23986 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73153 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98943 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53478 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4407 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45784 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82191 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16344 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28125 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->