### PR TITLE
[Testing][GreedyRegAlloc] Rematerialize constants in-place when possible

### DIFF
--- a/JSTests/stress/call-many-constant-args.js
+++ b/JSTests/stress/call-many-constant-args.js
@@ -1,0 +1,38 @@
+let nArgs = 50;
+
+let func = 'function foo(';
+for (let i = 0; i < nArgs - 1; i++)
+    func += `arg${i}, `;
+func += `args${nArgs - 1}) {\n`;
+func += '   return ';
+for (let i = 0; i < nArgs - 1; i++)
+    func += `arg${i} + `;
+func += `args${nArgs - 1};\n`;
+func += '}\n';
+func += 'noInline(foo);\n';
+
+let caller = `
+function bar() {
+   let sum = 0;
+   for (let i = 0; i < 10; i++)
+      sum += foo(
+`;
+for (let i = 0; i < nArgs - 1; i++)
+    caller += `${i}, `;
+caller += `${nArgs - 1});\n`;
+caller += `
+   return sum;
+}
+`;
+
+let main = `
+let sum = 0;
+for (let iters = 0; iters < testLoopCount; iters++)
+   sum += bar();
+sum;
+`
+
+let result = eval(func + caller + main);
+let expected = (nArgs - 1) * (nArgs / 2) * 10 * testLoopCount
+if (result != expected)
+    throw `got ${result} but expected ${expected}`;

--- a/JSTests/stress/out-of-registers.js
+++ b/JSTests/stress/out-of-registers.js
@@ -1,0 +1,21 @@
+function opt(a1, a2) {
+    try {
+        undefined(a1);
+    } catch(e) {}
+    ([1, 2, 3]).copyWithin();
+    function test() {
+        "test" + a2;
+    }
+    for (let i = 0; i < 100; i++) {
+        test("source");
+    }
+    for (let j = 0; j < 100; j++) {
+        try {
+            undefined.asin();
+        } catch(e) {}
+        for (let k = 0; k < 100; k++) {}
+    }
+}
+for (let m = 0; m < 100; m++) {
+    opt(m, opt);
+}

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1784,12 +1784,29 @@ private:
                             }
                         }
                         // If the Tmp holds a constant then we want to rematerialize its
-                        // value rather than loading it from the stack. In order for that
-                        // optimization to kick in, we need to avoid placing the Tmp's stack
-                        // address into the instruction.
-                        if (!Arg::isColdUse(role) && m_useCounts.isConstDef<bank>(AbsoluteTmpMapper<bank>::absoluteIndex(arg.tmp())))
+                        // value rather than loading it from the stack.
+                        unsigned tmpIndex = AbsoluteTmpMapper<bank>::absoluteIndex(arg.tmp());
+                        if (!Arg::isColdUse(role) && m_useCounts.isConstDef<bank>(tmpIndex)) {
+                            int64_t value = m_useCounts.constant<bank>(tmpIndex);
+                            Arg oldArg = arg;
+                            Arg imm;
+                            if (Arg::isValidImmForm(value))
+                                imm = Arg::imm(value);
+                            else
+                                imm = Arg::bigImm(value);
+                            ASSERT(inst.isValidForm());
+                            arg = imm;
+                            if (inst.isValidForm()) {
+                                m_stats[bank].numRematerializeConst++;
+                                dataLogLnIf(verbose(), "Rematerialized (direct imm), arg=", oldArg, ", inst=", inst);
+                                return;
+                            }
+                            // Couldn't insert the immediate into the instruction directly, so undo.
+                            arg = oldArg;
+                            // We can still rematerialize it into a register. In order for that optimization to kick in,
+                            // we need to avoid placing the Tmp's stack address into the instruction.
                             return;
-
+                        }
                         Width spillWidth = m_tmpWidth.requiredWidth(arg.tmp());
                         if (Arg::isAnyDef(role) && width < spillWidth) {
                             // Either there are users of this tmp who will use more than width,


### PR DESCRIPTION
#### c4a73a48b274ecda164e496f99ef55d8e9ad79fc
<pre>
[Testing][GreedyRegAlloc] Rematerialize constants in-place when possible
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/stress/call-many-constant-args.js: Added.
(let.caller):
* JSTests/stress/out-of-registers.js: Added.
(test):
(opt):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a73a48b274ecda164e496f99ef55d8e9ad79fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46626 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24164 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73269 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 25 flakes 104 failures; Uploaded test results; 11 flakes 75 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change; Passed layout tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45961 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88790 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103207 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94738 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81679 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23147 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118215 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22806 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->