### PR TITLE
[JSC] Add MulHigh

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1079,6 +1079,28 @@ public:
         m_assembler.umull(dest, left, right);
     }
 
+    void mulHigh32(RegisterID left, RegisterID right, RegisterID dest)
+    {
+        m_assembler.smull(dest, left, right);
+        m_assembler.asr<64>(dest, dest, 32);
+    }
+
+    void mulHigh64(RegisterID left, RegisterID right, RegisterID dest)
+    {
+        m_assembler.smulh(dest, left, right);
+    }
+
+    void uMulHigh32(RegisterID left, RegisterID right, RegisterID dest)
+    {
+        m_assembler.umull(dest, left, right);
+        m_assembler.lsr<64>(dest, dest, 32);
+    }
+
+    void uMulHigh64(RegisterID left, RegisterID right, RegisterID dest)
+    {
+        m_assembler.umulh(dest, left, right);
+    }
+
     void div32(RegisterID dividend, RegisterID divisor, RegisterID dest)
     {
         m_assembler.sdiv<32>(dest, dividend, divisor);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -561,6 +561,34 @@ public:
         m_assembler.imull_i32r(src, imm.m_value, dest);
     }
 
+    void x86MulHigh32(RegisterID src, RegisterID eax, RegisterID edx)
+    {
+        ASSERT_UNUSED(eax, eax == X86Registers::eax);
+        ASSERT_UNUSED(edx, edx == X86Registers::edx);
+        m_assembler.imull_r(src);
+    }
+
+    void x86MulHigh64(RegisterID src, RegisterID eax, RegisterID edx)
+    {
+        ASSERT_UNUSED(eax, eax == X86Registers::eax);
+        ASSERT_UNUSED(edx, edx == X86Registers::edx);
+        m_assembler.imulq_r(src);
+    }
+
+    void x86UMulHigh32(RegisterID src, RegisterID eax, RegisterID edx)
+    {
+        ASSERT_UNUSED(eax, eax == X86Registers::eax);
+        ASSERT_UNUSED(edx, edx == X86Registers::edx);
+        m_assembler.mull_r(src);
+    }
+
+    void x86UMulHigh64(RegisterID src, RegisterID eax, RegisterID edx)
+    {
+        ASSERT_UNUSED(eax, eax == X86Registers::eax);
+        ASSERT_UNUSED(edx, edx == X86Registers::edx);
+        m_assembler.mulq_r(src);
+    }
+
     void x86ConvertToDoubleWord32()
     {
         m_assembler.cdq();

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -506,6 +506,8 @@ private:
         GROUP3_OP_TEST = 0,
         GROUP3_OP_NOT  = 2,
         GROUP3_OP_NEG  = 3,
+        GROUP3_OP_MUL  = 4,
+        GROUP3_OP_IMUL = 5,
         GROUP3_OP_DIV = 6,
         GROUP3_OP_IDIV = 7,
 
@@ -1858,6 +1860,26 @@ public:
     void rolq_CLr(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP2_EvCL, GROUP2_OP_ROL, dst);
+    }
+
+    void mull_r(RegisterID reg)
+    {
+        m_formatter.oneByteOp(OP_GROUP3_Ev, GROUP3_OP_MUL, reg);
+    }
+
+    void mulq_r(RegisterID reg)
+    {
+        m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_MUL, reg);
+    }
+
+    void imull_r(RegisterID reg)
+    {
+        m_formatter.oneByteOp(OP_GROUP3_Ev, GROUP3_OP_IMUL, reg);
+    }
+
+    void imulq_r(RegisterID reg)
+    {
+        m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_IMUL, reg);
     }
 
     void imull_rr(RegisterID src, RegisterID dst)

--- a/Source/JavaScriptCore/b3/B3Const32Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const32Value.cpp
@@ -66,6 +66,22 @@ Value* Const32Value::mulConstant(Procedure& proc, const Value* other) const
     return proc.add<Const32Value>(origin(), m_value * other->asInt32());
 }
 
+Value* Const32Value::mulHighConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasInt32())
+        return nullptr;
+    int32_t result = static_cast<int32_t>((static_cast<int64_t>(static_cast<int32_t>(m_value)) * static_cast<int64_t>(static_cast<int32_t>(other->asInt32()))) >> 32);
+    return proc.add<Const32Value>(origin(), result);
+}
+
+Value* Const32Value::uMulHighConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasInt32())
+        return nullptr;
+    uint32_t result = static_cast<uint32_t>((static_cast<uint64_t>(static_cast<uint32_t>(m_value)) * static_cast<uint64_t>(static_cast<uint32_t>(other->asInt32()))) >> 32);
+    return proc.add<Const32Value>(origin(), static_cast<int32_t>(result));
+}
+
 Value* Const32Value::checkAddConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasInt32())

--- a/Source/JavaScriptCore/b3/B3Const32Value.h
+++ b/Source/JavaScriptCore/b3/B3Const32Value.h
@@ -44,6 +44,8 @@ public:
     Value* addConstant(Procedure&, const Value* other) const override;
     Value* subConstant(Procedure&, const Value* other) const override;
     Value* mulConstant(Procedure&, const Value* other) const override;
+    Value* mulHighConstant(Procedure&, const Value* other) const override;
+    Value* uMulHighConstant(Procedure&, const Value* other) const override;
     Value* checkAddConstant(Procedure&, const Value* other) const override;
     Value* checkSubConstant(Procedure&, const Value* other) const override;
     Value* checkMulConstant(Procedure&, const Value* other) const override;

--- a/Source/JavaScriptCore/b3/B3Const64Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const64Value.cpp
@@ -66,6 +66,22 @@ Value* Const64Value::mulConstant(Procedure& proc, const Value* other) const
     return proc.add<Const64Value>(origin(), m_value * other->asInt64());
 }
 
+Value* Const64Value::mulHighConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasInt64())
+        return nullptr;
+    int64_t result = static_cast<int64_t>((static_cast<Int128>(static_cast<int64_t>(m_value)) * static_cast<Int128>(static_cast<int64_t>(other->asInt64()))) >> 64);
+    return proc.add<Const64Value>(origin(), result);
+}
+
+Value* Const64Value::uMulHighConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasInt64())
+        return nullptr;
+    uint64_t result = static_cast<uint64_t>((static_cast<UInt128>(static_cast<uint64_t>(m_value)) * static_cast<UInt128>(static_cast<uint64_t>(other->asInt64()))) >> 64);
+    return proc.add<Const64Value>(origin(), static_cast<int64_t>(result));
+}
+
 Value* Const64Value::checkAddConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasInt64())

--- a/Source/JavaScriptCore/b3/B3Const64Value.h
+++ b/Source/JavaScriptCore/b3/B3Const64Value.h
@@ -44,6 +44,8 @@ public:
     Value* addConstant(Procedure&, const Value* other) const override;
     Value* subConstant(Procedure&, const Value* other) const override;
     Value* mulConstant(Procedure&, const Value* other) const override;
+    Value* mulHighConstant(Procedure&, const Value* other) const override;
+    Value* uMulHighConstant(Procedure&, const Value* other) const override;
     Value* checkAddConstant(Procedure&, const Value* other) const override;
     Value* checkSubConstant(Procedure&, const Value* other) const override;
     Value* checkMulConstant(Procedure&, const Value* other) const override;

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -150,6 +150,12 @@ void printInternal(PrintStream& out, Opcode opcode)
     case Mul:
         out.print("Mul");
         return;
+    case MulHigh:
+        out.print("MulHigh");
+        return;
+    case UMulHigh:
+        out.print("UMulHigh");
+        return;
     case Div:
         out.print("Div");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -90,6 +90,8 @@ enum Opcode : uint8_t {
     UDiv,
     Mod, // All bets are off as to what will happen when you execute this for -2^31%-1 and x%0.
     UMod,
+    MulHigh,
+    UMulHigh,
 
     // Polymorphic negation. Note that we only need this for floating point, since integer negation
     // is exactly like Sub(0, x). But that's not true for floating point. Sub(0, 0) is 0, while

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -210,6 +210,8 @@ public:
             case Add:
             case Sub:
             case Mul:
+            case MulHigh:
+            case UMulHigh:
             case Div:
             case UDiv:
             case Mod:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -329,6 +329,16 @@ Value* Value::mulConstant(Procedure&, const Value*) const
     return nullptr;
 }
 
+Value* Value::mulHighConstant(Procedure&, const Value*) const
+{
+    return nullptr;
+}
+
+Value* Value::uMulHighConstant(Procedure&, const Value*) const
+{
+    return nullptr;
+}
+
 Value* Value::checkAddConstant(Procedure&, const Value*) const
 {
     return nullptr;
@@ -656,6 +666,8 @@ Effects Value::effects() const
     case Add:
     case Sub:
     case Mul:
+    case MulHigh:
+    case UMulHigh:
     case Neg:
     case PurifyNaN:
     case BitAnd:
@@ -909,6 +921,8 @@ ValueKey Value::key() const
     case Add:
     case Sub:
     case Mul:
+    case MulHigh:
+    case UMulHigh:
     case Div:
     case UDiv:
     case Mod:
@@ -1088,6 +1102,8 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case Add:
     case Sub:
     case Mul:
+    case MulHigh:
+    case UMulHigh:
     case Div:
     case UDiv:
     case Mod:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -214,6 +214,8 @@ public:
     virtual Value* addConstant(Procedure&, const Value* other) const;
     virtual Value* subConstant(Procedure&, const Value* other) const;
     virtual Value* mulConstant(Procedure&, const Value* other) const;
+    virtual Value* mulHighConstant(Procedure&, const Value* other) const;
+    virtual Value* uMulHighConstant(Procedure&, const Value* other) const;
     virtual Value* checkAddConstant(Procedure&, const Value* other) const;
     virtual Value* checkSubConstant(Procedure&, const Value* other) const;
     virtual Value* checkMulConstant(Procedure&, const Value* other) const;
@@ -481,6 +483,8 @@ protected:
         case Add:
         case Sub:
         case Mul:
+        case MulHigh:
+        case UMulHigh:
         case Div:
         case UDiv:
         case Mod:
@@ -724,6 +728,8 @@ private:
         case Add:
         case Sub:
         case Mul:
+        case MulHigh:
+        case UMulHigh:
         case Div:
         case UDiv:
         case Mod:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -93,6 +93,8 @@ namespace JSC { namespace B3 {
     case Add: \
     case Sub: \
     case Mul: \
+    case MulHigh: \
+    case UMulHigh: \
     case Div: \
     case UDiv: \
     case Mod: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -90,6 +90,8 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case Add:
     case Sub:
     case Mul:
+    case MulHigh:
+    case UMulHigh:
     case Div:
     case UDiv:
     case Mod:

--- a/Source/JavaScriptCore/b3/air/AirInstInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirInstInlines.h
@@ -322,6 +322,37 @@ inline bool isX86UDiv64Valid(const Inst& inst)
     return isX86DivHelperValid(inst);
 }
 
+inline bool isX86MulHighHelperValid(const Inst& inst)
+{
+#if CPU(X86_64)
+    return inst.args[1] == Tmp(X86Registers::eax)
+        && inst.args[2] == Tmp(X86Registers::edx);
+#else
+    UNUSED_PARAM(inst);
+    return false;
+#endif
+}
+
+inline bool isX86MulHigh32Valid(const Inst& inst)
+{
+    return isX86MulHighHelperValid(inst);
+}
+
+inline bool isX86MulHigh64Valid(const Inst& inst)
+{
+    return isX86MulHighHelperValid(inst);
+}
+
+inline bool isX86UMulHigh32Valid(const Inst& inst)
+{
+    return isX86MulHighHelperValid(inst);
+}
+
+inline bool isX86UMulHigh64Valid(const Inst& inst)
+{
+    return isX86MulHighHelperValid(inst);
+}
+
 inline bool isAtomicStrongCASValid(const Inst& inst)
 {
 #if CPU(X86_64)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -309,6 +309,30 @@ arm64: MultiplySignExtend32 U:G:32, U:G:32, D:G:64
 arm64: MultiplyZeroExtend32 U:G:32, U:G:32, D:G:64
     Tmp, Tmp, Tmp
 
+arm64: MulHigh32 U:G:32, U:G:32, ZD:G:32
+    Tmp, Tmp, Tmp
+
+arm64: UMulHigh32 U:G:32, U:G:32, ZD:G:32
+    Tmp, Tmp, Tmp
+
+arm64: MulHigh64 U:G:64, U:G:64, D:G:64
+    Tmp, Tmp, Tmp
+
+arm64: UMulHigh64 U:G:64, U:G:64, D:G:64
+    Tmp, Tmp, Tmp
+
+x86: X86MulHigh32 U:G:32, UD:G:32, D:G:32
+    Tmp, Tmp*, Tmp*
+
+x86: X86UMulHigh32 U:G:32, UD:G:32, D:G:32
+    Tmp, Tmp*, Tmp*
+
+x86_64: X86MulHigh64 U:G:64, UD:G:64, D:G:64
+    Tmp, Tmp*, Tmp*
+
+x86_64: X86UMulHigh64 U:G:64, UD:G:64, D:G:64
+    Tmp, Tmp*, Tmp*
+
 arm64: Div32 U:G:32, U:G:32, ZD:G:32
     Tmp, Tmp, Tmp
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1391,4 +1391,9 @@ void testSShrCompare64(int64_t);
 void testInt52RoundTripUnary(int32_t);
 void testInt52RoundTripBinary();
 
+void testMulHigh32();
+void testMulHigh64();
+void testUMulHigh32();
+void testUMulHigh64();
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -939,6 +939,10 @@ void run(const TestConfig* config)
             RUN(testVectorFmulByElementFloat());
             RUN(testVectorFmulByElementDouble());
         }
+        RUN(testMulHigh32());
+        RUN(testMulHigh64());
+        RUN(testUMulHigh32());
+        RUN(testUMulHigh64());
     }
 
     Lock lock;


### PR DESCRIPTION
#### a4cc57da7cecacc29d071929c8941b27b906fba2
<pre>
[JSC] Add MulHigh
<a href="https://bugs.webkit.org/show_bug.cgi?id=290088">https://bugs.webkit.org/show_bug.cgi?id=290088</a>
<a href="https://rdar.apple.com/147473808">rdar://147473808</a>

Reviewed by Yijia Huang.

This patch adds MulHigh / UMulHigh B3 opcodes, which is extracting upper
extended bits from binary multiplication. (32bit * 32bit = 64bit, and
64bit&apos;s upper 32bit). This plays a critical role for Div / Mod&apos;s
strength reduction, so we would like to have them in IR explicitly.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::mulHigh32):
(JSC::MacroAssemblerARM64::mulHigh64):
(JSC::MacroAssemblerARM64::uMulHigh32):
(JSC::MacroAssemblerARM64::uMulHigh64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::x86MulHigh32):
(JSC::MacroAssemblerX86_64::x86MulHigh64):
(JSC::MacroAssemblerX86_64::x86UMulHigh32):
(JSC::MacroAssemblerX86_64::x86UMulHigh64):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::mull_r):
(JSC::X86Assembler::mulq_r):
(JSC::X86Assembler::imull_r):
(JSC::X86Assembler::imulq_r):
* Source/JavaScriptCore/b3/B3Const32Value.cpp:
(JSC::B3::Const32Value::mulHighConstant const):
(JSC::B3::Const32Value::uMulHighConstant const):
* Source/JavaScriptCore/b3/B3Const32Value.h:
* Source/JavaScriptCore/b3/B3Const64Value.cpp:
(JSC::B3::Const64Value::mulHighConstant const):
(JSC::B3::Const64Value::uMulHighConstant const):
* Source/JavaScriptCore/b3/B3Const64Value.h:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::mulHighConstant const):
(JSC::B3::Value::uMulHighConstant const):
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirInstInlines.h:
(JSC::B3::Air::isX86MulHighHelperValid):
(JSC::B3::Air::isX86MulHigh32Valid):
(JSC::B3::Air::isX86MulHigh64Valid):
(JSC::B3::Air::isX86UMulHigh32Valid):
(JSC::B3::Air::isX86UMulHigh64Valid):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testMulHigh64):
(testMulHigh32):
(testUMulHigh64):
(testUMulHigh32):

Canonical link: <a href="https://commits.webkit.org/292466@main">https://commits.webkit.org/292466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a4323bd6bb5faf5b61514559de71d935da7000d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46682 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73308 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/30537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4620 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46001 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88830 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103247 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94778 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23224 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82347 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81723 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16585 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23187 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118255 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22846 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->