### PR TITLE
[TexMap] Incorrect damage on layer property changes

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4374,12 +4374,6 @@ imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img
 
 fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html [ Skip ]
 
-webkit.org/b/289331 platform/glib/damage/layer-color-change.html [ Failure ]
-webkit.org/b/289331 platform/glib/damage/layer-opacity-change.html [ Failure ]
-webkit.org/b/289331 platform/glib/damage/layer-overlaps-with-opacity.html [ Failure ]
-webkit.org/b/289331 platform/glib/damage/layer-text-change.html [ Failure ]
-webkit.org/b/289331 platform/glib/damage/layer-visibility-change.html [ Failure ]
-
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/damage/layer-visibility-change.html
+++ b/LayoutTests/platform/glib/damage/layer-visibility-change.html
@@ -20,6 +20,7 @@
       setupTestCase({disableConsoleLog: true});
 
       var layer = document.getElementsByClassName("layer")[0];
+      var damageHistorySizeDuringPreviousFrame = null
 
       processAnimationFrameSequence({skipFirstFrameToEnsureInitialPaintingDone: true}, [
           () => {
@@ -29,14 +30,14 @@
               var damage = latestFrameDamage();
               assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
+              damageHistorySizeDuringPreviousFrame = allFramesDamages().length;
           },
           () => {
               layer.style.backgroundColor = "red";
           },
           () => {
-              var damage = latestFrameDamage();
-              assertValid(damage);
-              assertRectsEq(damage.rects, []);
+              // Expect nothing was rendered.
+              assertEq(allFramesDamages().length, damageHistorySizeDuringPreviousFrame, "unxpected damage history size");
           },
           () => {
               layer.style.visibility = "visible";
@@ -52,15 +53,16 @@
           () => {
               var damage = latestFrameDamage();
               assertValid(damage);
-              assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
+              // 'display' property invalidates the structure of the document so full damage is issued (due to layout).
+              assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
+              damageHistorySizeDuringPreviousFrame = allFramesDamages().length;
           },
           () => {
               layer.style.backgroundColor = "green";
           },
           () => {
-              var damage = latestFrameDamage();
-              assertValid(damage);
-              assertRectsEq(damage.rects, []);
+              // Expect nothing was rendered.
+              assertEq(allFramesDamages().length, damageHistorySizeDuringPreviousFrame, "unxpected damage history size");
           },
           () => {
               layer.style.display = "block";

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -193,6 +193,8 @@ private:
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenFilterAndMask(TextureMapperPaintOptions&, Damage&);
+    void collectDamageFromLayerAboutToBeRemoved(Damage&, TextureMapperLayer&);
+    inline void damageWholeLayer();
     void damageWholeLayerIncludingItsRectFromPreviousFrame();
 #endif
 


### PR DESCRIPTION
#### 3a5f6a7eb79d49b9984020d53de63bb65a53fff9
<pre>
[TexMap] Incorrect damage on layer property changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=289331">https://bugs.webkit.org/show_bug.cgi?id=289331</a>

Reviewed by Carlos Garcia Campos.

This change fixes the damage not being produced in the scenarios when
the color, visibility, or opacity of the layer changes.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/damage/layer-visibility-change.html:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::damageWholeLayer):
(WebCore::TextureMapperLayer::damageWholeLayerIncludingItsRectFromPreviousFrame):
(WebCore::TextureMapperLayer::collectDamageFromLayerAboutToBeRemoved):
(WebCore::TextureMapperLayer::removeFromParent):
(WebCore::TextureMapperLayer::setOpacity):
(WebCore::TextureMapperLayer::setSolidColor):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:

Canonical link: <a href="https://commits.webkit.org/292352@main">https://commits.webkit.org/292352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e07ce8065a9bdcfd9ff5c30e9665c4db7eca7f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30292 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4256 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45637 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81450 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26032 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16189 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15410 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22819 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->