### PR TITLE
Fix ancestor bounding box for "disabled" <foreignObject> and <image>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt
@@ -20,6 +20,6 @@ PASS polyline with no valid points doesn't contribute to parent bbox
 PASS getBBox on path with no height
 PASS path with no height should contribute to parent bbox
 PASS arc bbox should be tight
-FAIL empty foreignObject does not contribute to parent bbox assert_approx_equals: x expected 5 +/- 5.960464477539063e-8 but got 0
-FAIL empty image does not contribute to parent bbox assert_approx_equals: x expected 5 +/- 5.960464477539063e-8 but got 0
+PASS empty foreignObject does not contribute to parent bbox
+PASS empty image does not contribute to parent bbox
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -28,6 +28,8 @@
 #include "SVGRenderSupport.h"
 
 #include "ElementAncestorIteratorInlines.h"
+#include "LegacyRenderSVGForeignObject.h"
+#include "LegacyRenderSVGImage.h"
 #include "LegacyRenderSVGResourceClipper.h"
 #include "LegacyRenderSVGResourceFilter.h"
 #include "LegacyRenderSVGResourceMarker.h"
@@ -167,6 +169,12 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
             continue;
 
         if (auto* text = dynamicDowncast<RenderSVGText>(current.ptr()); (text && !text->isObjectBoundingBoxValid()))
+            continue;
+
+        if (auto* image = dynamicDowncast<LegacyRenderSVGImage>(current.ptr()); (image && !image->isObjectBoundingBoxValid()))
+            continue;
+
+        if (auto* foreignObject = dynamicDowncast<LegacyRenderSVGForeignObject>(current.ptr()); (foreignObject && !foreignObject->isObjectBoundingBoxValid()))
             continue;
 
         const AffineTransform& transform = current->localToParentTransform();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -44,6 +44,7 @@ public:
     void layout() override;
 
     FloatRect objectBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
+    bool isObjectBoundingBoxValid() const { return !m_viewport.isEmpty(); }
     FloatRect strokeBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const override { return FloatRect(FloatPoint(), m_viewport.size()); }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -52,6 +52,8 @@ public:
     // Note: Assumes the PaintInfo context has had all local transforms applied.
     void paintForeground(PaintInfo&);
 
+    bool isObjectBoundingBoxValid() const { return !m_objectBoundingBox.isEmpty(); }
+
 private:
     void willBeDestroyed() override;
 


### PR DESCRIPTION
#### 9e1dc10d3cc5f72394aebbad1b1edb1701eab5aa
<pre>
Fix ancestor bounding box for &quot;disabled&quot; &lt;foreignObject&gt; and &lt;image&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=290077">https://bugs.webkit.org/show_bug.cgi?id=290077</a>
<a href="https://rdar.apple.com/problem/147455573">rdar://problem/147455573</a>

Reviewed by Antoine Quint.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web Specification.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src/+/e47e6e98afe2de2d737ac7827e9309430e68b60b">https://chromium.googlesource.com/chromium/src/+/e47e6e98afe2de2d737ac7827e9309430e68b60b</a>

Per Web Specification [1] &amp; [2]:

[1] <a href="https://svgwg.org/svg2-draft/embedded.html#Placement">https://svgwg.org/svg2-draft/embedded.html#Placement</a>

&quot;A value of zero for either width or height disables rendering of the
element and its embedded content.&quot;

[2] <a href="https://svgwg.org/svg2-draft/coords.html#BoundingBoxes">https://svgwg.org/svg2-draft/coords.html#BoundingBoxes</a>

&quot;For each descendant graphics element child of parent:
  * If child is not rendered then continue to the next descendant
    graphics element.&quot;

&lt;foreignObject&gt; / &lt;image&gt; with &apos;width&apos; or &apos;height&apos; zero should not
contribute to an ancestor container&apos;s bounding box.

* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/292411@main">https://commits.webkit.org/292411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5957759556398763b1ed3022c2750f4a8a7df26b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81551 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28123 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->