### PR TITLE
[GTK][WPE] Remove invalid flag from Damage

### DIFF
--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
@@ -24,7 +24,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, Math.min(window.innerWidth, 2000), Math.min(window.innerHeight, 2000)]]);
           },
           () => {
@@ -33,7 +32,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, Math.min(window.innerWidth, 2000), Math.min(window.innerHeight, 2000)]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/animations-blur.html
+++ b/LayoutTests/platform/glib/damage/animations-blur.html
@@ -34,8 +34,7 @@
 
       setTimeout(() => {
           var damage = latestFrameDamage();
-          if (!assertValid(damage)
-              || !assertEq(damage.rects.length, 1, "wrong number of damage rects")
+          if (!assertEq(damage.rects.length, 1, "wrong number of damage rects")
               || !assertContains([22, 22, 120, 120], damage.rects[0])) {
               failTest(failure);
               return;

--- a/LayoutTests/platform/glib/damage/basic-propagation-001.html
+++ b/LayoutTests/platform/glib/damage/basic-propagation-001.html
@@ -22,7 +22,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 25, 25]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/basic-propagation-002.html
+++ b/LayoutTests/platform/glib/damage/basic-propagation-002.html
@@ -35,7 +35,6 @@
           () => {
               // Verify damage contains just a bounds of parent rect.
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 25, 25]]);
 
               // Mutate children.
@@ -45,7 +44,6 @@
           () => {
               // Verify only children produced damage.
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[15, 15, 10, 10], [0, 0, 10, 10]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/canvas-webgl.html
+++ b/LayoutTests/platform/glib/damage/canvas-webgl.html
@@ -22,7 +22,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/common.js
+++ b/LayoutTests/platform/glib/damage/common.js
@@ -56,12 +56,6 @@ function assertGt(actual, threshold, failureMessage) {
     return assert(actual > threshold, `${failureMessage}, ${actual} is not greater than ${threshold}`);
 }
 
-function assertValid(damage) {
-    if (!assert(damage, "damage is empty"))
-        return false;
-    return assert(damage.isValid, "damage is invalid");
-}
-
 function assertRectsEq(damageRects, expectedRects) {
     const rectCompareFunction = (a, b) => {
         for (var i = 0; i < 4; i++) {
@@ -169,7 +163,6 @@ function _simplifyDamages(damages) {
 
 function _simplifyDamage(damage) {
     var obj = {
-        isValid: damage.isValid,
         bounds: _simplifyDamageRect(damage.bounds),
         rects: damage.rects.map(r => _simplifyDamageRect(r)),
     };

--- a/LayoutTests/platform/glib/damage/image-as-layer-src-change.html
+++ b/LayoutTests/platform/glib/damage/image-as-layer-src-change.html
@@ -35,7 +35,6 @@
               },
               () => {
                   var damage = latestFrameDamage();
-                  assertValid(damage);
                   assertRectsEq(damage.rects, [[0, 50, 50, 50]]);
               },
               () => {
@@ -43,7 +42,6 @@
               },
               () => {
                   var damage = latestFrameDamage();
-                  assertValid(damage);
                   assertRectsEq(damage.rects, [[0, 50, 50, 50]]);
               },
           ], 0);

--- a/LayoutTests/platform/glib/damage/image-src-change.html
+++ b/LayoutTests/platform/glib/damage/image-src-change.html
@@ -33,7 +33,6 @@
               },
               () => {
                   var damage = latestFrameDamage();
-                  assertValid(damage);
                   assertRectsEq(damage.rects, [[0, 50, 50, 50]]);
               },
               () => {
@@ -41,7 +40,6 @@
               },
               () => {
                   var damage = latestFrameDamage();
-                  assertValid(damage);
                   assertRectsEq(damage.rects, [[0, 50, 50, 50]]);
               },
           ], 0);

--- a/LayoutTests/platform/glib/damage/layer-backdrop-filter.html
+++ b/LayoutTests/platform/glib/damage/layer-backdrop-filter.html
@@ -26,7 +26,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-color-change.html
+++ b/LayoutTests/platform/glib/damage/layer-color-change.html
@@ -27,7 +27,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
           () => {
@@ -35,7 +34,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-downsize-with-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-downsize-with-movement.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50], [60, 60, 10, 10]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-downsize.html
+++ b/LayoutTests/platform/glib/damage/layer-downsize.html
@@ -28,7 +28,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-in-layer-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-in-layer-movement.html
@@ -39,7 +39,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[10, 10, 60, 60], [70, 70, 60, 60]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-movement.html
@@ -29,7 +29,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[10, 10, 50, 50], [60, 60, 50, 50]]);
           },
           () => {
@@ -39,7 +38,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[20, 20, 50, 40], [20, 60, 90, 10], [60, 70, 50, 40]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-opacity-change.html
+++ b/LayoutTests/platform/glib/damage/layer-opacity-change.html
@@ -27,7 +27,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
           () => {
@@ -35,7 +34,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-overlaps-with-opacity.html
+++ b/LayoutTests/platform/glib/damage/layer-overlaps-with-opacity.html
@@ -28,7 +28,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 3], [7, 3+3, 50+7, 50-3], [7+7, 3+3+(50-3), 50, 3]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 3], [7, 3+3, 50+7, 50-3], [7+7, 3+3+(50-3), 50, 3]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-resize.html
+++ b/LayoutTests/platform/glib/damage/layer-resize.html
@@ -28,7 +28,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50], [7, 50+3, 40, 10]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-text-change.html
+++ b/LayoutTests/platform/glib/damage/layer-text-change.html
@@ -27,7 +27,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertEq(damage.rects.length, 1, "number of damage rects is not correct");
           },
           () => {
@@ -35,7 +34,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertEq(damage.rects.length, 1, "number of damage rects is not correct");
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-upsize.html
+++ b/LayoutTests/platform/glib/damage/layer-upsize.html
@@ -28,7 +28,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 60, 60]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/layer-visibility-change.html
+++ b/LayoutTests/platform/glib/damage/layer-visibility-change.html
@@ -28,7 +28,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
               damageHistorySizeDuringPreviousFrame = allFramesDamages().length;
           },
@@ -44,7 +43,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
           () => {
@@ -52,7 +50,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // 'display' property invalidates the structure of the document so full damage is issued (due to layout).
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
               damageHistorySizeDuringPreviousFrame = allFramesDamages().length;
@@ -69,7 +66,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[7, 3, 50, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
@@ -21,7 +21,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // We take a 1px margin into account as we cannot avoid it. It was added in:
               // https://github.com/WebKit/WebKit/commit/0e8b2662b634fbd074709ee8ac30b3499c10e081
               assertRectsEq(damage.rects, [[4, 4, 12, 12]]);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-downsizing.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-downsizing.html
@@ -25,7 +25,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // The expected area that changed on the screen is the union of canvas rect with old size and new size.
               assertRectsEq(damage.rects, [[0, 0, 50, 50]]);
           },

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
@@ -27,7 +27,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[26, 26, 12, 12]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
@@ -20,7 +20,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 50, 50]]);
           },
           () => {
@@ -30,7 +29,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 50, 50]]);
           },
           () => {
@@ -41,7 +39,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 11, 11], [19, 19, 12, 12]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-new-canvas.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-new-canvas.html
@@ -17,7 +17,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // Height is 54 as in case of block, the RenderBox adds extra 2+2.
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, 54]]);
           },

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
@@ -26,7 +26,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[9, 9, 32, 32]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[9, 9, 7, 7]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-resizing.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-resizing.html
@@ -25,7 +25,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // The expected area that changed on the screen is the union of canvas rect with old size and new size.
               assertRectsEq(damage.rects, [[0, 0, 55, 45], [0, 45, 50, 5]]);
           },

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-text.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-text.html
@@ -20,7 +20,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               if (assert(damage.rects.length == 1, "Expected exactly one rect")) {
                   // Checking only X coord not to make test case too sensitive.
                   assertGt(damage.rects[0][0], 0, "The damage rect's X coord is incorrect");

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-upsizing.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-upsizing.html
@@ -25,7 +25,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 55, 55]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-container-001.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-001.html
@@ -34,7 +34,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[17, 17, 100, 100]]);
           },
           () => {
@@ -42,7 +41,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[17, 17, 100, 100]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-container-002.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-002.html
@@ -34,7 +34,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[17, 17, 100, 100]]);
           },
           () => {
@@ -42,7 +41,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[17, 17, 100, 100]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-container-003.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-003.html
@@ -39,7 +39,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 113, 100, 100]]);
           },
           () => {
@@ -47,7 +46,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 113, 100, 100]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-container-004.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-004.html
@@ -42,7 +42,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 113, 100, 100]]);
           },
           () => {
@@ -50,7 +49,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 113, 100, 100]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-fullscreen-001.html
+++ b/LayoutTests/platform/glib/damage/scrolling-fullscreen-001.html
@@ -17,7 +17,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertContains(damage.bounds, [0, 0, window.innerWidth, window.innerHeight]);
           },
           () => {
@@ -25,7 +24,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertContains(damage.bounds, [0, 0, window.innerWidth, window.innerHeight]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-fullscreen-002.html
+++ b/LayoutTests/platform/glib/damage/scrolling-fullscreen-002.html
@@ -17,7 +17,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
           },
           () => {
@@ -25,7 +24,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/scrolling-fullscreen-003.html
+++ b/LayoutTests/platform/glib/damage/scrolling-fullscreen-003.html
@@ -22,7 +22,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
           },
           () => {
@@ -30,7 +29,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, window.innerWidth, window.innerHeight]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html
+++ b/LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html
@@ -25,7 +25,6 @@
           () => {
               // Excpect the same rects yet with 1px margin each.
               var damage = latestFrameDamage();
-              assertValid(damage);
               var expectedRects = [];
               for (let i = 0; i < mergingThreshold; i++) {
                   expectedRects.push([(i % 25) * 4, Math.floor(i / 25) * 4, 3, 3]);
@@ -42,7 +41,6 @@
               // Expect the single damage rectangle being a minimum bounding rectangle containg
               // all the small rects (taking 1px margin for each into account).
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[0, 0, 99, 7]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-2d-rotate.html
+++ b/LayoutTests/platform/glib/damage/transform-2d-rotate.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[27, 78, 70, 70]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               // (64*sqrt(2)-64)/2 ~= 13.254833995939045
               assertRectsEq(damage.rects, [[30-14, 81-14, 64+14+14, 64+14+14]]);
           },

--- a/LayoutTests/platform/glib/damage/transform-2d-scale.html
+++ b/LayoutTests/platform/glib/damage/transform-2d-scale.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16, 81+16, 32, 32]]);
           },
           () => {
@@ -46,7 +44,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16+8, 81+16+8, 16, 16]]);
           },
           () => {
@@ -54,7 +51,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16, 81+16, 32, 32]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-2d-skew.html
+++ b/LayoutTests/platform/glib/damage/transform-2d-skew.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[3, 81, 118, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[3, 81, 118, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-2d-translate.html
+++ b/LayoutTests/platform/glib/damage/transform-2d-translate.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 67, 50+25, 50]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+25, 67, 50+12, 50]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-dynamic-addition.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-dynamic-addition.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64+20, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[50, 81, 64+20, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-dynamic-re-addition.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-dynamic-re-addition.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64+20, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64+20, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-dynamic-removal.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-dynamic-removal.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64+20, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-rotate-1-axis.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-rotate-1-axis.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[39, 81, 46, 64]]);
           },
           () => {
@@ -46,7 +44,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[39, 81, 46, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes-content-update.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes-content-update.html
@@ -40,7 +40,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[47, 91, 30, 44]]);
           },
           () => {
@@ -48,7 +47,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[47, 91, 30, 44]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[25, 73, 74, 80]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[25, 73, 74, 80], [30, 70, 64, 3], [30, 153, 64, 3]]);
           },
           () => {
@@ -46,7 +44,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[25, 73, 74, 80], [30, 70, 64, 3], [30, 153, 64, 3]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-rotate-in-still-rotate.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-rotate-in-still-rotate.html
@@ -40,7 +40,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[54, 102, 16, 22]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-scale.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-scale.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16, 81+16, 32, 32]]);
           },
           () => {
@@ -46,7 +44,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16+8, 81+16+8, 16, 16]]);
           },
           () => {
@@ -54,7 +51,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30+16, 81+16, 32, 32]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective-content-update.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective-content-update.html
@@ -40,7 +40,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[51, 102, 22, 22]]);
           },
           () => {
@@ -48,7 +47,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[51, 102, 22, 22]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[40, 91, 44, 44]]);
           },
           () => {
@@ -46,7 +44,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[40, 91, 44, 44]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/transform-3d-translate.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-translate.html
@@ -30,7 +30,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[30, 81, 64+20, 64]]);
           },
           () => {
@@ -38,7 +37,6 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertValid(damage);
               assertRectsEq(damage.rects, [[50, 81, 64+20, 64]]);
           },
       ], 0);

--- a/LayoutTests/platform/glib/damage/video.html
+++ b/LayoutTests/platform/glib/damage/video.html
@@ -12,8 +12,7 @@
       var video = document.getElementsByTagName("video")[0];
       video.ontimeupdate = () => {
           var damage = latestFrameDamage();
-          if (!assertValid(damage)
-              || !assertRectsEq(damage.rects, [[0, 0, 160, 120]]))
+          if (!assertRectsEq(damage.rects, [[0, 0, 160, 120]]))
               failTest(failure);
           else
               passTest();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -114,8 +114,8 @@ public:
     Ref<TextureMapperGPUBuffer> acquireBufferFromPool(size_t, TextureMapperGPUBuffer::Type);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setDamage(const Damage& damage) { m_damage = damage; }
-    const Damage& damage() const { return m_damage; }
+    void setDamage(const std::optional<Damage>& damage) { m_damage = damage; }
+    const std::optional<Damage>& damage() const { return m_damage; }
 #endif
 
 private:
@@ -152,7 +152,7 @@ private:
     TextureMapperGLData* m_data;
     ClipStack m_clipStack;
 #if ENABLE(DAMAGE_TRACKING)
-    Damage m_damage;
+    std::optional<Damage> m_damage;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
@@ -46,13 +46,13 @@ std::unique_ptr<TextureMapperDamageVisualizer> TextureMapperDamageVisualizer::cr
     return nullptr;
 }
 
-void TextureMapperDamageVisualizer::paintDamage(TextureMapper& textureMapper, const Damage& damage) const
+void TextureMapperDamageVisualizer::paintDamage(TextureMapper& textureMapper, const std::optional<Damage>& damage) const
 {
-    if (damage.isInvalid())
+    if (!damage)
         return;
 
     const auto color = Color::red.colorWithAlphaByte(200);
-    for (const auto& rect : damage.rects())
+    for (const auto& rect : damage->rects())
         textureMapper.drawSolidColor(rect + m_margin, { }, color, true);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.h
@@ -43,7 +43,7 @@ public:
     explicit TextureMapperDamageVisualizer(unsigned margin)
         : m_margin(margin) { }
 
-    void paintDamage(TextureMapper&, const Damage&) const;
+    void paintDamage(TextureMapper&, const std::optional<Damage>&) const;
 
 private:
     FloatBoxExtent m_margin;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -386,13 +386,13 @@ Damage& TextureMapperLayer::ensureDamageInGlobalCoordinateSpace()
     return *m_damageInGlobalCoordinateSpace;
 }
 
-void TextureMapperLayer::setDamage(const Damage& damage)
+void TextureMapperLayer::setDamage(Damage&& damage)
 {
     // The damage is added not to override the damage that could be inferred from other set* operations.
     if (m_damageInLayerCoordinateSpace)
         m_damageInLayerCoordinateSpace->add(damage);
     else
-        m_damageInLayerCoordinateSpace = damage;
+        m_damageInLayerCoordinateSpace = WTFMove(damage);
 }
 
 void TextureMapperLayer::collectDamage(TextureMapper& textureMapper, Damage& damage)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -120,7 +120,7 @@ public:
 
 #if ENABLE(DAMAGE_TRACKING)
     void setDamagePropagation(bool enabled) { m_damagePropagation = enabled; }
-    void setDamage(const Damage&);
+    void setDamage(Damage&&);
     void collectDamage(TextureMapper&, Damage&);
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -71,9 +71,10 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
         ASSERT(tile.scale() == m_scale);
         const auto allEdgesExposed = allTileEdgesExposed(layerRect, tile.rect()) ? TextureMapper::AllEdgesExposed::Yes : TextureMapper::AllEdgesExposed::No;
 #if ENABLE(DAMAGE_TRACKING)
+        const auto& frameDamage = textureMapper.damage();
         const auto canUseDamageToDrawTextureFragment = [&]() {
-            return !textureMapper.damage().isInvalid()
-                && !textureMapper.damage().isEmpty()
+            return frameDamage
+                && !frameDamage->isEmpty()
                 && adjustedTransform.isIdentity()
                 && allEdgesExposed == TextureMapper::AllEdgesExposed::No
                 && opacity == 1.0
@@ -84,7 +85,7 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
             // We define damagedTileRect as a minimum bounding rectangle of all damage rects that intersect tile.rect()
             // - this way we can keep a single texture draw call yet with potentially smaller sourceRect.
             FloatRect damagedTileRect;
-            for (const auto& damageRect : textureMapper.damage().rects()) {
+            for (const auto& damageRect : frameDamage->rects()) {
                 if (!damageRect.isEmpty())
                     damagedTileRect.unite(intersection(tile.rect(), damageRect));
             }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -562,8 +562,7 @@ void CoordinatedPlatformLayer::setDirtyRegion(Vector<IntRect, 1>&& dirtyRegion)
 void CoordinatedPlatformLayer::setDamage(Damage&& damage)
 {
     ASSERT(m_lock.isHeld());
-    if (m_damage != damage)
-        m_damage = WTFMove(damage);
+    m_damage = WTFMove(damage);
     m_pendingChanges.add(Change::Damage);
 }
 #endif
@@ -910,7 +909,7 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
 
 #if ENABLE(DAMAGE_TRACKING)
     if (m_pendingChanges.contains(Change::Damage))
-        layer.setDamage(m_damage);
+        layer.setDamage(WTFMove(m_damage));
 #endif
 
     if (m_pendingChanges.contains(Change::Filters))

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7888,11 +7888,9 @@ ExceptionOr<Vector<Internals::FrameDamage>> Internals::getFrameDamageHistory() c
 
     Vector<Internals::FrameDamage> damageDetails;
     size_t sequenceId = 0;
-    for (const auto& [isValid, region] : damageForTesting->damageInformation()) {
+    for (const auto& region : damageForTesting->damageInformation()) {
         FrameDamage details;
         details.sequenceId = sequenceId++;
-
-        details.isValid = isValid;
 
         const auto& regionBounds = region.bounds();
         details.bounds = DOMRectReadOnly::create(regionBounds.x(), regionBounds.y(), regionBounds.width(), regionBounds.height());

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1570,7 +1570,6 @@ public:
     using DamagePropagation = Damage::Propagation;
     struct FrameDamage {
         unsigned sequenceId { 0 };
-        bool isValid { false };
         RefPtr<DOMRectReadOnly> bounds;
         Vector<Ref<DOMRectReadOnly>> rects;
     };

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -491,7 +491,6 @@ enum ContentsFormat {
     JSGenerateToJSObject,
 ] dictionary FrameDamage {
     unsigned long sequenceId;
-    boolean isValid = false;
     DOMRectReadOnly bounds;
     sequence<DOMRectReadOnly> rects;
 };

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -63,7 +63,8 @@ public:
     virtual void didRenderFrame() { }
 
 #if ENABLE(DAMAGE_TRACKING)
-    virtual const WebCore::Damage& addDamage(const WebCore::Damage&) { return WebCore::Damage::invalid(); };
+    virtual const std::optional<WebCore::Damage>& addDamage(WebCore::Damage&&) { return m_frameDamage; }
+    const std::optional<WebCore::Damage>& frameDamage() const { return m_frameDamage; }
 #endif
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
@@ -87,6 +88,9 @@ protected:
     Function<void()> m_frameCompleteHandler;
     WebCore::IntSize m_size;
     std::atomic<bool> m_isOpaque { true };
+#if ENABLE(DAMAGE_TRACKING)
+    std::optional<WebCore::Damage> m_frameDamage;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -91,7 +91,7 @@ private:
     void didRenderFrame() override;
 
 #if ENABLE(DAMAGE_TRACKING)
-    const WebCore::Damage& addDamage(const WebCore::Damage&) override;
+    const std::optional<WebCore::Damage>& addDamage(WebCore::Damage&&) override;
 #endif
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;
@@ -120,8 +120,8 @@ private:
 
         uint64_t id() const { return m_id; }
 #if ENABLE(DAMAGE_TRACKING)
-        const WebCore::Damage& damage() { return m_damage; }
-        void addDamage(const WebCore::Damage&);
+        const std::optional<WebCore::Damage>& damage() { return m_damage; }
+        void addDamage(const std::optional<WebCore::Damage>&);
 #endif
 
         virtual void willRenderFrame();
@@ -141,7 +141,7 @@ private:
         unsigned m_depthStencilBuffer { 0 };
         UnixFileDescriptor m_releaseFenceFD;
 #if ENABLE(DAMAGE_TRACKING)
-        WebCore::Damage m_damage { WebCore::Damage::invalid() };
+        std::optional<WebCore::Damage> m_damage;
 #endif
     };
 
@@ -240,7 +240,7 @@ private:
         void releaseUnusedBuffers();
 
 #if ENABLE(DAMAGE_TRACKING)
-        void addDamage(const WebCore::Damage&);
+        void addDamage(const std::optional<WebCore::Damage>&);
 #endif
 
         unsigned size() const { return m_freeTargets.size() + m_lockedTargets.size(); }
@@ -272,9 +272,6 @@ private:
     RenderTarget* m_target { nullptr };
     bool m_isVisible { false };
     bool m_useExplicitSync { false };
-#if ENABLE(DAMAGE_TRACKING)
-    WebCore::Damage m_frameDamage;
-#endif
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -35,9 +35,35 @@ using namespace WebCore;
 TEST(Damage, Basics)
 {
     Damage damage;
-    EXPECT_FALSE(damage.isInvalid());
     EXPECT_TRUE(damage.isEmpty());
     EXPECT_EQ(damage.rects().size(), 0);
+}
+
+TEST(Damage, Move)
+{
+    Damage damage;
+    damage.add(IntRect { 100, 100, 200, 200 });
+    damage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_FALSE(damage.isEmpty());
+    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.bounds().x(), 100);
+    EXPECT_EQ(damage.bounds().y(), 100);
+    EXPECT_EQ(damage.bounds().width(), 400);
+    EXPECT_EQ(damage.bounds().height(), 400);
+
+    Damage other = WTFMove(damage);
+    EXPECT_FALSE(other.isEmpty());
+    EXPECT_EQ(other.rects().size(), 2);
+    EXPECT_EQ(other.bounds().x(), 100);
+    EXPECT_EQ(other.bounds().y(), 100);
+    EXPECT_EQ(other.bounds().width(), 400);
+    EXPECT_EQ(other.bounds().height(), 400);
+    EXPECT_TRUE(damage.isEmpty());
+    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.bounds().x(), 100);
+    EXPECT_EQ(damage.bounds().y(), 100);
+    EXPECT_EQ(damage.bounds().width(), 400);
+    EXPECT_EQ(damage.bounds().height(), 400);
 }
 
 TEST(Damage, AddRect)
@@ -112,11 +138,6 @@ TEST(Damage, AddDamage)
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
     EXPECT_EQ(damage.bounds().height(), 400);
-
-    // Adding an invalid Damage invalidates the Damage.
-    damage.add(Damage::invalid());
-    EXPECT_TRUE(damage.isInvalid());
-    EXPECT_EQ(damage.rects().size(), 0);
 }
 
 TEST(Damage, Unite)


### PR DESCRIPTION
#### f84fa6a88b80c399fa10ed4b061021cd6c438ab3
<pre>
[GTK][WPE] Remove invalid flag from Damage
<a href="https://bugs.webkit.org/show_bug.cgi?id=290098">https://bugs.webkit.org/show_bug.cgi?id=290098</a>

Reviewed by Alejandro G. Castro.

The invalid flag is very confusing, it&apos;s not clear the difference
between empty and invalid Damage, and it&apos;s used with different meanings
in different places. We can just use std::optional which always means no
damage, so that the way we handle no damage depends on every case.
This patch also tries to avoid copying Damage whenever possible and
removes the method to get a region, since that&apos;s only used by the
FrameDamageHistory and it&apos;s an implementation detail.

* LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html:
* LayoutTests/platform/glib/damage/animations-blur.html:
* LayoutTests/platform/glib/damage/basic-propagation-001.html:
* LayoutTests/platform/glib/damage/basic-propagation-002.html:
* LayoutTests/platform/glib/damage/canvas-webgl.html:
* LayoutTests/platform/glib/damage/common.js:
* LayoutTests/platform/glib/damage/image-as-layer-src-change.html:
* LayoutTests/platform/glib/damage/image-src-change.html:
* LayoutTests/platform/glib/damage/layer-backdrop-filter.html:
* LayoutTests/platform/glib/damage/layer-color-change.html:
* LayoutTests/platform/glib/damage/layer-downsize-with-movement.html:
* LayoutTests/platform/glib/damage/layer-downsize.html:
* LayoutTests/platform/glib/damage/layer-in-layer-movement.html:
* LayoutTests/platform/glib/damage/layer-movement.html:
* LayoutTests/platform/glib/damage/layer-opacity-change.html:
* LayoutTests/platform/glib/damage/layer-overlaps-with-opacity.html:
* LayoutTests/platform/glib/damage/layer-resize.html:
* LayoutTests/platform/glib/damage/layer-text-change.html:
* LayoutTests/platform/glib/damage/layer-upsize.html:
* LayoutTests/platform/glib/damage/layer-visibility-change.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-downsizing.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-new-canvas.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-resizing.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-text.html:
* LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-upsizing.html:
* LayoutTests/platform/glib/damage/scrolling-container-001.html:
* LayoutTests/platform/glib/damage/scrolling-container-002.html:
* LayoutTests/platform/glib/damage/scrolling-container-003.html:
* LayoutTests/platform/glib/damage/scrolling-container-004.html:
* LayoutTests/platform/glib/damage/scrolling-fullscreen-001.html:
* LayoutTests/platform/glib/damage/scrolling-fullscreen-002.html:
* LayoutTests/platform/glib/damage/scrolling-fullscreen-003.html:
* LayoutTests/platform/glib/damage/storage-and-simplification-algorithm.html:
* LayoutTests/platform/glib/damage/transform-2d-rotate.html:
* LayoutTests/platform/glib/damage/transform-2d-scale.html:
* LayoutTests/platform/glib/damage/transform-2d-skew.html:
* LayoutTests/platform/glib/damage/transform-2d-translate.html:
* LayoutTests/platform/glib/damage/transform-3d-dynamic-addition.html:
* LayoutTests/platform/glib/damage/transform-3d-dynamic-re-addition.html:
* LayoutTests/platform/glib/damage/transform-3d-dynamic-removal.html:
* LayoutTests/platform/glib/damage/transform-3d-rotate-1-axis.html:
* LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes-content-update.html:
* LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes.html:
* LayoutTests/platform/glib/damage/transform-3d-rotate-in-still-rotate.html:
* LayoutTests/platform/glib/damage/transform-3d-scale.html:
* LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective-content-update.html:
* LayoutTests/platform/glib/damage/transform-3d-translate-w-perspective.html:
* LayoutTests/platform/glib/damage/transform-3d-translate.html:
* LayoutTests/platform/glib/damage/video.html:
* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::isEmpty const):
(WebCore::Damage::add):
(WebCore::FrameDamageHistory::damageInformation const):
(WebCore::FrameDamageHistory::addDamage):
(WebCore::operator&lt;&lt;):
(WebCore::Damage::invalid): Deleted.
(WebCore::Damage::region const): Deleted.
(WebCore::Damage::isInvalid const): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
(WebCore::TextureMapper::setDamage):
(WebCore::TextureMapper::damage const):
* Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp:
(WebCore::TextureMapperDamageVisualizer::paintDamage const):
* Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::setDamage):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getFrameDamageHistory const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::addDamage):
(WebKit::AcceleratedSurface::frameDamage const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::addDamage):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::addDamage):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::addDamage):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, Basics)):
(TestWebKitAPI::TEST(Damage, AddDamage)):

Canonical link: <a href="https://commits.webkit.org/292420@main">https://commits.webkit.org/292420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b66e3257ab3e211f546078c25a4172248ff6a628

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23082 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81614 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16430 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15448 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23045 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22704 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->