### PR TITLE
Fine tune StageMode interaction animation

### DIFF
--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -37,9 +37,9 @@ import simd
 @objc(WKStageModeInteractionDriver)
 final public class WKStageModeInteractionDriver: NSObject {
     private let kDragToRotationMultiplier: Float = 3.0
-    private let kPitchSettleAnimationDuration: Double = 0.2
+    private let kPitchSettleAnimationDuration: Double = 0.4
     private let kMaxDecelerationDuration: Double = 2.0
-    private let kDecelerationDampeningFactor: Float = 0.9
+    private let kDecelerationDampeningFactor: Float = 0.95
     private let kOrbitVelocityTerminationThreshold: Float = 0.0001
     
     private var stageModeOperation: WKStageModeOperation = .none
@@ -181,7 +181,7 @@ final public class WKStageModeInteractionDriver: NSObject {
         previousManipulationPose = .identity
         
         // Settle the pitch of the interaction container
-        pitchSettleAnimationController = self.interactionContainer.move(to: initialTargetPose, relativeTo: self.interactionContainer.parent, duration: kPitchSettleAnimationDuration, timingFunction: .easeOut)
+        pitchSettleAnimationController = self.interactionContainer.move(to: initialTargetPose, relativeTo: self.interactionContainer.parent, duration: kPitchSettleAnimationDuration, timingFunction: .cubicBezier(controlPoint1: .init(0.08, 0.6), controlPoint2: .init(0.4, 1.0)))
         subscribeToPitchChanges()
         pitchAnimationCompletionSubscription = self.interactionContainer.scene?.subscribe(to: AnimationEvents.PlaybackCompleted.self, on: self.interactionContainer) { [weak self] _ in
             guard let self else {


### PR DESCRIPTION
#### 4c614fac58149d5bb84b8b695f3ebb66c784d90e
<pre>
Fine tune StageMode interaction animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=290129">https://bugs.webkit.org/show_bug.cgi?id=290129</a>
<a href="https://rdar.apple.com/147529121">rdar://147529121</a>

Reviewed by Ada Chan.

This PR fine tunes the StageMode orbit animation curves such that it looks and feels nice
based on feedback.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.interactionDidEnd):

Canonical link: <a href="https://commits.webkit.org/292450@main">https://commits.webkit.org/292450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f765c68a939fc1df51ab5a873386ba770dc87940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30471 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99096 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/11986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86795 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53586 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11734 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45937 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23160 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81660 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26273 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16516 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23123 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->