### PR TITLE
[GTK][WPE] Make m_damageInLayerCoordinateSpace and m_damageInGlobalCoordinateSpace optional in TextureMapperLayer

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -193,7 +193,9 @@ private:
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenFilterAndMask(TextureMapperPaintOptions&, Damage&);
-    void collectDamageFromLayerAboutToBeRemoved(Damage&, TextureMapperLayer&);
+    void collectDamageFromLayerAboutToBeRemoved(TextureMapperLayer&);
+    ALWAYS_INLINE Damage& ensureDamageInLayerCoordinateSpace();
+    ALWAYS_INLINE Damage& ensureDamageInGlobalCoordinateSpace();
     inline void damageWholeLayer();
     void damageWholeLayerIncludingItsRectFromPreviousFrame();
 #endif
@@ -288,8 +290,8 @@ private:
 
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagation { false };
-    Damage m_damageInLayerCoordinateSpace;
-    Damage m_damageInGlobalCoordinateSpace;
+    std::optional<Damage> m_damageInLayerCoordinateSpace;
+    std::optional<Damage> m_damageInGlobalCoordinateSpace;
     FloatRect m_accumulatedOverlapRegionDamage;
     std::optional<FloatRect> m_previousLayerRectInGlobalCoordinateSpace;
 #endif


### PR DESCRIPTION
#### 3913debb53045b570fad33014b60513502a7e53e
<pre>
[GTK][WPE] Make m_damageInLayerCoordinateSpace and m_damageInGlobalCoordinateSpace optional in TextureMapperLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=290050">https://bugs.webkit.org/show_bug.cgi?id=290050</a>

Reviewed by Alejandro G. Castro.

That way we ensure we only create them for layers that contribute to
damage and when they are required.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::ensureDamageInLayerCoordinateSpace):
(WebCore::TextureMapperLayer::ensureDamageInGlobalCoordinateSpace):
(WebCore::TextureMapperLayer::setDamage):
(WebCore::TextureMapperLayer::collectDamageSelf):
(WebCore::TextureMapperLayer::damageWholeLayer):
(WebCore::TextureMapperLayer::damageWholeLayerIncludingItsRectFromPreviousFrame):
(WebCore::TextureMapperLayer::collectDamageFromLayerAboutToBeRemoved):
(WebCore::TextureMapperLayer::removeFromParent):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:

Canonical link: <a href="https://commits.webkit.org/292409@main">https://commits.webkit.org/292409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879891e5990c10e49e35b56f40cc9311ea7574f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73082 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98837 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11786 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53410 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81478 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16238 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15442 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->