### PR TITLE
AX: Add MessageSource::Accessibility console messages for Web Inspector

### DIFF
--- a/LayoutTests/inspector/console/webcore-logging-expected.txt
+++ b/LayoutTests/inspector/console/webcore-logging-expected.txt
@@ -17,6 +17,8 @@ PASS: Log channel has known source.
 PASS: Log channel disabled by default.
 PASS: Log channel has known source.
 PASS: Log channel disabled by default.
+PASS: Log channel has known source.
+PASS: Log channel disabled by default.
 
 -- Running test case: Console.Logging.InvalidLevel
 PASS: Unknown level: DOES_NOT_EXIST

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -192,6 +192,7 @@ static Protocol::Console::ChannelSource messageSourceValue(MessageSource source)
     case MessageSource::AppCache: return Protocol::Console::ChannelSource::Appcache;
     case MessageSource::Rendering: return Protocol::Console::ChannelSource::Rendering;
     case MessageSource::CSS: return Protocol::Console::ChannelSource::CSS;
+    case MessageSource::Accessibility: return Protocol::Console::ChannelSource::Accessibility;
     case MessageSource::Security: return Protocol::Console::ChannelSource::Security;
     case MessageSource::ContentBlocker: return Protocol::Console::ChannelSource::ContentBlocker;
     case MessageSource::Media: return Protocol::Console::ChannelSource::Media;

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -16,6 +16,7 @@
                 "appcache",
                 "rendering",
                 "css",
+                "accessibility",
                 "security",
                 "content-blocker",
                 "media",

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -83,6 +83,9 @@ static void appendMessagePrefix(StringBuilder& builder, MessageSource source, Me
     case MessageSource::CSS:
         sourceString = "CSS"_s;
         break;
+    case MessageSource::Accessibility:
+        sourceString = "Accessibility"_s;
+        break;
     case MessageSource::Security:
         sourceString = "SECURITY"_s;
         break;

--- a/Source/JavaScriptCore/runtime/ConsoleTypes.h
+++ b/Source/JavaScriptCore/runtime/ConsoleTypes.h
@@ -38,6 +38,7 @@ enum class MessageSource : uint8_t {
     AppCache,
     Rendering,
     CSS,
+    Accessibility,
     Security,
     ContentBlocker,
     Media,

--- a/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
@@ -96,6 +96,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Consol
     addLogChannel(Inspector::Protocol::Console::ChannelSource::Appcache);
     addLogChannel(Inspector::Protocol::Console::ChannelSource::Rendering);
     addLogChannel(Inspector::Protocol::Console::ChannelSource::CSS);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Accessibility);
     addLogChannel(Inspector::Protocol::Console::ChannelSource::Security);
     addLogChannel(Inspector::Protocol::Console::ChannelSource::ContentBlocker);
     addLogChannel(Inspector::Protocol::Console::ChannelSource::Media);

--- a/Source/WebInspectorUI/UserInterface/Models/ConsoleMessage.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ConsoleMessage.js
@@ -106,6 +106,7 @@ WI.ConsoleMessage.MessageSource = {
     Storage: "storage",
     Rendering: "rendering",
     CSS: "css",
+    Accessibility: "accessibility",
     Security: "security",
     Media: "media",
     MediaSource: "mediasource",

--- a/Source/WebInspectorUI/UserInterface/Models/IssueMessage.js
+++ b/Source/WebInspectorUI/UserInterface/Models/IssueMessage.js
@@ -49,6 +49,7 @@ WI.IssueMessage = class IssueMessage extends WI.Object
             break;
 
         case WI.ConsoleMessage.MessageSource.CSS:
+        case WI.ConsoleMessage.MessageSource.Accessibility:
         case WI.ConsoleMessage.MessageSource.XML:
             this._type = WI.IssueMessage.Type.PageIssue;
             break;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -129,6 +129,7 @@ NSString *WebConsoleMessageStorageMessageSource = @"StorageMessageSource";
 NSString *WebConsoleMessageAppCacheMessageSource = @"AppCacheMessageSource";
 NSString *WebConsoleMessageRenderingMessageSource = @"RenderingMessageSource";
 NSString *WebConsoleMessageCSSMessageSource = @"CSSMessageSource";
+NSString *WebConsoleMessageAccessibilityMessageSource = @"AccessibilityMessageSource";
 NSString *WebConsoleMessageSecurityMessageSource = @"SecurityMessageSource";
 NSString *WebConsoleMessageContentBlockerMessageSource = @"ContentBlockerMessageSource";
 NSString *WebConsoleMessageMediaMessageSource = @"MediaMessageSource";
@@ -404,6 +405,8 @@ inline static NSString *stringForMessageSource(MessageSource source)
         return WebConsoleMessageRenderingMessageSource;
     case MessageSource::CSS:
         return WebConsoleMessageCSSMessageSource;
+    case MessageSource::Accessibility:
+        return WebConsoleMessageAccessibilityMessageSource;
     case MessageSource::Security:
         return WebConsoleMessageSecurityMessageSource;
     case MessageSource::ContentBlocker:


### PR DESCRIPTION
#### b9845849e6d9330cf56ca8d9df2665ec6dad16d0
<pre>
AX: Add MessageSource::Accessibility console messages for Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=290157">https://bugs.webkit.org/show_bug.cgi?id=290157</a>

Reviewed by Tyler Wilcock.

To facilitate logging of accessibility-specific author errors (such as aria-hidden set
on a focusable element), this PR adds an &quot;Accessibility&quot; token to MessageSource for Web
Inspector console logging.

Source/JavaScriptCore:

* runtime/ConsoleTypes.h:
* runtime/ConsoleClient.cpp:
(JSC::appendMessagePrefix):
Add `Accessibility` to MessageSource.
* inspector/ConsoleMessage.cpp:
(Inspector::messageSourceValue):
Add `Accessibility` message source.
* inspector/protocol/Console.json:
(&quot;enum&quot; key)
Add &quot;accessibility&quot;.

Source/WebInspectorUI:

* UserInterface/Models/ConsoleMessage.js:
* UserInterface/Models/IssueMessage.js:
(WI.IssueMessage):
Add `Accessibility` message source.

Source/WebKitLegacy/mac:

* WebCoreSupport/WebChromeClient.mm:
(stringForMessageSource):
Add `MessageSource::Accessibility` message source.

Canonical link: <a href="https://commits.webkit.org/292838@main">https://commits.webkit.org/292838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3739ddf2b665b836f0721d7056aa2a77bae41845

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47209 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89916 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104346 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95862 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24315 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83139 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82547 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20770 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4774 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17830 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29434 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119487 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24103 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33546 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->