### PR TITLE
REGRESSION(292403@main): Some tests are flaky failures due to console messages after the test finished

### DIFF
--- a/LayoutTests/fast/css/create-columns-onload-crash.html
+++ b/LayoutTests/fast/css/create-columns-onload-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();

--- a/LayoutTests/fast/events/nested-event-remove-node-crash.html
+++ b/LayoutTests/fast/events/nested-event-remove-node-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/workers/worker-script-error-expected.txt
+++ b/LayoutTests/fast/workers/worker-script-error-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: foo
 Test Worker script error handling functionality. Should print a series of PASS messages, followed with DONE.
 
 PASS: onerror invoked for a script that has invalid syntax.

--- a/LayoutTests/fast/workers/worker-script-error.html
+++ b/LayoutTests/fast/workers/worker-script-error.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <body>
 <p>Test Worker script error handling functionality. Should print a series of PASS messages, followed with DONE.</p>
 <div id=result></div>

--- a/LayoutTests/performance-api/performance-observer-exception-expected.txt
+++ b/LayoutTests/performance-api/performance-observer-exception-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: EXCEPTION MESSAGE IN CALLBACK
 Ensure PerformanceObserver Exceptions are propogated.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/performance-api/performance-observer-exception.html
+++ b/LayoutTests/performance-api/performance-observer-exception.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE HTML>
 <html>
 <head>


### PR DESCRIPTION
#### ceb18ecf5067b52a85aaeddccbc6dd462e1d30bb
<pre>
REGRESSION(292403@main): Some tests are flaky failures due to console messages after the test finished
<a href="https://bugs.webkit.org/show_bug.cgi?id=290120">https://bugs.webkit.org/show_bug.cgi?id=290120</a>

Reviewed by Ryosuke Niwa.

&lt;<a href="https://commits.webkit.org/292403@main">https://commits.webkit.org/292403@main</a>&gt; added
dumpJSConsoleLogInStdErr=true to some tests. Added it to some more
tests.

* LayoutTests/fast/css/create-columns-onload-crash.html:
* LayoutTests/fast/events/nested-event-remove-node-crash.html:
* LayoutTests/fast/workers/worker-script-error-expected.txt:
* LayoutTests/fast/workers/worker-script-error.html:
* LayoutTests/performance-api/performance-observer-exception-expected.txt:
* LayoutTests/performance-api/performance-observer-exception.html:

Canonical link: <a href="https://commits.webkit.org/292524@main">https://commits.webkit.org/292524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04e2f9e8b220d9c755fe86d4a21615c1c67226ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73284 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30502 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99140 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12018 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81695 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16560 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->