### PR TITLE
Make parsing SVG transform lists more efficient

### DIFF
--- a/Source/WebCore/svg/SVGTransformList.h
+++ b/Source/WebCore/svg/SVGTransformList.h
@@ -63,7 +63,12 @@ public:
     String valueAsString() const override;
 
 private:
-    template<typename CharacterType> bool parseGeneric(StringParsingBuffer<CharacterType>&);
+
+    enum class ListReplacement : bool {
+        Append,
+        Replace
+    };
+    template<typename CharacterType> bool parseGeneric(StringParsingBuffer<CharacterType>&, ListReplacement = ListReplacement::Append);
     bool parse(StringParsingBuffer<LChar>&);
     bool parse(StringParsingBuffer<UChar>&);
 };

--- a/Source/WebCore/svg/SVGTransformable.h
+++ b/Source/WebCore/svg/SVGTransformable.h
@@ -26,13 +26,14 @@
 namespace WebCore {
     
 class AffineTransform;
+class SVGTransform;
 
 class SVGTransformable : public SVGLocatable {
 public:
     virtual ~SVGTransformable();
 
-    static std::optional<SVGTransformValue> parseTransformValue(SVGTransformValue::SVGTransformType, StringParsingBuffer<LChar>&);
-    static std::optional<SVGTransformValue> parseTransformValue(SVGTransformValue::SVGTransformType, StringParsingBuffer<UChar>&);
+    static RefPtr<SVGTransform> parseTransform(SVGTransformValue::SVGTransformType, StringParsingBuffer<LChar>&, RefPtr<SVGTransform> reusableValue);
+    static RefPtr<SVGTransform> parseTransform(SVGTransformValue::SVGTransformType, StringParsingBuffer<UChar>&, RefPtr<SVGTransform> reusableValue);
 
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringView);
     static std::optional<SVGTransformValue::SVGTransformType> parseTransformType(StringParsingBuffer<LChar>&);


### PR DESCRIPTION
#### bef74b7519fb97bcf4bc14a23641412ec593b926
<pre>
Make parsing SVG transform lists more efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=290192">https://bugs.webkit.org/show_bug.cgi?id=290192</a>
<a href="https://rdar.apple.com/147591008">rdar://147591008</a>

Reviewed by Said Abou-Hallawa.

Content that animates SVG transforms will often keep the same list of transform operations, but just
change the values. Currently, `SVGTransformList::parse()` implements this by clearing the list and
re-build it, but this involves a lot of object churn: each SVGTransform is heap-allocated, and itself
has a heap-allocated SVGMatrix. In addition, `detach()` and `attach()` have overhead.

Make this more efficient by re-using the existing SVGTransforms when possible. Do this by moving the
list management into `SVGTransformList::parseGeneric()`. Callers of `parse()` expect the list to be preserved
between calls, so the `ListReplacement` argument controls that behavior. Pass the existing object to
`SVGTransformable::parseTransform` if the type matches; we compare that with the return value to know
if the item was re-used. If not, we go back to appending.

Well tested by existing SVG tests.

* Source/WebCore/svg/SVGTransformList.cpp:
(WebCore::SVGTransformList::parseGeneric):
(WebCore::SVGTransformList::parse):
* Source/WebCore/svg/SVGTransformList.h:
* Source/WebCore/svg/SVGTransformable.cpp:
(WebCore::parseTransformGeneric):
(WebCore::SVGTransformable::parseTransform):
(WebCore::parseTransformValueGeneric): Deleted.
(WebCore::SVGTransformable::parseTransformValue): Deleted.
* Source/WebCore/svg/SVGTransformable.h:

Canonical link: <a href="https://commits.webkit.org/292545@main">https://commits.webkit.org/292545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09770fb56a699a8744d90a69df40ede317606b63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4849 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82505 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81880 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16845 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->