### PR TITLE
GPUP: Drawing 2D context to a layer is slow due to CGImage creation moment

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11111,15 +11111,17 @@ void Document::prepareCanvasesForDisplayOrFlushIfNeeded()
 
         context->setIsInPreparationForDisplayOrFlush(false);
 
-        // Some canvas contexts hold memory that should be periodically freed.
-        if (context->hasDeferredOperations())
-            context->flushDeferredOperations();
-
+        bool needsFlushDeferredOperations = context->hasDeferredOperations();
         // Some canvases need to do work when rendering has finished but before their content is composited.
         if (RefPtr htmlCanvas = dynamicDowncast<HTMLCanvasElement>(context->canvasBase())) {
-            if (htmlCanvas->needsPreparationForDisplay())
+            if (htmlCanvas->needsPreparationForDisplay()) {
                 htmlCanvas->prepareForDisplay();
+                needsFlushDeferredOperations = false;
+            }
         }
+        // Some canvas contexts hold memory that should be periodically freed.
+        if (needsFlushDeferredOperations)
+            context->flushDeferredOperations();
     }
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2481,13 +2481,14 @@ AffineTransform CanvasRenderingContext2DBase::baseTransform() const
 
 void CanvasRenderingContext2DBase::prepareForDisplay()
 {
-    if (auto buffer = canvasBase().buffer())
+    m_hasDeferredOperations = false; // Prepare for display will take care of flushing the deferred operations.
+    if (RefPtr buffer = canvasBase().buffer())
         buffer->prepareForDisplay();
 }
 
 bool CanvasRenderingContext2DBase::needsPreparationForDisplay() const
 {
-#if USE(SKIA)
+#if USE(SKIA) || USE(CG)
     return isAccelerated();
 #else
     return false;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -313,7 +313,6 @@ bool ImageBuffer::flushDrawingContextAsync()
 
 void ImageBuffer::prepareForDisplay()
 {
-    flushDrawingContextAsync();
     if (auto* backend = ensureBackend())
         backend->prepareForDisplay();
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -150,7 +150,7 @@ public:
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 
-    void prepareForDisplay();
+    WEBCORE_EXPORT virtual void prepareForDisplay();
 
     WEBCORE_EXPORT IntSize backendSize() const;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -145,6 +145,12 @@ unsigned ImageBufferIOSurfaceBackend::bytesPerRow() const
     return m_surface->bytesPerRow();
 }
 
+void ImageBufferIOSurfaceBackend::prepareForDisplay()
+{
+    // Caller has determined this is a good time to cache the native image.
+    copyNativeImage();
+}
+
 void ImageBufferIOSurfaceBackend::transferToNewContext(const ImageBufferCreationContext& creationContext)
 {
     m_ioSurfacePool = creationContext.surfacePool;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -80,6 +80,7 @@ protected:
     void transferToNewContext(const ImageBufferCreationContext&) final;
 
     unsigned bytesPerRow() const override;
+    void prepareForDisplay() final;
 
     // Returns true if this invalidation requires a flush to complete
     bool invalidateCachedNativeImage();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -207,6 +207,12 @@ void RemoteImageBuffer::flushContextSync(CompletionHandler<void()>&& completionH
     completionHandler();
 }
 
+void RemoteImageBuffer::prepareForDisplay()
+{
+    assertIsCurrent(workQueue());
+    imageBuffer()->prepareForDisplay();
+}
+
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 void RemoteImageBuffer::dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&& completionHandler)
 {

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -75,6 +75,7 @@ private:
     void transformToColorSpace(const WebCore::DestinationColorSpace&);
     void flushContext();
     void flushContextSync(CompletionHandler<void()>&&);
+    void prepareForDisplay();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     void dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -38,6 +38,7 @@ messages -> RemoteImageBuffer Stream {
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
     FlushContext()
     FlushContextSync() -> () Synchronous
+    PrepareForDisplay()
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     DynamicContentScalingDisplayList() -> (std::optional<WebCore::DynamicContentScalingDisplayList> displayList) Synchronous NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -98,9 +98,13 @@ void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdat
 {
     m_context.reset();
 
+    // Instead of a flush, we do a prepareForDisplay. This will create the resources needed to
+    // draw the front buffer to front buffer of the next frame for incremental rendering.
     RefPtr frontBuffer = m_frontBuffer;
-    if (frontBuffer)
+    if (frontBuffer) {
+        frontBuffer->prepareForDisplay();
         frontBuffer->flushDrawingContext();
+    }
 
 #if PLATFORM(COCOA)
     auto bufferIdentifier = [](RefPtr<WebCore::ImageBuffer> buffer) -> std::optional<WebCore::RenderingResourceIdentifier> {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -375,6 +375,11 @@ bool RemoteImageBufferProxy::flushDrawingContextAsync()
     return true;
 }
 
+void RemoteImageBufferProxy::prepareForDisplay()
+{
+    send(Messages::RemoteImageBuffer::PrepareForDisplay());
+}
+
 void RemoteImageBufferProxy::prepareForBackingStoreChange()
 {
     // If the backing store is mapped in the process and the changes happen in the other

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -102,6 +102,7 @@ private:
 
     void flushDrawingContext() final;
     bool flushDrawingContextAsync() final;
+    void prepareForDisplay() final;
 
     void prepareForBackingStoreChange();
 


### PR DESCRIPTION
#### e48b0c6373a0f63e97f2d1d77ce369351576078e
<pre>
GPUP: Drawing 2D context to a layer is slow due to CGImage creation moment
<a href="https://bugs.webkit.org/show_bug.cgi?id=290168">https://bugs.webkit.org/show_bug.cgi?id=290168</a>
<a href="https://rdar.apple.com/147572105">rdar://147572105</a>

Reviewed by NOBODY (OOPS!).

The CGImage for a particular 2D context canvas rendering would be
created during the process in which the canvas backing buffer is drawn
to the layer. It was done at last possible moment, e.g. at the
DrawImageBuffer call site.

For accelerated CG, creating an image will be flushing operation. This
may cause waiting on the already drawn layer content to be scheduled.

Instead, create images for all the updated 2d context canvas elements
during the &quot;prepareForDisplay&quot; phase. This way the flushes happen
with only the canvas draw calls in the queues, minimizing the
wait time.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::prepareForDisplay):
Avoid flushing here. Instead, prepareForDisplay should be an isolated
command: it should do whatever it needs, for the particular backend.
Before, it was only implemented for Skia, and that did not need
the flush.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::prepareForDisplay):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::prepareForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e48b0c6373a0f63e97f2d1d77ce369351576078e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103734 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15891 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50691 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27845 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20447 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85658 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85199 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21841 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->