### PR TITLE
[GTK][WPE] False positive `use-after-free` error on GCC 12 in `CSSValue::operator delete()`

### DIFF
--- a/Source/WebCore/css/FontVariantBuilder.cpp
+++ b/Source/WebCore/css/FontVariantBuilder.cpp
@@ -222,7 +222,7 @@ FontVariantAlternates extractFontVariantAlternates(const CSSValue& value, Style:
 
     if (RefPtr valueList = dynamicDowncast<CSSValueList>(value)) {
         for (Ref item : *valueList) {
-            if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(item)) {
+            if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(item.get())) {
                 switch (primitive->valueID()) {
                 case CSSValueHistoricalForms:
                     result.valuesRef().historicalForms = true;
@@ -231,7 +231,7 @@ FontVariantAlternates extractFontVariantAlternates(const CSSValue& value, Style:
                     builderState.setCurrentPropertyInvalidAtComputedValueTime();
                     return FontVariantAlternates::Normal();
                 }
-            } else if (RefPtr function = dynamicDowncast<CSSFunctionValue>(item)) {
+            } else if (RefPtr function = dynamicDowncast<CSSFunctionValue>(item.get())) {
                 switch (function->name()) {
                 case CSSValueSwash:
                     if (!processSingleItemFunction(*function, result.valuesRef().swash))

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1233,7 +1233,7 @@ inline void BuilderCustom::applyInheritFill(BuilderState& builderState)
 inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& value)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
-    RefPtr<const CSSValue> localValue = &value;
+    RefPtr<const CSSValue> localValue;
     String url;
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
         auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, *list->item(0));
@@ -1241,12 +1241,10 @@ inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& 
             return;
         url = primitiveValue->stringValue();
         localValue = list->protectedItem(1);
+        if (!localValue)
+            return;
     }
-
-    if (!localValue)
-        return;
-
-    auto [color, paintType] = colorAndSVGPaintType(builderState, *localValue, url);
+    auto [color, paintType] = colorAndSVGPaintType(builderState, localValue ? *localValue : value, url);
     svgStyle.setFillPaint(paintType, color, url, builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 
@@ -1266,7 +1264,7 @@ inline void BuilderCustom::applyInheritStroke(BuilderState& builderState)
 inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue& value)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
-    RefPtr<const CSSValue> localValue = &value;
+    RefPtr<const CSSValue> localValue;
     String url;
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
         auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, *list->item(0));
@@ -1274,12 +1272,11 @@ inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue
             return;
         url = primitiveValue->stringValue();
         localValue = list->protectedItem(1);
+        if (!localValue)
+            return;
     }
 
-    if (!localValue)
-        return;
-
-    auto [color, paintType] = colorAndSVGPaintType(builderState, *localValue, url);
+    auto [color, paintType] = colorAndSVGPaintType(builderState, localValue ? *localValue : value, url);
     svgStyle.setStrokePaint(paintType, color, url, builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 


### PR DESCRIPTION
#### 8255a10580c516e3caf5119f1d0bf6902c82e4e9
<pre>
[GTK][WPE] False positive `use-after-free` error on GCC 12 in `CSSValue::operator delete()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=290185">https://bugs.webkit.org/show_bug.cgi?id=290185</a>

Reviewed by Sam Weinig.

In `extractFontVariantAlternates()`, we loop through `valueList`
capturing an `item` in a `Ref`. In the loop, we check if the item is
primitive or function by downcasting it. In both branches we pass
the `item` `Ref` by copy. That makes the compiler think that by exiting
`dynamicDowncast(Ref source)` the underlying `CSSValue` can be deleted.

Passing `item`&apos;s raw reference instead makes the compiler to pick
`dynamicDowncast(Source&amp; source)` overload and thus eliminates potential
`deref()` call. The returned raw pointer is immediately captured in
a `Ref`, so the code stays safe.

In `BuilderCustom::applyValueFill()` the compiler is confused because we
re-assigning `RefPrt&lt;const CSSValue&gt; localValue`. It&apos;s possible to
slightly modify the code to keep the original logic without assigning
the new value to `localValue`.

* Source/WebCore/css/FontVariantBuilder.cpp:
(WebCore::extractFontVariantAlternates):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFill):
(WebCore::Style::BuilderCustom::applyValueStroke):

Canonical link: <a href="https://commits.webkit.org/292887@main">https://commits.webkit.org/292887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf4f8581bc5fddb1989236d9c4f8d2ad92b19883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31274 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100233 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12962 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5806 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24306 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17729 "Found 2 new test failures: imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.htm imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83120 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29420 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->