### PR TITLE
[WebInspector] make customizable limit for content resources kept for network page of WebInspector

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3911,6 +3911,19 @@ InspectorAttachmentSide:
     WebKit:
       default: 0
 
+InspectorMaximumResourcesContentSize:
+  type: uint32_t
+  status: embedder
+  defaultValue:
+    WebKitLegacy:
+      default: 200
+    WebKit:
+      "PLATFORM(WPE)": 50
+      default: 200
+    WebCore:
+      "PLATFORM(WPE)": 50
+      default: 200
+
 InspectorStartsAttached:
   type: bool
   status: embedder

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -44,8 +44,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkResourcesData::ResourceData);
 
 using namespace Inspector;
 
-static const size_t maximumResourcesContentSize = 200 * 1000 * 1000; // 200MB
-static const size_t maximumSingleResourceContentSize = 50 * 1000 * 1000; // 50MB
+static const unsigned maximumSingleResourceContentSizeMB = 50; // 50MB
 
 NetworkResourcesData::ResourceData::ResourceData(const String& requestId, const String& loaderId)
     : m_requestId(requestId)
@@ -115,9 +114,9 @@ void NetworkResourcesData::ResourceData::decodeDataToContent()
     }
 }
 
-NetworkResourcesData::NetworkResourcesData()
-    : m_maximumResourcesContentSize(maximumResourcesContentSize)
-    , m_maximumSingleResourceContentSize(maximumSingleResourceContentSize)
+NetworkResourcesData::NetworkResourcesData(uint32_t maximumResourcesContentSize)
+    : m_maximumResourcesContentSize(maximumResourcesContentSize * MB)
+    , m_maximumSingleResourceContentSize(maximumSingleResourceContentSizeMB * MB)
 {
 }
 

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -133,7 +133,7 @@ public:
         WallTime m_responseTimestamp;
     };
 
-    NetworkResourcesData();
+    NetworkResourcesData(uint32_t maximumResourcesContentSize);
     ~NetworkResourcesData();
 
     void resourceCreated(const String& requestId, const String& loaderId, InspectorPageAgent::ResourceType);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -189,12 +189,12 @@ Ref<Inspector::Protocol::Network::WebSocketFrame> buildWebSocketMessage(const We
 
 } // namespace
 
-InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context)
+InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context, uint32_t maximumResourcesContentSize)
     : InspectorAgentBase("Network"_s, context)
     , m_frontendDispatcher(makeUnique<Inspector::NetworkFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::NetworkBackendDispatcher::create(context.backendDispatcher, this))
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_resourcesData(makeUnique<NetworkResourcesData>())
+    , m_resourcesData(makeUnique<NetworkResourcesData>(maximumResourcesContentSize))
 {
 }
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -139,7 +139,7 @@ public:
     void searchInRequest(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::RequestId&, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>&);
 
 protected:
-    InspectorNetworkAgent(WebAgentContext&);
+    InspectorNetworkAgent(WebAgentContext&, uint32_t);
 
     virtual Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*) = 0;
     virtual Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*) = 0;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -45,7 +45,7 @@ using namespace Inspector;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PageNetworkAgent);
 
 PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* client)
-    : InspectorNetworkAgent(context)
+    : InspectorNetworkAgent(context, context.inspectedPage->settings().inspectorMaximumResourcesContentSize())
     , m_inspectedPage(context.inspectedPage)
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     , m_client(client)

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -39,7 +39,7 @@ using namespace Inspector;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerNetworkAgent);
 
 WorkerNetworkAgent::WorkerNetworkAgent(WorkerAgentContext& context)
-    : InspectorNetworkAgent(context)
+    : InspectorNetworkAgent(context, context.globalScope->settingsValues().inspectorMaximumResourcesContentSize)
     , m_globalScope(context.globalScope)
 {
     ASSERT(context.globalScope->isContextThread());


### PR DESCRIPTION
#### fb4a8f7902cf4b439590dc24596ff821bb901509
<pre>
[WebInspector] make customizable limit for content resources kept for network page of WebInspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=290160">https://bugs.webkit.org/show_bug.cgi?id=290160</a>

Reviewed by Adrian Perez de Castro, Michael Catanzaro, and Devin Rousso.

Without this change, `maximumResourcesContentSize` is hardcoded (200MB) in
`NetworkResourcesData`. On system with limited memory (embedded devices) it
would be good to have smaller value (50MB).

This change provides the web preference `InspectorMaximumResourcesContentSize`
which is used to set a different value depending on the platform (50 MB for
WPE and 200MB for the rest).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::NetworkResourcesData):
* Source/WebCore/inspector/NetworkResourcesData.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::InspectorNetworkAgent):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
(WebCore::PageNetworkAgent::PageNetworkAgent):
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp:
(WebCore::WorkerNetworkAgent::WorkerNetworkAgent):

Canonical link: <a href="https://commits.webkit.org/293008@main">https://commits.webkit.org/293008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0042c39d538c34c2f3749a23f782af31eccc487

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74402 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31594 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47656 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90360 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104792 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96307 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24764 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18362 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29894 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119932 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24547 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33662 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->