### PR TITLE
[iPad] chatgpt.com: Unable to scroll when selection extents from text inside the chat history to text in the chat box

### DIFF
--- a/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2-expected.txt
+++ b/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2-expected.txt
@@ -1,0 +1,12 @@
+Verifies that a text selection on text outside of an overflow scrolling container does not prevent the user from scrolling the container
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Scrolled overflow container
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Start selection here
+
+End selection here

--- a/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2.html
+++ b/LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
+<style>
+body, html {
+    width: 100%;
+    margin: 0;
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+main.container {
+    overflow: hidden;
+    width: 100%;
+    border: 1px solid red;
+    box-sizing: border-box;
+    z-index: 0;
+    position: relative;
+}
+
+div.scroller {
+    overflow: scroll;
+    width: 100%;
+    height: 250px;
+    border: 1px solid green;
+    box-sizing: border-box;
+}
+
+p.tall {
+    width: 100%;
+    margin: 200px auto;
+    text-align: center;
+}
+
+#base {
+    border: 1px solid red;
+}
+</style>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that a text selection on text outside of an overflow scrolling container does not prevent the user from scrolling the container");
+
+    const base = document.getElementById("base");
+    const extent = document.getElementById("extent");
+    const scroller = document.querySelector(".scroller");
+
+    await UIHelper.longPressElement(base);
+    await UIHelper.waitForSelectionToAppear();
+
+    const range = getSelection().getRangeAt(0);
+    range.setEndAfter(extent);
+    getSelection().removeAllRanges(0);
+    getSelection().addRange(range);
+    await UIHelper.ensurePresentationUpdate();
+
+    const scrollerMidpoint = UIHelper.midPointOfRect(scroller.getBoundingClientRect());
+
+    const swipeStart = { x : scrollerMidpoint.x + 100, y : scrollerMidpoint.y + 50 };
+    const swipeEnd = { x : scrollerMidpoint.x + 100, y : scrollerMidpoint.y - 250 };
+    const maxNumberOfAttempts = 8;
+    let numberOfAttemptsRemaining = maxNumberOfAttempts;
+
+    do {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(swipeStart.x, swipeStart.y)
+            .move(swipeEnd.x, swipeEnd.y, 0.5)
+            .end()
+            .takeResult());
+        await UIHelper.waitForZoomingOrScrollingToEnd();
+
+        if (scroller.scrollTop >= 100) {
+            testPassed("Scrolled overflow container");
+            finishJSTest();
+            return;
+        }
+
+        await UIHelper.delayFor(200);
+    } while (--numberOfAttemptsRemaining)
+
+    testFailed(`Failed to scroll after ${maxNumberOfAttempts} swipes`);
+    finishJSTest();
+
+});
+</script>
+</head>
+<body>
+    <main class="container">
+        <div class="scroller">
+            <p class="tall">Start <span id="base">selection</span> here</p>
+        </div>
+        <p id="extent">End selection here</p>
+    </main>
+</body>

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -28,7 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIKit.h>
-#import <wtf/RetainPtr.h>
+#import <wtf/Forward.h>
 
 @interface UIScrollView (WebKitInternal)
 @property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
@@ -53,6 +53,7 @@
 @end
 
 @interface UIView (WebKitInternal)
+- (void)_wk_collectDescendantsIncludingSelf:(Vector<RetainPtr<UIView>>&)descendants matching:(NS_NOESCAPE BOOL(^)(UIView *))block;
 - (BOOL)_wk_isAncestorOf:(UIView *)view;
 @property (nonatomic, readonly) UIScrollView *_wk_parentScrollView;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -239,6 +239,15 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     return NO;
 }
 
+- (void)_wk_collectDescendantsIncludingSelf:(Vector<RetainPtr<UIView>>&)descendants matching:(NS_NOESCAPE BOOL(^)(UIView *))block
+{
+    if (block(self))
+        descendants.append(self);
+
+    for (UIView *subview in self.subviews)
+        [subview _wk_collectDescendantsIncludingSelf:descendants matching:block];
+}
+
 - (UIViewController *)_wk_viewControllerForFullScreenPresentation
 {
     auto controller = self.window.rootViewController;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1214,12 +1214,13 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
 {
     Vector<RetainPtr<UIView>> viewsToRestore;
     for (UIView *view in [_textInteractionWrapper managedTextSelectionViews]) {
-        if (!view.userInteractionEnabled)
-            continue;
-
-        viewsToRestore.append(view);
-        view.userInteractionEnabled = NO;
+        [view _wk_collectDescendantsIncludingSelf:viewsToRestore matching:^(UIView *view) {
+            return view.userInteractionEnabled;
+        }];
     }
+
+    for (RetainPtr view : viewsToRestore)
+        [view setUserInteractionEnabled:NO];
 
     return makeScopeExit(Function<void()> { [viewsToRestore = WTFMove(viewsToRestore)] {
         for (RetainPtr view : viewsToRestore)


### PR DESCRIPTION
#### bc301ce99d4880f7ffb069967d289b892b0440ef
<pre>
[iPad] chatgpt.com: Unable to scroll when selection extents from text inside the chat history to text in the chat box
<a href="https://bugs.webkit.org/show_bug.cgi?id=290063">https://bugs.webkit.org/show_bug.cgi?id=290063</a>
<a href="https://rdar.apple.com/147239642">rdar://147239642</a>

Reviewed by Abrar Rahman Protyasha, Megan Gardner, Aditya Keerthi, Tim Horton, and Richard Robinson.

Even after the changes in 287294@main, it&apos;s still possible for the text selection highlight to
prevent scrolling in subscrollable areas in the case where the subscrollable region is inside of a
`position: relative;` container that has a layer (e.g. by specifying a `z-index`).

In this case, even though all text interaction views (highlight, caret decorations, etc.) are marked
non-interactive when hit-testing `WKScrollView` for a subscrollable region to (possibly) begin
scrolling, it&apos;s still possible in this case for the `_UITextSelectionRangeView` under the
`_UITextSelectionHighlightView` to have user interaction enabled, even though its superview disables
user interaction. In the case where the range view happens to also cover the subscrollable region,
scrolling becomes impossible because we hit-test to a view above or outside of the view subtree
containing the `WKChildScrollView`.

Fix this by teaching `-makeTextSelectionViewsNonInteractiveForScope` to recurse through all subtrees
under the managed selection views, and mark all managed selection views as non-interactive (not just
the top-level views).

* LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2-expected.txt: Added.
* LayoutTests/editing/selection/ios/scroll-overflow-container-with-selection-2.html: Added.

Add another layout test to exercise this fix.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_collectDescendantsIncludingSelf:matching:]):

Add a helper to aggregate all subviews (including `self`) for which the given block returns `YES`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView makeTextSelectionViewsNonInteractiveForScope]):

Canonical link: <a href="https://commits.webkit.org/292390@main">https://commits.webkit.org/292390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d148b6e47f86e08564f42169e15c9e1a1f2558

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5445 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46399 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23936 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73115 "49 flakes 117 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30343 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4355 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22957 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82156 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3554 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22920 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->