### PR TITLE
Introduce top-document and child-document content blocking resource types

### DIFF
--- a/LayoutTests/http/tests/contentextensions/block-child-document-resource-type-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-child-document-resource-type-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-child-document-resource-type.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/iframe.html
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
+        layer at (0,0) size 300x150
+          RenderView at (0,0) size 300x150
+        layer at (0,0) size 300x150
+          RenderBlock {HTML} at (0,0) size 300x150
+            RenderBody {BODY} at (8,8) size 284x134
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html
+++ b/LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html
@@ -1,0 +1,5 @@
+<head>
+</head>
+<body>
+<iframe src="resources/iframe.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html.json
+++ b/LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "trigger": {
+            "url-filter": ".*",
+            "resource-type": ["child-document"]
+        },
+        "action": {
+            "type": "block"
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-top-document-resource-type.html from loading a resource from http://127.0.0.1:8000/contentextensions/block-top-document-resource-type.html
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document-expected.txt
@@ -1,0 +1,12 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
+        layer at (0,0) size 300x150
+          RenderView at (0,0) size 300x150
+        layer at (0,0) size 300x150
+          RenderBlock {HTML} at (0,0) size 300x150
+            RenderBody {BODY} at (8,8) size 284x134
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html
@@ -1,0 +1,5 @@
+<head>
+</head>
+<body>
+<iframe src="resources/iframe.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html.json
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "trigger": {
+            "url-filter": "iframe",
+            "resource-type": ["top-document"]
+        },
+        "action": {
+            "type": "block"
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html
@@ -1,0 +1,4 @@
+<head>
+</head>
+<body>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html.json
+++ b/LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "trigger": {
+            "url-filter": ".*",
+            "resource-type": ["top-document"]
+        },
+        "action": {
+            "type": "block"
+        }
+    }
+]

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -242,7 +242,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
 
         if (initiatingDocumentLoader.isLoadingMainResource()
             && frame->isMainFrame()
-            && resourceType == ResourceType::Document)
+            && resourceType.containsAny({ ResourceType::TopDocument, ResourceType::ChildDocument }))
             mainDocumentURL = url;
         else if (auto* page = frame->page())
             mainDocumentURL = page->mainFrameURL();
@@ -270,7 +270,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
                 results.summary.blockedCookies = true;
                 result.blockedCookies = true;
             }, [&](const CSSDisplayNoneSelectorAction& actionData) {
-                if (resourceType == ResourceType::Document)
+                if (resourceType.containsAny({ ResourceType::TopDocument, ResourceType::ChildDocument }))
                     initiatingDocumentLoader.addPendingContentExtensionDisplayNoneSelector(contentRuleListIdentifier, actionData.string, action.actionID());
                 else if (currentDocument)
                     currentDocument->extensionStyleSheets().addDisplayNoneSelector(contentRuleListIdentifier, actionData.string, action.actionID());
@@ -300,7 +300,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
 
         if (!actionsFromContentRuleList.sawIgnorePreviousRules) {
             if (auto* styleSheetContents = globalDisplayNoneStyleSheet(contentRuleListIdentifier)) {
-                if (resourceType == ResourceType::Document)
+                if (resourceType.containsAny({ ResourceType::TopDocument, ResourceType::ChildDocument }))
                     initiatingDocumentLoader.addPendingContentExtensionSheet(contentRuleListIdentifier, *styleSheetContents);
                 else if (currentDocument)
                     currentDocument->extensionStyleSheets().maybeAddContentExtensionSheet(contentRuleListIdentifier, *styleSheetContents);

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -605,7 +605,7 @@ bool StyleSheetContents::subresourcesAllowReuse(CachePolicy cachePolicy, FrameLo
         auto* documentLoader = loader.documentLoader();
         if (page && documentLoader) {
             const auto& request = resource.resourceRequest();
-            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester()), *documentLoader);
+            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester(), loader.frame().isMainFrame()), *documentLoader);
             if (results.summary.blockedLoad || results.summary.madeHTTPS)
                 return true;
         }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -568,7 +568,7 @@ void DocumentLoader::handleSubstituteDataLoadNow()
     if (RefPtr page = m_frame ? m_frame->page() : nullptr) {
         // We intentionally do nothing with the results of this call.
         // We want the CSS to be loaded for us, but we ignore any attempt to block or upgrade the connection since there is no connection.
-        page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, response.url(), ContentExtensions::ResourceType::Document, *this);
+        page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, response.url(), m_frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument, *this);
     }
 #endif
 

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -35,52 +35,53 @@ namespace WebCore::ContentExtensions {
 
 enum class ActionCondition : uint32_t {
     None = 0x00000,
-    IfTopURL = 0x20000,
-    UnlessTopURL = 0x40000,
-    IfFrameURL = 0x60000,
-    UnlessFrameURL = 0x80000
+    IfTopURL = 0x40000,
+    UnlessTopURL = 0x80000,
+    IfFrameURL = 0x140000,
+    UnlessFrameURL = 0x180000
 };
-static constexpr uint32_t ActionConditionMask = 0xE0000;
+static constexpr uint32_t ActionConditionMask = 0x1C0000;
 
 enum class ResourceType : uint32_t {
-    Document = 0x0001,
-    Image = 0x0002,
-    StyleSheet = 0x0004,
-    Script = 0x0008,
-    Font = 0x0010,
-    SVGDocument = 0x0020,
-    Media = 0x0040,
-    Popup = 0x0080,
-    Ping = 0x0100,
-    Fetch = 0x0200,
-    WebSocket = 0x0400,
-    Other = 0x0800,
-    CSPReport = 0x10000,
+    TopDocument = 0x0001,
+    ChildDocument = 0x0002,
+    Image = 0x0004,
+    StyleSheet = 0x0008,
+    Script = 0x0010,
+    Font = 0x0020,
+    SVGDocument = 0x0040,
+    Media = 0x0080,
+    Popup = 0x0100,
+    Ping = 0x0200,
+    Fetch = 0x0400,
+    WebSocket = 0x0800,
+    CSPReport = 0x1000,
+    Other = 0x2000,
 };
-static constexpr uint32_t ResourceTypeMask = 0x10FFF;
+static constexpr uint32_t ResourceTypeMask = 0x3FFF;
 
 enum class LoadType : uint32_t {
-    FirstParty = 0x1000,
-    ThirdParty = 0x2000,
+    FirstParty = 0x4000,
+    ThirdParty = 0x8000,
 };
-static constexpr uint32_t LoadTypeMask = 0x3000;
+static constexpr uint32_t LoadTypeMask = 0xC000;
 
 enum class LoadContext : uint32_t {
-    TopFrame = 0x4000,
-    ChildFrame = 0x8000,
+    TopFrame = 0x10000,
+    ChildFrame = 0x20000,
 };
-static constexpr uint32_t LoadContextMask = 0xC000;
+static constexpr uint32_t LoadContextMask = 0x30000;
 
 using ResourceFlags = uint32_t;
 
 constexpr ResourceFlags AllResourceFlags = LoadTypeMask | ResourceTypeMask | LoadContextMask | ActionConditionMask;
 
 // The first 32 bits of a uint64_t action are used for the action location.
-// The next 20 bits are used for the flags (ResourceType, LoadType, LoadContext, ActionCondition).
+// The next 21 bits are used for the flags (ResourceType, LoadType, LoadContext, ActionCondition).
 // The values -1 and -2 are used for removed and empty values in HashTables.
-static constexpr uint64_t ActionFlagMask = 0x000FFFFF00000000;
+static constexpr uint64_t ActionFlagMask = 0x001FFFFF00000000;
 
-OptionSet<ResourceType> toResourceType(CachedResource::Type, ResourceRequestRequester);
+OptionSet<ResourceType> toResourceType(CachedResource::Type, ResourceRequestRequester, bool isMainFrame);
 std::optional<OptionSet<ResourceType>> readResourceType(StringView);
 std::optional<OptionSet<LoadType>> readLoadType(StringView);
 std::optional<OptionSet<LoadContext>> readLoadContext(StringView);

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -86,7 +86,7 @@ void ResourceMonitor::setDocumentURL(URL&& url)
 
     m_frameURL = WTFMove(url);
 
-    didReceiveResponse(m_frameURL, ContentExtensions::ResourceType::Document);
+    didReceiveResponse(m_frameURL, m_frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument);
 
     if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(frame->ownerElement())) {
         if (auto& url = iframe->initiatorSourceURL(); !url.isEmpty())

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -125,7 +125,7 @@ SubresourceLoader::SubresourceLoader(LocalFrame& frame, CachedResource& resource
     subresourceLoaderCounter.increment();
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
-    m_resourceType = ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester());
+    m_resourceType = ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester(), frame.isMainFrame());
 #endif
     m_canCrossOriginRequestsAskUserForCredentials = resource.type() == CachedResource::Type::MainResource;
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1175,7 +1175,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         const auto& resourceRequest = request.resourceRequest();
         if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes) {
             RegistrableDomain originalDomain { resourceRequest.url() };
-            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester()), *documentLoader);
+            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
             bool blockedLoad = results.summary.blockedLoad;
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTFMove(results), page.ptr());

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -151,7 +151,7 @@ ContentRuleListResults UserContentProvider::processContentRuleListsForLoad(Page&
 {
     auto results = userContentExtensionBackend().processContentRuleListsForLoad(page, url, resourceType, initiatingDocumentLoader, redirectFrom, ruleListFilter(initiatingDocumentLoader));
 
-    if (resourceType.contains(ContentExtensions::ResourceType::Document))
+    if (resourceType.containsAny({ ContentExtensions::ResourceType::TopDocument, ContentExtensions::ResourceType::ChildDocument }))
         applyLinkDecorationFilteringIfNeeded(results, page, url, initiatingDocumentLoader);
 
     return results;

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -54,7 +54,7 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
     // This should be incremented every time a functional change is made to the bytecode, file format, etc.
     // to prevent crashing while loading old data.
-    static constexpr uint32_t CurrentContentRuleListFileVersion = 18;
+    static constexpr uint32_t CurrentContentRuleListFileVersion = 19;
 
     static ContentRuleListStore& defaultStoreSingleton();
     static Ref<ContentRuleListStore> storeWithPath(const WTF::String& storePath);


### PR DESCRIPTION
#### d5d74427397d8dec2e03456dae6ea4de50060d53
<pre>
Introduce top-document and child-document content blocking resource types
<a href="https://bugs.webkit.org/show_bug.cgi?id=290067">https://bugs.webkit.org/show_bug.cgi?id=290067</a>
<a href="https://rdar.apple.com/147442279">rdar://147442279</a>

Reviewed by Timothy Hatcher and Alex Christensen.

This patch breaks out the Document resource type to be TopDocument and
ChildDocument. The motive behind this change is that currently, a dNR rule that
doesn&apos;t specify resource types gets converted into two WebKit content blocking
rules.

E.g.

{
  ...

  trigger = {
    load-context = child-frame
    resource-type = document
  }

  ...
}

{
  ...

  trigger = {
    resource-type = script, ping, ...
  }

  ...
}

By introducing the child-document resource type, those two rules can be
collapsed into one.

* LayoutTests/http/tests/contentextensions/block-child-document-resource-type-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html: Added.
* LayoutTests/http/tests/contentextensions/block-child-document-resource-type.html.json: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type-with-child-document.html.json: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html: Added.
* LayoutTests/http/tests/contentextensions/block-top-document-resource-type.html.json: Added.
Introduce new layout tests to verify that the top-document and child-document
resource types behave as expected.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
Update the resourceType check to look for TopDocument or ChildDocument, rather
than Document.

* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::subresourcesAllowReuse const):
Pass in whether or not the frame is the main frame.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::handleSubstituteDataLoadNow):
Set the ResourceType to either TopDocument or ChildDocument, rather than
Document.

* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::toResourceType):
Return an option set with either TopDocument or ChildDocument ResourceType if
the cached resource type is a main resource. Also, update this method to take
in a parameter as to whether or not the resource is the main frame, which is
used to decide whether to return TopDocument or ChildDocument.

(WebCore::ContentExtensions::readResourceType):
Return an option set with both TopDocument and ChildDocument ResourceTypes if
the content blocking rule specifies &quot;document&quot; resource type.

Return TopDocument and ChildDocument for their resource type strings.

(WebCore::ContentExtensions::resourceTypeToString):
Return the resource type strings for the TopDocument and ChildDocument
ResourceTypes.

* Source/WebCore/loader/ResourceLoadInfo.h:
Replace the Document ResourceType with TopDocument and ChildDocument, and
update the byte code.

* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::setDocumentURL):
Set the ResourceType to either TopDocument or ChildDocument, rather than
Document.

* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::SubresourceLoader):
Pass in whether or not the frame is the main frame.

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
Pass in whether or not the frame is the main frame.

* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::UserContentProvider::processContentRuleListsForLoad):
Update the resourceType check to look for TopDocument or ChildDocument, rather
than Document.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
Update the content rule list file version since we modified the byte code.

* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::mainDocumentRequest):
(TestWebKitAPI::subResourceRequest):
(TestWebKitAPI::requestInTopAndFrameURLs):
(TestWebKitAPI::TEST_F(ContentExtensionTest, TopURL)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, LoadType)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, ResourceType)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, ResourceOrLoadTypeMatchingEverything)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, MatchesEverything)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, IfFrameURL)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, UnlessFrameURL)):
Update the tests to use TopDocument and ChildDocument ResourceTypes, since Document
was removed.

Canonical link: <a href="https://commits.webkit.org/292482@main">https://commits.webkit.org/292482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a644db08ff7c6ef7dba159c2093ef3cadfdcdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5788 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24254 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/101272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99210 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/4673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/46052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/4770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/103300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23274 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/103300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23525 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/82931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/103300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/26377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15478 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23237 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22896 "Failed to checkout and rebase branch from PR 42722") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/26376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->