### PR TITLE
[Page color sampling] Improve color sampling stability for fixed containers with visible borders

### DIFF
--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top-expected.txt
@@ -1,0 +1,11 @@
+PASS initialTopColor is "rgb(255, 255, 255)"
+PASS Top color became rgb(238, 238, 238)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+To manually test, scroll this page down; the top sampled color should remain solid white
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+    font-family: system-ui;
+}
+
+header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100px;
+    border-top: rgb(231, 112, 13) solid 3px;
+    border-bottom: lightgray solid 2px;
+    box-sizing: border-box;
+    background: white;
+}
+
+.tall {
+    width: 10px;
+    height: 2000px;
+}
+
+#description {
+    margin-top: 100px;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+async function sampledTopColor() {
+    return (await UIHelper.fixedContainerEdgeColors()).top;
+}
+
+addEventListener("load", async () => {
+    let header = document.querySelector("header");
+    description("To manually test, scroll this page down; the top sampled color should remain solid white");
+
+    await UIHelper.ensurePresentationUpdate();
+    initialTopColor = await sampledTopColor();
+    shouldBeEqualToString("initialTopColor", "rgb(255, 255, 255)");
+
+    while (pageYOffset < 500) {
+        scrollBy(0, 10);
+        const topColor = await sampledTopColor();
+        if (topColor !== "rgb(255, 255, 255)")
+            testFailed(`Unexpected color sample: ${topColor} at offset ${pageYOffset}`);
+    }
+
+    header.style.borderTop = "rgb(238, 238, 238) solid 80px";
+    await UIHelper.waitForFixedContainerEdgeColors({
+        top: "rgb(238, 238, 238)",
+        left: null,
+        right: null,
+        bottom: null
+    });
+    testPassed("Top color became rgb(238, 238, 238)");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <header></header>
+    <p id="description"></p>
+    <div class="tall"></div>
+</body>
+</html>


### PR DESCRIPTION
#### 72ec2a274bb316c8aa64fbac9b8c9bb51ebf099c
<pre>
[Page color sampling] Improve color sampling stability for fixed containers with visible borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=290148">https://bugs.webkit.org/show_bug.cgi?id=290148</a>
<a href="https://rdar.apple.com/147362111">rdar://147362111</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the edge color sampling heuristic to recognize when a fixed-position container near the top,
left, right, or bottom edge has a (thin) visible border facing that edge. Instead of sampling colors
along the border, we push the sampling rect inwards by the border width to capture any predominant
solid colors in the interior of the fixed container.

* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html: Added.

Add a layout test to verify that color sampling &quot;skips&quot; over the solid orange `border-top`, and
returns solid white while scrolling through the page.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/292472@main">https://commits.webkit.org/292472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc100288671dc5b8fbfdeaa4d40f165d81cfca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30512 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99149 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12027 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53630 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82331 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81707 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20506 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26321 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23176 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->