### PR TITLE
GPUP: Creating NativeImage out IOSurface ImageBuffer flushes even without changes to ImageBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -234,7 +234,10 @@ CGContextRef GraphicsContextCG::platformContext() const
 CGContextRef GraphicsContextCG::contextForDraw()
 {
     ASSERT(m_cgContext);
-    m_hasDrawn = true;
+    if (!m_hasDrawn) {
+        m_currentImage = nullptr;
+        m_hasDrawn = true;
+    }
     return m_cgContext.get();
 }
 
@@ -1526,13 +1529,6 @@ void GraphicsContextCG::addDestinationAtPoint(const String& name, const FloatPoi
 bool GraphicsContextCG::canUseShadowBlur() const
 {
     return (renderingMode() == RenderingMode::Unaccelerated) && hasBlurredDropShadow() && !m_state.shadowsIgnoreTransforms();
-}
-
-bool GraphicsContextCG::consumeHasDrawn()
-{
-    bool hasDrawn = m_hasDrawn;
-    m_hasDrawn = false;
-    return hasDrawn;
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -144,6 +144,10 @@ public:
     // Returns false if there has not been any potential draws since last call.
     // Returns true if there has been potential draws since last call.
     bool consumeHasDrawn();
+    // Function to cache current image of the drawing. This value will be
+    // cleared before any draw to this context.
+    void setCurrentImage(RefPtr<NativeImage>);
+    RefPtr<NativeImage> currentImage() const;
 
 protected:
     void setCGShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
@@ -158,6 +162,7 @@ private:
 
     const RetainPtr<CGContextRef> m_cgContext;
     mutable std::optional<DestinationColorSpace> m_colorSpace;
+    RefPtr<NativeImage> m_currentImage;
     const RenderingMode m_renderingMode : 2; // NOLINT
     const bool m_isLayerCGContext : 1;
     mutable bool m_userToDeviceTransformKnownToBeIdentity : 1 { false };
@@ -166,6 +171,24 @@ private:
 };
 
 CGAffineTransform getUserToBaseCTM(CGContextRef);
+
+inline bool GraphicsContextCG::consumeHasDrawn()
+{
+    bool hasDrawn = m_hasDrawn;
+    m_hasDrawn = false;
+    return hasDrawn;
+}
+
+inline void GraphicsContextCG::setCurrentImage(RefPtr<NativeImage> image)
+{
+    ASSERT(!m_hasDrawn);
+    m_currentImage = WTFMove(image);
+}
+
+inline RefPtr<NativeImage> GraphicsContextCG::currentImage() const
+{
+    return m_currentImage;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -112,6 +112,7 @@ GraphicsContext& ImageBufferIOSurfaceBackend::context()
     if (!m_context) {
         m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
         applyBaseTransform(*m_context);
+        m_context->setCurrentImage(WTFMove(m_currentImageIfNoContext));
     }
     return *m_context;
 }
@@ -154,6 +155,8 @@ void ImageBufferIOSurfaceBackend::transferToNewContext(const ImageBufferCreation
 
 bool ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()
 {
+    setCurrentImage(nullptr);
+
     // Force QuartzCore to invalidate its cached CGImageRef for this IOSurface.
     // This is necessary in cases where we know (a priori) that the IOSurface has been
     // modified, but QuartzCore may have a cached CGImageRef that does not reflect the
@@ -170,7 +173,12 @@ bool ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage()
 {
-    return NativeImage::create(createImage());
+    RefPtr<NativeImage> currentImage = this->currentImage();
+    if (!currentImage) {
+        currentImage = NativeImage::create(createImage());
+        setCurrentImage(RefPtr { currentImage });
+    }
+    return currentImage;
 }
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::createNativeImageReference()
@@ -219,7 +227,14 @@ bool ImageBufferIOSurfaceBackend::isInUse() const
 
 void ImageBufferIOSurfaceBackend::releaseGraphicsContext()
 {
+    // Currently we do not move m_context->currentImage() to m_currentImageIfNoContext because
+    // destroying the m_platformContext would read back the data from the IOSurface to a buffer
+    // in the image.
     m_context = nullptr;
+
+    // Currently we also have to clear m_currentImageIfNoContext, since we are clearing m_platformContext.
+    // This is for the same read back reason.
+    m_currentImageIfNoContext = nullptr;
     m_platformContext = nullptr;
 }
 
@@ -318,6 +333,22 @@ RetainPtr<CGImageRef> ImageBufferIOSurfaceBackend::createImageReference()
     // This also skips WebKit GraphicsContext subimage cache.
     CGImageSetCachingFlags(image.get(), kCGImageCachingTransient);
     return image;
+}
+
+void ImageBufferIOSurfaceBackend::setCurrentImage(RefPtr<NativeImage> image)
+{
+    // Cache the current image in the context, so that the context may clear it before a draw.
+    if (m_context)
+        m_context->setCurrentImage(WTFMove(image));
+    else
+        m_currentImageIfNoContext = WTFMove(image);
+}
+
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::currentImage() const
+{
+    if (m_context)
+        return m_context->currentImage();
+    return m_currentImageIfNoContext;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -88,9 +88,12 @@ protected:
 
     RetainPtr<CGImageRef> createImage();
     RetainPtr<CGImageRef> createImageReference();
+    void setCurrentImage(RefPtr<NativeImage>);
+    RefPtr<NativeImage> currentImage() const;
 
     std::unique_ptr<IOSurface> m_surface;
     RetainPtr<CGContextRef> m_platformContext;
+    RefPtr<NativeImage> m_currentImageIfNoContext;
     const PlatformDisplayID m_displayID;
     bool m_mayHaveOutstandingBackingStoreReferences { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };


### PR DESCRIPTION
#### 783a2988e40d80db16ba874e80045342cda00d63
<pre>
GPUP: Creating NativeImage out IOSurface ImageBuffer flushes even without changes to ImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=290181">https://bugs.webkit.org/show_bug.cgi?id=290181</a>
<a href="https://rdar.apple.com/problem/147583419">rdar://problem/147583419</a>

Reviewed by NOBODY (OOPS!).

Currently, creating CGImage out of IOSurface -based ImageBuffer flushes the
CGIOSurfaceContext internal queues. This causes needless slowdown in
cases where the image is already available, and no operation has done
to the context.

Fix by doing a similar cache in IOSurfaceBackend. Store the current
image to the GraphicsContextCG. The GraphicsContextCG can discard
the image before any draw, because it tracks the draws.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::contextForDraw):
(WebCore::GraphicsContextCG::consumeHasDrawn): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
(WebCore::GraphicsContextCG::consumeHasDrawn):
(WebCore::GraphicsContextCG::setCurrentImage):
(WebCore::GraphicsContextCG::currentImage const):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::context):
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::releaseGraphicsContext):
(WebCore::ImageBufferIOSurfaceBackend::setCurrentImage):
(WebCore::ImageBufferIOSurfaceBackend::currentImage const):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/783a2988e40d80db16ba874e80045342cda00d63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24249 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73346 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103295 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23269 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16947 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/combobox-active-element-selected-children.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82379 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81754 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28387 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->