### PR TITLE
Sync `media-elements/track` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/track-element-src-aborted-load-onerror-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/track-element-src-aborted-load-onerror-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>HTMLTrackElement 'src' attribute changed, load pending, 'error' handler mutates</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#start-the-track-processing-model">
+<link rel="help" href="https://crbug.com/1374341">
+<video></video>
+<script>
+  const video = document.querySelector('video');
+  video.style.visibility = 'collapse';
+  video.setAttribute('crossorigin', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const track = document.createElement('track');
+  track.src = 'x';
+  track.track.mode = 'hidden';
+  video.appendChild(track);
+  track.onerror = () => {
+    for (let i = 0; i < 10; ++i)
+      video.setAttribute('foo' + i, 'bar');
+  };
+  setTimeout(() => {
+    track.src = 'y';
+  }, 0);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/track-element-src-aborted-load-onerror-crash.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-inline.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <video>
     <source src="/media/test.mp4" type="video/mp4">
-    <source src="/media/test.ogv" type="video/ogg">
+    <source src="/media/test.webm" type="video/webm">
 </video>
 <script>
 test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL HTMLTrackElement 'src' attribute changed, load pending assert_unreached: first source should not load Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>HTMLTrackElement 'src' attribute changed, load pending</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#start-the-track-processing-model">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(t => {
+  const track = document.createElement('track');
+  track.onload = t.unreached_func('first source should not load');
+  track.onerror = t.step_func_done();
+  track.src = 'resources/settings.vtt?pipe=trickle(d3600)';
+  track.track.mode = 'hidden';
+  document.querySelector('video').appendChild(track);
+  t.step_timeout(() => {
+    track.src = 'resources/entities.vtt';
+  }, 0);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-remove-insert-ready-state.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-remove-insert-ready-state.html
@@ -5,34 +5,34 @@
 <script src="/resources/testharnessreport.js"></script>
 <video>
     <track src="resources/no-webvtt.vtt" kind="captions" default>
-    <script>
-    async_test(function(t) {
-        var video = document.querySelector('video');
-        video.src = getVideoURI('/media/test');
-        video.oncanplaythrough = t.step_func(canplaythrough);
-
-        function canplaythrough() {
-            video.oncanplaythrough = null;
-            var track = document.querySelector('track');
-
-            // Track should have error as ready state.
-            assert_equals(track.readyState, HTMLTrackElement.ERROR);
-
-            // Remove the video element from body.
-            document.body.removeChild(video);
-
-            // Reset the video src attribute to re-trigger resource selection for tracks.
-            video.src = getVideoURI('/media/test');
-
-            // Append the video element back to the body.
-            document.body.appendChild(video);
-
-            assert_equals(track.readyState, HTMLTrackElement.ERROR);
-
-            video.onplaying = t.step_func_done();
-            video.play();
-            // The video should start playing.
-        }
-    });
-    </script>
 </video>
+<script>
+  async_test(function(t) {
+    var video = document.querySelector('video');
+    video.src = getVideoURI('/media/test');
+    video.oncanplaythrough = t.step_func(canplaythrough);
+
+    function canplaythrough() {
+      video.oncanplaythrough = null;
+      var track = document.querySelector('track');
+
+      // Track should have error as ready state.
+      assert_equals(track.readyState, HTMLTrackElement.ERROR);
+
+      // Remove the video element from body.
+      document.body.removeChild(video);
+
+      // Reset the video src attribute to re-trigger resource selection for tracks.
+      video.src = getVideoURI('/media/test');
+
+      // Append the video element back to the body.
+      document.body.appendChild(video);
+
+      assert_equals(track.readyState, HTMLTrackElement.ERROR);
+
+      video.onplaying = t.step_func_done();
+      video.play();
+      // The video should start playing.
+    }
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/w3c-import.log
@@ -60,6 +60,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-disabled-addcue.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-dom-change.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change-error.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-helpers.js


### PR DESCRIPTION
#### 40a09d41e954f3acc76d329f66ce55edbe858a0d
<pre>
Sync `media-elements/track` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=290090">https://bugs.webkit.org/show_bug.cgi?id=290090</a>
<a href="https://rdar.apple.com/147477594">rdar://147477594</a>

Reviewed by Youenn Fablet.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/11d0a493dc7f9552ce1f99da80bb6e9238a60510">https://github.com/web-platform-tests/wpt/commit/11d0a493dc7f9552ce1f99da80bb6e9238a60510</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/track-element-src-aborted-load-onerror-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-aborted-load.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-remove-insert-ready-state.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/292432@main">https://commits.webkit.org/292432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fd3aafa01b31ea0353403747ec586e7ade99485

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73178 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103074 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81592 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20474 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->