### PR TITLE
Crash after calling browser.scripting.updateContentScripts().

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -243,25 +243,25 @@ void WebExtensionRegisteredScript::merge(WebExtensionRegisteredScriptParameters&
     if (!parameters.js && m_parameters.js)
         parameters.js = m_parameters.js.value();
 
-    if (!parameters.injectionTime)
+    if (!parameters.injectionTime && m_parameters.injectionTime)
         parameters.injectionTime = m_parameters.injectionTime.value();
 
     if (!parameters.excludeMatchPatterns && m_parameters.excludeMatchPatterns)
         parameters.excludeMatchPatterns = m_parameters.excludeMatchPatterns.value();
 
-    if (!parameters.matchPatterns)
+    if (!parameters.matchPatterns && m_parameters.matchPatterns)
         parameters.matchPatterns = m_parameters.matchPatterns.value();
 
-    if (!parameters.allFrames)
+    if (!parameters.allFrames && m_parameters.allFrames)
         parameters.allFrames = m_parameters.allFrames.value();
 
     if (!parameters.matchParentFrame && m_parameters.matchParentFrame)
         parameters.matchParentFrame = m_parameters.matchParentFrame.value();
 
-    if (!parameters.persistent)
+    if (!parameters.persistent && m_parameters.persistent)
         parameters.persistent = m_parameters.persistent.value();
 
-    if (!parameters.world)
+    if (!parameters.world && m_parameters.world)
         parameters.world = m_parameters.world.value();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -1012,6 +1012,26 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIScripting, UpdateContentScriptsWithMinimalParametersShouldNotCrash)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['script.js'] }])",
+        @"await browser.scripting.updateContentScripts([{ id: '1', allFrames: true }])",
+
+        @"const results = await browser.scripting.getRegisteredContentScripts()",
+        @"browser.test.assertDeepEq(results, [{ id: '1', matches: ['*://localhost/*'], js: ['script.js'], allFrames: true, persistAcrossSessions: true }])",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"script.js": @"document.body.style.backgroundColor = 'red'",
+    };
+
+    Util::loadAndRunExtension(scriptingManifest, resources);
+}
+
 TEST(WKWebExtensionAPIScripting, GetContentScripts)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### f4cc960998d97ca6fcd57602e98562abc35679b8
<pre>
Crash after calling browser.scripting.updateContentScripts().
<a href="https://webkit.org/b/290140">https://webkit.org/b/290140</a>
<a href="https://rdar.apple.com/146812539">rdar://146812539</a>

Reviewed by Brian Weinstein.

We were accessing a std::optional without checking if it has a value first.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::merge): Always check the optionals before
accessing the value.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, UpdateContentScriptsWithMinimalParametersShouldNotCrash)): Added.

Canonical link: <a href="https://commits.webkit.org/292487@main">https://commits.webkit.org/292487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3db33c2374063b0fd17e503e7e613769a0d9af2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46627 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73270 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81680 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16541 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15480 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28303 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->