### PR TITLE
[JSC][GreedyRegAlloc] Try to rematerialize constants in-place

### DIFF
--- a/JSTests/stress/call-many-constant-args.js
+++ b/JSTests/stress/call-many-constant-args.js
@@ -1,0 +1,38 @@
+let nArgs = 50;
+
+let func = 'function foo(';
+for (let i = 0; i < nArgs - 1; i++)
+    func += `arg${i}, `;
+func += `args${nArgs - 1}) {\n`;
+func += '   return ';
+for (let i = 0; i < nArgs - 1; i++)
+    func += `arg${i} + `;
+func += `args${nArgs - 1};\n`;
+func += '}\n';
+func += 'noInline(foo);\n';
+
+let caller = `
+function bar() {
+   let sum = 0;
+   for (let i = 0; i < 10; i++)
+      sum += foo(
+`;
+for (let i = 0; i < nArgs - 1; i++)
+    caller += `${i}, `;
+caller += `${nArgs - 1});\n`;
+caller += `
+   return sum;
+}
+`;
+
+let main = `
+let sum = 0;
+for (let iters = 0; iters < testLoopCount; iters++)
+   sum += bar();
+sum;
+`
+
+let result = eval(func + caller + main);
+let expected = (nArgs - 1) * (nArgs / 2) * 10 * testLoopCount
+if (result != expected)
+    throw `got ${result} but expected ${expected}`;


### PR DESCRIPTION
#### 02a1d9b70c0c7843547aabe16c0222e3cd587192
<pre>
[JSC][GreedyRegAlloc] Try to rematerialize constants in-place
<a href="https://bugs.webkit.org/show_bug.cgi?id=290150">https://bugs.webkit.org/show_bug.cgi?id=290150</a>
<a href="https://rdar.apple.com/146125985">rdar://146125985</a>

Reviewed by Yusuke Suzuki.

If an instruction has a constant args and the allocator starts to spill,
the register allocator will create an unspillable tmp to rematerialize
the constant into. If the instruction has many such arguments
(e.g. Patch), the register allocator can run out of registers. To avoid
this, it should rematerialize the constant directly into the instruction
when possible (which should be the same cases where the instruction
admits stack, which must be possible, or else stack spills would also
run out of registers).

This is also a potential optimization as it removes an unnecessary
move instruction even at points where registers are available.

* JSTests/stress/call-many-constant-args.js: Added.
(let.caller):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):

Canonical link: <a href="https://commits.webkit.org/292654@main">https://commits.webkit.org/292654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41910f63102a9afba99b1a455386fd3710c26672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45985 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88814 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103231 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94762 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16902 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82325 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81701 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28326 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118239 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22830 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33400 "Found 4 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->