### PR TITLE
AX: Exiting early from AXObjectCache::childrenChanged(RenderObject*) when we can't `get` an object for anonymous renderers can result in content being missing from the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-inline-continuation-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-inline-continuation-expected.txt
@@ -1,0 +1,108 @@
+This test ensures the accessibility tree is correct after inserting elements near a render continuation.
+
+
+{AXRole: AXStaticText AXValue: 1}
+
+{#div1 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 2}
+
+{AXRole: AXStaticText AXValue: 3}
+
+{AXRole: AXStaticText AXValue: 4}
+
+{#group-2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 5}
+
+{AXRole: AXStaticText AXValue: 6}
+
+{#div2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 7}
+
+{AXRole: AXStaticText AXValue: 8}
+
+{AXRole: AXStaticText AXValue: 9}
+
+{AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 10}
+
+
+
+{AXRole: AXStaticText AXValue: 1}
+
+{AXRole: AXButton}
+
+{#div1 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 2}
+
+{AXRole: AXStaticText AXValue: 3}
+
+{AXRole: AXStaticText AXValue: 4}
+
+{#group-2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 5}
+
+{AXRole: AXStaticText AXValue: 6}
+
+{#div2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 7}
+
+{AXRole: AXStaticText AXValue: 8}
+
+{AXRole: AXStaticText AXValue: 9}
+
+{AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 10}
+
+
+
+{AXRole: AXStaticText AXValue: 1}
+
+{#div1 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 2}
+
+{AXRole: AXStaticText AXValue: 3}
+
+{AXRole: AXStaticText AXValue: 4}
+
+{#group-2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 5}
+
+{AXRole: AXStaticText AXValue: 6}
+
+{AXRole: AXButton}
+
+{#div2 AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 7}
+
+{AXRole: AXStaticText AXValue: 8}
+
+{AXRole: AXStaticText AXValue: 9}
+
+{AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: 10}
+
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+1
+2
+3 4
+5
+6foo
+7
+8 9
+10

--- a/LayoutTests/accessibility/mac/dynamic-inline-continuation.html
+++ b/LayoutTests/accessibility/mac/dynamic-inline-continuation.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test">
+    <span id="parent1">1<div id="div1" role="group">2</div>3</span>
+    <span>4</span><div id="group-2" role="group">5</div>
+</div>
+
+<div>
+    <span id="parent2">6<div id="div2" role="group">7</div>8</span>
+    <span>9</span><div role="group">10</div>
+</div>
+
+<script>
+var output = "This test ensures the accessibility tree is correct after inserting elements near a render continuation.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += `${dumpAXSearchTraversal(webArea)}\n\n`;
+
+    var button = document.createElement("button");
+    button.innerText = "foo";
+
+    var expected = `{AXRole: AXStaticText AXValue: 1}
+
+{AXRole: AXButton}`;
+    var traversalResult;
+    setTimeout(async function() {
+        document.getElementById("parent1").insertBefore(button, document.getElementById("div1"));
+        // Wait for the button to come after the first static text in the accessibility tree.
+        expected = `{AXRole: AXStaticText AXValue: 1}
+
+{AXRole: AXButton}`;
+        await waitFor(() => {
+            traversalResult = dumpAXSearchTraversal(webArea);
+            return traversalResult.includes(expected);
+        });
+        output += `${traversalResult}\n\n`;
+
+        document.getElementById("parent2").insertBefore(button, document.getElementById("div2"));
+        // Wait for the button to come after the sixth static text in the accessibility tree.
+        expected = `{AXRole: AXStaticText AXValue: 6}
+
+{AXRole: AXButton}`;
+        await waitFor(() => {
+            traversalResult = dumpAXSearchTraversal(webArea);
+            return traversalResult.includes(expected);
+        });
+        output += `${traversalResult}\n\n`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -322,13 +322,21 @@ public:
     {
         return renderer ? get(*renderer) : nullptr;
     }
-    AccessibilityObject* get(RenderObject&) const;
+    inline AccessibilityObject* get(RenderObject& renderer) const
+    {
+        auto axID = m_renderObjectMapping.getOptional(renderer);
+        return axID ? m_objects.get(*axID) : nullptr;
+    }
 
     inline AccessibilityObject* get(Widget* widget) const
     {
         return widget ? get(*widget) : nullptr;
     }
-    AccessibilityObject* get(Widget&) const;
+    inline AccessibilityObject* get(Widget& widget) const
+    {
+        auto axID = m_widgetObjectMapping.getOptional(widget);
+        return axID ? m_objects.get(*axID) : nullptr;
+    }
 
     inline AccessibilityObject* get(Node* node) const
     {
@@ -695,6 +703,10 @@ protected:
     bool shouldSkipBoundary(const CharacterOffset&, const CharacterOffset&);
 private:
     AccessibilityObject* rootWebArea();
+
+    // Returns the object or nearest render-tree ancestor object that is already created (i.e.
+    // retrievable by |get|, not |getOrCreate|).
+    AccessibilityObject* getIncludingAncestors(RenderObject*) const;
 
     // The AX focus is more finegrained than the notion of focused Node. This method handles those cases where the focused AX object is a descendant or a sub-part of the focused Node.
     AccessibilityObject* focusedObjectForNode(Node*);


### PR DESCRIPTION
#### 02c3f17b1e4a5a83009a8f897716a47c1413dbd4
<pre>
AX: Exiting early from AXObjectCache::childrenChanged(RenderObject*) when we can&apos;t `get` an object for anonymous renderers can result in content being missing from the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=290069">https://bugs.webkit.org/show_bug.cgi?id=290069</a>
<a href="https://rdar.apple.com/147283521">rdar://147283521</a>

Reviewed by Chris Fleizach.

Exiting early from AXObjectCache::childrenChanged(RenderObject*) when we can&apos;t `AXObjectCache::get` an object for
anonymous renderers can result in content being missing from the accessibility tree. Sometimes the only children-changed
we get from the render tree for some subtrees is for an anonymous renderer, so if we just drop it, we can have a stale
accessibility tree. This problem is specific to anonymous renderers because we walk the DOM when building the accessibility
tree, so it&apos;s unlikely that we will have created an accessibility object for this renderer (since it only exists in the render tree).

This commit resolves the problem by changing AXObjectCache::childrenChanged(RenderObject*) to check whether a renderer
is anonymous, and if we can&apos;t AXObjectCache::get an accessibility object for it, ascends to the nearest thing we can get
an accessibility object for and submits the children-changed event for that instead.

This bug was found on a real tax preparation webpage, but unfortunately I couldn&apos;t figure out how to distill it into a layout test.
The key seems to be anonymous continuation renderers destroyed and recreated as part of a call to Node::insertBefore().
Newly added test dynamic-inline-continuation.html gets close to reproducing the issue, following many of the same
codepaths as the real bug, but unfortunately will still pass even without this commit.

For posterity, here&apos;s a stacktrace that gives us one of these children-changed events that used to be dropped but no
longer is:

2   AXObjectCache::childrenChanged(WebCore::RenderObject*, WebCore::RenderObject*)
3   RenderTreeBuilder::Block::detach(WebCore::RenderBlock&amp;, WebCore::RenderObject&amp;, WebCore::RenderTreeBuilder::WillBeDestroyed, WebCore::RenderTreeBuilder::CanCollapseAnonymousBlock)
4   RenderTreeBuilder::destroy(WebCore::RenderObject&amp;, WebCore::RenderTreeBuilder::CanCollapseAnonymousBlock)
5   RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(WebCore::RenderObject&amp;, WebCore::RenderElement const*)
6   RenderTreeUpdater::tearDownRenderers(WebCore::Element&amp;, WebCore::RenderTreeUpdater::TeardownType, WebCore::RenderTreeBuilder&amp;)
7   RenderTreeUpdater::tearDownRenderers(WebCore::Element&amp;, WebCore::RenderTreeUpdater::TeardownType)
8   ContainerNode::removeBetween(WebCore::Node*, WebCore::Node*, WebCore::Node&amp;)
9   ContainerNode::removeChild(WebCore::Node&amp;)
10  ContainerNode::removeSelfOrChildNodesForInsertion(WebCore::Node&amp;, WTF::Vector&lt;WTF::Ref&lt;WebCore::Node, WTF::RawPtrTraits&lt;WebCore::Node&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Node&gt;&gt;, 11ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt;&amp;)
11  ContainerNode::appendChildWithoutPreInsertionValidityCheck(WebCore::Node&amp;)
12  ContainerNode::insertBefore(WebCore::Node&amp;, WTF::RefPtr&lt;WebCore::Node, WTF::RawPtrTraits&lt;WebCore::Node&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Node&gt;&gt;&amp;&amp;)

This commit also inlines AXObjectCache::get(RenderObject&amp;) and AXObjectCache::(Widget&amp;) for better performance.

* LayoutTests/accessibility/mac/dynamic-inline-continuation-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-inline-continuation.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::childrenChanged):
(WebCore::AXObjectCache::getIncludingAncestors const):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/292433@main">https://commits.webkit.org/292433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc2693decc6c89fcaa43ad05fed14c9cdcef033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30368 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103018 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22997 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16764 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82186 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28115 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->