### PR TITLE
Introduce Haiku in Tools/Scripts

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -131,6 +131,7 @@ Usage: $programName [options] [options to pass to build system]
   --cross-target=<target_machine>   Use the cross-toolchain-helper to build WebKit for the specified machine (Linux platforms only)
 
   --gtk                             Build the GTK+ port
+  --haiku                           Build the Haiku port
   --wpe                             Build the WPE port
   --win                             Build the Windows port
   --playstation                     Build the PlayStation port

--- a/Tools/Scripts/webkitpy/common/system/platforminfo.py
+++ b/Tools/Scripts/webkitpy/common/system/platforminfo.py
@@ -102,6 +102,9 @@ class PlatformInfo(object):
     def is_cygwin(self):
         return self._is_cygwin
 
+    def is_haiku(self):
+        return self.os_name == 'haiku'
+
     def is_linux(self):
         return self.os_name == 'linux'
 
@@ -234,6 +237,8 @@ class PlatformInfo(object):
             return 'mac'
         if sys_platform == 'ios' or sys_platform == 'watchos':
             return 'ios'
+        if sys_platform.startswith('haiku'):
+            return 'haiku'
         if sys_platform.startswith('linux'):
             return 'linux'
         if sys_platform.startswith('win') or sys_platform == 'cygwin':

--- a/Tools/Scripts/webkitpy/common/system/platforminfo_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/platforminfo_mock.py
@@ -49,6 +49,9 @@ class MockPlatformInfo(object):
     def is_ios(self):
         return self.os_name == 'ios'
 
+    def is_haiku(self):
+        return self.os_name == 'haiku'
+
     def is_linux(self):
         return self.os_name == 'linux'
 

--- a/Tools/Scripts/webkitpy/common/system/platforminfo_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/platforminfo_unittest.py
@@ -80,7 +80,7 @@ class TestPlatformInfo(unittest.TestCase):
         if info.is_mac() or info.is_win():
             self.assertIsNotNone(info.os_version)
         self.assertNotEqual(info.display_name(), '')
-        self.assertTrue(info.is_mac() or info.is_win() or info.is_linux() or info.is_freebsd())
+        self.assertTrue(info.is_mac() or info.is_win() or info.is_linux() or info.is_freebsd() or info.is_haiku())
         self.assertIsNotNone(info.terminal_width())
 
         if info.is_mac():

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -80,6 +80,9 @@ class VersionNameMap(object):
                 'Vista': Version(6),
                 'XP': Version(5, 1),
             },
+            'haiku': {
+                '': Version(1)
+            },
 
             # This entry avoids hitting the assert in mapping_for_platform() on Linux,
             # but otherwise shouldn't contain any useful key-value pairs.


### PR DESCRIPTION
#### 32a5c661ad9347eb809a1c542673b0579a359c43
<pre>
Introduce Haiku in Tools/Scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=290172">https://bugs.webkit.org/show_bug.cgi?id=290172</a>

Reviewed by Sam Sneddon.

Let the scripts know about Haiku as an operating system, with a few
basic things like getting the number of CPUs and detecting the OS
version.

* Tools/Scripts/build-webkit:
* Tools/Scripts/webkitdirs.pm:
(determineArchitecture):
(determineNumberOfCPUs):
(argumentsForConfiguration):
(determinePortName):
(isHaiku):
(launcherPath):
(launcherName):
(wrapperPrefixIfNeeded):
* Tools/Scripts/webkitpy/common/system/platforminfo.py:
(PlatformInfo.is_haiku):
(PlatformInfo._determine_os_name):
* Tools/Scripts/webkitpy/common/system/platforminfo_mock.py:
(MockPlatformInfo.is_haiku):
* Tools/Scripts/webkitpy/common/system/platforminfo_unittest.py:
(TestPlatformInfo.test_real_code):
* Tools/Scripts/webkitpy/common/version_name_map.py:
(VersionNameMap.__init__):

Canonical link: <a href="https://commits.webkit.org/293732@main">https://commits.webkit.org/293732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45dbade4f3577f0ccfda869134411e9546d740dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56236 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/99148 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49631 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92353 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107165 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98292 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84352 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6734 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20579 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26730 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121909 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26545 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34051 "Found 1 new JSC stress test failure: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->