### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Live Text selection handles are incorrectly positioned in overflow scrollers

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area-expected.txt
@@ -1,0 +1,15 @@
+Verifies that the highlight and handles show up in the correct place when selecting Live Text inside a subscrollable container
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Select text in the image above. This test requires WebKitTestRunner.
+
+PASS selectionRects.length is 1
+PASS UIHelper.rectContainsOtherRect(imageRect, selectionRects[0]) is true
+PASS UIHelper.rectContainsOtherRect(imageRect, startHandleRect) is true
+PASS UIHelper.rectContainsOtherRect(imageRect, endHandleRect) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area.html
+++ b/LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+.scroller {
+    width: 200px;
+    height: 250px;
+    margin: 0 auto;
+    overflow: scroll;
+    border: 1px solid lightgray;
+    padding: 1em;
+}
+
+.tall {
+    width: 1px;
+    height: 500px;
+}
+
+img {
+    width: 100%;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the highlight and handles show up in the correct place when selecting Live Text inside a subscrollable container");
+
+    const image = document.querySelector("img");
+    // Rect centered in the image, rotated by 5 degrees clockwise.
+    const liveTextQuad = {
+        topLeft : new DOMPointReadOnly(0.1837, 0.3269),
+        topRight : new DOMPointReadOnly(0.7814, 0.2746),
+        bottomRight : new DOMPointReadOnly(0.8163, 0.6731),
+        bottomLeft : new DOMPointReadOnly(0.2186, 0.7254),
+    };
+
+    window.internals?.installImageOverlay(image, [
+        {
+            topLeft : liveTextQuad.topLeft,
+            topRight : liveTextQuad.topRight,
+            bottomRight : liveTextQuad.bottomRight,
+            bottomLeft : liveTextQuad.bottomLeft,
+            children: [
+                {
+                    text : "Dice",
+                    topLeft : liveTextQuad.topLeft,
+                    topRight : liveTextQuad.topRight,
+                    bottomRight : liveTextQuad.bottomRight,
+                    bottomLeft : liveTextQuad.bottomLeft
+                }
+            ]
+        }
+    ]);
+
+    await UIHelper.longPressElement(image);
+    await UIHelper.waitForSelectionToAppear();
+
+    imageRect = image.getBoundingClientRect();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+    startHandleRect = await UIHelper.getSelectionStartGrabberViewRect()
+    endHandleRect = await UIHelper.getSelectionEndGrabberViewRect();
+
+    shouldBe("selectionRects.length", "1");
+    shouldBeTrue("UIHelper.rectContainsOtherRect(imageRect, selectionRects[0])");
+    shouldBeTrue("UIHelper.rectContainsOtherRect(imageRect, startHandleRect)");
+    shouldBeTrue("UIHelper.rectContainsOtherRect(imageRect, endHandleRect)");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="description"></div>
+    <div class="scroller">
+        <img src="../../../fast/images/resources/dice.png">
+        <p>Select text in the image above. This test requires WebKitTestRunner.</p>
+        <div class="tall"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1100,6 +1100,13 @@ window.UIHelper = class UIHelper {
         return { x: rect.left + (rect.width / 2), y: rect.top + (rect.height / 2) };
     }
 
+    static rectContainsOtherRect(rect, otherRect) {
+        return rect.left <= otherRect.left
+            && rect.top <= otherRect.top
+            && (rect.left + rect.width) >= (otherRect.left + otherRect.width)
+            && (rect.top + rect.height) >= (otherRect.top + otherRect.height);
+    }
+
     static computeLineBounds(element, firstRunIndex, lastRunIndex = undefined) {
         const range = document.createRange();
         range.selectNodeContents(element);

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
@@ -32,8 +32,16 @@
 #endif
 
 namespace WebCore {
+class FloatQuad;
 class SelectionGeometry;
 }
+
+@class WKTextSelectionRect;
+
+@protocol WKTextSelectionRectDelegate
+- (CGFloat)scaleFactorForSelectionRect:(WKTextSelectionRect *)rect;
+- (WebCore::FloatQuad)selectionRect:(WKTextSelectionRect *)rect convertQuadToSelectionContainer:(const WebCore::FloatQuad&)quad;
+@end
 
 #if PLATFORM(IOS_FAMILY)
 @interface WKTextSelectionRect : UITextSelectionRect
@@ -42,7 +50,7 @@ class SelectionGeometry;
 #endif
 
 - (instancetype)initWithCGRect:(CGRect)rect;
-- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry scaleFactor:(CGFloat)scaleFactor;
+- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry delegate:(id<WKTextSelectionRectDelegate>)delegate;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -30,6 +30,10 @@
 #import <UIKit/UIKit.h>
 #import <wtf/Forward.h>
 
+namespace WebCore {
+class FloatQuad;
+}
+
 @interface UIScrollView (WebKitInternal)
 @property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
 @property (readonly, nonatomic) BOOL _wk_isScrolledBeyondExtents;
@@ -55,6 +59,7 @@
 @interface UIView (WebKitInternal)
 - (void)_wk_collectDescendantsIncludingSelf:(Vector<RetainPtr<UIView>>&)descendants matching:(NS_NOESCAPE BOOL(^)(UIView *))block;
 - (BOOL)_wk_isAncestorOf:(UIView *)view;
+- (WebCore::FloatQuad)_wk_convertQuad:(const WebCore::FloatQuad&)quad toCoordinateSpace:(id<UICoordinateSpace>)destination;
 @property (nonatomic, readonly) UIScrollView *_wk_parentScrollView;
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -30,6 +30,7 @@
 
 #import "UIKitSPI.h"
 #import <WebCore/FloatPoint.h>
+#import <WebCore/FloatQuad.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
@@ -255,6 +256,16 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     while ((nextPresentedController = controller.presentedViewController))
         controller = nextPresentedController;
     return controller.viewIfLoaded.window == self.window ? controller : nil;
+}
+
+- (WebCore::FloatQuad)_wk_convertQuad:(const WebCore::FloatQuad&)quad toCoordinateSpace:(id<UICoordinateSpace>)destination
+{
+    return {
+        [self convertPoint:quad.p1() toCoordinateSpace:destination],
+        [self convertPoint:quad.p2() toCoordinateSpace:destination],
+        [self convertPoint:quad.p3() toCoordinateSpace:destination],
+        [self convertPoint:quad.p4() toCoordinateSpace:destination],
+    };
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -50,6 +50,7 @@
 #import "WKSTextAnimationManager.h"
 #import "WKSTextAnimationSourceDelegate.h"
 #import "WKTextAnimationType.h"
+#import "WKTextSelectionRect.h"
 #import <WebKit/WKActionSheetAssistant.h>
 #import <WebKit/WKAirPlayRoutePicker.h>
 #import <WebKit/WKContactPicker.h>
@@ -671,7 +672,7 @@ struct ImageAnalysisContextMenuActionData {
 
 @end
 
-@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextInput, WKFormAccessoryViewDelegate, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
+@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextInput, WKFormAccessoryViewDelegate, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate, WKTextSelectionRectDelegate
 #if HAVE(CONTACTSUI)
     , WKContactPickerDelegate
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6418,11 +6418,21 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 {
 }
 
-static NSArray<WKTextSelectionRect *> *textSelectionRects(const Vector<WebCore::SelectionGeometry>& rects, CGFloat scaleFactor)
+- (NSArray<WKTextSelectionRect *> *)_textSelectionRects:(const Vector<WebCore::SelectionGeometry>&)rects
 {
-    return createNSArray(rects, [scaleFactor] (auto& rect) {
-        return adoptNS([[WKTextSelectionRect alloc] initWithSelectionGeometry:rect scaleFactor:scaleFactor]);
+    return createNSArray(rects, [&](auto& rect) {
+        return adoptNS([[WKTextSelectionRect alloc] initWithSelectionGeometry:rect delegate:self]);
     }).autorelease();
+}
+
+- (CGFloat)scaleFactorForSelectionRect:(WKTextSelectionRect *)rect
+{
+    return self._contentZoomScale;
+}
+
+- (WebCore::FloatQuad)selectionRect:(WKTextSelectionRect *)rect convertQuadToSelectionContainer:(const WebCore::FloatQuad&)quad
+{
+    return [self _wk_convertQuad:quad toCoordinateSpace:[self _selectionContainerViewInternal]];
 }
 
 - (WebCore::FloatRect)_scaledCaretRectForSelectionStart:(WebCore::FloatRect)caretRect
@@ -6474,7 +6484,7 @@ static NSArray<WKTextSelectionRect *> *textSelectionRects(const Vector<WebCore::
 
     auto caretStartRect = [self _scaledCaretRectForSelectionStart:_page->editorState().visualData->caretRectAtStart];
     auto caretEndRect = [self _scaledCaretRectForSelectionEnd:_page->editorState().visualData->caretRectAtEnd];
-    auto selectionRects = textSelectionRects(_page->editorState().visualData->selectionGeometries, self._contentZoomScale);
+    auto selectionRects = [self _textSelectionRects:_page->editorState().visualData->selectionGeometries];
     auto selectedTextLength = editorState.postLayoutData->selectedTextLength;
 
     _cachedSelectedTextRange = [WKTextRange textRangeWithState:!hasSelection isRange:isRange isEditable:isContentEditable startRect:caretStartRect endRect:caretEndRect selectionRects:selectionRects selectedTextLength:selectedTextLength];
@@ -6526,7 +6536,7 @@ static NSArray<WKTextSelectionRect *> *textSelectionRects(const Vector<WebCore::
     auto isContentEditable = editorState.isContentEditable;
     auto caretStartRect = [self _scaledCaretRectForSelectionStart:unscaledCaretRectAtStart];
     auto caretEndRect = [self _scaledCaretRectForSelectionEnd:unscaledCaretRectAtEnd];
-    auto selectionRects = textSelectionRects(visualData.markedTextRects, self._contentZoomScale);
+    auto selectionRects = [self _textSelectionRects:visualData.markedTextRects];
     auto selectedTextLength = postLayoutData.markedText.length();
     return [WKTextRange textRangeWithState:!hasComposition isRange:isRange isEditable:isContentEditable startRect:caretStartRect endRect:caretEndRect selectionRects:selectionRects selectedTextLength:selectedTextLength];
 }


### PR DESCRIPTION
#### fc97a476c1ba96242447c97545d192d3aa7453ef
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Live Text selection handles are incorrectly positioned in overflow scrollers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290115">https://bugs.webkit.org/show_bug.cgi?id=290115</a>
<a href="https://rdar.apple.com/147430337">rdar://147430337</a>

Reviewed by Abrar Rahman Protyasha.

In order to support rotated text selections for Live Text in images, we make `WKTextSelectionRect`
return custom selection handle info (i.e., a `CGPoint` quad indicating where the selection handles
should be placed relative to the container). Currently, the points that comprise this quad is in
root view coordinates, but with the &quot;Selection Honors Overflow Scrolling&quot; feature enabled, this is
no longer (generally) correct, since the selection container may now be a child compositing view
under the content view.

This incorrect coordinate space causes just the handles of the selection to be terribly offset in
some cases — e.g., when the image with Live Text is inside of a subscrollable container. To fix this
bug, we map the custom selection handle quad into selection container coordinates through a new
`WKTextSelectionRectDelegate` method implemented by `WKContentView`.

See below for more details.

* LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-highlight-for-live-text-in-scrollable-area.html: Added.

Add a layout test to exercise this change, by verifying that selection UI in Live Text is contained
within the image element&apos;s bounds.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.rectContainsOtherRect):
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h:
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm:

Add an optional `WKTextSelectionRectDelegate` argument to the initializer here, which takes the
place of the `scaleFactor` argument. Instead, this new delegate has two methods: one that returns
the current content scale factor (replacing the `_scaleFactor` ivar) and another method to convert
a `FloatQuad` into selection container coordinates, which we use below to fix the bug.

(-[WKTextSelectionRect initWithCGRect:]):
(-[WKTextSelectionRect initWithSelectionGeometry:delegate:]):
(-[WKTextSelectionRect _path]):
(-[WKTextSelectionRect _convertQuadToSelectionContainer:]):
(-[WKTextSelectionRect _customHandleInfo]):

See above for more information.

(-[WKTextSelectionRect initWithSelectionGeometry:scaleFactor:]): Deleted.
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_convertQuad:toCoordinateSpace:]):

Add a helper method to convert a `WebCore::FloatQuad` into the given coordinate space (inspired by
existing UIKit API to convert `CGPoint` / `CGRect` from one coordinate space to another).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _textSelectionRects:]):
(-[WKContentView scaleFactorForSelectionRect:]):
(-[WKContentView selectionRect:convertQuadToSelectionContainer:]):

Implement the new `WKTextSelectionRectDelegate` methods.

(-[WKContentView selectedTextRange]):
(-[WKContentView markedTextRange]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Additionally, make Live Text selections parented in the the enclosing layer of the host image,
rather than being inside the absolutely positioned containers in the UA shadow DOM. This prevents
unnecessarily unparenting/reparenting of the managed text interaction subviews when selecting Live
Text across word or line boundaries.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::sanityCheckCustomHandlePath):
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):

Add some more assertions to sanity check the custom path of the selection handles, and verify that
they&apos;re never so far outside of the bounds of the handle view itself, that they don&apos;t intersect with
the handle view.

Canonical link: <a href="https://commits.webkit.org/292449@main">https://commits.webkit.org/292449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3d57cf2c772cfaa55341861955b405f5edfb8c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45918 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82279 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23104 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->