### PR TITLE
Stop using GridAxis in RenderGrid.

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -130,7 +130,16 @@ void GridTrack::ensureGrowthLimitIsBiggerThanBaseSize()
         m_growthLimit = std::max(m_baseSize, 0_lu);
 }
 
-// Static helper methods.
+
+GridAxis gridAxisForDirection(GridTrackSizingDirection direction)
+{
+    return direction == GridTrackSizingDirection::ForColumns ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
+}
+
+GridTrackSizingDirection gridDirectionForAxis(GridAxis axis)
+{
+    return axis == GridAxis::GridRowAxis ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
+}
 
 static bool hasRelativeMarginOrPaddingForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
@@ -1216,7 +1225,7 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& g
     ASSERT(wasSetup());
     ASSERT(canParticipateInBaselineAlignment(gridItem, baselineAxis));
 
-    ItemPosition align = m_renderGrid->selfAlignmentForGridItem(baselineAxis, gridItem).position();
+    auto align = m_renderGrid->selfAlignmentForGridItem(gridDirectionForAxis(baselineAxis), gridItem).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, GridLayoutFunctions::gridDirectionForAxis(baselineAxis));
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, gridItem, baselineAxis);
@@ -1233,7 +1242,7 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForGridItem(const RenderBox& 
         return LayoutUnit();
 
     ASSERT_IMPLIES(baselineAxis == GridAxis::GridColumnAxis, !m_renderGrid->isSubgridRows());
-    ItemPosition align = m_renderGrid->selfAlignmentForGridItem(baselineAxis, gridItem).position();
+    auto align = m_renderGrid->selfAlignmentForGridItem(gridDirectionForAxis(baselineAxis), gridItem).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, GridLayoutFunctions::gridDirectionForAxis(baselineAxis));
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     return m_baselineAlignment.baselineOffsetForGridItem(align, alignmentContext, gridItem, baselineAxis);
@@ -1247,7 +1256,7 @@ void GridTrackSizingAlgorithm::clearBaselineItemsCache()
 
 void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, GridAxis axis, bool cachingRowSubgridsForRootGrid)
 {
-    ASSERT(downcast<RenderGrid>(item.parent())->isBaselineAlignmentForGridItem(item, axis));
+    ASSERT(downcast<RenderGrid>(item.parent())->isBaselineAlignmentForGridItem(item, gridDirectionForAxis(axis)));
 
     if (GridLayoutFunctions::isOrthogonalParent(*m_renderGrid, *item.parent()))
         axis = axis == GridAxis::GridColumnAxis ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -394,4 +394,7 @@ protected:
     GridTrackSizingAlgorithm& m_algorithm;
 };
 
+GridAxis gridAxisForDirection(GridTrackSizingDirection);
+GridTrackSizingDirection gridDirectionForAxis(GridAxis);
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -88,9 +88,9 @@ public:
     std::optional<LayoutUnit> explicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
     void updateGridAreaLogicalSize(RenderBox&, std::optional<LayoutUnit> width, std::optional<LayoutUnit> height) const;
     bool isBaselineAlignmentForGridItem(const RenderBox&) const;
-    bool isBaselineAlignmentForGridItem(const RenderBox& gridItem, GridAxis, AllowedBaseLine = AllowedBaseLine::BothLines) const;
+    bool isBaselineAlignmentForGridItem(const RenderBox& gridItem, GridTrackSizingDirection alignmentContext, AllowedBaseLine = AllowedBaseLine::BothLines) const;
 
-    StyleSelfAlignmentData selfAlignmentForGridItem(GridAxis, const RenderBox&, const RenderStyle* = nullptr) const;
+    StyleSelfAlignmentData selfAlignmentForGridItem(GridTrackSizingDirection alignmentContext, const RenderBox&, const RenderStyle* = nullptr) const;
 
     StyleContentAlignmentData contentAlignment(GridTrackSizingDirection) const;
 
@@ -163,8 +163,8 @@ private:
     ASCIILiteral renderName() const override;
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
-    bool selfAlignmentChangedToStretch(GridAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
-    bool selfAlignmentChangedFromStretch(GridAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
+    bool selfAlignmentChangedToStretch(GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
+    bool selfAlignmentChangedFromStretch(GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
 
     SubgridDidChange subgridDidChange(const RenderStyle& oldStyle) const;
     bool explicitGridDidResize(const RenderStyle&) const;

--- a/Source/WebCore/rendering/style/GridPositionsResolver.h
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.h
@@ -40,8 +40,8 @@ class RenderGrid;
 class RenderStyle;
 
 enum class GridTrackSizingDirection : uint8_t {
-    ForColumns,
-    ForRows
+    ForColumns = 1 << 0,
+    ForRows = 1 << 1
 };
 
 class NamedLineCollectionBase {


### PR DESCRIPTION
#### af55c45287dbe1b1e8a5bd8c114bcbb4ad06d848
<pre>
Stop using GridAxis in RenderGrid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286716">https://bugs.webkit.org/show_bug.cgi?id=286716</a>
<a href="https://rdar.apple.com/problem/143852695">rdar://problem/143852695</a>

Reviewed by Alan Baradlay.

This patch serves as a first step towards removing the confusing
GridAxis enum in grid layout code by first removing the uses within
RenderGrid.

The reason why I would like to remove this enum is because I find the
name and its value somewhat ambiguous. For example, when I read
GridAxis::GridColumnAxis I could interpret it as either of the following
two ways:

1.) The direction in which the lines of the column itself grow
2.) The direction in which the columns themselves are added/grow

My first interpretation leads me to interpret it as 2, however that is
not how the code uses it which I find unexpected.

The main reason why I feel like we should just remove this enum rather
than trying to do some form of a rename is because we already have
existing capabilities and terminology to capture what it is trying to
do.

The lines of the rows always grow in the inline direction of the
grid and the lines of the columns always grow in the block direction
of the grid.

We also have the GridTrackSizingDirection enum which is used to
represent what type of track (i.e. row or column) we are working
or performing some sort of computation on. For example,
GridTrackSizingDirection::ForRows would mean that we are working on a
row, which is defined by a set of lines running across the inline axis
of the grid. That, along with potentially some other information such as
the track index, provides the physical area we are working upon.

The notion of the GridAxis is mainly being used in the code for
positioning/alignment of the grid items. This means we should just be
able to swap out the uses of GridAxis in the code with the equivalent
value of GridTrackSizingAlgorithm while still retaining all the
necessary information like in RenderGrid::selfAlignmentForGridItem. That
function determines the self alignment value for an item in a particular
GridAxis. An equivalent way of looking at this using some spec terms
would be that we are attempting to find the self-alignment value of an
item inside of a particular alignment context. In this case, a value of
GridAxis::GridColumnAxis, aligning the item along the block direction,
would mean aligning the item inside a row alignment context.

There are some cases where RenderGrid code needs to use a
GridTrackSizingAlgorithm API that takes in a GridAxis and vice versa.
Since this patch only focuses on removing the use of GridAxis inside of
RenderGrid, we can use a helper function that translates the use of one
enum to another so we can remove all uses in RenderGrid. When this is
all done, we should not only be able to get rid of the enum but also the
helper functions since we will just have GridTrackSizingDirection.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::gridAxisForDirection):
(WebCore::gridDirectionForAxis):
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForGridItem const):
(WebCore::GridTrackSizingAlgorithm::cacheBaselineAlignedItem):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::selfAlignmentForGridItem const):
(WebCore::RenderGrid::selfAlignmentChangedToStretch const):
(WebCore::RenderGrid::selfAlignmentChangedFromStretch const):
(WebCore::RenderGrid::styleDidChange):
(WebCore::cacheBaselineAlignedGridItems):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::isBaselineAlignmentForGridItem const):
(WebCore::RenderGrid::getBaselineGridItem const):
(WebCore::RenderGrid::columnAxisBaselineOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisBaselineOffsetForGridItem const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridPositionsResolver.h:

Canonical link: <a href="https://commits.webkit.org/292609@main">https://commits.webkit.org/292609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05b31d2ce927aae842f9415ef24bc3039dfa9362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73374 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12128 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46102 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103351 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82415 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26418 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16697 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->