### PR TITLE
REGRESSION(286164@main): HDR images are washed out if SupportHDRDisplayEnabled is off

### DIFF
--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -134,7 +134,7 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asRGB() const
     if (CGColorSpaceGetModel(colorSpace) != kCGColorSpaceModelRGB)
         return std::nullopt;
 
-    if (!usesStandardRange())
+    if (usesExtendedRange())
         return std::nullopt;
 
     return DestinationColorSpace(colorSpace);
@@ -164,16 +164,6 @@ bool DestinationColorSpace::usesExtendedRange() const
 {
 #if USE(CG)
     return CGColorSpaceUsesExtendedRange(platformColorSpace());
-#else
-    notImplemented();
-    return false;
-#endif
-}
-
-bool DestinationColorSpace::usesRec2100TransferFunctions() const
-{
-#if USE(CG)
-    return CGColorSpaceUsesITUR_2100TF(platformColorSpace());
 #else
     notImplemented();
     return false;

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -66,8 +66,6 @@ public:
     WEBCORE_EXPORT bool supportsOutput() const;
 
     bool usesExtendedRange() const;
-    bool usesRec2100TransferFunctions() const;
-    bool usesStandardRange() const { return !usesExtendedRange() && !usesRec2100TransferFunctions(); }
 
 private:
     PlatformColorSpace m_platformColorSpace;

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -55,7 +55,7 @@ public:
     bool hasAlpha() const;
     std::optional<Color> singlePixelSolidColor() const;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const;
-    Headroom headroom() const;
+    WEBCORE_EXPORT Headroom headroom() const;
 
     void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions);
     void clearSubimages();

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -104,11 +104,6 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(const ShareableBitmapConfigurati
     return adoptRef(new ShareableBitmap(configuration, WTFMove(sharedMemory)));
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image)
-{
-    return createFromImageDraw(image, image.colorSpace());
-}
-
 RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image, const DestinationColorSpace& colorSpace)
 {
     return createFromImageDraw(image, colorSpace, image.size());

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -139,7 +139,6 @@ public:
 #if USE(CG)
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImagePixels(NativeImage&);
 #endif
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&);
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&);
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&, const IntSize&);
 

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -59,7 +59,7 @@ std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColor
         return colorSpaceAsRGB;
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_SRGB_COLOR_SPACE)
-    return DestinationColorSpace(extendedSRGBColorSpaceRef());
+    return DestinationColorSpace::ExtendedSRGB();
 #else
     return DestinationColorSpace::SRGB();
 #endif

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -163,11 +163,11 @@ protected:
     WEBCORE_EXPORT void appendStateChangeItemIfNecessary();
     FloatRect initialClip() const { return m_initialClip; }
 
+    const DestinationColorSpace& colorSpace() const final { return m_colorSpace; }
+
 private:
     bool hasPlatformContext() const final { return false; }
     PlatformGraphicsContext* platformContext() const final { ASSERT_NOT_REACHED(); return nullptr; }
-
-    const DestinationColorSpace& colorSpace() const final { return m_colorSpace; }
 
 #if USE(CG)
     bool isCALayerContext() const final { return false; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -116,6 +116,7 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
             .logicalSize = size(),
             .resolutionScale = scale(),
             .colorSpace = colorSpace(),
+            .contentsFormat = contentsFormat(),
             .pixelFormat = pixelFormat(),
             .renderingMode = type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated,
             .renderingPurpose = WebCore::RenderingPurpose::LayerBacking,

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/ContentsFormat.h>
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/ImageBufferPixelFormat.h>
@@ -42,6 +43,7 @@ struct RemoteImageBufferSetConfiguration {
     WebCore::FloatSize logicalSize;
     float resolutionScale { 1.0f };
     WebCore::DestinationColorSpace colorSpace { WebCore::DestinationColorSpace::SRGB() };
+    WebCore::ContentsFormat contentsFormat { WebCore::ContentsFormat::RGBA8 };
     WebCore::ImageBufferPixelFormat pixelFormat { WebCore::ImageBufferPixelFormat::BGRA8 };
     WebCore::RenderingMode renderingMode { WebCore::RenderingMode::Unaccelerated };
     WebCore::RenderingPurpose renderingPurpose { WebCore::RenderingPurpose::Unspecified };

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
@@ -28,6 +28,7 @@ header: "RemoteImageBufferSetConfiguration.h"
     WebCore::FloatSize logicalSize;
     float resolutionScale;
     WebCore::DestinationColorSpace colorSpace;
+    WebCore::ContentsFormat contentsFormat;
     WebCore::ImageBufferPixelFormat pixelFormat;
     WebCore::RenderingMode renderingMode;
     WebCore::RenderingPurpose renderingPurpose;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -49,7 +49,7 @@ class RemoteDisplayListRecorderProxy : public WebCore::DisplayList::Recorder {
     WTF_MAKE_TZONE_ALLOCATED(RemoteDisplayListRecorderProxy);
 public:
     RemoteDisplayListRecorderProxy(RemoteImageBufferProxy&, RemoteRenderingBackendProxy&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&);
-    RemoteDisplayListRecorderProxy(RemoteRenderingBackendProxy& , WebCore::RenderingResourceIdentifier, const WebCore::DestinationColorSpace&, WebCore::RenderingMode, const WebCore::FloatRect&, const WebCore::AffineTransform&);
+    RemoteDisplayListRecorderProxy(RemoteRenderingBackendProxy& , WebCore::RenderingResourceIdentifier, const WebCore::DestinationColorSpace&, WebCore::ContentsFormat, WebCore::RenderingMode, const WebCore::FloatRect&, const WebCore::AffineTransform&);
     virtual ~RemoteDisplayListRecorderProxy();
 
     void disconnect();
@@ -166,6 +166,7 @@ private:
     WebCore::RenderingResourceIdentifier m_destinationBufferIdentifier;
     ThreadSafeWeakPtr<RemoteImageBufferProxy> m_imageBuffer;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
+    std::optional<WebCore::ContentsFormat> m_contentsFormat;
     WebCore::RenderingMode m_renderingMode;
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     Lock m_sharedVideoFrameWriterLock;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -277,7 +277,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
     if (m_remoteNeedsConfigurationUpdate) {
         send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_configuration));
 
-        m_displayListRecorder = Ref { *m_remoteRenderingBackendProxy }->createDisplayListRecorder(m_displayListIdentifier, m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat);
+        m_displayListRecorder = Ref { *m_remoteRenderingBackendProxy }->createDisplayListRecorder(m_displayListIdentifier, m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.contentsFormat, m_configuration.pixelFormat);
     }
     m_remoteNeedsConfigurationUpdate = false;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
@@ -33,7 +33,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-std::unique_ptr<RemoteNativeImageBackendProxy> RemoteNativeImageBackendProxy::create(NativeImage& image)
+std::unique_ptr<RemoteNativeImageBackendProxy> RemoteNativeImageBackendProxy::create(NativeImage& image, const DestinationColorSpace& colorSpace)
 {
     RefPtr<ShareableBitmap> bitmap;
     PlatformImagePtr platformImage;
@@ -45,7 +45,7 @@ std::unique_ptr<RemoteNativeImageBackendProxy> RemoteNativeImageBackendProxy::cr
 
     // If we failed to create ShareableBitmap or PlatformImage, fall back to image-draw method.
     if (!platformImage) {
-        bitmap = ShareableBitmap::createFromImageDraw(image);
+        bitmap = ShareableBitmap::createFromImageDraw(image, colorSpace);
         if (bitmap)
             platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
@@ -35,7 +35,7 @@ class RemoteResourceCacheProxy;
 
 class RemoteNativeImageBackendProxy final : public WebCore::NativeImageBackend {
 public:
-    static std::unique_ptr<RemoteNativeImageBackendProxy> create(WebCore::NativeImage&);
+    static std::unique_ptr<RemoteNativeImageBackendProxy> create(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     ~RemoteNativeImageBackendProxy() final;
 
     const WebCore::PlatformImagePtr& platformImage() const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -266,12 +266,12 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
     return imageBuffer;
 }
 
-std::unique_ptr<RemoteDisplayListRecorderProxy> RemoteRenderingBackendProxy::createDisplayListRecorder(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat)
+std::unique_ptr<RemoteDisplayListRecorderProxy> RemoteRenderingBackendProxy::createDisplayListRecorder(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ContentsFormat contentsFormat, ImageBufferPixelFormat pixelFormat)
 {
     ASSERT(WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM));
     ImageBufferParameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
     auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters));
-    return makeUnique<RemoteDisplayListRecorderProxy>(*this, renderingResourceIdentifier, colorSpace, renderingMode, FloatRect { { }, size }, transform);
+    return makeUnique<RemoteDisplayListRecorderProxy>(*this, renderingResourceIdentifier, colorSpace, contentsFormat, renderingMode, FloatRect { { }, size }, transform);
 }
 
 void RemoteRenderingBackendProxy::releaseImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -136,7 +136,7 @@ public:
     Function<bool()> flushImageBuffers();
 #endif
 
-    std::unique_ptr<RemoteDisplayListRecorderProxy> createDisplayListRecorder(WebCore::RenderingResourceIdentifier, const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
+    std::unique_ptr<RemoteDisplayListRecorderProxy> createDisplayListRecorder(WebCore::RenderingResourceIdentifier, const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ContentsFormat, WebCore::ImageBufferPixelFormat);
 
     struct BufferSet {
         RefPtr<WebCore::ImageBuffer> front;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -106,7 +106,7 @@ void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
     }
 }
 
-void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
+void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image, const DestinationColorSpace& colorSpace)
 {
     if (isMainRunLoop())
         WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();
@@ -117,7 +117,7 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
     RemoteNativeImageBackendProxy* backend = dynamicDowncast<RemoteNativeImageBackendProxy>(image.backend());
     std::unique_ptr<RemoteNativeImageBackendProxy> newBackend;
     if (!backend) {
-        newBackend = RemoteNativeImageBackendProxy::create(image);
+        newBackend = RemoteNativeImageBackendProxy::create(image, colorSpace);
         backend = newBackend.get();
     }
     std::optional<ShareableBitmap::Handle> handle;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -57,7 +57,7 @@ public:
     RefPtr<RemoteImageBufferProxy> cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
     void forgetImageBuffer(WebCore::RenderingResourceIdentifier);
 
-    void recordNativeImageUse(WebCore::NativeImage&);
+    void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     void recordFontUse(WebCore::Font&);
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -294,10 +294,10 @@ void PlatformCALayerRemote::ensureBackingStore()
 
 DestinationColorSpace PlatformCALayerRemote::displayColorSpace() const
 {
+#if PLATFORM(IOS_FAMILY)
     if (auto displayColorSpace = contentsFormatExtendedColorSpace(contentsFormat()))
         return displayColorSpace.value();
-
-#if !PLATFORM(IOS_FAMILY)
+#else
     if (auto displayColorSpace = m_context ? m_context->displayColorSpace() : std::nullopt)
         return displayColorSpace.value();
 #endif


### PR DESCRIPTION
#### 0489eb20b522872f7d0a88eb37acb2ff944fb73f
<pre>
REGRESSION(286164@main): HDR images are washed out if SupportHDRDisplayEnabled is off
<a href="https://bugs.webkit.org/show_bug.cgi?id=290061">https://bugs.webkit.org/show_bug.cgi?id=290061</a>
<a href="https://rdar.apple.com/147430003">rdar://147430003</a>

Reviewed by Simon Fraser.

When transferring the NativeImage to GPUProcess through ShareableBitmap the
image colorSpace is used. After 286164@main and if the colorSpace of the image
UsesITUR_2100TF, ShareableBitmapConfiguration::validateColorSpace() will return
ExtendedSRGB.

Drawing an image with ExtendedSRGB backing store on an sRGB destination context
makes the image look as it is washed out.

To fix this regression, a few things needs to be corrected as well.

1. DestinationColorSpace::usesRec2100TransferFunctions() is not the correct to
   check whether an image has HDR contents or not. This function will return
   false for colorSpace ITUR_2020. The image headroom should be used instead.

2. On macOS, CALayer should be created with the colorSpace of the screen. This
   was the behavior before 284617@main.

3. Layer contentsFormat should be propagated to RemoteDisplayListRecorderProxy
   through RemoteImageBufferSetConfiguration.

4. When transferring a NativeImage to GPUProcess and the Headroom of NativeImage
   is greater than 1 and
   a) The layer contentsFormat is RGBA16F, ExtendedSRGB colorSpace will be used.
   b) On iOS, DisplayP3 colorSpace will be used.
   c) Otherwise SRGB colorSpace will be used.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::asRGB const):
(WebCore::DestinationColorSpace::usesRec2100TransferFunctions const): Deleted.
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
(WebCore::DestinationColorSpace::usesStandardRange const): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::validateColorSpace):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h:
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp:
(WebKit::RemoteNativeImageBackendProxy::create):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createDisplayListRecorder):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::displayColorSpace const):

Canonical link: <a href="https://commits.webkit.org/292734@main">https://commits.webkit.org/292734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5d83f5236aef46519b930411c972861a047e5c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24996 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12697 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54190 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/12455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5515 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46782 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104031 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24002 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26967 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17505 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23964 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/23791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->