### PR TITLE
[Screen Time Refactoring] Promote SPI to API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -540,6 +540,10 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 */
 @property (nonatomic, nullable, copy) id interactionState WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
+/*! @abstract A Boolean value indicating whether Screen Time blocking has occurred.
+ */
+@property (nonatomic, readonly) BOOL isBlockedByScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 /*! @abstract Sets the webpage contents from the passed data as if it was the
  response to the supplied request. The request is never actually sent to the
  supplied URL, though loads of resources defined in the NSData object would

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -427,7 +427,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     // Thus, we have to instantiate its view for URLIsBlocked to update properly.
     RetainPtr screenTimeView = [_screenTimeWebpageController view];
 
-    if ([_configuration _showsSystemScreenTimeBlockingView]) {
+    if ([_configuration showsSystemScreenTimeBlockingView]) {
         [screenTimeView setFrame:self.bounds];
         [self addSubview:screenTimeView.get()];
     }
@@ -465,7 +465,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     viewIsVisible = viewIsVisible && ((self.window.occlusionState & NSWindowOcclusionStateVisible) == NSWindowOcclusionStateVisible);
 #endif
 
-    BOOL showsSystemScreenTimeBlockingView = [_configuration _showsSystemScreenTimeBlockingView];
+    BOOL showsSystemScreenTimeBlockingView = [_configuration showsSystemScreenTimeBlockingView];
 
     if (viewIsInWindow) {
         BOOL previouslyInstalledScreenTimeWebpageController = !!_screenTimeWebpageController;
@@ -504,16 +504,16 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 
         if (urlWasBlocked != urlIsBlocked) {
             [self setAllMediaPlaybackSuspended:urlIsBlocked completionHandler:nil];
-            [self willChangeValueForKey:@"_isBlockedByScreenTime"];
+            [self willChangeValueForKey:@"isBlockedByScreenTime"];
             _isBlockedByScreenTime = urlIsBlocked;
-            [self didChangeValueForKey:@"_isBlockedByScreenTime"];
+            [self didChangeValueForKey:@"isBlockedByScreenTime"];
             if (urlIsBlocked)
                 RELEASE_LOG(ScreenTime, "Screen Time is blocking the URL.");
             else
                 RELEASE_LOG(ScreenTime, "Screen Time is not blocking the URL.");
         }
         if (wasBlockedByScreenTime != _isBlockedByScreenTime) {
-            if (!_screenTimeBlurredSnapshot && ![_configuration _showsSystemScreenTimeBlockingView]) {
+            if (!_screenTimeBlurredSnapshot && ![_configuration showsSystemScreenTimeBlockingView]) {
 #if PLATFORM(MAC)
                 _screenTimeBlurredSnapshot = adoptNS([[NSVisualEffectView alloc] init]);
                 [_screenTimeBlurredSnapshot setMaterial:NSVisualEffectMaterialUnderWindowBackground];
@@ -3299,15 +3299,6 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 - (BOOL)_isBeingInspected
 {
     return _page && _page->hasInspectorFrontend();
-}
-
-- (BOOL)_isBlockedByScreenTime
-{
-#if ENABLE(SCREEN_TIME)
-    return _isBlockedByScreenTime;
-#else
-    return NO;
-#endif
 }
 
 - (_WKInspector *)_inspector

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -140,6 +140,11 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  */
 @property (nonatomic) BOOL allowsAirPlayForMediaPlayback WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
+/*! @abstract A Boolean value indicating whether the System Screen Time blocking view should be shown.
+ @discussion The default value is YES.
+ */
+@property (nonatomic) BOOL showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 /*! @abstract A Boolean value indicating whether HTTP requests to servers known to support HTTPS should be automatically upgraded to HTTPS requests.
  @discussion The default value is YES.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -498,6 +498,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._protectedPageConfiguration->setWebsiteDataStore(websiteDataStore ? websiteDataStore->_websiteDataStore.get() : nullptr);
 }
 
+- (BOOL)showsSystemScreenTimeBlockingView
+{
+    return _pageConfiguration->showsSystemScreenTimeBlockingView();
+}
+
+- (void)setShowsSystemScreenTimeBlockingView:(BOOL)shows
+{
+    _pageConfiguration->setShowsSystemScreenTimeBlockingView(shows);
+}
+
 - (WKWebpagePreferences *)defaultWebpagePreferences
 {
     return wrapper(self._protectedPageConfiguration->protectedDefaultWebsitePolicies().get());
@@ -737,12 +747,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (BOOL)_showsSystemScreenTimeBlockingView
 {
-    return _pageConfiguration->showsSystemScreenTimeBlockingView();
+    return [self showsSystemScreenTimeBlockingView];
 }
 
 - (void)_setShowsSystemScreenTimeBlockingView:(BOOL)shows
 {
-    _pageConfiguration->setShowsSystemScreenTimeBlockingView(shows);
+    [self setShowsSystemScreenTimeBlockingView:shows];
 }
 
 - (BOOL)_allowTopNavigationToDataURLs

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -288,7 +288,6 @@ struct PerWebProcessState {
 #else
     RetainPtr<UIVisualEffectView> _screenTimeBlurredSnapshot;
 #endif
-    BOOL _isBlockedByScreenTime;
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -176,8 +176,6 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @property (nonatomic, weak, setter=_setIconLoadingDelegate:) id <_WKIconLoadingDelegate> _iconLoadingDelegate;
 @property (nonatomic, weak, setter=_setResourceLoadDelegate:) id <_WKResourceLoadDelegate> _resourceLoadDelegate WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
-@property (nonatomic, readonly) BOOL _isBlockedByScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-
 @property (nonatomic, readonly) NSURL *_unreachableURL;
 @property (nonatomic, readonly) NSURL *_mainFrameURL WK_API_AVAILABLE(macos(10.15), ios(13.0));
 @property (nonatomic, readonly) NSURL *_resourceDirectoryURL WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
@@ -71,6 +71,9 @@ WK_EXTERN NSString * const WKWebsiteDataTypeMediaKeys WK_API_AVAILABLE(macos(14.
 /*! @constant WKWebsiteDataTypeHashSalt Hash salt for deviceId */
 WK_EXTERN NSString * const WKWebsiteDataTypeHashSalt WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
+/*! @constant WKWebsiteDataTypeScreenTime Screen Time information */
+WK_EXTERN NSString * const WKWebsiteDataTypeScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 /*! A WKWebsiteDataRecord represents website data, grouped by domain name using the public suffix list. */
 WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -57,7 +57,6 @@ NSString * const _WKWebsiteDataTypeAdClickAttributions = @"_WKWebsiteDataTypeAdC
 NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTypePrivateClickMeasurements";
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
 NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
-NSString * const _WKWebsiteDataTypeScreenTime = WKWebsiteDataTypeScreenTime;
 
 @implementation WKWebsiteDataRecord
 
@@ -116,7 +115,7 @@ static NSString *dataTypesToString(NSSet *dataTypes)
     if ([dataTypes containsObject:_WKWebsiteDataTypeAlternativeServices])
         [array addObject:@"Alternative Services"];
 #if ENABLE(SCREEN_TIME)
-    if ([dataTypes containsObject:_WKWebsiteDataTypeScreenTime])
+    if ([dataTypes containsObject:WKWebsiteDataTypeScreenTime])
         [array addObject:@"Screen Time"];
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -81,7 +81,7 @@ static inline std::optional<WebsiteDataType> toWebsiteDataType(NSString *website
         return WebsiteDataType::AlternativeServices;
 #endif
 #if ENABLE(SCREEN_TIME)
-    if ([websiteDataType isEqualToString:_WKWebsiteDataTypeScreenTime])
+    if ([websiteDataType isEqualToString:WKWebsiteDataTypeScreenTime])
         return WebsiteDataType::ScreenTime;
 #endif
     return std::nullopt;
@@ -145,7 +145,7 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
 #endif
 #if ENABLE(SCREEN_TIME)
     if (websiteDataTypes.contains(WebsiteDataType::ScreenTime))
-        [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeScreenTime];
+        [wkWebsiteDataTypes addObject:WKWebsiteDataTypeScreenTime];
 #endif
 
     return wkWebsiteDataTypes;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -39,7 +39,6 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABL
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
-WK_EXTERN NSString * const _WKWebsiteDataTypeScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -491,7 +491,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
             WKWebsiteDataTypeSearchFieldRecentSearches,
             WKWebsiteDataTypeMediaKeys,
 #if ENABLE(SCREEN_TIME)
-            _WKWebsiteDataTypeScreenTime,
+            WKWebsiteDataTypeScreenTime,
 #endif
             WKWebsiteDataTypeHashSalt ]]);
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
@@ -121,7 +121,7 @@ static void testSuppressUsageRecordingWithDataStore(RetainPtr<WKWebsiteDataStore
         return nil;
 
     _webView = webView;
-    [_webView addObserver:self forKeyPath:@"_isBlockedByScreenTime" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:&blockedStateObserverChangeKVOContext];
+    [_webView addObserver:self forKeyPath:@"isBlockedByScreenTime" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:&blockedStateObserverChangeKVOContext];
     return self;
 }
 
@@ -172,7 +172,7 @@ static BOOL systemScreenTimeBlockingViewIsPresent(TestWKWebView *webView)
 static RetainPtr<TestWKWebView> testShowsSystemScreenTimeBlockingView(bool showsSystemScreenTimeBlockingView)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration _setShowsSystemScreenTimeBlockingView:showsSystemScreenTimeBlockingView];
+    [configuration setShowsSystemScreenTimeBlockingView:showsSystemScreenTimeBlockingView];
 
     RetainPtr webView = webViewForScreenTimeTests(configuration.get());
     [webView synchronouslyLoadHTMLString:@""];
@@ -182,7 +182,7 @@ static RetainPtr<TestWKWebView> testShowsSystemScreenTimeBlockingView(bool shows
     RetainPtr controller = [webView _screenTimeWebpageController];
     [controller setURLIsBlocked:YES];
 
-    EXPECT_EQ(showsSystemScreenTimeBlockingView, [configuration _showsSystemScreenTimeBlockingView]);
+    EXPECT_EQ(showsSystemScreenTimeBlockingView, [configuration showsSystemScreenTimeBlockingView]);
 
     // Check if ScreenTime's blocking view is hidden or not.
     EXPECT_EQ(showsSystemScreenTimeBlockingView, systemScreenTimeBlockingViewIsPresent(webView.get()));
@@ -197,7 +197,7 @@ static RetainPtr<TestWKWebView> testShowsSystemScreenTimeBlockingView(bool shows
 static void testWebContentIsNotClickableShowingSystemScreenTimeBlockingView(bool showsSystemScreenTimeBlockingView)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration _setShowsSystemScreenTimeBlockingView:showsSystemScreenTimeBlockingView];
+    [configuration setShowsSystemScreenTimeBlockingView:showsSystemScreenTimeBlockingView];
 
     RetainPtr webView = webViewForScreenTimeTests(configuration.get());
     RetainPtr observer = adoptNS([[BlockedStateObserver alloc] initWithWebView:webView.get()]);
@@ -250,7 +250,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeTrue)
     RetainPtr controller = [webView _screenTimeWebpageController];
     [controller setURLIsBlocked:YES];
 
-    EXPECT_TRUE([webView _isBlockedByScreenTime]);
+    EXPECT_TRUE([webView isBlockedByScreenTime]);
 }
 
 TEST(ScreenTime, IsBlockedByScreenTimeFalse)
@@ -263,7 +263,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeFalse)
     RetainPtr controller = [webView _screenTimeWebpageController];
     [controller setURLIsBlocked:NO];
 
-    EXPECT_FALSE([webView _isBlockedByScreenTime]);
+    EXPECT_FALSE([webView isBlockedByScreenTime]);
 }
 
 TEST(ScreenTime, IsBlockedByScreenTimeMultiple)
@@ -277,7 +277,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeMultiple)
 
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_FALSE([webView _isBlockedByScreenTime]);
+    EXPECT_FALSE([webView isBlockedByScreenTime]);
 }
 
 TEST(ScreenTime, IsBlockedByScreenTimeKVO)
@@ -294,7 +294,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeKVO)
 
     TestWebKitAPI::Util::run(&stateDidChange);
 
-    EXPECT_TRUE([webView _isBlockedByScreenTime]);
+    EXPECT_TRUE([webView isBlockedByScreenTime]);
 
     stateDidChange = false;
 
@@ -302,7 +302,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeKVO)
 
     TestWebKitAPI::Util::run(&stateDidChange);
 
-    EXPECT_FALSE([webView _isBlockedByScreenTime]);
+    EXPECT_FALSE([webView isBlockedByScreenTime]);
 
     stateDidChange = false;
 
@@ -310,7 +310,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeKVO)
 
     TestWebKitAPI::Util::run(&stateDidChange);
 
-    EXPECT_TRUE([webView _isBlockedByScreenTime]);
+    EXPECT_TRUE([webView isBlockedByScreenTime]);
 }
 
 TEST(ScreenTime, IdentifierNil)
@@ -396,7 +396,7 @@ TEST(ScreenTime, ShowSystemScreenTimeBlockingFalseAndRemoved)
     RetainPtr webView = testShowsSystemScreenTimeBlockingView(false);
     RetainPtr controller = [webView _screenTimeWebpageController];
     [controller setURLIsBlocked:NO];
-    EXPECT_FALSE([[webView configuration] _showsSystemScreenTimeBlockingView]);
+    EXPECT_FALSE([[webView configuration] showsSystemScreenTimeBlockingView]);
     // Check if blurred blocking view is removed when URLIsBlocked is false.
     EXPECT_FALSE(blurredViewIsPresent(webView.get()));
 }
@@ -565,7 +565,7 @@ TEST(ScreenTime, FetchData)
         })
     };
 
-    RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[ _WKWebsiteDataTypeScreenTime ]]);
+    RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[ WKWebsiteDataTypeScreenTime ]]);
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -598,7 +598,7 @@ TEST(ScreenTime, RemoveDataWithTimeInterval)
         })
     };
 
-    RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[_WKWebsiteDataTypeScreenTime]]);
+    RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[ WKWebsiteDataTypeScreenTime ]]);
 
     RetainPtr uuid = [NSUUID UUID];
     RetainPtr websiteDataStore = [WKWebsiteDataStore dataStoreForIdentifier:uuid.get()];
@@ -647,7 +647,7 @@ TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)
 TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [configuration _setShowsSystemScreenTimeBlockingView:NO];
+    [configuration setShowsSystemScreenTimeBlockingView:NO];
 
     RetainPtr webView = webViewForScreenTimeTests(configuration.get());
     [webView synchronouslyLoadHTMLString:@""];


### PR DESCRIPTION
#### f3ca138c547dddd9a40cbd6f7d8a90e5fc4c2740
<pre>
[Screen Time Refactoring] Promote SPI to API
<a href="https://bugs.webkit.org/show_bug.cgi?id=290197">https://bugs.webkit.org/show_bug.cgi?id=290197</a>
<a href="https://rdar.apple.com/147535122">rdar://147535122</a>

Reviewed by Aditya Keerthi.

Move SPI to API.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView _updateScreenTimeBasedOnWindowVisibility]):
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):
(-[WKWebView _isBlockedByScreenTime]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration showsSystemScreenTimeBlockingView]):
(-[WKWebViewConfiguration setShowsSystemScreenTimeBlockingView:]):
(-[WKWebViewConfiguration _showsSystemScreenTimeBlockingView]):
(-[WKWebViewConfiguration _setShowsSystemScreenTimeBlockingView:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
(WebKit::toWebsiteDataType):
(WebKit::toWKWebsiteDataTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore allWebsiteDataTypes]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(-[BlockedStateObserver initWithWebView:]):
(testShowsSystemScreenTimeBlockingView):
(testWebContentIsNotClickableShowingSystemScreenTimeBlockingView):
(TEST(ScreenTime, IsBlockedByScreenTimeTrue)):
(TEST(ScreenTime, IsBlockedByScreenTimeFalse)):
(TEST(ScreenTime, IsBlockedByScreenTimeMultiple)):
(TEST(ScreenTime, IsBlockedByScreenTimeKVO)):
(TEST(ScreenTime, ShowSystemScreenTimeBlockingFalseAndRemoved)):
(TEST(ScreenTime, FetchData)):
(TEST(ScreenTime, RemoveDataWithTimeInterval)):
(TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)):

Canonical link: <a href="https://commits.webkit.org/292514@main">https://commits.webkit.org/292514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e8e0fbc8c49281f151d48a8cf3d3990f2b7389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5873 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/46808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/101356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/46808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99292 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/86977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/11906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4742 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/46135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/4840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81806 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/26445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15493 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23319 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/22978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/26458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->