### PR TITLE
REGRESSION(290212@main): Sometimes web content never becomes accessible because the isolated tree never gets built

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1083,7 +1083,7 @@ void AXObjectCache::buildAccessibilityTreeIfNeeded()
         return;
 
     if (isIsolatedTreeEnabled())
-        isolatedTreeRootObject();
+        getOrCreateIsolatedTree();
 }
 #endif
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -292,7 +292,9 @@ public:
 
     // Returns the root object for a specific frame.
     WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     WEBCORE_EXPORT void buildAccessibilityTreeIfNeeded();
+#endif
 
     // Creation/retrieval of AX objects associated with a DOM or RenderTree object.
     inline AccessibilityObject* getOrCreate(RenderObject* renderer)


### PR DESCRIPTION
#### b9f8037aea654c6dd7ca25330fe9e4522e99a872
<pre>
REGRESSION(290212@main): Sometimes web content never becomes accessible because the isolated tree never gets built
<a href="https://bugs.webkit.org/show_bug.cgi?id=290194">https://bugs.webkit.org/show_bug.cgi?id=290194</a>
<a href="https://rdar.apple.com/147592259">rdar://147592259</a>

Reviewed by Chris Fleizach.

In <a href="https://commits.webkit.org/290212@main">https://commits.webkit.org/290212@main</a>, we made `-[WKAccessibilityWebPageObjectBase focusedLocalFrame]` return
nullptr if off the main-thread to avoid unsafely accessing the `WebPage` (which can only be used on the main-thread).
This was the right thing to do, but had unexpected fallout, as it meant that when `-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]`
was called with a nullptr frame, we never actually called `AXObjectCache::rootObjectForFrame`, which would kick off
creation of the isolated tree.

With this commit, -[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:] now will try to re-retrieve a
frame after dispatching to the main-thread if the one we had was nullptr for any reason.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::buildAccessibilityTreeIfNeeded):
Drive-by fix to call getOrCreateIsolatedTree() instead of isolatedTreeRootObject(), as the former better describes
the intent of behavior we want to achieve in this function. There is no change in actual behavior here, and unrelated
to the bug described above.
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):

Canonical link: <a href="https://commits.webkit.org/292613@main">https://commits.webkit.org/292613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b47a5490b2f3ca7dca767c87c4a8be5fdadd36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99293 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53727 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46136 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23357 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23608 "Failed to checkout and rebase branch from PR 42823") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20593 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16731 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->