### PR TITLE
Remove a redundant internal feature flag: FixedContainerEdgeSamplingEnabled

### DIFF
--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>
@@ -68,6 +68,7 @@ async function showContainer(edge, expectedColors) {
 }
 
 addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(50, 50, 50, 50);
     await showContainer("top", { top: "rgb(0, 122, 255)", left: null, right: null, bottom: null });
 
     await showContainer("left", { top:

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -52,6 +52,7 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(75, 0, 75, 0);
         await UIHelper.ensurePresentationUpdate();
         sampledColors = [];
         for (i = 0; i < 5; ++i) {

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -44,6 +44,7 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(75, 0, 75, 0);
         await UIHelper.ensurePresentationUpdate();
         colors = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("colors.top", "rgb(255, 99, 71)");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -39,6 +39,7 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
         await UIHelper.ensurePresentationUpdate();
         colorBeforeFading = await UIHelper.fixedContainerEdgeColors();
 

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -34,6 +34,8 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+
         let header = document.querySelector("header");
         sampledTopColors = []
         for (let i = 0; i < 10; ++i) {

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">
@@ -34,6 +34,8 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+
         let frame = document.querySelector("iframe");
         await UIHelper.callFunctionAndWaitForEvent(() => {
             frame.srcdoc = `

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta charset="utf-8">
@@ -39,6 +39,8 @@ async function sampledTopColor() {
 }
 
 addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+
     let header = document.querySelector("header");
     description("To manually test, scroll this page down; the top sampled color should remain solid white");
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1853,14 +1853,15 @@ window.UIHelper = class UIHelper {
         });
     }
 
-    static setObscuredInsets(top, right, bottom, left)
+    static async setObscuredInsets(top, right, bottom, left)
     {
-        if (!this.isWebKit2() || !this.isIOSFamily())
-            return Promise.resolve();
-
-        return new Promise(resolve => {
-            testRunner.runUIScript(`uiController.setObscuredInsets(${top}, ${right}, ${bottom}, ${left})`, resolve);
-        });
+        if (this.isWebKit2() && this.isIOSFamily()) {
+            const scriptToRun = `uiController.setObscuredInsets(${top}, ${right}, ${bottom}, ${left})`;
+            await new Promise(resolve => testRunner.runUIScript(scriptToRun, resolve));
+            await this.ensureVisibleContentRectUpdate();
+        } else
+            testRunner.setObscuredContentInsets(top, right, bottom, left);
+        await this.ensurePresentationUpdate();
     }
 
     static rotateDevice(orientationName, animatedResize = false)

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2146,7 +2146,7 @@ ContentInsetBackgroundFillEnabled:
   status: internal
   humanReadableName: "Content Inset Background Fill"
   humanReadableDescription: "Fill content insets with background colors"
-  condition: ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+  condition: PLATFORM(COCOA)
   defaultValue:
     WebKit:
       default: WebKit::defaultContentInsetBackgroundFillEnabled()
@@ -3093,20 +3093,6 @@ FilterLinkDecorationByDefaultEnabled:
       default: true
     WebCore:
       default: true
-
-FixedContainerEdgeSamplingEnabled:
-  type: bool
-  status: internal
-  humanReadableName: "Fixed container edge sampling"
-  humanReadableDescription: "Enable fixed container edge sampling"
-  condition: PLATFORM(COCOA)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultFixedContainerEdgeSamplingEnabled()
-    WebCore:
-      default: false
 
 FixedFontFamily:
   type: String

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -361,7 +361,7 @@ public:
     // and adjusting for page scale.
     LayoutPoint scrollPositionForFixedPosition() const;
 
-    WEBCORE_EXPORT FixedContainerEdges fixedContainerEdges() const;
+    WEBCORE_EXPORT FixedContainerEdges fixedContainerEdges(BoxSideSet) const;
     
     // Static function can be called from another thread.
     WEBCORE_EXPORT static LayoutPoint scrollPositionForFixedPosition(const LayoutRect& visibleContentRect, const LayoutSize& totalContentsSize, const LayoutPoint& scrollPosition, const LayoutPoint& scrollOrigin, float frameScaleFactor, bool fixedElementsLayoutRelativeToFrame, ScrollBehaviorForFixedElements, int headerHeight, int footerHeight);

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -96,17 +96,17 @@ bool defaultUseSCContentSharingPicker()
 }
 #endif
 
+#if !ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+bool defaultContentInsetBackgroundFillEnabled()
+{
+    return false;
+}
+#endif
+
 } // namespace WebKit
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPreferencesDefaultValuesCocoaAdditions.mm>)
 #import <WebKitAdditions/WebPreferencesDefaultValuesCocoaAdditions.mm>
-#else
-namespace WebKit {
-bool defaultFixedContainerEdgeSamplingEnabled()
-{
-    return false;
-}
-}
 #endif
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -102,10 +102,6 @@ bool defaultWheelEventGesturesBecomeNonBlocking();
 bool defaultAppleMailPaginationQuirkEnabled();
 #endif
 
-#if PLATFORM(COCOA)
-bool defaultFixedContainerEdgeSamplingEnabled();
-#endif
-
 #if ENABLE(MEDIA_STREAM)
 bool defaultCaptureAudioInGPUProcessEnabled();
 bool defaultCaptureAudioInUIProcessEnabled();
@@ -178,7 +174,7 @@ bool defaultRequiresPageVisibilityForVideoToBeNowPlaying();
 
 bool defaultCookieStoreAPIEnabled();
 
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+#if PLATFORM(COCOA)
 bool defaultContentInsetBackgroundFillEnabled();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1331,6 +1331,34 @@ void WebPage::drawPagesToPDFFromPDFDocument(CGContextRef, PDFDocument *, const P
 
 #endif
 
+BoxSideSet WebPage::sidesRequiringFixedContainerEdges() const
+{
+    if (!m_page->settings().contentInsetBackgroundFillEnabled())
+        return { };
+
+#if PLATFORM(IOS_FAMILY)
+    auto obscuredInsets = m_page->obscuredInsets();
+#else
+    auto obscuredInsets = m_page->obscuredContentInsets();
+#endif
+
+    BoxSideSet sides;
+
+    if (obscuredInsets.top() > 0)
+        sides.add(BoxSideFlag::Top);
+
+    if (obscuredInsets.left() > 0)
+        sides.add(BoxSideFlag::Left);
+
+    if (obscuredInsets.right() > 0)
+        sides.add(BoxSideFlag::Right);
+
+    if (obscuredInsets.bottom() > 0)
+        sides.add(BoxSideFlag::Bottom);
+
+    return sides;
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5021,8 +5021,8 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setThemeColor(page->themeColor());
     layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
     layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
-    if (page->settings().fixedContainerEdgeSamplingEnabled())
-        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges());
+    if (auto sides = sidesRequiringFixedContainerEdges())
+        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges(sides));
 
     layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());
     layerTransaction.setMinStableLayoutViewportOrigin(frameView->minStableLayoutViewportOrigin());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2522,6 +2522,10 @@ private:
     void setDefaultSpatialTrackingLabel(const String&);
 #endif
 
+#if PLATFORM(COCOA)
+    WebCore::BoxSideSet sidesRequiringFixedContainerEdges() const;
+#endif
+
     void frameNameWasChangedInAnotherProcess(WebCore::FrameIdentifier, const String& frameName);
 
     struct Internals;


### PR DESCRIPTION
#### 9e2216433237c18d3213f383da23a4775c2de499
<pre>
Remove a redundant internal feature flag: FixedContainerEdgeSamplingEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=290179">https://bugs.webkit.org/show_bug.cgi?id=290179</a>
<a href="https://rdar.apple.com/147580751">rdar://147580751</a>

Reviewed by Aditya Keerthi.

Remove `FixedContainerEdgeSamplingEnabled`, and instead use the extant feature flag
`ContentInsetBackgroundFillEnabled` to determine whether we need to enable sampling.

See below for more details.

* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html:
* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html:
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html:

Adjust these layout tests to:
1. Turn on `ContentInsetBackgroundFillEnabled` instead of `FixedContainerEdgeSamplingEnabled`.
2. Set obscured insets on all relevant sides, for each test.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async setObscuredInsets):

Augment this existing `UIHelper` method to work on macOS as well, and make it `async` to wait for
the next rendering update (and also the next visible content rect update, on iOS).

(window.UIHelper.setObscuredInsets): Deleted.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Remove the old feature flag. Also, make `ContentInsetBackgroundFillEnabled` compile on all
`PLATFORM(COCOA)`, such that we&apos;re still able to get coverage for `fast/page-color-sampling` on EWS,
even if system support for (part of) the content inset fill is missing.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Make this take a `BoxSideSet` denoting which viewport sides we need to detect/sample. This allows us
to limit the work done here to _only_ edges with obscured (content) insets.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultFixedContainerEdgeSamplingEnabled): Deleted.
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sidesRequiringFixedContainerEdges const):

Replace the check for `fixedContainerEdgeSamplingEnabled` with an option set of `BoxSideFlags`,
indicating which sides to sample. If it&apos;s empty (e.g., if `contentInsetBackgroundFillEnabled` is not
set), we skip this work altogether.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/292506@main">https://commits.webkit.org/292506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6648333987ce863f763da23f410fb20f6fd92abc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73358 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46066 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88894 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103314 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94842 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16961 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23251 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118319 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22910 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->