### PR TITLE
[iOS] Displayed values for date controls may cause overflow onto multiple lines

### DIFF
--- a/LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls-expected.txt
+++ b/LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls-expected.txt
@@ -1,0 +1,21 @@
+
+This test verifies that the initial width of date/time-related inputs with no value is equal to the input's width when its value is set to one which would produce the widest possible displayed string for the date or time, and that the displayed value does not overflow onto two lines.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+NOTE: Since the values to check are hardcoded, the values are only certain to produce the widest possible displayed string for locale en_US with 12 hour time.
+
+PASS The datetime-local input's width did not change after its value was set.
+PASS The datetime-local input's height did not change after its value was set.
+PASS The date input's width did not change after its value was set.
+PASS The date input's height did not change after its value was set.
+PASS The time input's width did not change after its value was set.
+PASS The time input's height did not change after its value was set.
+PASS The month input's width did not change after its value was set.
+PASS The month input's height did not change after its value was set.
+PASS The week input's width did not change after its value was set.
+PASS The week input's height did not change after its value was set.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls.html
+++ b/LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body onload="runTest()">
+<div id=parent>
+<input id='datetime-local' type='datetime-local'>
+<input id='date' type='date'>
+<input id='time' type='time'>
+<input id='month' type='month'>
+<input id='week' type='week'>
+</div>
+<pre id="description"></pre>
+<pre id="console"></pre>
+<script>
+var initialWidth;
+var initialHeight;
+
+function runTest() {
+    description("This test verifies that the initial width of date/time-related inputs with no value is equal to the input's width when its value is set to one which would produce the widest possible displayed string for the date or time, and that the displayed value does not overflow onto two lines.");
+    debug("NOTE: Since the values to check are hardcoded, the values are only certain to produce the widest possible displayed string for locale en_US with 12 hour time.\n");
+
+    var values = [ "4444-05-30T10:44", "4444-05-30", "10:44", "4444-09", "4444-W44" ];
+    var children = document.getElementsByTagName("input")
+
+    for (var i = 0; i < children.length; i++) {
+        let input = children[i];
+        initialWidth = input.clientWidth;
+        initialHeight = input.clientHeight;
+        input.value = values[i];
+        
+        if (initialWidth == input.clientWidth)
+            testPassed("The " + input.id + " input's width did not change after its value was set.");
+        else
+            testFailed("The " + input.id + " input's width changed from " + initialWidth + " to " + input.clientWidth + "after its value was set.");
+
+        if (initialHeight == input.clientHeight)
+            testPassed("The " + input.id + " input's height did not change after its value was set.");
+        else
+            testFailed("The " + input.id + " input's height changed from " + initialHeight + " to " + input.clientHeight + "after its value was set.");
+    }
+
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/fast/forms/time/time-input-rendering-basic-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/time/time-input-rendering-basic-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (60,0) size 4x19
-        text run at (60,0) width 4: " "
+      RenderText {#text} at (61,0) size 4x19
+        text run at (61,0) width 4: " "
       RenderText {#text} at (0,0) size 0x0
-layer at (8,8) size 60x22 clip at (9,9) size 58x20
-  RenderFlexibleBox {INPUT} at (0,0) size 60x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 48x14
-      RenderText {#text} at (3,0) size 42x14
-        text run at (3,0) width 42: "9:41\x{202F}AM"
-layer at (72,8) size 60x22 clip at (73,9) size 58x20
-  RenderFlexibleBox {INPUT} at (64,0) size 60x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 48x14
-      RenderText {#text} at (3,0) size 42x14
+layer at (8,8) size 61x22 clip at (9,9) size 59x20
+  RenderFlexibleBox {INPUT} at (0,0) size 61x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 49x14
+      RenderText {#text} at (3,0) size 43x14
+        text run at (3,0) width 43: "9:41\x{202F}AM"
+layer at (73,8) size 61x22 clip at (74,9) size 59x20
+  RenderFlexibleBox {INPUT} at (65,0) size 61x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 49x14
+      RenderText {#text} at (3,0) size 43x14
         text run at (3,0) width 18: "AM"
         text run at (20,0) width 3 RTL: "\x{202F}"
-        text run at (22,0) width 23: "9:41"
+        text run at (22,0) width 24: "9:41"

--- a/Source/WebCore/platform/text/cocoa/LocalizedDateCache.h
+++ b/Source/WebCore/platform/text/cocoa/LocalizedDateCache.h
@@ -42,7 +42,7 @@ public:
 class LocalizedDateCache {
 public:
     NSDateFormatter *formatterForDateType(DateComponentsType);
-    float maximumWidthForDateType(DateComponentsType, const FontCascade&, const MeasureTextClient&);
+    float estimatedMaximumWidthForDateType(DateComponentsType, const FontCascade&, const MeasureTextClient&);
     void localeChanged();
 
 private:
@@ -50,7 +50,7 @@ private:
     ~LocalizedDateCache();
 
     RetainPtr<NSDateFormatter> createFormatterForType(DateComponentsType);
-    float calculateMaximumWidth(DateComponentsType, const MeasureTextClient&);
+    float estimateMaximumWidth(DateComponentsType, const MeasureTextClient&);
 
     // Using int instead of DateComponentsType for the key because the enum
     // does not have a default hash and hash traits. Usage of the maps

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -459,13 +459,13 @@ static void adjustInputElementButtonStyle(RenderStyle& style, const HTMLInputEle
     // Enforce the width and set the box-sizing to content-box to not conflict with the padding.
     FontCascade font = style.fontCascade();
 
-    float maximumWidth = localizedDateCache().maximumWidthForDateType(dateType, font, RenderThemeMeasureTextClient(font, style));
+    float maximumWidth = localizedDateCache().estimatedMaximumWidthForDateType(dateType, font, RenderThemeMeasureTextClient(font, style));
 
     ASSERT(maximumWidth >= 0);
 
     if (maximumWidth > 0) {
         int width = static_cast<int>(std::ceil(maximumWidth));
-        style.setLogicalWidth(Length(width, LengthType::Fixed));
+        style.setLogicalMinWidth(Length(width, LengthType::Fixed));
         style.setBoxSizing(BoxSizing::ContentBox);
     }
 }


### PR DESCRIPTION
#### f53f6698c4254d602172dfe68a25279f77901c9d
<pre>
[iOS] Displayed values for date controls may cause overflow onto multiple lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=290080">https://bugs.webkit.org/show_bug.cgi?id=290080</a>
<a href="https://rdar.apple.com/146902737">rdar://146902737</a>

Reviewed by Aditya Keerthi.

Certain wide values for date controls could cause the displayed string to overflow onto
a second line. This was caused by incorrect logic in `LocalizedDateCache::calculateMaximumWidth`
which returned the width of an arbitrary date based on the assumption numbers typically have equal
width, which is not true. The method has been updated to estimate the maximum width based on the
width of each number 0-9. It includes logic to handle localized numerals and a variety of different
date and time formats. The name of the method and its caller were update to reflect the fact that
this is just an estimation as factors such as kerning are not taken into account.

The value returned by this method is now used as the `min-width` for the date/time controls
instead of setting `width` to the value. This is done so that, even in the case where the
estimated maximum width is incorrect, the displayed value will still be on one line as the
control will now expand.

Updated the name of `LocalizedDateCache::calculatedMaximumWidthForWeek` to
`estimatedMaximumWidthForWeek` to reflect that kerning is not accounted for. Removed
an unnecessary `adoptNS()` from the method. Added logic so that it too considers the
width of localized numerals rather than only Arabic numerals.

Added a layout test which ensures that the estimated maximum width is always correct for
the system font at the default size, and that the displayed value is always displayed on
a single line.

Updated iOS test expectations for fast/forms/ios/initial-size-for-date-time-related-controls.html
since the control width has changed slightly since its width is based on estimatedMaximumWidth,
which is no longer using an arbitrary time.

* LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls-expected.txt: Added.
* LayoutTests/fast/forms/ios/initial-size-for-date-time-related-controls.html: Added.
* LayoutTests/platform/ios/fast/forms/time/time-input-rendering-basic-expected.txt:
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.h:
* Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm:
(WebCore::LocalizedDateCache::estimatedMaximumWidthForDateType):
(WebCore::estimateMaximumWidthForWeek):
(WebCore::LocalizedDateCache::estimateMaximumWidth):
(WebCore::LocalizedDateCache::maximumWidthForDateType): Deleted.
(WebCore::calculateMaximumWidthForWeek): Deleted.
(WebCore::LocalizedDateCache::calculateMaximumWidth): Deleted.
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::adjustInputElementButtonStyle):

Canonical link: <a href="https://commits.webkit.org/292441@main">https://commits.webkit.org/292441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f98e9d4d5aa5f37615f7668f08fc3b34d68017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96048 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73222 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99051 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11947 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23115 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81636 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16471 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15457 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23078 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->