### PR TITLE
Use mach_vm_remap instead of mach_vm_map to set up permanent mapping for g_config

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -65,29 +65,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #include <fcntl.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>
-
-extern "C" {
-    /* Routine mach_vm_remap */
-#ifdef mig_external
-    mig_external
-#else
-    extern
-#endif /* mig_external */
-    kern_return_t mach_vm_remap
-    (
-     vm_map_t target_task,
-     mach_vm_address_t *target_address,
-     mach_vm_size_t size,
-     mach_vm_offset_t mask,
-     int flags,
-     vm_map_t src_task,
-     mach_vm_address_t src_address,
-     boolean_t copy,
-     vm_prot_t *cur_protection,
-     vm_prot_t *max_protection,
-     vm_inherit_t inheritance
-     );
-}
+#include <wtf/spi/cocoa/MachVMSPI.h>
 #endif
 
 #if USE(INLINE_JIT_PERMISSIONS_API)

--- a/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
@@ -39,6 +39,8 @@ kern_return_t mach_vm_allocate(vm_map_t target, mach_vm_address_t*, mach_vm_size
 kern_return_t mach_vm_deallocate(vm_map_t target, mach_vm_address_t, mach_vm_size_t);
 kern_return_t mach_vm_map(vm_map_t targetTask, mach_vm_address_t*, mach_vm_size_t, mach_vm_offset_t mask, int flags,
     mem_entry_name_port_t, memory_object_offset_t, boolean_t copy, vm_prot_t currentProtection, vm_prot_t maximumProtection, vm_inherit_t);
+kern_return_t mach_vm_remap(vm_map_t targetTask, mach_vm_address_t*, mach_vm_size_t, mach_vm_offset_t mask, int flags,
+    vm_map_t srcTask, mach_vm_address_t srcAddress, boolean_t copy, vm_prot_t* currentProtection, vm_prot_t* maximumProtection, vm_inherit_t);
 kern_return_t mach_vm_protect(vm_map_t targetTask, mach_vm_address_t, mach_vm_size_t, boolean_t setMaximum, vm_prot_t newProtection);
 kern_return_t mach_vm_region(vm_map_t targetTask, mach_vm_address_t*, mach_vm_size_t*, vm_region_flavor_t, vm_region_info_t,
     mach_msg_type_number_t* infoCount, mach_port_t* objectName);


### PR DESCRIPTION
#### 153af8646bb89084c5525d2b1983144a5a4178f4
<pre>
Use mach_vm_remap instead of mach_vm_map to set up permanent mapping for g_config
<a href="https://bugs.webkit.org/show_bug.cgi?id=290066">https://bugs.webkit.org/show_bug.cgi?id=290066</a>
<a href="https://rdar.apple.com/147347736">rdar://147347736</a>

Reviewed by Mark Lam.

Uses mach_vm_remap to set up permanent mapping for g_config, preventing
a possible issue where g_config values that were set up prior to WTF
initialization would be zeroed out.

* Source/WTF/wtf/WTFConfig.cpp:
(WTF::setPermissionsOfConfigPage):
(WTF::Config::initialize):

Canonical link: <a href="https://commits.webkit.org/292440@main">https://commits.webkit.org/292440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fd6795d661c13959b49525d6faf1a63171e973f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96057 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45901 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88730 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103147 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94678 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23124 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26242 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16480 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23087 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118155 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22746 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->