### PR TITLE
Unreviewed non-unified source build fix 2025-03 (part 17)

### DIFF
--- a/Source/WebCore/css/CSSFontFaceDescriptors.cpp
+++ b/Source/WebCore/css/CSSFontFaceDescriptors.cpp
@@ -30,9 +30,12 @@
 #include "CSSPropertyParser.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
+#include "DeprecatedCSSOMValueList.h"
 #include "Document.h"
+#include "MutableStyleProperties.h"
 #include "Settings.h"
 #include "StyleAttributeMutationScope.h"
+#include "StyleSheetContents.h"
 #include "StyledElement.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/css/CSSFontFaceDescriptors.h
+++ b/Source/WebCore/css/CSSFontFaceDescriptors.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSFontFaceRule;
+struct CSSParserContext;
 
 class CSSFontFaceDescriptors final : public CSSStyleDeclaration, public RefCounted<CSSFontFaceDescriptors> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSFontFaceDescriptors);

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -30,6 +30,7 @@
 #include "CSSRule.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
+#include "DeprecatedCSSOMValue.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.h
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class ContainerNode;
 class Node;
 
 struct ParsedTextDirective {


### PR DESCRIPTION
#### fa97fa3ac9fd0c0355fd47b99dfbe3882588ffe6
<pre>
Unreviewed non-unified source build fix 2025-03 (part 17)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288990">https://bugs.webkit.org/show_bug.cgi?id=288990</a>

* Source/WebCore/css/CSSFontFaceDescriptors.cpp:
* Source/WebCore/css/CSSFontFaceDescriptors.h:
* Source/WebCore/css/CSSStyleProperties.cpp:
* Source/WebCore/dom/FragmentDirectiveUtilities.h:

Canonical link: <a href="https://commits.webkit.org/292394@main">https://commits.webkit.org/292394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a045352c974b3d605340a63e15200d05d9050d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5504 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23990 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/101005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98947 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/4413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/45788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/4515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23262 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/82688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/81558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26148 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15434 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22974 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22633 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->