### PR TITLE
Set model to orbit-fit when setting to StageMode

### DIFF
--- a/LayoutTests/model-element/model-element-entity-transform.html
+++ b/LayoutTests/model-element/model-element-entity-transform.html
@@ -56,12 +56,26 @@ promise_test(async t => {
     assert_equals(model.stageMode, "");
     assert_3d_matrix_is_identity(originalTransform, false);
 
-    model.stageMode = "orbit";
-    assert_equals(model.stageMode, "orbit");
-
-    let scaledTransform = originalTransform.scale(2, 2, 2);
+    let scaledTransform = originalTransform.scale(2000, 2000, 2000);
     model.entityTransform = scaledTransform;
-    assert_3d_matrix_equals(model.entityTransform, originalTransform);
+
+    assert_3d_matrix_equals(model.entityTransform, scaledTransform);
+    model.stageMode = "orbit";
+
+    await new Promise((resolve) => t.step_timeout(resolve, 100));
+
+    assert_equals(model.stageMode, "orbit");
+    assert_3d_matrix_not_equals(model.entityTransform, scaledTransform);
+    assert_3d_matrix_not_equals(model.entityTransform, originalTransform);
+    let orbitFitTransform = model.entityTransform;
+
+    model.stageMode = "none";
+    await new Promise((resolve) => t.step_timeout(resolve, 100));
+
+    assert_equals(model.stageMode, "none");
+    assert_3d_matrix_not_equals(model.entityTransform, scaledTransform);
+    assert_3d_matrix_not_equals(model.entityTransform, originalTransform);
+    assert_3d_matrix_equals(model.entityTransform, orbitFitTransform);
 }, `<model> ignores entityTransform when stagemode is set`);
 
 </script>

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -142,10 +142,11 @@ public:
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
 
-    void computeTransform();
+    void computeTransform(bool);
     void applyEnvironmentMapDataAndRelease();
     void applyStageModeOperationToDriver();
     bool stageModeInteractionInProgress() const;
+    void updateTransformSRT();
 
     WebCore::ModelPlayerIdentifier m_id;
     Ref<IPC::Connection> m_webProcessConnection;

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -101,6 +101,11 @@ public final class WKSRKEntity: NSObject {
         guard let boundingBox = self.boundingBox else { return SIMD3<Float>(0, 0, 0) }
         return boundingBox.center
     }
+    
+    @objc(boundingRadius) public var boundingRadius: Float {
+        guard let boundingBox = self.boundingBox else { return 0.0 }
+        return boundingBox.boundingRadius
+    }
 
     private var boundingBox: BoundingBox? {
         entity.visualBounds(relativeTo: entity)
@@ -363,6 +368,18 @@ public final class WKSRKEntity: NSObject {
     
     @objc(interactionContainerDidRecenterFromTransform:) public func interactionContainerDidRecenter(_ transform: simd_float4x4) {
         entity.setTransformMatrix(transform, relativeTo: nil)
+    }
+    
+    @objc(recenterEntityAtTransform:) public func recenterEntity(at newTransform: WKEntityTransform) {
+        // Apply the scale and translation of the entity separately from the rotation
+        transform = WKEntityTransform(scale: newTransform.scale, rotation: .init(ix: 0, iy: 0, iz: 0, r: 1), translation: newTransform.translation)
+        
+        // The pivot for the orientation may be different from the center of the model's bounding box
+        // As a result, we offset the translation after the rotation has been applied to recenter it
+        let pivotPoint = interactionPivotPoint
+        transform = newTransform
+        let offset = pivotPoint - interactionPivotPoint
+        transform = WKEntityTransform(scale: newTransform.scale, rotation: newTransform.rotation, translation: newTransform.translation + offset)
     }
 }
 

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -50,6 +50,7 @@ typedef struct {
 
 @property (nonatomic, readonly) simd_float3 boundingBoxExtents;
 @property (nonatomic, readonly) simd_float3 boundingBoxCenter;
+@property (nonatomic, readonly) float boundingRadius;
 @property (nonatomic, readonly) simd_float3 interactionPivotPoint;
 @property (nonatomic) WKEntityTransform transform;
 @property (nonatomic) float opacity;
@@ -66,6 +67,7 @@ typedef struct {
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
 - (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform NS_SWIFT_NAME(interactionContainerDidRecenter(_:));
+- (void)recenterEntityAtTransform:(WKEntityTransform)transform NS_SWIFT_NAME(recenterEntity(at:));
 - (void)applyDefaultIBL NS_SWIFT_NAME(applyDefaultIBL());
 @end
 


### PR DESCRIPTION
#### 256e7b32f25c8ce4c6180576dfdb3f6c888b847a
<pre>
Set model to orbit-fit when setting to StageMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=290136">https://bugs.webkit.org/show_bug.cgi?id=290136</a>
<a href="https://rdar.apple.com/146901729">rdar://146901729</a>

Reviewed by Ada Chan.

This PR adjusts the way we calculate the bounding box and center of the model based
on whether it is in StageMode orbit or not. When in orbit, we want to inset the model
based on the bounding sphere instead of the bounding box, such that as we rotate the
model it does not get clipped. Since the model&apos;s entityTransform is read-write when
we transition back to StageMode none, we do not re-compute when we exit StageMode
orbit. We let web developers recompute the transform as they please.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::computeSRT):
- Added a boolean to set either a default rotation (if we just loaded the model or
moved it outside the portal); or reuse the existing rotation of the model
- Also added a separate compute path to use the boundingRadius of the model
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::setHasPortal):
(WebKit::ModelProcessModelPlayerProxy::setStageMode):
- Updated callbacks for computeTransform
* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.boundingRadius):
- Returns bounding radius of the model
(WKSRKEntity.recenterEntity(at:)):
- Recenters the model such that the interaction pivot point is at the center
of the model for orbit fit
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:

Canonical link: <a href="https://commits.webkit.org/292749@main">https://commits.webkit.org/292749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/517d38a13aae42a31460ee885c30ef62efc3b3aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73905 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54241 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104121 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82954 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20702 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4578 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17592 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29206 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->