### PR TITLE
Apply “smart” alignment safety to positioned layout

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7643,6 +7643,7 @@ webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/posi
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-add-no-overflow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-out.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-valid.tentative.html [ ImageOnlyFailure ]
@@ -7655,8 +7656,10 @@ imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anch
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-position-fixed.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-stacked-child.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-stacked-child.tentative.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-stacked-child.html [ ImageOnlyFailure ]
+ imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remove-no-overflow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition.html [ Pass Failure ]
 
 # timeouts

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 20px; right: 10px;" data-offset-x="5">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 20px; right: 10px;" data-offset-x="0">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -20px; right: -10px;" data-offset-x="-20">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 20px; right: 10px;" data-offset-x="5">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 20px; right: 10px;" data-offset-x="0">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -20px; right: -10px;" data-offset-x="-20">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 20px; right: 10px;" data-offset-x="5">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 20px; right: 10px;" data-offset-x="0">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -20px; right: -10px;" data-offset-x="-20">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 20px; right: 10px;" data-offset-x="5">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 20px; right: 10px;" data-offset-x="0">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -20px; right: -10px;" data-offset-x="-20">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="0">
-    <div class="inner" style="width: 95px;"></div>
-  </div>
-</div>
-offsetLeft expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: 10px; right: 20px;" data-offset-x="-20">
-    <div class="inner" style="width: 120px;"></div>
-  </div>
-</div>
-offsetLeft expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="left: -10px; right: -20px;" data-offset-x="-40">
-    <div class="inner" style="width: 160px;"></div>
-  </div>
-</div>
-offsetLeft expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="5">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 5 but got 8
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 20px; bottom: 10px;" data-offset-y="0">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -5
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -20px; bottom: -10px;" data-offset-y="-20">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -35
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-htb-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 10px; bottom: 20px;" data-offset-y="0">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 10px; bottom: 20px;" data-offset-y="-20">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -10px; bottom: -20px;" data-offset-y="-40">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 10px; bottom: 20px;" data-offset-y="0">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 10px; bottom: 20px;" data-offset-y="-20">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -10px; bottom: -20px;" data-offset-y="-40">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-vrl-expected.txt
@@ -12,52 +12,16 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="top: 10px; bottom: 20px;" data-offset-y="0">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -2
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="top: 10px; bottom: 20px;" data-offset-y="-20">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -15
+PASS .item 3
+PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="top: -10px; bottom: -20px;" data-offset-y="-40">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -40 but got -25
+PASS .item 7
 PASS .item 8
 PASS .item 9
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 10px; bottom: 20px;" data-offset-y="0">
-    <div class="inner" style="height: 95px;"></div>
-  </div>
-</div>
-offsetTop expected 0 but got -2
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: 10px; bottom: 20px;" data-offset-y="-20">
-    <div class="inner" style="height: 120px;"></div>
-  </div>
-</div>
-offsetTop expected -20 but got -15
+PASS .item 10
+PASS .item 11
 PASS .item 12
 PASS .item 13
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="top: -10px; bottom: -20px;" data-offset-y="-40">
-    <div class="inner" style="height: 160px;"></div>
-  </div>
-</div>
-offsetTop expected -40 but got -25
+PASS .item 14
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-fallback-transition-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-fallback-transition-behavior-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL anchor-center aligned bottom anchored element overflowing IMCB assert_equals: Positioned using --right fallback expected 100 but got 0
+FAIL anchor-center aligned bottom anchored element overflowing IMCB assert_equals: Positioned using --right fallback expected 100 but got -50
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb.html
@@ -59,7 +59,7 @@
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="20"></div>
+  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="0"></div>
 </div>
 
 <div class="container">
@@ -80,7 +80,7 @@
 <!-- both insets -->
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="30"></div>
+  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="10"></div>
 </div>
 
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl.html
@@ -60,7 +60,7 @@
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="20"></div>
+  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="0"></div>
 </div>
 
 <div class="container">
@@ -81,7 +81,7 @@
 <!-- both insets -->
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="30"></div>
+  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="10"></div>
 </div>
 
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb.html
@@ -61,7 +61,7 @@
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="20"></div>
+  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="0"></div>
 </div>
 
 <div class="container">
@@ -82,7 +82,7 @@
 <!-- both insets -->
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="30"></div>
+  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="10"></div>
 </div>
 
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl.html
@@ -60,7 +60,7 @@
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="20"></div>
+  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="0"></div>
 </div>
 
 <div class="container">
@@ -81,7 +81,7 @@
 <!-- both insets -->
 <div class="container">
   <div class="anchor"></div>
-  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="30"></div>
+  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="10"></div>
 </div>
 
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL anchor-scroll-position-try-013 assert_equals: Anchored element should be at the top of anchor expected 159 but got 259
-PASS anchor-scroll-position-try-013 1
-FAIL anchor-scroll-position-try-013 2 assert_equals: Anchored element should be at the top of anchor expected 119 but got 219
+FAIL anchor-scroll-position-try-013 assert_equals: Anchored element should be at the top of anchor expected 159 but got 209
+FAIL anchor-scroll-position-try-013 1 assert_equals: Anchored element should be at the bottom of anchor expected 159 but got 109
+FAIL anchor-scroll-position-try-013 2 assert_equals: Anchored element should be at the top of anchor expected 119 but got 169
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL anchor-scroll-position-try-014 assert_equals: Anchored element should be at the bottom of anchor expected 44 but got -56
-PASS anchor-scroll-position-try-014 1
-FAIL anchor-scroll-position-try-014 2 assert_equals: Anchored element should be at the bottom of anchor expected 59 but got -41
+FAIL anchor-scroll-position-try-014 assert_equals: Anchored element should be at the bottom of anchor expected 44 but got -6
+FAIL anchor-scroll-position-try-014 1 assert_equals: Anchored element should be at the top of anchor expected 9 but got 59
+FAIL anchor-scroll-position-try-014 2 assert_equals: Anchored element should be at the bottom of anchor expected 59 but got 9
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got -100
-FAIL No successful position, keep flip-block assert_equals: expected 250 but got -50
+FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
 PASS Base position without fallback now successful
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got -100
-FAIL No successful position, keep flip-block assert_equals: expected 250 but got -50
-PASS No successful position, last successful invalidated by position-try-fallbacks change
+FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
+FAIL No successful position, last successful invalidated by position-try-fallbacks change assert_equals: expected -50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Starts rendering with --try
-FAIL No successful position, keep --try assert_equals: expected 250 but got -50
-PASS No successful position, last successful invalidated by @position-try change
+FAIL No successful position, keep --try assert_equals: expected 250 but got 0
+FAIL No successful position, last successful invalidated by @position-try change assert_equals: expected -50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got -100
-FAIL No successful position, keep flip-block assert_equals: expected 250 but got -50
+FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
 PASS Base position without fallback now successful
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got -100
-FAIL No successful position (with intermediate successful), keep flip-block assert_equals: expected 250 but got -50
+FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+FAIL No successful position (with intermediate successful), keep flip-block assert_equals: expected 250 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Offsets for position-area: span-all
-FAIL Offsets for position-area: left span-all assert_equals: Check expected offsetLeft expected -200 but got 0
-FAIL Offsets for position-area: span-left span-all assert_equals: Check expected offsetLeft expected -100 but got 0
+PASS Offsets for position-area: left span-all
+PASS Offsets for position-area: span-left span-all
 PASS Offsets for position-area: span-all center
 PASS Offsets for position-area: span-right span-all
 PASS Offsets for position-area: right span-all

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html
@@ -8,6 +8,9 @@
     position: relative;
     width: 400px;
     height: 400px;
+    margin: 0 auto;
+    border: 2px solid;
+    background: #eee;
   }
   #anchor {
     position: absolute;
@@ -16,12 +19,15 @@
     width: 100px;
     height: 100px;
     anchor-name: --anchor;
+    background: blue;
   }
   #anchored {
     position: absolute;
     align-self: stretch;
     justify-self: stretch;
     position-anchor: --anchor;
+    background: #FA08;
+    outline: 1px solid orange;
   }
 </style>
 <div id="container">
@@ -40,17 +46,17 @@
     }, "Offsets for position-area: " + position_area);
   }
 
-  test_position_area("span-all", {left:0, top:0, width:400, height:400});
+  test_position_area("span-all", {left:-200, top:0, width:600, height:600});
 
-  test_position_area("left span-all", {left:-200, top:0, width:0, height:400});
-  test_position_area("span-left span-all", {left:-100, top:0, width:0, height:400});
-  test_position_area("span-all center", {left:-200, top:0, width:100, height:400});
-  test_position_area("span-right span-all", {left:-200, top:0, width:600, height:400});
-  test_position_area("right span-all", {left:-100, top:0, width:500, height:400});
+  test_position_area("left span-all", {left:-200, top:0, width:0, height:600});
+  test_position_area("span-left span-all", {left:-200, top:0, width:100, height:600});
+  test_position_area("span-all center", {left:-200, top:0, width:100, height:600});
+  test_position_area("span-right span-all", {left:-200, top:0, width:600, height:600});
+  test_position_area("right span-all", {left:-100, top:0, width:500, height:600});
 
-  test_position_area("top span-all", {left:0, top:0, width:400, height:500});
-  test_position_area("span-top span-all", {left:0, top:0, width:400, height:600});
-  test_position_area("center span-all", {left:0, top:500, width:400, height:100});
-  test_position_area("span-bottom span-all", {left:0, top:500, width:400, height:0});
-  test_position_area("bottom span-all", {left:0, top:600, width:400, height:0});
+  test_position_area("top span-all", {left:-200, top:0, width:600, height:500});
+  test_position_area("span-top span-all", {left:-200, top:0, width:600, height:600});
+  test_position_area("center span-all", {left:-200, top:500, width:600, height:100});
+  test_position_area("span-bottom span-all", {left:-200, top:500, width:600, height:100});
+  test_position_area("bottom span-all", {left:-200, top:600, width:600, height:0});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside-expected.txt
@@ -5,7 +5,7 @@ PASS Offsets for position-area: span-left span-all
 PASS Offsets for position-area: span-all center
 PASS Offsets for position-area: span-right span-all
 PASS Offsets for position-area: right span-all
-FAIL Offsets for position-area: top span-all assert_equals: Check expected offsetTop expected -50 but got 0
+PASS Offsets for position-area: top span-all
 PASS Offsets for position-area: span-top span-all
 PASS Offsets for position-area: center span-all
 PASS Offsets for position-area: span-bottom span-all

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html
@@ -8,6 +8,9 @@
     position: relative;
     width: 400px;
     height: 400px;
+    margin: 100px auto;
+    border: 2px solid;
+    background: #eee;
   }
   #anchor {
     position: absolute;
@@ -16,12 +19,15 @@
     width: 100px;
     height: 100px;
     anchor-name: --anchor;
+    background: blue;
   }
   #anchored {
     position: absolute;
     align-self: stretch;
     justify-self: stretch;
     position-anchor: --anchor;
+    background: #FA08;
+    outline: 1px solid orange;
   }
 </style>
 <div id="container">
@@ -40,17 +46,17 @@
     }, "Offsets for position-area: " + position_area);
   }
 
-  test_position_area("span-all", {left:0, top:0, width:400, height:400});
+  test_position_area("span-all", {left:0, top:-50, width:450, height:450});
 
-  test_position_area("left span-all", {left:0, top:0, width:350, height:400});
-  test_position_area("span-left span-all", {left:0, top:0, width:450, height:400});
-  test_position_area("span-all center", {left:350, top:0, width:100, height:400});
-  test_position_area("span-right span-all", {left:350, top:0, width:50, height:400});
-  test_position_area("right span-all", {left:450, top:0, width:0, height:400});
+  test_position_area("left span-all", {left:0, top:-50, width:350, height:450});
+  test_position_area("span-left span-all", {left:0, top:-50, width:450, height:450});
+  test_position_area("span-all center", {left:350, top:-50, width:100, height:450});
+  test_position_area("span-right span-all", {left:350, top:-50, width:100, height:450});
+  test_position_area("right span-all", {left:450, top:-50, width:0, height:450});
 
-  test_position_area("top span-all", {left:0, top:-50, width:400, height:0});
-  test_position_area("span-top span-all", {left:0, top:0, width:400, height:50});
-  test_position_area("center span-all", {left:0, top:-50, width:400, height:100});
-  test_position_area("span-bottom span-all", {left:0, top:-50, width:400, height:450});
-  test_position_area("bottom span-all", {left:0, top:50, width:400, height:350});
+  test_position_area("top span-all", {left:0, top:-50, width:450, height:0});
+  test_position_area("span-top span-all", {left:0, top:-50, width:450, height:100});
+  test_position_area("center span-all", {left:0, top:-50, width:450, height:100});
+  test_position_area("span-bottom span-all", {left:0, top:-50, width:450, height:450});
+  test_position_area("bottom span-all", {left:0, top:50, width:450, height:350});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html
@@ -26,12 +26,17 @@
     position: absolute;
     width: 400px;
     height: 400px;
+    margin: 0 auto;
+    border: 2px solid;
+    background: #eee;
   }
   #anchored {
     position: absolute;
     align-self: stretch;
     justify-self: stretch;
     position-anchor: --anchor;
+    background: #FA08;
+    outline: 1px solid orange;
   }
   #anchor {
     margin-top: 150px;
@@ -39,6 +44,7 @@
     width: 150px;
     height: 75px;
     anchor-name: --anchor;
+    background: blue;
   }
 </style>
 <div id="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt
@@ -52,8 +52,8 @@ PASS Placement: --bottom, --top
 PASS Placement: --bottom, --right, --top
 PASS Placement: --bottom, --right, --left, --top
 PASS Placement: --bottom, --left, --top, --right
-FAIL Placement: --right flip-inline assert_equals: offsetLeft expected 40 but got 350
-FAIL Placement: --bottom flip-block assert_equals: offsetLeft expected 95 but got 350
+FAIL Placement: --right flip-inline assert_equals: offsetLeft expected 40 but got 140
+FAIL Placement: --bottom flip-block assert_equals: offsetLeft expected 95 but got 140
 FAIL Placement: --left flip-start assert_equals: offsetLeft expected 95 but got 40
 FAIL Placement: --left flip-inline, --top assert_equals: offsetLeft expected 95 but got 40
 FAIL Placement: --top flip-block, --left assert_equals: offsetLeft expected 40 but got 95

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallbacks-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallbacks-003-expected.txt
@@ -1,9 +1,9 @@
 
-PASS initial position
-PASS scroll to 100
+FAIL initial position assert_equals: expected -250 but got 0
+FAIL scroll to 100 assert_equals: expected -250 but got 0
 FAIL scroll to 101 assert_equals: expected 250 but got 100
 FAIL scroll back to 100 assert_equals: expected 250 but got 100
-PASS redisplay at 100
+FAIL redisplay at 100 assert_equals: expected -250 but got 0
 FAIL scroll to 299 assert_equals: expected 250 but got 100
 FAIL scroll to 300 assert_equals: expected 250 but got 100
 FAIL scroll back to 0 assert_equals: expected 250 but got 100

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -753,8 +753,6 @@ private:
     ShapeOutsideInfo& ensureShapeOutsideInfo();
     void removeShapeOutsideInfo();
 
-    void computeAnchorCenteredPosition(const PositionedLayoutConstraints&, LogicalExtentComputedValues&) const;
-
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).
     LayoutRect m_frameRect;


### PR DESCRIPTION
#### bcd02c50969fbbfe3fe9442bceb763eeff0e36b1
<pre>
Apply “smart” alignment safety to positioned layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=289911">https://bugs.webkit.org/show_bug.cgi?id=289911</a>
<a href="https://rdar.apple.com/147247286">rdar://147247286</a>

Reviewed by Antti Koivisto.

Implements the latest overflow alignment safety rules for abspos boxes
whose self-alignment is not `normal`, and re-implements `anchor-center`
on top of this new generic abspos alignment code.

Also fixes handling of negative-size `position-area` containing blocks.

See <a href="https://drafts.csswg.org/css-align-3/#auto-safety-position">https://drafts.csswg.org/css-align-3/#auto-safety-position</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-htb-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-default-overflow-vrl-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-htb-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-default-overflow-vrl-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-fallback-transition-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-outside.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-anchor-partially-outside.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallbacks-003-expected.txt:
Update results, correct errors in tests, and colorify for ease of understanding.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::adjustForPositionArea):
Floor CB at zero.

(WebCore::PositionedLayoutConstraints::resolveAlignmentShift const):
(WebCore::PositionedLayoutConstraints::resolveAlignmentValue const):
(WebCore::PositionedLayoutConstraints::resolveAlignmentAdjustment const): Deleted.
(WebCore::PositionedLayoutConstraints::resolveAlignmentPosition const): Deleted.
Add smart alignment safety and fold in align-center handling. Rename methods.

* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::LayoutRange::floorMinEdgeTo):
(WebCore::LayoutRange::floorMaxEdgeTo):
(WebCore::LayoutRange::capMinEdgeTo):
(WebCore::LayoutRange::capMaxEdgeTo):
(WebCore::LayoutRange::sizeFromMinEdge):
(WebCore::LayoutRange::sizeFromMaxEdge):
(WebCore::LayoutRange::floorSizeFromMinEdge):
(WebCore::LayoutRange::floorSizeFromMaxEdge):
Add convenience methods for resizing ranges.

(WebCore::PositionedLayoutConstraints::startIsBefore const):
(WebCore::PositionedLayoutConstraints::isLogicalLeftInlineStart const): Deleted.
Extract writing mode coordinate logic into convenience method.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::removeShapeOutsideInfo):
(WebCore::isObjectAncestorContainerOf): Deleted.
(WebCore::findClosestCommonContainer): Deleted.
(WebCore::RenderBox::computeAnchorCenteredPosition const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
Remove computeAnchorCenteredPosition() in favor of resolveAlignmentShift().

Canonical link: <a href="https://commits.webkit.org/292501@main">https://commits.webkit.org/292501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7992b2ce3eebf148e5af6c86d67e0efe619af002

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73307 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23227 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16916 "Found 2 new test failures: html5lib/generated/run-entities01-write.html inspector/animation/lifecycle-web-animation.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28345 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->