### PR TITLE
Move WebKitTestRunner's console.log output to UI process

### DIFF
--- a/LayoutTests/accessibility/form-control-value-settable.html
+++ b/LayoutTests/accessibility/form-control-value-settable.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE HTML>
 <html>
 <body>

--- a/LayoutTests/compositing/visible-rect/iframe-and-layers.html
+++ b/LayoutTests/compositing/visible-rect/iframe-and-layers.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 
 <html>

--- a/LayoutTests/fast/text/font-face-crash.html
+++ b/LayoutTests/fast/text/font-face-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/tests/media/fairplay/fps-init-data-cenc-oob-crash.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-init-data-cenc-oob-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/wpt/webcodecs/videodecoderconfig-detached-description.html
+++ b/LayoutTests/http/wpt/webcodecs/videodecoderconfig-detached-description.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <script>

--- a/LayoutTests/js/dom/modules/module-execution-error-inside-dependent-module-should-be-propagated-to-onerror.html
+++ b/LayoutTests/js/dom/modules/module-execution-error-inside-dependent-module-should-be-propagated-to-onerror.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE HTML>
 <html>
 <head>

--- a/LayoutTests/js/dom/modules/module-execution-error-should-be-propagated-to-onerror.html
+++ b/LayoutTests/js/dom/modules/module-execution-error-should-be-propagated-to-onerror.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE HTML>
 <html>
 <head>

--- a/LayoutTests/js/dom/rejected-promise-creation-should-check-exception.html
+++ b/LayoutTests/js/dom/rejected-promise-creation-should-check-exception.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--validateExceptionChecks=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--validateExceptionChecks=true, dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/js/throw-large-string-oom-expected.txt
+++ b/LayoutTests/js/throw-large-string-oom-expected.txt
@@ -1,4 +1,4 @@
-Out of memory
+CONSOLE MESSAGE: Out of memory
 This test makes sure we don't crash when throwing an error with a very large message
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/media/audio-no-installed-engines.html
+++ b/LayoutTests/media/audio-no-installed-engines.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <script>

--- a/LayoutTests/webaudio/decode-audio-data-basic.html
+++ b/LayoutTests/webaudio/decode-audio-data-basic.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -356,6 +356,7 @@ struct WebPageCreationParameters {
     String presentingApplicationBundleIdentifier;
 #endif
     bool hasReceivedAXRequestInUIProcess { false };
+    bool shouldSendConsoleLogsToUIProcessForTesting { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -276,6 +276,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #endif
 
     bool hasReceivedAXRequestInUIProcess;
+    bool shouldSendConsoleLogsToUIProcessForTesting;
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -395,6 +395,9 @@ public:
     bool showsSystemScreenTimeBlockingView() const { return m_data.showsSystemScreenTimeBlockingView; }
     void setShowsSystemScreenTimeBlockingView(bool shows) { m_data.showsSystemScreenTimeBlockingView = shows; }
 
+    bool shouldSendConsoleLogsToUIProcessForTesting() const { return m_data.shouldSendConsoleLogsToUIProcessForTesting; }
+    void setShouldSendConsoleLogsToUIProcessForTesting(bool should) { m_data.shouldSendConsoleLogsToUIProcessForTesting = should; }
+
     bool shouldDeferAsynchronousScriptsUntilAfterDocumentLoad() const { return m_data.shouldDeferAsynchronousScriptsUntilAfterDocumentLoad; }
     void setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad(bool defer) { m_data.shouldDeferAsynchronousScriptsUntilAfterDocumentLoad = defer; }
 
@@ -634,6 +637,7 @@ private:
         bool scrollToTextFragmentIndicatorEnabled { true };
         bool scrollToTextFragmentMarkingEnabled { true };
         bool showsSystemScreenTimeBlockingView { true };
+        bool shouldSendConsoleLogsToUIProcessForTesting { false };
 #if PLATFORM(VISION)
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -157,6 +157,7 @@ public:
     virtual void decidePolicyForNotificationPermissionRequest(WebKit::WebPageProxy&, SecurityOrigin&, CompletionHandler<void(bool allowed)>&& completionHandler) { completionHandler(false); }
     virtual void requestStorageAccessConfirm(WebKit::WebPageProxy&, WebKit::WebFrameProxy*, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&& completionHandler) { completionHandler(WebCore::CookieConsentDecisionResult::NotSupported); }
+    virtual void addMessageToConsoleForTesting(WebKit::WebPageProxy&, WTF::String&&) { }
 
     // Printing.
     virtual float headerHeight(WebKit::WebPageProxy&, WebKit::WebFrameProxy&) { return 0; }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1926,6 +1926,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             completionHandler(String());
         }
 
+        void addMessageToConsoleForTesting(WebPageProxy& page, String&& message) final
+        {
+            if (!m_client.addMessageToConsole)
+                return;
+            m_client.addMessageToConsole(toAPI(&page), toAPI(message.impl()), m_client.base.clientInfo);
+        }
+
         void setStatusText(WebPageProxy* page, const String& text) final
         {
             if (!m_client.setStatusText)

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -120,6 +120,11 @@ void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration
     toImpl(configuration)->setAllowTestOnlyIPC(allowTestOnlyIPC);
 }
 
+void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(WKPageConfigurationRef configuration, bool should)
+{
+    toImpl(configuration)->setShouldSendConsoleLogsToUIProcessForTesting(should);
+}
+
 void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
 {
     toImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -59,6 +59,7 @@ WK_EXPORT void WKPageConfigurationSetInitialCapitalizationEnabled(WKPageConfigur
 WK_EXPORT void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef configuration, double cpuLimit); // Terminates process if it uses more than CPU limit over an extended period of time while in the background.
 
 WK_EXPORT void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration, bool allowTestOnlyIPC);
+WK_EXPORT void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(WKPageConfigurationRef configuration, bool should);
 
 WK_EXPORT void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
 

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -163,6 +163,7 @@ typedef void (*WKPageRunJavaScriptAlertCallback_deprecatedForUseWithV5)(WKPageRe
 typedef bool (*WKPageRunJavaScriptConfirmCallback_deprecatedForUseWithV5)(WKPageRef page, WKStringRef message, WKFrameRef frame, WKSecurityOriginRef securityOrigin, const void *clientInfo);
 typedef WKStringRef (*WKPageRunJavaScriptPromptCallback_deprecatedForUseWithV5)(WKPageRef page, WKStringRef message, WKStringRef defaultValue, WKFrameRef frame, WKSecurityOriginRef securityOrigin, const void *clientInfo);
 typedef bool (*WKPageRunBeforeUnloadConfirmPanelCallback_deprecatedForUseWithV6)(WKPageRef page, WKStringRef message, WKFrameRef frame, const void *clientInfo);
+typedef void (*WKPageAddMessageToConsoleCallback)(WKPageRef page, WKStringRef message, const void* clientInfo);
 
 typedef struct WKPageUIClientBase {
     int                                                                 version;
@@ -1939,6 +1940,8 @@ typedef struct WKPageUIClientV19 {
     // Version 18.
     WKLockScreenOrientationCallback                                     lockScreenOrientation;
     WKUnlockScreenOrientationCallback                                   unlockScreenOrientation;
+
+    WKPageAddMessageToConsoleCallback addMessageToConsole;
 } WKPageUIClientV19;
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11544,6 +11544,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
         .mainFrameIdentifier = mainFrameIdentifier,
         .openedMainFrameName = m_openedMainFrameName,
         .initialSandboxFlags = m_mainFrame ? m_mainFrame->effectiveSandboxFlags() : SandboxFlags { },
+        .shouldSendConsoleLogsToUIProcessForTesting = m_configuration->shouldSendConsoleLogsToUIProcessForTesting()
     };
 
     parameters.processDisplayName = m_configuration->processDisplayName();
@@ -15971,6 +15972,11 @@ void WebPageProxy::layerTreeAsTextForTesting(FrameIdentifier frameID, size_t bas
 
     auto [result] = sendResult.takeReply();
     completionHandler(WTFMove(result));
+}
+
+void WebPageProxy::addMessageToConsoleForTesting(String&& message)
+{
+    m_uiClient->addMessageToConsoleForTesting(*this, WTFMove(message));
 }
 
 void WebPageProxy::frameTextForTesting(WebCore::FrameIdentifier frameID, CompletionHandler<void(String&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3321,6 +3321,7 @@ private:
     void postMessageToRemote(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
+    void addMessageToConsoleForTesting(String&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -656,6 +656,7 @@ messages -> WebPageProxy {
     [EnabledBy=SiteIsolationEnabled] RenderTreeAsTextForTesting(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
     [EnabledBy=SiteIsolationEnabled] FrameTextForTesting(WebCore::FrameIdentifier frameID) -> (String text) Synchronous
     [EnabledBy=SiteIsolationEnabled] LayerTreeAsTextForTesting(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions> options) -> (String layerTreeDump) Synchronous
+    AddMessageToConsoleForTesting(String message) AllowedWhenWaitingForSyncReply
     [EnabledBy=SiteIsolationEnabled] BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
     [EnabledBy=SiteIsolationEnabled] DocumentURLForConsoleLog(WebCore::FrameIdentifier frameID) -> (URL url)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -490,7 +490,12 @@ void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel lev
 {
     // Notify the bundle client.
     auto page = protectedPage();
+    // FIXME: Remove this after rdar://143399667 is fixed.
     page->injectedBundleUIClient().willAddMessageToConsole(page.ptr(), source, level, message, lineNumber, columnNumber, sourceID);
+
+    if (!page->shouldSendConsoleLogsToUIProcessForTesting())
+        return;
+    page->send(Messages::WebPageProxy::AddMessageToConsoleForTesting(message.length() > String::MaxLength / 2 ? "Out of memory"_s : message), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 
 void WebChromeClient::addMessageWithArgumentsToConsole(MessageSource source, MessageLevel level, const String& message, std::span<const String> messageArguments, unsigned lineNumber, unsigned columnNumber, const String& sourceID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -600,6 +600,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if ENABLE(WEBGL)
     , m_shouldRenderWebGLInGPUProcess { parameters.shouldRenderWebGLInGPUProcess}
 #endif
+    , m_shouldSendConsoleLogsToUIProcessForTesting(parameters.shouldSendConsoleLogsToUIProcessForTesting)
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
     , m_textCheckingControllerProxy(makeUniqueRefWithoutRefCountedCheck<TextCheckingControllerProxy>(*this))
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1978,6 +1978,8 @@ public:
     bool hasActiveContextMenuInteraction() const { return m_hasActiveContextMenuInteraction; }
 #endif
 
+    bool shouldSendConsoleLogsToUIProcessForTesting() const { return m_shouldSendConsoleLogsToUIProcessForTesting; }
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2583,6 +2585,7 @@ private:
 #if ENABLE(APP_BOUND_DOMAINS)
     bool m_needsInAppBrowserPrivacyQuirks { false };
 #endif
+    const bool m_shouldSendConsoleLogsToUIProcessForTesting { false };
 
 #if PLATFORM(COCOA)
     bool m_pdfPluginEnabled { false };

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -334,7 +334,6 @@ void InjectedBundle::beginTesting(WKDictionaryRef settings, BegingTestingMode te
 {
     m_dumpPixels = booleanValue(settings, "DumpPixels");
     m_timeout = Seconds::fromMilliseconds(uint64Value(settings, "Timeout"));
-    m_dumpJSConsoleLogInStdErr = booleanValue(settings, "DumpJSConsoleLogInStdErr");
 
     m_pixelResult.clear();
     m_repaintRects.clear();
@@ -423,17 +422,6 @@ void InjectedBundle::dumpBackForwardListsForAllPages(StringBuilder& stringBuilde
     size_t size = m_pages.size();
     for (size_t i = 0; i < size; ++i)
         stringBuilder.append(m_pages[i]->dumpHistory());
-}
-
-void InjectedBundle::dumpToStdErr(const String& output)
-{
-    if (!isTestRunning())
-        return;
-    if (output.isEmpty())
-        return;
-    // FIXME: Do we really have to convert to UTF-8 instead of using toWK?
-    auto string = output.tryGetUTF8();
-    postPageMessage("DumpToStdErr", string ? string->data() : "Out of memory\n");
 }
 
 void InjectedBundle::outputText(StringView output, IsFinalTestOutput isFinalTestOutput)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -76,11 +76,9 @@ public:
     void setTopLoadingFrame(WKBundleFrameRef frame) { m_topLoadingFrame = frame; }
 
     bool shouldDumpPixels() const { return m_dumpPixels; }
-    bool dumpJSConsoleLogInStdErr() const { return m_dumpJSConsoleLogInStdErr; };
 
     enum class IsFinalTestOutput : bool { No, Yes };
     void outputText(StringView, IsFinalTestOutput = IsFinalTestOutput::No);
-    void dumpToStdErr(const String&);
     void postNewBeforeUnloadReturnValue(bool);
     void postSetWindowIsKey(bool);
     void postSetViewSize(double width, double height);
@@ -189,7 +187,6 @@ private:
     bool m_dumpPixels { false };
     bool m_useWorkQueue { false };
     bool m_pixelResultIsPending { false };
-    bool m_dumpJSConsoleLogInStdErr { false };
     bool m_accessibilityIsolatedTreeMode { false };
 
     WTF::Seconds m_timeout;

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -106,10 +106,8 @@ private:
     bool shouldCacheResponse(WKBundlePageRef, WKBundleFrameRef, uint64_t identifier);
 
     // UI Client
-    static void willAddMessageToConsole(WKBundlePageRef, WKStringRef message, uint32_t lineNumber, const void* clientInfo);
     static void willSetStatusbarText(WKBundlePageRef, WKStringRef statusbarText, const void* clientInfo);
     static uint64_t didExceedDatabaseQuota(WKBundlePageRef, WKSecurityOriginRef, WKStringRef databaseName, WKStringRef databaseDisplayName, uint64_t currentQuotaBytes, uint64_t currentOriginUsageBytes, uint64_t currentDatabaseUsageBytes, uint64_t expectedUsageBytes, const void* clientInfo);
-    void willAddMessageToConsole(WKStringRef message);
     void willSetStatusbarText(WKStringRef statusbarText);
     uint64_t didExceedDatabaseQuota(WKSecurityOriginRef, WKStringRef databaseName, WKStringRef databaseDisplayName, uint64_t currentQuotaBytes, uint64_t currentOriginUsageBytes, uint64_t currentDatabaseUsageBytes, uint64_t expectedUsageBytes);
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -134,7 +134,6 @@ WKRetainPtr<WKMutableDictionaryRef> TestInvocation::createTestSettingsDictionary
     setValue(beginTestMessageBody, "UseFlexibleViewport", options().useFlexibleViewport());
     setValue(beginTestMessageBody, "DumpPixels", m_dumpPixels);
     setValue(beginTestMessageBody, "Timeout", static_cast<uint64_t>(m_timeout.milliseconds()));
-    setValue(beginTestMessageBody, "DumpJSConsoleLogInStdErr", m_dumpJSConsoleLogInStdErr);
     setValue(beginTestMessageBody, "additionalSupportedImageTypes", options().additionalSupportedImageTypes().c_str());
     auto allowedHostsValue = adoptWK(WKMutableArrayCreate());
     for (auto& host : TestController::singleton().allowedHosts())
@@ -379,11 +378,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "TextOutput") || WKStringIsEqualToUTF8CString(messageName, "FinalTextOutput")) {
         m_textOutput.append(toWTFString(stringValue(messageBody)));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "DumpToStdErr")) {
-        fprintf(stderr, "%s", toWTFString(stringValue(messageBody)).utf8().data());
         return;
     }
 

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -57,6 +57,8 @@ public:
 
     void setCustomTimeout(Seconds duration) { m_timeout = duration; }
     void setDumpJSConsoleLogInStdErr(bool value) { m_dumpJSConsoleLogInStdErr = value; }
+    bool shouldDumpJSConsoleLogInStdErr() const { return m_dumpJSConsoleLogInStdErr; }
+    bool gotFinalMessage() const { return m_gotFinalMessage; }
 
     Seconds shortTimeout() const;
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -190,6 +190,7 @@ void initializeWebViewConfiguration(const char* libraryPath, WKStringRef injecte
         [configuration setRequiresUserActionForMediaPlayback:NO];
 #endif
         [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+        WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting((__bridge WKPageConfigurationRef)configuration.get(), true);
 
 #if USE(SYSTEM_PREVIEW)
         [configuration _setSystemPreviewEnabled:YES];


### PR DESCRIPTION
#### 54145af5747eeeea428693af607908f525d2ca30
<pre>
Move WebKitTestRunner&apos;s console.log output to UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=290052">https://bugs.webkit.org/show_bug.cgi?id=290052</a>
<a href="https://rdar.apple.com/147418844">rdar://147418844</a>

Reviewed by Charlie Wolfe.

In order for the messages to be ordered correctly with other synchronous messages with test output,
I need to use IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply.  In order to prevent
performance issues, I only do this when WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting
has been used.  Applications can already use WKUserScript and WKScriptMessageHandler to get console.log
output asynchronously.

A few tests occasionally output things after the test is finished, which used to be checked by
InjectedBundle::isTestRunning.  Now I check TestInvocation::gotFinalMessage, but that&apos;s still a
little racy because right now the source of truth is the web content process.  To reduce flakyness,
I also add dumpJSConsoleLogInStdErr=true to some tests where it is helpful in reducing flakyness.

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::shouldSendConsoleLogsToUIProcessForTesting const):
(API::PageConfiguration::setShouldSendConsoleLogsToUIProcessForTesting):
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::addMessageToConsoleForTesting):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Source/WebKit/UIProcess/API/C/WKPageUIClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::addMessageToConsoleForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::addMessageToConsole):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::beginTesting):
(WTR::InjectedBundle::dumpToStdErr): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
(WTR::InjectedBundle::shouldDumpPixels const):
(WTR::InjectedBundle::dumpJSConsoleLogInStdErr const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::InjectedBundlePage):
(WTR::InjectedBundlePage::willAddMessageToConsole): Deleted.
(WTR::lastFileURLPathComponent): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::lastFileURLPathComponent):
(WTR::addMessageToConsole):
(WTR::TestController::generatePageConfiguration):
(WTR::TestController::createWebViewWithOptions):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::createTestSettingsDictionary):
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::initializeWebViewConfiguration):

Canonical link: <a href="https://commits.webkit.org/292403@main">https://commits.webkit.org/292403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/302d1a64008acbe1bb73ec3bdcfcef81be85ca2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24009 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73163 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98966 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53497 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45807 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88636 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103051 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94584 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23030 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81572 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26167 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16367 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22993 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118061 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22652 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26132 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->