### PR TITLE
[JSC] Remove more unnecessary exits and checks

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1539,6 +1539,27 @@ private:
                 break;
             }
 
+            case ArithSub: {
+                switch (node->binaryUseKind()) {
+                case Int52RepUse: {
+                    if (shouldCheckOverflow(node->arithMode())) {
+                        auto& leftValue = m_state.forNode(node->child1());
+                        auto& rightValue = m_state.forNode(node->child2());
+                        if (!leftValue.couldBeType(SpecNonInt32AsInt52) && !rightValue.couldBeType(SpecNonInt32AsInt52)) {
+                            node->setArithMode(Arith::Unchecked);
+                            changed = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                default:
+                    break;
+                }
+                break;
+            }
+
             case ArithAdd: {
                 JSValue left = m_state.forNode(node->child1()).value();
                 JSValue right = m_state.forNode(node->child2()).value();
@@ -1566,6 +1587,20 @@ private:
                     }
                     break;
                 }
+
+                case Int52RepUse: {
+                    if (shouldCheckOverflow(node->arithMode())) {
+                        auto& leftValue = m_state.forNode(node->child1());
+                        auto& rightValue = m_state.forNode(node->child2());
+                        if (!leftValue.couldBeType(SpecNonInt32AsInt52) && !rightValue.couldBeType(SpecNonInt32AsInt52)) {
+                            node->setArithMode(Arith::Unchecked);
+                            changed = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+
                 default:
                     break;
                 }

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -186,18 +186,18 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         return Exits;
 
     case ArithBitNot:
-        if (node->child1().useKind() == Int32Use)
+        if (isInt32(node->child1().useKind()))
             break;
         return Exits;
 
     case ArithAbs:
-        if (node->arithMode() == Arith::Mode::Unchecked && node->child1().useKind() == Int32Use)
+        if (node->arithMode() == Arith::Mode::Unchecked && isInt32(node->child1().useKind()))
             break;
         return Exits;
 
     case ArithMin:
     case ArithMax:
-        if (graph.child(node, 0).useKind() == Int32Use)
+        if (isInt32(graph.child(node, 0).useKind()))
             break;
         if (graph.child(node, 0).useKind() == DoubleRepUse)
             break;
@@ -209,26 +209,36 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case ArithBitAnd:
     case ArithBitOr:
     case ArithBitXor:
-        if (node->isBinaryUseKind(Int32Use))
+        if (node->isBinaryInt32UseKind())
             break;
         return Exits;
 
     case ArithClz32:
-        if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use)
+        if (isInt32(node->child1().useKind()))
             break;
         return Exits;
 
     case ArithAdd:
     case ArithSub:
+        if (node->arithMode() == Arith::Mode::Unchecked) {
+            if (node->isBinaryInt32UseKind())
+                break;
+            if (node->isBinaryUseKind(Int52RepUse))
+                break;
+        }
+        if (node->isBinaryUseKind(DoubleRepUse))
+            break;
+        return Exits;
+
     case ArithMul:
-        if (node->arithMode() == Arith::Mode::Unchecked && node->isBinaryUseKind(Int32Use))
+        if (node->arithMode() == Arith::Mode::Unchecked && node->isBinaryInt32UseKind())
             break;
         if (node->isBinaryUseKind(DoubleRepUse))
             break;
         return Exits;
 
     case ArithNegate:
-        if (node->arithMode() == Arith::Mode::Unchecked && node->child1().useKind() == Int32Use)
+        if (node->arithMode() == Arith::Mode::Unchecked && isInt32(node->child1().useKind()))
             break;
         if (node->child1().useKind() == DoubleRepUse)
             break;
@@ -237,6 +247,18 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case ArithDiv:
     case ArithMod:
         if (node->isBinaryUseKind(DoubleRepUse))
+            break;
+        return Exits;
+
+    case BooleanToNumber:
+        if (node->child1().useKind() == BooleanUse)
+            break;
+        return Exits;
+
+    case ValueToInt32:
+        if (node->child1().useKind() == Int52RepUse)
+            break;
+        if (node->child1().useKind() == DoubleRepUse)
             break;
         return Exits;
 
@@ -253,7 +275,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CompareLessEq:
     case CompareGreater:
     case CompareGreaterEq:
-        if (node->isBinaryUseKind(Int32Use))
+        if (node->isBinaryInt32UseKind())
             break;
         if (node->isBinaryUseKind(DoubleRepUse))
             break;
@@ -264,7 +286,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         return Exits;
 
     case ArithPow:
-        if (node->isBinaryUseKind(Int32Use))
+        if (node->isBinaryInt32UseKind())
             break;
         if (node->isBinaryUseKind(DoubleRepUse))
             break;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2922,6 +2922,12 @@ public:
         return isBinaryUseKind(left, right) || isBinaryUseKind(right, left);
     }
 
+    // Can handle both Int32Use and KnownInt32Use
+    bool isBinaryInt32UseKind()
+    {
+        return isInt32(child1().useKind()) && isInt32(child2().useKind());
+    }
+
     Edge childFor(UseKind useKind)
     {
         if (child1().useKind() == useKind)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -5012,13 +5012,12 @@ void SpeculativeJIT::compileArithAdd(Node* node)
         
 #if USE(JSVALUE64)
     case Int52RepUse: {
-        ASSERT(shouldCheckOverflow(node->arithMode()));
         ASSERT(!shouldCheckNegativeZero(node->arithMode()));
 
         // Will we need an overflow check? If we can prove that neither input can be
         // Int52 then the overflow check will not be necessary.
-        if (!m_state.forNode(node->child1()).couldBeType(SpecNonInt32AsInt52)
-            && !m_state.forNode(node->child2()).couldBeType(SpecNonInt32AsInt52)) {
+        if (!shouldCheckOverflow(node->arithMode()) ||
+            (!m_state.forNode(node->child1()).couldBeType(SpecNonInt32AsInt52) && !m_state.forNode(node->child2()).couldBeType(SpecNonInt32AsInt52))) {
             SpeculateWhicheverInt52Operand op1(this, node->child1());
             SpeculateWhicheverInt52Operand op2(this, node->child2(), op1);
             GPRTemporary result(this, Reuse, op1);
@@ -5026,7 +5025,7 @@ void SpeculativeJIT::compileArithAdd(Node* node)
             int52Result(result.gpr(), node, op1.format());
             return;
         }
-        
+
         SpeculateInt52Operand op1(this, node->child1());
         SpeculateInt52Operand op2(this, node->child2());
         GPRTemporary result(this);
@@ -5195,13 +5194,12 @@ void SpeculativeJIT::compileArithSub(Node* node)
         
 #if USE(JSVALUE64)
     case Int52RepUse: {
-        ASSERT(shouldCheckOverflow(node->arithMode()));
         ASSERT(!shouldCheckNegativeZero(node->arithMode()));
 
         // Will we need an overflow check? If we can prove that neither input can be
         // Int52 then the overflow check will not be necessary.
-        if (!m_state.forNode(node->child1()).couldBeType(SpecNonInt32AsInt52)
-            && !m_state.forNode(node->child2()).couldBeType(SpecNonInt32AsInt52)) {
+        if (!shouldCheckOverflow(node->arithMode()) ||
+            (!m_state.forNode(node->child1()).couldBeType(SpecNonInt32AsInt52) && !m_state.forNode(node->child2()).couldBeType(SpecNonInt32AsInt52))) {
             SpeculateWhicheverInt52Operand op1(this, node->child1());
             SpeculateWhicheverInt52Operand op2(this, node->child2(), op1);
             GPRTemporary result(this, Reuse, op1);

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -250,6 +250,17 @@ inline bool isDouble(UseKind kind)
     }
 }
 
+inline bool isInt32(UseKind kind)
+{
+    switch (kind) {
+    case Int32Use:
+    case KnownInt32Use:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // Returns true if the use kind only admits cells, and is therefore appropriate for
 // SpeculateCellOperand in the DFG or lowCell() in the FTL.
 inline bool isCell(UseKind kind)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -2900,8 +2900,8 @@ private:
         }
 
         case Int52RepUse: {
-            if (!abstractValue(m_node->child1()).couldBeType(SpecNonInt32AsInt52)
-                && !abstractValue(m_node->child2()).couldBeType(SpecNonInt32AsInt52)) {
+            if (!shouldCheckOverflow(m_node->arithMode()) ||
+                (!abstractValue(m_node->child1()).couldBeType(SpecNonInt32AsInt52) && !abstractValue(m_node->child2()).couldBeType(SpecNonInt32AsInt52))) {
                 Int52Kind kind;
                 LValue left = lowWhicheverInt52(m_node->child1(), kind);
                 LValue right = lowInt52(m_node->child2(), kind);


### PR DESCRIPTION
#### 3ec466b410b38256372c4691f8f402b6f565ac2c
<pre>
[JSC] Remove more unnecessary exits and checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=290162">https://bugs.webkit.org/show_bug.cgi?id=290162</a>
<a href="https://rdar.apple.com/147562500">rdar://147562500</a>

Reviewed by Yijia Huang.

Start removing some unnecessary checks around Int52 in ArithAdd /
ArithSub, and also removing unnecessary Exits for various nodes so that
we can further remote unnecessary checks in Int52 in subsequent changes.

* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::isBinaryInt32UseKind):
* Source/JavaScriptCore/dfg/DFGUseKind.h:
(JSC::DFG::isInt32):

Canonical link: <a href="https://commits.webkit.org/292481@main">https://commits.webkit.org/292481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95954ba057631af04ea7deb6f2422bd419de53d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96175 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46692 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73320 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30544 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99178 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12055 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4638 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46019 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103265 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94796 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82358 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81734 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26348 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16609 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23205 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118273 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22864 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->