### PR TITLE
[WGSL] Buffer length passed to functions should be adjusted for internal pointers

### DIFF
--- a/LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt
+++ b/LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt
@@ -1,0 +1,9 @@
+PASS output[0] is 13
+PASS output[1] is 42
+PASS output[2] is 1
+PASS output[3] is 2
+PASS output[4] is 3
+PASS output[5] is 4
+PASS output[6] is 5
+PASS output[7] is 6
+

--- a/LayoutTests/fast/webgpu/array-length-pointer-parameter.html
+++ b/LayoutTests/fast/webgpu/array-length-pointer-parameter.html
@@ -1,0 +1,100 @@
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+  globalThis.testRunner?.dumpAsText();
+  globalThis.testRunner?.waitUntilDone();
+  const log = globalThis.$vm?.print ?? console.log;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+struct ad {
+    c: u32,
+    af: ae,
+}
+
+struct ae {
+  c: u32,
+  af: array<u32>,
+}
+
+@group(0) @binding(0) var<storage, read_write> ac: ad;
+
+fn z(t: ptr<storage, array<u32>, read_write>) {
+    t[0] = 1;
+    ac.af.af[1] = 2;
+}
+
+fn y(t: ptr<storage, ae, read_write>) {
+    t.af[2] = 3;
+    ac.af.af[3] = 4;
+    z(&t.af);
+}
+
+fn x(t: ptr<storage, ad, read_write>) {
+    t.af.af[4] = 5;
+    ac.af.af[5] = 6;
+    y(&t.af);
+}
+
+fn f()
+{
+    ac.c = 13;
+    ac.af.c = 42;
+    x(&ac);
+}
+
+@compute @workgroup_size(1)
+fn main()
+{
+    f();
+}
+`;
+    let module = device.createShaderModule({code});
+    let bindGroupLayout0 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let buffer0 = device.createBuffer({
+      size: 32, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    await device.queue.onSubmittedWorkDone();
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout0, entries: [
+        {binding: 0, resource: {buffer: buffer0}},
+      ],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]});
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    let computePipeline = device.createComputePipeline({layout: pipelineLayout, compute: {module}});
+    computePassEncoder.setPipeline(computePipeline);
+    computePassEncoder.setBindGroup(0, bindGroup0);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    let outputBuffer0 = device.createBuffer({size: buffer0.size, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer0, 0, outputBuffer0, 0, buffer0.size);
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer0.mapAsync(GPUMapMode.READ);
+    output = [...new Uint32Array(outputBuffer0.getMappedRange())]
+    shouldBe('output[0]', '13');
+    shouldBe('output[1]', '42');
+    shouldBe('output[2]', '1');
+    shouldBe('output[3]', '2');
+    shouldBe('output[4]', '3');
+    shouldBe('output[5]', '4');
+    shouldBe('output[6]', '5');
+    shouldBe('output[7]', '6');
+    outputBuffer0.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-147280474-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-147280474-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: fuzz-147280474.html
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-147280474.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-147280474.html
@@ -1,0 +1,215 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.dumpAsText();
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxStorageTexturesPerShaderStage: 4,
+    maxUniformBufferBindingSize: 12506870,
+    maxStorageBufferBindingSize: 136104497,
+  },
+});
+// START
+a = device0.createTexture({
+  size : [ 2, 60, 8 ],
+  format : 'bgra8unorm',
+  usage : GPUTextureUsage.STORAGE_BINDING
+})
+b = device0.createTexture(
+    {size : [], format : 'r32uint', usage : GPUTextureUsage.STORAGE_BINDING})
+c = a.createView()
+d = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 3,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'r32uint', viewDimension : '2d-array'}
+    },
+    {binding : 69, visibility : GPUShaderStage.COMPUTE, externalTexture : {}}, {
+      binding : 94,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage'}
+    },
+    {
+      binding : 131,
+      visibility : GPUShaderStage.VERTEX,
+      buffer : {type : 'read-only-storage'}
+    },
+    {
+      binding : 449,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'bgra8unorm', viewDimension : '2d-array'}
+    }
+  ]
+})
+e = device0.createPipelineLayout({bindGroupLayouts : [ d, d ]})
+f = device0.createPipelineLayout({bindGroupLayouts : [ d ]})
+j = device0.createShaderModule({
+  code : ` 
+             @compute @workgroup_size(1) fn g() {}
+            `
+})
+h = device0.createShaderModule({
+  code : ` 
+             @compute @workgroup_size(1) fn i() {}
+            `
+})
+n = device0.createBuffer({size : 32, usage : GPUBufferUsage.STORAGE})
+k = await device0.createComputePipelineAsync(
+    {layout : e, compute : {module : h}})
+l = k.getBindGroupLayout(1)
+m = device0.createTexture({
+  size : [ 5, 5, 6 ],
+  dimension : '3d',
+  format : 'rg11b10ufloat',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT
+})
+s = m.createView()
+aa = device0.createBuffer({size : 80, usage : GPUBufferUsage.STORAGE})
+o = device0.createComputePipeline({layout : f, compute : {module : j}})
+p = b.createView({dimension : '2d-array'})
+ab = o.getBindGroupLayout(0)
+q = new VideoFrame(
+    new ArrayBuffer(16),
+    {codedWidth : 2, codedHeight : 2, format : 'RGBX', timestamp : 0})
+r = b.createView({dimension : '2d-array'})
+x = device0.createShaderModule({
+  code : ` 
+            fn y(t: ptr<storage, array<u32>, read_write>) {
+            t[2083] = 9;
+          }
+            @group(0) @binding(94) var<storage, read_write> ac: ad;
+            struct ad {
+            c: u32,   af: array<u32>}
+            @vertex fn ag() -> @builtin(position) vec4f {
+            var ah: vec4f;
+            return ah;
+          }
+            @fragment fn ai() -> @location(200) vec4f {
+            var ah: vec4f;
+            y(&ac.af);
+            return ah;
+          }
+           `
+})
+aj = device0.createCommandEncoder()
+ak = device0.createTexture(
+    {size : [], format : 'bgra8unorm', usage : GPUTextureUsage.STORAGE_BINDING})
+al = device0.createRenderPipeline({
+  layout : e,
+  fragment : {module : x, targets : [ {format : 'rg11b10ufloat'} ]},
+  vertex : {module : x},
+  primitive : {topology : 'point-list'}
+})
+am = device0.createBuffer({size : 16, usage : GPUBufferUsage.STORAGE})
+an = aj.beginRenderPass({
+  colorAttachments :
+      [ {view : s, depthSlice : 4, loadOp : 'clear', storeOp : 'discard'} ]
+})
+ap = device0.importExternalTexture({source : q})
+try {
+  an.setPipeline(al)
+} catch {}
+aq = device0.createBindGroup({
+  layout : l,
+  entries : [
+    {binding : 449, resource : c}, {binding : 94, resource : {buffer : n}},
+    {binding : 131, resource : {buffer : aa}}, {binding : 69, resource : ap},
+    {binding : 3, resource : p}
+  ]
+})
+ar = ak.createView({dimension : '2d-array'})
+try {
+  an.setBindGroup(0, aq)
+} catch {}
+as = device0.createBuffer({size : 60, usage : GPUBufferUsage.STORAGE})
+at = device0.createBindGroup({
+  layout : ab,
+  entries : [
+    {binding : 3, resource : r}, {binding : 449, resource : ar},
+    {binding : 69, resource : ap}, {binding : 131, resource : {buffer : am}},
+    {binding : 94, resource : {buffer : as}}
+  ]
+})
+try {
+  an.setBindGroup(1, at)
+an.draw(5)
+an.end()
+} catch {}
+au = aj.finish()
+try {
+  device0.queue.submit([ au ])
+} catch {}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('Pass');
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/tests/valid/array-length-pointer2.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-length-pointer2.wgsl
@@ -1,0 +1,35 @@
+// RUN: %metal-compile main
+
+struct ad {
+    c: u32,
+    af: ae,
+}
+
+struct ae {
+  c: u32,
+  af: array<u32>,
+}
+
+@group(0) @binding(94) var<storage, read_write> ac: ad;
+
+fn z(t: ptr<storage, array<u32>, read_write>) {
+    t[2083] = 9;
+    ac.af.af[2083] = 9;
+}
+
+fn y(t: ptr<storage, ae, read_write>) {
+    t.af[2083] = 9;
+    ac.af.af[2083] = 9;
+    z(&t.af);
+}
+
+fn x(t: ptr<storage, ad, read_write>) {
+    t.af.af[2083] = 9;
+    ac.af.af[2083] = 9;
+    y(&t.af);
+}
+
+@fragment fn main()
+{
+    x(&ac);
+}


### PR DESCRIPTION
#### 521c3717a92ec9e5462c2acdbbf01a9874404317
<pre>
[WGSL] Buffer length passed to functions should be adjusted for internal pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290059">https://bugs.webkit.org/show_bug.cgi?id=290059</a>
<a href="https://rdar.apple.com/147280474">rdar://147280474</a>

Reviewed by Mike Wyrzykowski.

When using runtime-sized arrays, we track usages of arrayLength to determine when
the length of the buffer needs to be passed to calles. However, the array can be
passed as a pointer, or if it&apos;s nested in a struct it can be passed through multiple
steps of internal pointers (e.g. f(&amp;a) -&gt; g(&amp;a.b) -&gt; h(&amp;a.b.c) -&gt; ...). We already
handled this, but the issue was that the length we pass isn&apos;t just for the array,
but for the entire buffer. To calculate the array length we then subtract the offset
of the array and divide it by the array stride. This is implemented correctly when
the access happens directly on a global variable, but not when it&apos;s indirect via
pointer arguments/parameters. The fix is to simply adjust the length passed to
a callee when the argument is an internal pointer by subtracting the offset of
the pointer as we&apos;d do when calculating the arrayLength.
e.g. where we generated the equivalent `f(&amp;a.b, sizeof(a))`, it should be
`f(&amp;a.b, sizeof(a) - offsetof(decltype(a), b))`

* LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt: Added.
* LayoutTests/fast/webgpu/array-length-pointer-parameter.html: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-147280474-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-147280474.html: Added.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
* Source/WebGPU/WGSL/tests/valid/array-length-pointer2.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/292407@main">https://commits.webkit.org/292407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82b304cf03fd0259d6d4becfd5e88086fa7d6907

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73104 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30331 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22934 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16726 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82146 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16271 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28052 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->