### PR TITLE
[ wk2 Release ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html is a flaky failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Multiple queued lazy load navigations do not crash the page assert_true: The iframe should be navigated to the resource provided by the latest `src` mutation expected true got false
+PASS Multiple queued lazy load navigations do not crash the page
 

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -82,6 +82,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isReplaced(const RenderStyle&) const final { return true; }
 
+    ReferrerPolicy referrerPolicyFromAttribute() const;
     bool shouldLoadFrameLazily() final;
     bool isLazyLoadObserverActive() const final;
 

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -99,6 +99,12 @@ void LazyLoadFrameObserver::unobserve()
     frameObserver.m_observer->unobserve(m_element);
 }
 
+void LazyLoadFrameObserver::update(const AtomString& frameURL, const ReferrerPolicy& referrerPolicy)
+{
+    m_frameURL = frameURL;
+    m_referrerPolicy = referrerPolicy;
+}
+
 IntersectionObserver* LazyLoadFrameObserver::intersectionObserver(Document& document)
 {
     if (!m_observer) {

--- a/Source/WebCore/html/LazyLoadFrameObserver.h
+++ b/Source/WebCore/html/LazyLoadFrameObserver.h
@@ -45,6 +45,8 @@ public:
     AtomString frameURL() const { return m_frameURL; }
     ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }
 
+    void update(const AtomString& frameURL, const ReferrerPolicy&);
+
 private:
     IntersectionObserver* intersectionObserver(Document&);
     bool isObserved(Element&) const;


### PR DESCRIPTION
#### 02abcb409e5cfc7b6712585d512ad320898f7e54
<pre>
[ wk2 Release ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289479">https://bugs.webkit.org/show_bug.cgi?id=289479</a>
<a href="https://rdar.apple.com/146675979">rdar://146675979</a>

Reviewed by Per Arne Vollan.

The flakiness was caused by frameURL in LazyLoadFrameObserver getting out of sync with url set in HTMLIframeElement&apos;s src attribute in most cases but not always.

Fixed the flakiness by always updating LazyLoadFrameObserver&apos;s url and referrer policy in HTMLIFrameElement::shouldLoadFrameLazily() regardless of whether
m_lazyLoadFrameObserver already exists or not.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::referrerPolicy const):
(WebCore::HTMLIFrameElement::referrerPolicyFromAttribute const): Extracted from referrerPolicy.
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
(WebCore::LazyLoadFrameObserver::update): Added.
* Source/WebCore/html/LazyLoadFrameObserver.h:

Canonical link: <a href="https://commits.webkit.org/292445@main">https://commits.webkit.org/292445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4571907c08419c58fbce489ab214578217e5fdd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73172 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30398 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4445 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103068 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16791 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82213 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81586 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16384 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28165 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->