### PR TITLE
[JSC][GreedyRegAlloc] fastTmps should spill as a last resort

### DIFF
--- a/JSTests/stress/fasttmps-cause-out-of-registers.js
+++ b/JSTests/stress/fasttmps-cause-out-of-registers.js
@@ -1,0 +1,22 @@
+//@ runDefault("--useConcurrentJIT=0",  "--thresholdForFTLOptimizeAfterWarmUp=100")
+function opt(a1, a2) {
+    try {
+        undefined(a1);
+    } catch(e) {}
+    ([1, 2, 3]).copyWithin();
+    function test() {
+        "test" + a2;
+    }
+    for (let i = 0; i < 100; i++) {
+        test("source");
+    }
+    for (let j = 0; j < 100; j++) {
+        try {
+            undefined.asin();
+        } catch(e) {}
+        for (let k = 0; k < 100; k++) {}
+    }
+}
+for (let m = 0; m < 100; m++) {
+    opt(m, opt);
+}

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -36,6 +36,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 #define FOR_EACH_REGISTER_ALLOCATOR_STAT(macro) \
     macro(numTmpsIn)                            \
+    macro(numFastTmps)                          \
     macro(numUnspillableTmps)                   \
     macro(numSpillTmps)                         \
     macro(numSplitTmps)                         \


### PR DESCRIPTION
#### 259a8560a7d22a95247c2dadf3c921db7592eb6b
<pre>
[JSC][GreedyRegAlloc] fastTmps should spill as a last resort
<a href="https://bugs.webkit.org/show_bug.cgi?id=290039">https://bugs.webkit.org/show_bug.cgi?id=290039</a>
<a href="https://rdar.apple.com/147419532">rdar://147419532</a>

Reviewed by Yijia Huang.

Rather than marking fastTmps as unspillable, make them
spillable but with a very high spill cost so that they will
be spilled only as a last resort. Otherwise, the register
allocator can run out of registers.

* JSTests/stress/fasttmps-cause-out-of-registers.js: Added.
(test):
(opt):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::TmpData::dump const):
(JSC::B3::Air::Greedy::TmpData::spillCost):
(JSC::B3::Air::Greedy::GreedyAllocator::initSpillCosts):
(JSC::B3::Air::Greedy::GreedyAllocator::addSpillTmpWithInterval):
(JSC::B3::Air::Greedy::GreedyAllocator::tryEvict):
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:

Canonical link: <a href="https://commits.webkit.org/292484@main">https://commits.webkit.org/292484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b444c3b2913079f7bd4a6dabe4a4405ce5509fc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46727 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24255 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86914 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/53686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46053 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88881 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103301 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94829 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23275 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82933 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/81770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26378 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3817 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23238 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118306 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22897 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->