### PR TITLE
NEW TEST(292000@main): [macOS iOS Debug] fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html (flaky in EWS)

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -53,7 +53,7 @@
     </script>
 </head>
 <body>
-<div class="top">
+<div class="top"></div>
 <div class="tall"></div>
 <header></header>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7755,5 +7755,3 @@ imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vlr-lt
 imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vrl-ltr-ltr-in-multicol.html [ ImageOnlyFailure ]
 
 webkit.org/b/289986 [ Debug ] imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html [ Crash ]
-
-webkit.org/b/290123 [ Debug ] fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2084,5 +2084,3 @@ imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-s
 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-scrolled-remove-sibling-002.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/289986 [ Debug ] imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html [ Crash ]
-
-webkit.org/b/290123 [ Debug ] fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html [ Failure ]


### PR DESCRIPTION
#### d72280371901d8c7aa6b4ba360aca6f9f20a9798
<pre>
NEW TEST(292000@main): [macOS iOS Debug] fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290123">https://bugs.webkit.org/show_bug.cgi?id=290123</a>
<a href="https://rdar.apple.com/147523562">rdar://147523562</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

In debug builds, `LocalFrameView::paintContents` fills fixed-container color sampling snapshots with
the warning color (`rgb(255, 64, 255)`) instead of leaving the background transparent black. In the
context of this test failure, this debug-only behavior causes the color sampling snapshot to blend
transparent fixed-position content against solid purple.

This subsequently causes the test to fail, since the test is checking that the snapshot finds
transparent colors when performing the fixed-position content snapshot if the fixed-position header
is fully (or almost-fully) transparent.

Fix the bug by avoiding the warning color fill on debug builds if `FixedAndStickyLayersOnly` is set.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:

Drive-by fix: close the `div` tag here (there&apos;s no change in behavior to the test itself).

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Remove failing expectations.

* Source/WebCore/page/LocalFrameView.cpp:

Also take the chance to clean up the code a bit, by adjusting the comments (the warning color is
much closer to purple, not red) and refactoring the code to use early returns per branch in an
immediately-invoked lambda.

(WebCore::LocalFrameView::paintContents):

Canonical link: <a href="https://commits.webkit.org/292462@main">https://commits.webkit.org/292462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/013eb831fb9c10d2a9cbd0423c65c737acb6ec5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45949 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103195 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82302 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20497 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16528 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23135 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->