### PR TITLE
Save scroll position before sending Messages::WebFullScreenManagerProxy::EnterFullScreen

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position-with-scroll-during-enter-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position-with-scroll-during-enter-expected.txt
@@ -1,0 +1,6 @@
+This tests that page scroll is restored after fullscreen. Press any key to start the test.
+
+
+EVENT(load)
+EXPECTED ((document.scrollingElement.scrollTop === originalScroll) == 'true') OK
+

--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position-with-scroll-during-enter.html
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position-with-scroll-during-enter.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>fullscreen-restore-scroll-position</title>
+        <script src="../media/video-test.js"></script>
+        <script src="../media/media-file.js"></script>
+        <style>
+            html, body, .spacer {
+                height: 100%;
+            }
+            video {
+                width: 600px;
+                height: 400px;
+            }
+        </style>
+        <script>
+
+        let originalScroll = 0;
+
+        if (window.testRunner) {
+            if (testRunner.scrollDuringEnterFullscreen) {
+                testRunner.scrollDuringEnterFullscreen();
+            }
+        }
+
+        waitFor(window, 'load').then(async event => {
+
+            if (Element.prototype.webkitRequestFullScreen == undefined) {
+                logResult(false, "Element.prototype.webkitRequestFullScreen == undefined");
+                endTest();
+                return;
+            }
+
+            video = document.getElementsByTagName('video')[0];
+            video.src = findMediaFile('video', '../media/content/test');
+            waitFor(video, 'canplaythrough', true);
+
+            originalScroll = document.body.clientHeight;
+            document.scrollingElement.scrollTop = originalScroll;
+            originalScroll = document.scrollingElement.scrollTop;
+
+            document.onwebkitfullscreenchange = async (event) => {
+
+                if (document.webkitIsFullScreen) {
+                    await sleepFor(100);
+                    document.webkitCancelFullScreen();
+                    return;
+                }
+
+                await testExpectedEventually("(document.scrollingElement.scrollTop === originalScroll)", true);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            };
+
+            runWithKeyDown(() => document.getElementById('parent').webkitRequestFullScreen());
+        });
+
+        </script>
+    </head>
+    <body>
+    <p>This tests that page scroll is restored after fullscreen. Press any key to start the test.</p>
+    <div class="spacer"></div>
+    <div id="parent">
+        <video id="video" controls><video>
+    </div>
+    <div class="spacer"></div>
+    </body>
+</html>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1221,7 +1221,9 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.willEnterFullScreen)
                 return completionHandler(false);
-            completionHandler(m_client.willEnterFullScreen(toAPI(m_page.get()), m_client.base.clientInfo));
+            m_client.willEnterFullScreen(toAPI(m_page.get()), toAPI(CompletionListener::create([completionHandler = WTFMove(completionHandler)] mutable {
+                completionHandler(true);
+            }).ptr()), m_client.base.clientInfo);
         }
 
         void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&& completionHandler) override

--- a/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
@@ -33,7 +33,7 @@ extern "C" {
 
 typedef struct WKRect WKRect;
 
-typedef bool (*WKPageWillEnterFullScreenCallback)(WKPageRef page, const void* clientInfo);
+typedef void (*WKPageWillEnterFullScreenCallback)(WKPageRef page, WKCompletionListenerRef listener, const void* clientInfo);
 typedef void (*WKPageBeganEnterFullScreenCallback)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, const void* clientInfo);
 typedef void (*WKPageExitFullScreenCallback)(WKPageRef page, const void* clientInfo);
 typedef void (*WKPageBeganExitFullScreenCallback)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, WKCompletionListenerRef listener, const void* clientInfo);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -309,6 +309,12 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
         willEnterFullScreen(element, WTFMove(willEnterFullScreenCallback), WTFMove(didEnterFullScreenCallback), mode);
         m_inWindowFullScreenMode = true;
     } else {
+
+        if (RefPtr page = m_page->corePage()) {
+            if (RefPtr view = page->mainFrame().virtualView())
+                m_scrollPosition = view->scrollPosition();
+        }
+
         m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::EnterFullScreen(frameID, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), WTFMove(mediaDetails)), [
             this,
             protectedThis = Ref { *this },
@@ -317,7 +323,6 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
             didEnterFullScreenCallback = WTFMove(didEnterFullScreenCallback)
         ] (bool success) mutable {
             if (success) {
-                m_scrollPosition = m_page->corePage()->mainFrame().virtualView()->scrollPosition();
                 willEnterFullScreen(element, WTFMove(willEnterFullScreenCallback), WTFMove(didEnterFullScreenCallback));
                 return;
             }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -461,6 +461,7 @@ interface TestRunner {
     Promise<undefined> flushConsoleLogs();
     Promise<undefined> updatePresentation();
 
+    undefined scrollDuringEnterFullscreen();
     undefined waitBeforeFinishingFullscreenExit();
     undefined finishFullscreenExit();
     undefined requestExitFullscreenFromUIProcess();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2106,6 +2106,11 @@ void TestRunner::waitBeforeFinishingFullscreenExit()
     postPageMessage("WaitBeforeFinishingFullscreenExit");
 }
 
+void TestRunner::scrollDuringEnterFullscreen()
+{
+    postPageMessage("ScrollDuringEnterFullscreen");
+}
+
 void TestRunner::finishFullscreenExit()
 {
     postPageMessage("FinishFullscreenExit");

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -566,6 +566,7 @@ public:
 
     void flushConsoleLogs(JSContextRef, JSValueRef callback);
     void updatePresentation(JSContextRef, JSValueRef callback);
+    void scrollDuringEnterFullscreen();
     void waitBeforeFinishingFullscreenExit();
     void finishFullscreenExit();
     void requestExitFullscreenFromUIProcess();

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -199,11 +199,12 @@ public:
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
+    void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
     void finishFullscreenExit();
     void requestExitFullscreenFromUIProcess(WKPageRef);
 
-    static bool willEnterFullScreen(WKPageRef, const void*);
-    bool willEnterFullScreen(WKPageRef);
+    static void willEnterFullScreen(WKPageRef, WKCompletionListenerRef, const void*);
+    void willEnterFullScreen(WKPageRef, WKCompletionListenerRef);
     static void beganEnterFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, const void*);
     void beganEnterFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame);
     static void exitFullScreen(WKPageRef, const void*);
@@ -815,6 +816,7 @@ private:
     bool m_dumpPolicyDelegateCallbacks { false };
     bool m_dumpFullScreenCallbacks { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
+    bool m_scrollDuringEnterFullscreen { false };
 
 #if PLATFORM(WPE)
     bool m_useWPEPlatformAPI { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -707,6 +707,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "ScrollDuringEnterFullscreen")) {
+        TestController::singleton().scrollDuringEnterFullscreen();
+        return;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "FinishFullscreenExit")) {
         TestController::singleton().finishFullscreenExit();
         return;


### PR DESCRIPTION
#### daaa90772fea480a4f5a3c8e2d14c7fe78c8f2de
<pre>
Save scroll position before sending Messages::WebFullScreenManagerProxy::EnterFullScreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=290068">https://bugs.webkit.org/show_bug.cgi?id=290068</a>
<a href="https://rdar.apple.com/147242681">rdar://147242681</a>

Reviewed by Simon Fraser.

In 290276@main I simplified the IPC, but especially on iOS things can change between the message
being sent and the reply being received.  I verified that saving the scroll position before it changes
fixes the issue, and fullscreen/fullscreen-restore-scroll-position.html still passes.

I also modified the test fullscreen/fullscreen-restore-scroll-position.html to scroll during entering
fullscreen to make the test cover this change.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Canonical link: <a href="https://commits.webkit.org/292402@main">https://commits.webkit.org/292402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c310dc74a6ae49aea3ac0e2cf643d285fc2fc3e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95965 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24011 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30388 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98968 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4428 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45809 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23032 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81573 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26165 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16369 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15439 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22995 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->