### PR TITLE
[Materials] Add support for a more translucent hosted material for media controls

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2025,6 +2025,8 @@ constexpr CSSValueID toCSSValueID(AppleVisualEffect effect)
         return CSSValueAppleSystemHostedThinBlurMaterial;
     case AppleVisualEffect::HostedMediaControlsMaterial:
         return CSSValueAppleSystemHostedMediaControlsMaterial;
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+        return CSSValueAppleSystemHostedThinMediaControlsMaterial;
 #endif
     case AppleVisualEffect::VibrancyLabel:
         return CSSValueAppleSystemVibrancyLabel;
@@ -2069,6 +2071,8 @@ template<> constexpr AppleVisualEffect fromCSSValueID(CSSValueID valueID)
         return AppleVisualEffect::HostedThinBlurMaterial;
     case CSSValueAppleSystemHostedMediaControlsMaterial:
         return AppleVisualEffect::HostedMediaControlsMaterial;
+    case CSSValueAppleSystemHostedThinMediaControlsMaterial:
+        return AppleVisualEffect::HostedThinMediaControlsMaterial;
 #endif
     case CSSValueAppleSystemVibrancyLabel:
         return AppleVisualEffect::VibrancyLabel;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
@@ -47,6 +47,7 @@ static bool isKeywordValidForAppleVisualEffect(CSSValueID keyword)
     case CSSValueID::CSSValueAppleSystemHostedBlurMaterial:
     case CSSValueID::CSSValueAppleSystemHostedThinBlurMaterial:
     case CSSValueID::CSSValueAppleSystemHostedMediaControlsMaterial:
+    case CSSValueID::CSSValueAppleSystemHostedThinMediaControlsMaterial:
 #endif
     case CSSValueID::CSSValueAppleSystemVibrancyFill:
     case CSSValueID::CSSValueAppleSystemVibrancyLabel:

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -46,6 +46,7 @@ bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -75,6 +76,7 @@ bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
 #endif
         return false;
     case AppleVisualEffect::VibrancyLabel:
@@ -99,6 +101,7 @@ bool appleVisualEffectIsHostedMaterial(AppleVisualEffect effect)
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
         return true;
     case AppleVisualEffect::None:
     case AppleVisualEffect::BlurUltraThinMaterial:
@@ -152,6 +155,9 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
         break;
     case AppleVisualEffect::HostedMediaControlsMaterial:
         ts << "hosted-media-controls-material";
+        break;
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+        ts << "hosted-thin-media-controls-material";
         break;
 #endif
     case AppleVisualEffect::VibrancyLabel:

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -46,6 +46,7 @@ enum class AppleVisualEffect : uint8_t {
     HostedBlurMaterial,
     HostedThinBlurMaterial,
     HostedMediaControlsMaterial,
+    HostedThinMediaControlsMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, WKHostedMaterialEffectType) {
     WKHostedMaterialEffectTypeBlur,
     WKHostedMaterialEffectTypeThinBlur,
     WKHostedMaterialEffectTypeMediaControls,
+    WKHostedMaterialEffectTypeThinMediaControls,
 };
 
 typedef NS_ENUM(NSInteger, WKHostedMaterialColorScheme) {

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -89,6 +89,8 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
             return Material._hostedThinBlurMaterial
         case .mediaControls:
             return Material._hostedMediaControlsMaterial
+        case .thinMediaControls:
+            return Material._hostedThinMediaControlsMaterial
         @unknown default:
             return nil
         }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -171,6 +171,7 @@ static MTCoreMaterialRecipe materialRecipeForAppleVisualEffect(AppleVisualEffect
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -211,6 +212,7 @@ static MTCoreMaterialVisualStyle materialVisualStyleForAppleVisualEffect(AppleVi
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
@@ -240,6 +242,7 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
     case AppleVisualEffect::HostedBlurMaterial:
     case AppleVisualEffect::HostedThinBlurMaterial:
     case AppleVisualEffect::HostedMediaControlsMaterial:
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
@@ -257,6 +260,8 @@ static WKHostedMaterialEffectType hostedMaterialEffectTypeForAppleVisualEffect(A
         return WKHostedMaterialEffectTypeThinBlur;
     case AppleVisualEffect::HostedMediaControlsMaterial:
         return WKHostedMaterialEffectTypeMediaControls;
+    case AppleVisualEffect::HostedThinMediaControlsMaterial:
+        return WKHostedMaterialEffectTypeThinMediaControls;
     case AppleVisualEffect::None:
     case AppleVisualEffect::BlurUltraThinMaterial:
     case AppleVisualEffect::BlurThinMaterial:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8106,6 +8106,7 @@ enum class WebCore::AppleVisualEffect : uint8_t {
     HostedBlurMaterial,
     HostedThinBlurMaterial,
     HostedMediaControlsMaterial,
+    HostedThinMediaControlsMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,


### PR DESCRIPTION
#### 2ffc937fecb7e398edfaa25edacda47c6d8fd16f
<pre>
[Materials] Add support for a more translucent hosted material for media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=290087">https://bugs.webkit.org/show_bug.cgi?id=290087</a>
<a href="https://rdar.apple.com/146127218">rdar://146127218</a>

Reviewed by Abrar Rahman Protyasha.

Introduce support for a hosted material that is more translucent than the one
added in 291405@main.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp:
(WebCore::CSSPropertyParserHelpers::isKeywordValidForAppleVisualEffect):
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop):
(WebCore::appleVisualEffectAppliesFilter):
(WebCore::appleVisualEffectIsHostedMaterial):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(MaterialHostingView.resolvedMaterialEffect(for:)):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::materialVisualStyleForAppleVisualEffect):
(WebKit::materialVisualStyleCategoryForAppleVisualEffect):
(WebKit::hostedMaterialEffectTypeForAppleVisualEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/292436@main">https://commits.webkit.org/292436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44d414bf48870238ab7abab9cc653a5e0d9b3d72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73170 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30396 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103067 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81585 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16383 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28164 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->