### PR TITLE
[css-anchor-position-1] Anchor element can establish an anchor scope containing itself

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Can anchor to a name both defined and scoped by the same element
-FAIL Sibling can not anchor into anchor-scope, even when anchor-name present assert_equals: expected "30px" but got "40px"
+PASS Sibling can not anchor into anchor-scope, even when anchor-name present
 PASS anchor-scope:all on common ancestor
 PASS anchor-scope:--a on common ancestor
 PASS anchor-scope:all on sibling

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -747,17 +747,19 @@ static bool firstChildPrecedesSecondChild(const RenderObject* firstChild, const 
     return false;
 }
 
-// Given an anchor element and its anchor names, locate the closest ancestor element
+// Given an anchor element and its anchor names, locate the closest ancestor (*) element
 // that establishes an anchor scope affecting this anchor element, and return the pointer
 // to such element. If no ancestor establishes an anchor scope affecting this anchor,
 // returns nullptr.
-static CheckedPtr<Element> anchorScopeForAnchorElement(const Element& anchorElement, const Vector<ScopedName>& anchorNames)
+// (*): an anchor element can also establish an anchor scope containing itself. In this
+// case, the return value is itself.
+static CheckedPtr<const Element> anchorScopeForAnchorElement(const Element& anchorElement, const Vector<ScopedName>& anchorNames)
 {
     // Precondition: anchorElement is an anchor, which has at least one anchor name.
     ASSERT(!anchorNames.isEmpty());
 
-    // Traverse up the composed tree through each ancestor.
-    for (CheckedPtr currentAncestor = anchorElement.parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
+    // Traverse up the composed tree through itself and each ancestor.
+    for (CheckedPtr<const Element> currentAncestor = &anchorElement; currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
         CheckedPtr currentAncestorStyle = currentAncestor->renderStyle();
         if (!currentAncestorStyle)
             continue;


### PR DESCRIPTION
#### b31aa95e64e1bff3b3dd2d9284579623dfbfbf46
<pre>
[css-anchor-position-1] Anchor element can establish an anchor scope containing itself
<a href="https://rdar.apple.com/146986819">rdar://146986819</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289737">https://bugs.webkit.org/show_bug.cgi?id=289737</a>

Reviewed by Antti Koivisto.

An anchor element can establish an anchor scope containing itself.

Given this document:

&lt;div id=&quot;anchor&quot; style=&quot;anchor-name: --foo; anchor-scope: --foo&quot;&gt;
  &lt;div id=&quot;anchor-positioned&quot; style=&quot;position-anchor: --foo&quot;&gt;&lt;/div&gt;
&lt;/div&gt;

Element #anchor is an anchor named --foo, and also establishes an anchor
scope for its descendants. Therefore #anchor-positioned can access --foo,
which is #anchor. However our current algorithm does not consider #anchor
to be the element establishing an anchor scope for #anchor, because we
only consider ancestors of #anchor.

This patch fixes the anchor scope resolution process by also considering
the anchor itself as the anchor scope before going up the ancestor chain.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorScopeForAnchorElement):

Canonical link: <a href="https://commits.webkit.org/292523@main">https://commits.webkit.org/292523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb7d5df1bf6a9ac8193320219cf5ce4515b5a5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30592 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103332 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82402 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16679 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23268 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->