### PR TITLE
document.importNode from standards to quirks mode document can result in broken selector matching

### DIFF
--- a/LayoutTests/fast/dom/importNode-quirks-class-sharing-expected.txt
+++ b/LayoutTests/fast/dom/importNode-quirks-class-sharing-expected.txt
@@ -1,0 +1,18 @@
+Test that cloning elements between quirks and no-quirks document handles case folding properly
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.compatMode is 'CSS1Compat'
+PASS quirksFrame.contentDocument.compatMode is 'BackCompat'
+PASS noQuirksFrame.contentDocument.compatMode is 'CSS1Compat'
+PASS quirksFrame.contentDocument.querySelector('.pageContentClass') is sectionElementImportedToQuirksDocument
+PASS quirksFrame.contentDocument.querySelector('.pagecontentclass') is sectionElementImportedToQuirksDocument
+PASS document.querySelector('.pageContentClass') is sectionElement
+PASS noQuirksFrame.contentDocument.querySelector('.pageContentClass') is sectionElementImportedToNoQuirksDocument
+PASS quirksFrame.contentDocument.querySelector('.pageContentClass') is sectionElementImportedToQuirksDocument
+PASS quirksFrame.contentDocument.querySelector('.pagecontentclass') is sectionElementImportedToQuirksDocument
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/importNode-quirks-class-sharing.html
+++ b/LayoutTests/fast/dom/importNode-quirks-class-sharing.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<section id="pageContent" class="pageContentClass"></section>
+<iframe id="quirksFrame" src="about:blank" style="display:none"></iframe>
+<script>
+
+description("Test that cloning elements between quirks and no-quirks document handles case folding properly");
+
+var quirksFrame = document.getElementById("quirksFrame");
+
+var noQuirksFrame = document.createElement("iframe");
+noQuirksFrame.srcdoc = "<!DOCTYPE html><html><head></head><body></body></html>";
+noQuirksFrame.style = "display:none";
+document.body.appendChild(noQuirksFrame);
+
+onload = function() {
+
+    // Sanity check.
+    shouldBe("document.compatMode", "'CSS1Compat'");
+    shouldBe("quirksFrame.contentDocument.compatMode", "'BackCompat'");
+    shouldBe("noQuirksFrame.contentDocument.compatMode", "'CSS1Compat'");
+
+    // Test that cloning from standards mode to quirks mode doesn't mutate the original.
+    sectionElement = document.getElementById("pageContent");
+    sectionElementImportedToQuirksDocument = quirksFrame.contentDocument.importNode(sectionElement);
+    quirksFrame.contentDocument.body.appendChild(sectionElementImportedToQuirksDocument);
+    shouldBe("quirksFrame.contentDocument.querySelector('.pageContentClass')", "sectionElementImportedToQuirksDocument");
+    shouldBe("quirksFrame.contentDocument.querySelector('.pagecontentclass')", "sectionElementImportedToQuirksDocument");
+    shouldBe("document.querySelector('.pageContentClass')", "sectionElement");
+
+    // Same for cloning from quirks to no-quirks.
+    sectionElementImportedToNoQuirksDocument = noQuirksFrame.contentDocument.importNode(sectionElementImportedToQuirksDocument);
+    noQuirksFrame.contentDocument.body.appendChild(sectionElementImportedToNoQuirksDocument);
+    shouldBe("noQuirksFrame.contentDocument.querySelector('.pageContentClass')", "sectionElementImportedToNoQuirksDocument");
+    shouldBe("quirksFrame.contentDocument.querySelector('.pageContentClass')", "sectionElementImportedToQuirksDocument");
+    shouldBe("quirksFrame.contentDocument.querySelector('.pagecontentclass')", "sectionElementImportedToQuirksDocument");
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5650,7 +5650,10 @@ void Element::cloneAttributesFromElement(const Element& other)
         && (!uniqueElementData->inlineStyle() || !uniqueElementData->inlineStyle()->hasCSSOMWrapper()))
         const_cast<Element&>(other).m_elementData = uniqueElementData->makeShareableCopy();
 
-    if (!other.m_elementData->isUnique())
+    bool canShareElementData = !other.m_elementData->isUnique()
+        && (document().inQuirksMode() == other.document().inQuirksMode()); // Case folding in quirks mode documents can mutate element data.
+
+    if (canShareElementData)
         m_elementData = other.m_elementData;
     else
         m_elementData = other.m_elementData->makeUniqueCopy();


### PR DESCRIPTION
#### 8d714c80eaa3f4ac5e58570a1c638d225e0c3346
<pre>
document.importNode from standards to quirks mode document can result in broken selector matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=289795">https://bugs.webkit.org/show_bug.cgi?id=289795</a>
<a href="https://rdar.apple.com/147548958">rdar://147548958</a>

Reviewed by Ryosuke Niwa.

Avoid sharing ElementData when cloning if one document has case folding behavior, and
another doesn&apos;t.

* LayoutTests/fast/dom/importNode-quirks-class-sharing-expected.txt: Added.
* LayoutTests/fast/dom/importNode-quirks-class-sharing.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneAttributesFromElement):

Canonical link: <a href="https://commits.webkit.org/292542@main">https://commits.webkit.org/292542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43142c5251d1477ef2a76d7efb3e327bb762866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73377 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30608 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46109 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82003 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28448 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->