### PR TITLE
WTF::Vector initial capacity isn't validated in RemoteGraphicsContextGL

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -485,6 +485,8 @@
     void getFloatv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (!WTF::isValidCapacityForVector<GCGLfloat>(valueSize))
+            valueSize = 16;
         Vector<GCGLfloat, 16> value(valueSize, 0);
         protectedContext()->getFloatv(pname, value);
         completionHandler(spanReinterpretCast<const float>(value.span()));
@@ -492,6 +494,8 @@
     void getIntegerv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (!WTF::isValidCapacityForVector<GCGLint>(valueSize))
+            valueSize = 4;
         Vector<GCGLint, 4> value(valueSize, 0);
         protectedContext()->getIntegerv(pname, value);
         completionHandler(spanReinterpretCast<const int32_t>(value.span()));
@@ -533,6 +537,8 @@
     void getBooleanv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const bool>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (!WTF::isValidCapacityForVector<GCGLboolean>(valueSize))
+            valueSize = 4;
         Vector<GCGLboolean, 4> value(valueSize, 0);
         protectedContext()->getBooleanv(pname, value);
         completionHandler(spanReinterpretCast<const bool>(value.span()));
@@ -634,6 +640,8 @@
         }
         if (program)
             program = m_objectNames.get(program);
+        if (!WTF::isValidCapacityForVector<GCGLfloat>(valueSize))
+            valueSize = 16;
         Vector<GCGLfloat, 16> value(valueSize, 0);
         protectedContext()->getUniformfv(program, location, value);
         completionHandler(spanReinterpretCast<const float>(value.span()));
@@ -647,6 +655,8 @@
         }
         if (program)
             program = m_objectNames.get(program);
+        if (!WTF::isValidCapacityForVector<GCGLint>(valueSize))
+            valueSize = 4;
         Vector<GCGLint, 4> value(valueSize, 0);
         protectedContext()->getUniformiv(program, location, value);
         completionHandler(spanReinterpretCast<const int32_t>(value.span()));
@@ -660,6 +670,8 @@
         }
         if (program)
             program = m_objectNames.get(program);
+        if (!WTF::isValidCapacityForVector<GCGLuint>(valueSize))
+            valueSize = 4;
         Vector<GCGLuint, 4> value(valueSize, 0);
         protectedContext()->getUniformuiv(program, location, value);
         completionHandler(spanReinterpretCast<const uint32_t>(value.span()));
@@ -1779,6 +1791,8 @@
         }
         if (program)
             program = m_objectNames.get(program);
+        if (!WTF::isValidCapacityForVector<GCGLint>(paramsSize))
+            paramsSize = 4;
         Vector<GCGLint, 4> params(paramsSize, 0);
         protectedContext()->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
         completionHandler(spanReinterpretCast<const int32_t>(params.span()));
@@ -1977,6 +1991,8 @@
     void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (!WTF::isValidCapacityForVector<GCGLint>(paramsSize))
+            paramsSize = 4;
         Vector<GCGLint, 4> params(paramsSize, 0);
         protectedContext()->getInternalformativ(target, internalformat, pname, params);
         completionHandler(spanReinterpretCast<const int32_t>(params.span()));

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -949,6 +949,10 @@ class webkit_ipc_cpp_impl(object):
             size_arg = cpp_arg(get_cpp_type("size_t"), f"{a.name}Size")
             self.args.args += [size_arg]
             store_arg = cpp_arg(webkit_ipc_get_span_store_type(a.type), a.name)
+            inline_capacity = store_arg.type.arity
+            contained_type = a.type.contained_type.type_name
+            self.pre_call_stmts += [f"if (!WTF::isValidCapacityForVector<{contained_type}>({a.name}Size))"]
+            self.pre_call_stmts += [f"    {a.name}Size = {inline_capacity};"]
             self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)}({a.name}Size, 0);"]
             self.in_exprs += [cpp_expr(store_arg.type, f"{store_arg.name}")]
             webkit_ipc_type = webkit_ipc_types[a.type]


### PR DESCRIPTION
#### 634d3c001793240a980bc2fa9dc5cbcc979ae6bf
<pre>
WTF::Vector initial capacity isn&apos;t validated in RemoteGraphicsContextGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=290201">https://bugs.webkit.org/show_bug.cgi?id=290201</a>
<a href="https://rdar.apple.com/146284403">rdar://146284403</a>

Reviewed by Kimmo Kinnunen.

Validate vector capacity in auto-generated code.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getFloatv):
(getIntegerv):
(getBooleanv):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getActiveUniformBlockiv):
(getInternalformativ):
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_impl.process_out_arg):

Canonical link: <a href="https://commits.webkit.org/292806@main">https://commits.webkit.org/292806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aeffeba729602936de0f5d9f95fe670622509a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74033 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100191 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12920 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54380 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47111 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24263 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83076 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20743 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4720 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17767 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24227 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24050 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->