### PR TITLE
[GStreamer] Make gstObjectHasProperty use ASCIILiteral

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -66,10 +66,10 @@ void GStreamerIceTransportBackend::iceTransportChanged()
     g_object_get(m_backend.get(), "transport", &m_iceTransport.outPtr(), nullptr);
 
     // Setting same libnice socket size options as LibWebRTC. 1MB for incoming streams and 256Kb for outgoing streams.
-    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "receive-buffer-size"))
+    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "receive-buffer-size"_s))
         g_object_set(m_iceTransport.get(), "receive-buffer-size", 1048576, nullptr);
 
-    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "send-buffer-size"))
+    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "send-buffer-size"_s))
         g_object_set(m_iceTransport.get(), "send-buffer-size", 262144, nullptr);
 
     g_signal_connect_swapped(m_iceTransport.get(), "notify::state", G_CALLBACK(+[](GStreamerIceTransportBackend* backend) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -187,7 +187,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
         return false;
     }
 
-    if (gstObjectHasProperty(rtpBin.get(), "add-reference-timestamp-meta")) {
+    if (gstObjectHasProperty(rtpBin.get(), "add-reference-timestamp-meta"_s)) {
         auto disableCaptureTimeTracking = StringView::fromLatin1(g_getenv("WEBKIT_GST_DISABLE_WEBRTC_CAPTURE_TIME_TRACKING"));
         if (disableCaptureTimeTracking.isEmpty() || disableCaptureTimeTracking == "0"_s)
             g_object_set(rtpBin.get(), "add-reference-timestamp-meta", TRUE, nullptr);
@@ -1104,7 +1104,7 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
 
     if (!mediaStreamID.isEmpty()) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Setting msid to %s on sink pad %" GST_PTR_FORMAT, mediaStreamID.ascii().data(), sinkPad.get());
-        if (gstObjectHasProperty(sinkPad.get(), "msid"))
+        if (gstObjectHasProperty(sinkPad.get(), "msid"_s))
             g_object_set(sinkPad.get(), "msid", mediaStreamID.ascii().data(), nullptr);
     }
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -255,10 +255,10 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
     if (codecName.startsWith("mp4a"_s)) {
         const char* streamFormat = config.isAacADTS.value_or(false) ? "adts" : "raw";
         m_outputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4, "stream-format", G_TYPE_STRING, streamFormat, nullptr));
-        if (gstObjectHasProperty(m_encoder.get(), "bitrate") && config.bitRate && config.bitRate < std::numeric_limits<int>::max())
+        if (gstObjectHasProperty(m_encoder.get(), "bitrate"_s) && config.bitRate && config.bitRate < std::numeric_limits<int>::max())
             g_object_set(m_encoder.get(), "bitrate", static_cast<int>(config.bitRate), nullptr);
     } else if (codecName == "mp3"_s) {
-        if (gstObjectHasProperty(m_encoder.get(), "cbr")) {
+        if (gstObjectHasProperty(m_encoder.get(), "cbr"_s)) {
             switch (config.bitRateMode) {
             case BitrateMode::Constant:
                 g_object_set(m_encoder.get(), "cbr", TRUE, nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1626,7 +1626,7 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
 
 void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>& element)
 {
-    if (gstObjectHasProperty(element.get(), "max-errors"))
+    if (gstObjectHasProperty(element.get(), "max-errors"_s))
         g_object_set(element.get(), "max-errors", 0, nullptr);
 
     // rawaudioparse-specific:
@@ -1636,10 +1636,10 @@ void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>& element)
 
 void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>& element)
 {
-    if (gstObjectHasProperty(element.get(), "max-threads"))
+    if (gstObjectHasProperty(element.get(), "max-threads"_s))
         g_object_set(element.get(), "max-threads", 1, nullptr);
 
-    if (gstObjectHasProperty(element.get(), "max-errors"))
+    if (gstObjectHasProperty(element.get(), "max-errors"_s))
         g_object_set(element.get(), "max-errors", 0, nullptr);
 
     // avdec-specific:
@@ -1656,39 +1656,39 @@ void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>& element)
 
 void configureMediaStreamVideoDecoder(GstElement* element)
 {
-    if (gstObjectHasProperty(element, "automatic-request-sync-points"))
+    if (gstObjectHasProperty(element, "automatic-request-sync-points"_s))
         g_object_set(element, "automatic-request-sync-points", TRUE, nullptr);
 
-    if (gstObjectHasProperty(element, "discard-corrupted-frames"))
+    if (gstObjectHasProperty(element, "discard-corrupted-frames"_s))
         g_object_set(element, "discard-corrupted-frames", TRUE, nullptr);
 
-    if (gstObjectHasProperty(element, "output-corrupt"))
+    if (gstObjectHasProperty(element, "output-corrupt"_s))
         g_object_set(element, "output-corrupt", FALSE, nullptr);
 
-    if (gstObjectHasProperty(element, "max-errors"))
+    if (gstObjectHasProperty(element, "max-errors"_s))
         g_object_set(element, "max-errors", -1, nullptr);
 }
 
 void configureVideoRTPDepayloader(GstElement* element)
 {
-    if (gstObjectHasProperty(element, "request-keyframe"))
+    if (gstObjectHasProperty(element, "request-keyframe"_s))
         g_object_set(element, "request-keyframe", TRUE, nullptr);
 
-    if (gstObjectHasProperty(element, "wait-for-keyframe"))
+    if (gstObjectHasProperty(element, "wait-for-keyframe"_s))
         g_object_set(element, "wait-for-keyframe", TRUE, nullptr);
 }
 
-bool gstObjectHasProperty(GstObject* gstObject, const char* name)
+bool gstObjectHasProperty(GstObject* gstObject, ASCIILiteral name)
 {
-    return g_object_class_find_property(G_OBJECT_GET_CLASS(gstObject), name);
+    return g_object_class_find_property(G_OBJECT_GET_CLASS(gstObject), name.characters());
 }
 
-bool gstObjectHasProperty(GstElement* element, const char* name)
+bool gstObjectHasProperty(GstElement* element, ASCIILiteral name)
 {
     return gstObjectHasProperty(GST_OBJECT_CAST(element), name);
 }
 
-bool gstObjectHasProperty(GstPad* pad, const char* name)
+bool gstObjectHasProperty(GstPad* pad, ASCIILiteral name)
 {
     return gstObjectHasProperty(GST_OBJECT_CAST(pad), name);
 }
@@ -1697,13 +1697,13 @@ bool gstElementMatchesFactoryAndHasProperty(GstElement* element, ASCIILiteral fa
 {
     auto factory = gst_element_get_factory(element);
     if (!factory)
-        return gstObjectHasProperty(element, propertyName.characters());
+        return gstObjectHasProperty(element, propertyName);
 
     auto nameView = StringView::fromLatin1(GST_OBJECT_NAME(factory));
     if (fnmatch(factoryNamePattern.characters(), nameView.toStringWithoutCopying().ascii().data(), 0))
         return false;
 
-    return gstObjectHasProperty(element, propertyName.characters());
+    return gstObjectHasProperty(element, propertyName);
 }
 
 GRefPtr<GstBuffer> wrapSpanData(const std::span<const uint8_t>& span)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -312,9 +312,9 @@ void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
 void configureMediaStreamVideoDecoder(GstElement*);
 void configureVideoRTPDepayloader(GstElement*);
 
-bool gstObjectHasProperty(GstObject*, const char* name);
-bool gstObjectHasProperty(GstElement*, const char* name);
-bool gstObjectHasProperty(GstPad*, const char* name);
+bool gstObjectHasProperty(GstObject*, ASCIILiteral name);
+bool gstObjectHasProperty(GstElement*, ASCIILiteral name);
+bool gstObjectHasProperty(GstPad*, ASCIILiteral name);
 
 bool gstElementMatchesFactoryAndHasProperty(GstElement*, ASCIILiteral factoryNamePattern, ASCIILiteral propertyName);
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3353,7 +3353,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
         g_object_set(decoder, "max-threads", 2, nullptr);
     }
 
-    if (gstObjectHasProperty(decoder, "max-errors"))
+    if (gstObjectHasProperty(decoder, "max-errors"_s))
         g_object_set(decoder, "max-errors", 0, nullptr);
 
 #if USE(TEXTURE_MAPPER)
@@ -4036,7 +4036,7 @@ GstElement* MediaPlayerPrivateGStreamer::createVideoSink()
             g_value_unset(&value);
         }
 
-        if (gstObjectHasProperty(sink, "max-lateness")) {
+        if (gstObjectHasProperty(sink, "max-lateness"_s)) {
             uint64_t maxLateness = 100 * GST_MSECOND;
             g_object_set(sink, "max-lateness", maxLateness, nullptr);
         } else {

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 bool GStreamerHolePunchQuirkBcmNexus::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle")))
+    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
@@ -50,7 +50,7 @@ GstElement* GStreamerHolePunchQuirkRialto::createHolePunchVideoSink(bool isLegac
 
 bool GStreamerHolePunchQuirkRialto::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle")))
+    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
@@ -53,7 +53,7 @@ GstElement* GStreamerHolePunchQuirkWesteros::createHolePunchVideoSink(bool isLeg
 
 bool GStreamerHolePunchQuirkWesteros::setHolePunchVideoRectangle(GstElement* videoSink, const IntRect& rect)
 {
-    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle")))
+    if (UNLIKELY(!gstObjectHasProperty(videoSink, "rectangle"_s)))
         return false;
 
     auto rectString = makeString(rect.x(), ',', rect.y(), ',', rect.width(), ',', rect.height());

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -50,12 +50,12 @@ GstElement* GStreamerQuirkAmLogic::createWebAudioSink()
 
 void GStreamerQuirkAmLogic::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
-    if (gstObjectHasProperty(element, "disable-xrun")) {
+    if (gstObjectHasProperty(element, "disable-xrun"_s)) {
         GST_INFO("Set property disable-xrun to TRUE");
         g_object_set(element, "disable-xrun", TRUE, nullptr);
     }
 
-    if (characteristics.contains(ElementRuntimeCharacteristics::HasVideo) && gstObjectHasProperty(element, "wait-video")) {
+    if (characteristics.contains(ElementRuntimeCharacteristics::HasVideo) && gstObjectHasProperty(element, "wait-video"_s)) {
         GST_INFO("Set property wait-video to TRUE");
         g_object_set(element, "wait-video", TRUE, nullptr);
     }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -51,7 +51,7 @@ void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionS
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstBrcmPCMSink") && gstObjectHasProperty(element, "low_latency")) {
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstBrcmPCMSink") && gstObjectHasProperty(element, "low_latency"_s)) {
         GST_DEBUG("Set 'low_latency' in brcmpcmsink");
         g_object_set(element, "low_latency", TRUE, "low_latency_max_queued_ms", 60, nullptr);
     }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
@@ -157,7 +157,7 @@ void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerP
 
                 // The multiqueue reference is useless if we can't access its stats (on older GStreamer versions).
                 if (peerElement && !g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue")
-                    && gstObjectHasProperty(peerElement.get(), "stats"))
+                    && gstObjectHasProperty(peerElement.get(), "stats"_s))
                     state.m_multiqueue = peerElement;
                 break;
             }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -60,12 +60,12 @@ void GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSe
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (gstObjectHasProperty(element, "media-tunnel")) {
+    if (gstObjectHasProperty(element, "media-tunnel"_s)) {
         GST_INFO("Enable 'immediate-output' in rtkaudiosink");
         g_object_set(element, "media-tunnel", FALSE, "audio-service", TRUE, "lowdelay-sync-mode", TRUE, nullptr);
     }
 
-    if (gstObjectHasProperty(element, "lowdelay-mode")) {
+    if (gstObjectHasProperty(element, "lowdelay-mode"_s)) {
         GST_INFO("Enable 'lowdelay-mode' in rtk omx decoder");
         g_object_set(element, "lowdelay-mode", TRUE, nullptr);
     }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -66,7 +66,7 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output")) {
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output"_s)) {
         GST_INFO("Enable 'immediate-output' in WesterosSink");
         g_object_set(element, "immediate-output", TRUE, nullptr);
     }

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -973,7 +973,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     break;
                 }
             }, [](GstElement* encoder, LatencyMode mode) {
-                if (!gstObjectHasProperty(encoder, "usage-profile"))
+                if (!gstObjectHasProperty(encoder, "usage-profile"_s))
                     return;
                 switch (mode) {
                 case REALTIME_LATENCY_MODE:

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -409,7 +409,7 @@ void MediaRecorderPrivateBackend::setSink(GstElement* element)
 
 void MediaRecorderPrivateBackend::configureAudioEncoder(GstElement* element)
 {
-    if (!gstObjectHasProperty(element, "bitrate")) {
+    if (!gstObjectHasProperty(element, "bitrate"_s)) {
         GST_WARNING_OBJECT(m_pipeline.get(), "Audio encoder %" GST_PTR_FORMAT " has no bitrate property, skipping configuration", element);
         return;
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -116,7 +116,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
     if (auto minPTime = gstStructureGetString(structure.get(), "minptime"_s)) {
         if (auto value = parseIntegerAllowingTrailingJunk<int64_t>(minPTime)) {
-            if (gstObjectHasProperty(payloader.get(), "min-ptime"))
+            if (gstObjectHasProperty(payloader.get(), "min-ptime"_s))
                 g_object_set(payloader.get(), "min-ptime", *value * GST_MSECOND, nullptr);
             else
                 GST_WARNING_OBJECT(payloader.get(), "min-ptime property not supported");

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -125,7 +125,7 @@ String GStreamerIncomingTrackProcessor::mediaStreamIdFromPad()
 {
     // Look-up the mediastream ID, using the msid attribute, fall back to pad name if there is no msid.
     String mediaStreamId;
-    if (gstObjectHasProperty(m_pad.get(), "msid")) {
+    if (gstObjectHasProperty(m_pad.get(), "msid"_s)) {
         GUniqueOutPtr<char> msid;
         g_object_get(m_pad.get(), "msid", &msid.outPtr(), nullptr);
         if (msid) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -64,12 +64,12 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
 
     auto codec = emptyString();
     if (encoding == "vp8"_s) {
-        if (gstObjectHasProperty(payloader.get(), "picture-id-mode"))
+        if (gstObjectHasProperty(payloader.get(), "picture-id-mode"_s))
             gst_util_set_object_arg(G_OBJECT(payloader.get()), "picture-id-mode", "15-bit");
 
         codec = "vp8"_s;
     } else if (encoding == "vp9"_s) {
-        if (gstObjectHasProperty(payloader.get(), "picture-id-mode"))
+        if (gstObjectHasProperty(payloader.get(), "picture-id-mode"_s))
             gst_util_set_object_arg(G_OBJECT(payloader.get()), "picture-id-mode", "15-bit");
 
         VPCodecConfigurationRecord record;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -86,7 +86,7 @@ void RealtimeOutgoingMediaSourceGStreamer::initialize()
     m_tee = gst_element_factory_make("tee", nullptr);
 
     m_rtpFunnel = gst_element_factory_make("rtpfunnel", nullptr);
-    if (gstObjectHasProperty(m_rtpFunnel.get(), "forward-unknown-ssrc"))
+    if (gstObjectHasProperty(m_rtpFunnel.get(), "forward-unknown-ssrc"_s))
         g_object_set(m_rtpFunnel.get(), "forward-unknown-ssrc", TRUE, nullptr);
 
     m_rtpCapsfilter = gst_element_factory_make("capsfilter", nullptr);


### PR DESCRIPTION
#### f246ae5c57661c74904fac2cdc99edba2509aa7f
<pre>
[GStreamer] Make gstObjectHasProperty use ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=290035">https://bugs.webkit.org/show_bug.cgi?id=290035</a>

Reviewed by Philippe Normand.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::GStreamerIceTransportBackend::iceTransportChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::requestPad):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::initialize):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::configureAudioDecoderForHarnessing):
(WebCore::configureVideoDecoderForHarnessing):
(WebCore::configureMediaStreamVideoDecoder):
(WebCore::configureVideoRTPDepayloader):
(WebCore::gstObjectHasProperty):
(WebCore::gstElementMatchesFactoryAndHasProperty):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSink):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.cpp:
(WebCore::GStreamerHolePunchQuirkBcmNexus::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp:
(WebCore::GStreamerHolePunchQuirkRialto::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp:
(WebCore::GStreamerHolePunchQuirkWesteros::setHolePunchVideoRectangle):
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp:
(WebCore::GStreamerQuirkAmLogic::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp:
(WebCore::GStreamerQuirkBroadcom::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp:
(WebCore::GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp:
(WebCore::GStreamerQuirkRealtek::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::configureElement):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::configureAudioEncoder):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
(WebCore::GStreamerAudioRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::mediaStreamIdFromPad):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::initialize):

Canonical link: <a href="https://commits.webkit.org/292351@main">https://commits.webkit.org/292351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6200626052ccf45fd63959af01430f27e0322123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45633 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26025 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22815 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->