### PR TITLE
SourceBufferPrivateClient::InitializationSegment should be using Ref<T>

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -71,29 +71,29 @@ public:
         MediaTime duration;
 
         struct AudioTrackInformation {
-            RefPtr<MediaDescription> description;
-            RefPtr<AudioTrackPrivate> track;
+            Ref<MediaDescription> description;
+            Ref<AudioTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<AudioTrackPrivate> protectedTrack() const { return track; }
+            Ref<MediaDescription> protectedDescription() const { return description; }
+            Ref<AudioTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<AudioTrackInformation> audioTracks;
 
         struct VideoTrackInformation {
-            RefPtr<MediaDescription> description;
-            RefPtr<VideoTrackPrivate> track;
+            Ref<MediaDescription> description;
+            Ref<VideoTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<VideoTrackPrivate> protectedTrack() const { return track; }
+            Ref<MediaDescription> protectedDescription() const { return description; }
+            Ref<VideoTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<VideoTrackInformation> videoTracks;
 
         struct TextTrackInformation {
-            RefPtr<MediaDescription> description;
-            RefPtr<InbandTextTrackPrivate> track;
+            Ref<MediaDescription> description;
+            Ref<InbandTextTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<InbandTextTrackPrivate> protectedTrack() const { return track; }
+            Ref<MediaDescription> protectedDescription() const { return description; }
+            Ref<InbandTextTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<TextTrackInformation> textTracks;
     };


### PR DESCRIPTION
#### 6ac0afb8796746ac81932dd47f3067caef85985c
<pre>
SourceBufferPrivateClient::InitializationSegment should be using Ref&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=254661">https://bugs.webkit.org/show_bug.cgi?id=254661</a>
<a href="https://rdar.apple.com/problem/107366003">rdar://problem/107366003</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation::protectedDescription const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation::protectedTrack const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation::protectedDescription const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation::protectedTrack const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::TextTrackInformation::protectedDescription const):
(WebCore::SourceBufferPrivateClient::InitializationSegment::TextTrackInformation::protectedTrack const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ac0afb8796746ac81932dd47f3067caef85985c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95912 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15526 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97957 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15821 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23958 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/100971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98915 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/15821 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/100971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/15821 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/15821 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/103000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/22979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/23958 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/103000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/23230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/103000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/5470 "Hash 6ac0afb8 for PR 42714 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/22942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/22601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/26081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->