### PR TITLE
[GTK][WPE] Add a mode enum to Damage

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -552,7 +552,10 @@ void TextureMapperLayer::collectDamageSelfChildrenFilterAndMask(TextureMapperPai
 
 void TextureMapperLayer::damageWholeLayer()
 {
-    ensureDamageInLayerCoordinateSpace().add(layerRect());
+    // FIXME: this will be simply changing the mode when we create damage with the layer size.
+    auto& damage = ensureDamageInLayerCoordinateSpace();
+    damage.resize(layerRect().size());
+    damage.setMode(Damage::Mode::Full);
 }
 
 void TextureMapperLayer::damageWholeLayerIncludingItsRectFromPreviousFrame()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -898,9 +898,12 @@ void GraphicsLayerCoordinated::updateDamage()
         return;
 
     Damage damage;
-    if (m_dirtyRegion.fullRepaint)
+    if (m_dirtyRegion.fullRepaint) {
+        // FIXME: this will be simply changing the mode when we create damage with the layer size.
+        damage.resize(m_size);
+        damage.setMode(Damage::Mode::Full);
         damage.add(FloatRect({ }, m_size));
-    else {
+    } else {
         for (const auto& rect : m_dirtyRegion.rects)
             damage.add(rect);
     }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -264,15 +264,12 @@ void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& mat
     currentRootLayer.prepareForPainting(*m_textureMapper);
     if (m_damagePropagation != Damage::Propagation::None) {
         Damage frameDamage;
+        if (m_damagePropagation == Damage::Propagation::Unified)
+            frameDamage.setMode(Damage::Mode::BoundingBox);
+
         WTFBeginSignpost(this, CollectDamage);
         currentRootLayer.collectDamage(*m_textureMapper, frameDamage);
         WTFEndSignpost(this, CollectDamage);
-
-        if (m_damagePropagation == Damage::Propagation::Unified) {
-            Damage boundsDamage;
-            boundsDamage.add(frameDamage.bounds());
-            frameDamage = WTFMove(boundsDamage);
-        }
 
         if (m_frameDamageHistory)
             m_frameDamageHistory->addDamage(frameDamage);

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -39,6 +39,88 @@ TEST(Damage, Basics)
     EXPECT_EQ(damage.rects().size(), 0);
 }
 
+TEST(Damage, Mode)
+{
+    // Rectangles is the default mode.
+    Damage rectsDamage;
+    rectsDamage.resize(IntSize { 1024, 768 });
+    rectsDamage.add(IntRect { 100, 100, 200, 200 });
+    rectsDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_FALSE(rectsDamage.isEmpty());
+    EXPECT_EQ(rectsDamage.rects().size(), 2);
+    EXPECT_EQ(rectsDamage.bounds().x(), 100);
+    EXPECT_EQ(rectsDamage.bounds().y(), 100);
+    EXPECT_EQ(rectsDamage.bounds().width(), 400);
+    EXPECT_EQ(rectsDamage.bounds().height(), 400);
+
+    // BoundingBox always unite damage in bounds.
+    Damage bboxDamage;
+    bboxDamage.resize(IntSize { 1024, 768 });
+    bboxDamage.setMode(Damage::Mode::BoundingBox);
+    bboxDamage.add(IntRect { 100, 100, 200, 200 });
+    bboxDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_FALSE(bboxDamage.isEmpty());
+    EXPECT_EQ(bboxDamage.rects().size(), 1);
+    EXPECT_EQ(bboxDamage.rects()[0], bboxDamage.bounds());
+    EXPECT_EQ(bboxDamage.bounds().x(), 100);
+    EXPECT_EQ(bboxDamage.bounds().y(), 100);
+    EXPECT_EQ(bboxDamage.bounds().width(), 400);
+    EXPECT_EQ(bboxDamage.bounds().height(), 400);
+
+    // Full ignores any adds and always reports the whole area.
+    Damage fullDamage;
+    fullDamage.resize(IntSize { 1024, 768 });
+    fullDamage.setMode(Damage::Mode::Full);
+    fullDamage.add(IntRect { 100, 100, 200, 200 });
+    fullDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_FALSE(fullDamage.isEmpty());
+    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
+    EXPECT_EQ(fullDamage.bounds().x(), 0);
+    EXPECT_EQ(fullDamage.bounds().y(), 0);
+    EXPECT_EQ(fullDamage.bounds().width(), 1024);
+    EXPECT_EQ(fullDamage.bounds().height(), 768);
+
+    // We can change the existing mode.
+    Damage bboxDamage2 = rectsDamage;
+    bboxDamage2.setMode(Damage::Mode::BoundingBox);
+    EXPECT_FALSE(bboxDamage2.isEmpty());
+    EXPECT_EQ(bboxDamage2.rects().size(), 1);
+    EXPECT_EQ(bboxDamage2.rects()[0], bboxDamage.bounds());
+    EXPECT_EQ(bboxDamage2.bounds().x(), 100);
+    EXPECT_EQ(bboxDamage2.bounds().y(), 100);
+    EXPECT_EQ(bboxDamage2.bounds().width(), 400);
+    EXPECT_EQ(bboxDamage2.bounds().height(), 400);
+
+    Damage fullDamage2 = rectsDamage;
+    fullDamage2.setMode(Damage::Mode::Full);
+    EXPECT_FALSE(fullDamage2.isEmpty());
+    EXPECT_EQ(fullDamage2.rects().size(), 1);
+    EXPECT_EQ(fullDamage2.rects()[0], fullDamage.bounds());
+    EXPECT_EQ(fullDamage2.bounds().x(), 0);
+    EXPECT_EQ(fullDamage2.bounds().y(), 0);
+    EXPECT_EQ(fullDamage2.bounds().width(), 1024);
+    EXPECT_EQ(fullDamage2.bounds().height(), 768);
+
+    Damage rectsDamage2 = bboxDamage;
+    rectsDamage2.setMode(Damage::Mode::Rectangles);
+    EXPECT_FALSE(rectsDamage2.isEmpty());
+    EXPECT_EQ(rectsDamage2.rects().size(), 1);
+    EXPECT_EQ(rectsDamage2.bounds().x(), 100);
+    EXPECT_EQ(rectsDamage2.bounds().y(), 100);
+    EXPECT_EQ(rectsDamage2.bounds().width(), 400);
+    EXPECT_EQ(rectsDamage2.bounds().height(), 400);
+
+    Damage rectsDamage3 = fullDamage;
+    rectsDamage3.setMode(Damage::Mode::Rectangles);
+    EXPECT_FALSE(rectsDamage3.isEmpty());
+    EXPECT_EQ(rectsDamage3.rects().size(), 1);
+    EXPECT_EQ(rectsDamage3.bounds().x(), 0);
+    EXPECT_EQ(rectsDamage3.bounds().y(), 0);
+    EXPECT_EQ(rectsDamage3.bounds().width(), 1024);
+    EXPECT_EQ(rectsDamage3.bounds().height(), 768);
+}
+
 TEST(Damage, Move)
 {
     Damage damage;
@@ -143,7 +225,7 @@ TEST(Damage, AddDamage)
 TEST(Damage, Unite)
 {
     Damage damage;
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add several rects to the first tile.
     damage.add(IntRect { 0, 0, 4, 4 });
@@ -163,7 +245,7 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[0], damage.bounds());
 
     damage = { };
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add several rects to the second tile.
     damage.add(IntRect { 300, 0, 4, 4 });
@@ -184,7 +266,7 @@ TEST(Damage, Unite)
 
 
     damage = { };
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add several rects to the third tile.
     damage.add(IntRect { 0, 300, 4, 4 });
@@ -204,7 +286,7 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[2], damage.bounds());
 
     damage = { };
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add several rects to the fourth tile.
     damage.add(IntRect { 300, 300, 4, 4 });
@@ -225,7 +307,7 @@ TEST(Damage, Unite)
 
 
     damage = { };
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add one rect per tile.
     damage.add(IntRect { 0, 0, 4, 4 });
@@ -258,7 +340,7 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[3].height(), 4);
 
     damage = { };
-    damage.resize({ 512, 512 });
+    damage.resize(IntSize { 512, 512 });
 
     // Add rects with points off the grid area.
     damage.add(IntRect { -2, 0, 4, 4 });
@@ -299,7 +381,7 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[3].height(), 254);
 
     damage = { };
-    damage.resize({ 128, 128 });
+    damage.resize(IntSize { 128, 128 });
 
     // Add several rects and check that unite works for single tile grid.
     damage.add(IntRect { 10, 10, 4, 4 });


### PR DESCRIPTION
#### ac177a35074fd0c9a9d5537147fd5f6e9c4c69f1
<pre>
[GTK][WPE] Add a mode enum to Damage
<a href="https://bugs.webkit.org/show_bug.cgi?id=290108">https://bugs.webkit.org/show_bug.cgi?id=290108</a>

Reviewed by Alejandro G. Castro.

With 3 different modes:
 - Rectangles: that&apos;s the default where rectangles are added.
 - BoundingBox: added rectangles are always united in bounding box.
 - Full: always reports the whole area as the damage.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::Damage):
(WebCore::Damage::resize):
(WebCore::Damage::setMode):
(WebCore::Damage::add):
(WebCore::Damage::shouldAdd const):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::damageWholeLayer):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::updateDamage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, Mode)):
(TestWebKitAPI::TEST(Damage, Unite)):

Canonical link: <a href="https://commits.webkit.org/292581@main">https://commits.webkit.org/292581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ac280cbd4a663670a0e092b7deb570a42a7bc88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73323 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103268 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81735 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3802 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16612 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28363 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->