### PR TITLE
Text indicator sometimes is clipped during bounce.

### DIFF
--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -131,6 +131,38 @@ RefPtr<TextIndicator> TextIndicator::createWithSelectionInFrame(LocalFrame& fram
     return TextIndicator::create(data);
 }
 
+bool TextIndicator::wantsBounce() const
+{
+    switch (m_data.presentationTransition) {
+    case WebCore::TextIndicatorPresentationTransition::BounceAndCrossfade:
+    case WebCore::TextIndicatorPresentationTransition::Bounce:
+        return true;
+
+    case WebCore::TextIndicatorPresentationTransition::FadeIn:
+    case WebCore::TextIndicatorPresentationTransition::None:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+bool TextIndicator::wantsManualAnimation() const
+{
+    switch (m_data.presentationTransition) {
+    case WebCore::TextIndicatorPresentationTransition::FadeIn:
+        return true;
+
+    case WebCore::TextIndicatorPresentationTransition::Bounce:
+    case WebCore::TextIndicatorPresentationTransition::BounceAndCrossfade:
+    case WebCore::TextIndicatorPresentationTransition::None:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 static bool hasNonInlineOrReplacedElements(const SimpleRange& range)
 {
     for (auto& node : intersectingNodes(range)) {

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -167,6 +167,9 @@ public:
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }
 
+    bool wantsBounce() const;
+    WEBCORE_EXPORT bool wantsManualAnimation() const;
+
     TextIndicatorData data() const { return m_data; }
 
 private:

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.h
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.h
@@ -42,9 +42,6 @@ WEBCORE_EXPORT @interface WebTextIndicatorLayer : CALayer {
 
 - (instancetype)initWithFrame:(CGRect)frame textIndicator:(WebCore::TextIndicator&)textIndicator margin:(CGSize)margin offset:(CGPoint)offset;
 
-- (bool)indicatorWantsManualAnimation:(const WebCore::TextIndicator&)indicator;
-- (bool)indicatorWantsBounce:(const WebCore::TextIndicator&)indicator;
-
 - (void)present;
 - (void)hideWithCompletionHandler:(void(^)(void))completionHandler;
 

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -91,38 +91,6 @@ static bool indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
     return false;
 }
 
-- (bool)indicatorWantsBounce:(const WebCore::TextIndicator&)indicator
-{
-    switch (indicator.presentationTransition()) {
-    case WebCore::TextIndicatorPresentationTransition::BounceAndCrossfade:
-    case WebCore::TextIndicatorPresentationTransition::Bounce:
-        return true;
-
-    case WebCore::TextIndicatorPresentationTransition::FadeIn:
-    case WebCore::TextIndicatorPresentationTransition::None:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
-- (bool)indicatorWantsManualAnimation:(const WebCore::TextIndicator&)indicator
-{
-    switch (indicator.presentationTransition()) {
-    case WebCore::TextIndicatorPresentationTransition::FadeIn:
-        return true;
-
-    case WebCore::TextIndicatorPresentationTransition::Bounce:
-    case WebCore::TextIndicatorPresentationTransition::BounceAndCrossfade:
-    case WebCore::TextIndicatorPresentationTransition::None:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
 - (instancetype)initWithFrame:(CGRect)frame textIndicator:(WebCore::TextIndicator&)textIndicator margin:(CGSize)margin offset:(CGPoint)offset
 {
     if (!(self = [super init]))
@@ -287,7 +255,7 @@ static RetainPtr<CABasicAnimation> createFadeInAnimation(CFTimeInterval duration
 
 - (CFTimeInterval)_animationDuration
 {
-    if ([self indicatorWantsBounce:*_textIndicator]) {
+    if (_textIndicator->wantsBounce()) {
         if (indicatorWantsContentCrossfade(*_textIndicator))
             return bounceWithCrossfadeAnimationDuration;
         return WebCore::bounceAnimationDuration.value();
@@ -304,7 +272,7 @@ static RetainPtr<CABasicAnimation> createFadeInAnimation(CFTimeInterval duration
 - (void)present
 {
     RefPtr textIndicator = _textIndicator;
-    bool wantsBounce = [self indicatorWantsBounce:*textIndicator];
+    bool wantsBounce = textIndicator->wantsBounce();
     bool wantsCrossfade = indicatorWantsContentCrossfade(*textIndicator);
     bool wantsFadeIn = indicatorWantsFadeIn(*textIndicator);
     CFTimeInterval animationDuration = [self _animationDuration];
@@ -326,7 +294,7 @@ static RetainPtr<CABasicAnimation> createFadeInAnimation(CFTimeInterval duration
 
     [CATransaction begin];
     for (CALayer *bounceLayer in _bounceLayers.get()) {
-        if ([self indicatorWantsManualAnimation:*textIndicator])
+        if (textIndicator->wantsManualAnimation())
             bounceLayer.speed = 0;
 
         if (!wantsFadeIn)

--- a/Source/WebCore/page/mac/TextIndicatorWindow.mm
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.mm
@@ -85,7 +85,7 @@ void TextIndicatorWindow::clearTextIndicator(WebCore::TextIndicatorDismissalAnim
     if ([m_textIndicatorLayer isFadingOut])
         return;
 
-    if (textIndicator && [m_textIndicatorLayer indicatorWantsManualAnimation:*textIndicator] && [m_textIndicatorLayer hasCompletedAnimation] && animation == WebCore::TextIndicatorDismissalAnimation::FadeOut) {
+    if (textIndicator && textIndicator->wantsManualAnimation() && [m_textIndicatorLayer hasCompletedAnimation] && animation == WebCore::TextIndicatorDismissalAnimation::FadeOut) {
         startFadeOut();
         return;
     }
@@ -104,8 +104,9 @@ void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGR
 
     CGFloat horizontalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultHorizontalMargin;
     CGFloat verticalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultVerticalMargin;
-    
-    if ([m_textIndicatorLayer indicatorWantsBounce:*m_textIndicator]) {
+
+    RefPtr<TextIndicator> local_textIndicator = m_textIndicator;
+    if (local_textIndicator->wantsBounce()) {
         horizontalMargin = std::max(horizontalMargin, textBoundingRectInScreenCoordinates.size.width * (WebCore::midBounceScale - 1) + horizontalMargin);
         verticalMargin = std::max(verticalMargin, textBoundingRectInScreenCoordinates.size.height * (WebCore::midBounceScale - 1) + verticalMargin);
     }
@@ -124,7 +125,7 @@ void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGR
 
     NSRect frame = NSMakeRect(0, 0, [m_textIndicatorWindow frame].size.width, [m_textIndicatorWindow frame].size.height);
     m_textIndicatorLayer = adoptNS([[WebTextIndicatorLayer alloc] initWithFrame:frame
-        textIndicator:*m_textIndicator margin:NSMakeSize(horizontalMargin, verticalMargin) offset:fractionalTextOffset]);
+        textIndicator:*local_textIndicator margin:NSMakeSize(horizontalMargin, verticalMargin) offset:fractionalTextOffset]);
     m_textIndicatorView = adoptNS([[WebTextIndicatorView alloc] initWithFrame:frame]);
     [m_textIndicatorView setLayer:m_textIndicatorLayer.get()];
     [m_textIndicatorView setWantsLayer:YES];
@@ -133,7 +134,7 @@ void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGR
     [[m_targetView window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
     [m_textIndicatorWindow setReleasedWhenClosed:NO];
 
-    if (m_textIndicator->presentationTransition() != TextIndicatorPresentationTransition::None)
+    if (local_textIndicator->presentationTransition() != TextIndicatorPresentationTransition::None)
         [m_textIndicatorLayer present];
 
     if (lifetime == TextIndicatorLifetime::Temporary)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12432,7 +12432,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     if ([_textIndicatorLayer isFadingOut])
         return;
 
-    if (textIndicator && [_textIndicatorLayer indicatorWantsManualAnimation:*textIndicator] && [_textIndicatorLayer hasCompletedAnimation] && animation == WebCore::TextIndicatorDismissalAnimation::FadeOut) {
+    if (textIndicator && textIndicator->wantsManualAnimation() && [_textIndicatorLayer hasCompletedAnimation] && animation == WebCore::TextIndicatorDismissalAnimation::FadeOut) {
         [self startFadeOut];
         return;
     }


### PR DESCRIPTION
#### 4a9813ddb4606e51b94b3273e1138cd953ef932c
<pre>
Text indicator sometimes is clipped during bounce.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290207">https://bugs.webkit.org/show_bug.cgi?id=290207</a>
<a href="https://rdar.apple.com/147602900">rdar://147602900</a>

Reviewed by Wenson Hsieh.

For some reason the code for what kind of animation that a text
indicator &apos;wanted&apos; was on the TextIndicatorLayer. But if the layer
didn&apos;t exists when asking the question, then it would give a
false negative, meaning that the window wasn&apos;t created large enough
to hold the bounce, meaning that the animation would be clipped.
There&apos;s no reason that this logic shouldn&apos;t just be on the text
indicator itself, so just move that logic and update all the call points.

* Source/WebCore/page/TextIndicator.cpp:
(WebCore::TextIndicator::wantsBounce):
(WebCore::TextIndicator::wantsManualAnimation):
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.h:
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(-[WebTextIndicatorLayer _animationDuration]):
(-[WebTextIndicatorLayer present]):
(-[WebTextIndicatorLayer indicatorWantsBounce:]): Deleted.
(-[WebTextIndicatorLayer indicatorWantsManualAnimation:]): Deleted.
* Source/WebCore/page/mac/TextIndicatorWindow.mm:
(WebCore::TextIndicatorWindow::clearTextIndicator):
(WebCore::TextIndicatorWindow::setTextIndicator):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView clearTextIndicator:]):

Canonical link: <a href="https://commits.webkit.org/292612@main">https://commits.webkit.org/292612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21efd7c418f348f9021dc7dca0217a523575720d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73585 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30815 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83341 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82011 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->