### PR TITLE
[WPE] Use ASharedMemory when targeting Android

### DIFF
--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -86,6 +86,8 @@ platform/libwpe/PlatformPasteboardLibWPE.cpp
 platform/text/Hyphenation.cpp
 platform/text/LocaleICU.cpp
 
+platform/android/SharedMemoryAndroid.cpp
+
 platform/unix/LoggingUnix.cpp
 platform/unix/SharedMemoryUnix.cpp
 

--- a/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
+++ b/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2025 Igalia S.L.
  * Copyright (C) 2010 Apple Inc. All rights reserved.
  * Copyright (c) 2010 University of Szeged
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
@@ -28,8 +29,9 @@
 #include "config.h"
 #include "SharedMemory.h"
 
-#if USE(UNIX_DOMAIN_SOCKETS) && !OS(ANDROID)
+#if OS(ANDROID)
 
+#include <android/sharedmem.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -44,11 +46,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
-
-#if HAVE(LINUX_MEMFD_H)
-#include <linux/memfd.h>
-#include <sys/syscall.h>
-#endif
 
 namespace WebCore {
 
@@ -76,60 +73,24 @@ static inline int accessModeMMap(SharedMemory::Protection protection)
     return PROT_READ | PROT_WRITE;
 }
 
-static UnixFileDescriptor createSharedMemory()
+static UnixFileDescriptor createSharedMemory(size_t size)
 {
-    int fileDescriptor = -1;
-
-#if HAVE(LINUX_MEMFD_H)
-    static bool isMemFdAvailable = true;
-    if (isMemFdAvailable) {
-        do {
-            fileDescriptor = syscall(__NR_memfd_create, "WebKitSharedMemory", MFD_CLOEXEC);
-        } while (fileDescriptor == -1 && errno == EINTR);
-
-        if (fileDescriptor != -1)
-            return UnixFileDescriptor { fileDescriptor, UnixFileDescriptor::Adopt };
-
-        if (errno != ENOSYS)
-            return { };
-
-        isMemFdAvailable = false;
-    }
-#endif
-
-#if HAVE(SHM_ANON)
-    do {
-        fileDescriptor = shm_open(SHM_ANON, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
-    } while (fileDescriptor == -1 && errno == EINTR);
-#else
-    CString tempName;
-    for (int tries = 0; fileDescriptor == -1 && tries < 10; ++tries) {
-        auto name = makeString("/WK2SharedMemory."_s, cryptographicallyRandomNumber<unsigned>());
-        tempName = name.utf8();
-
-        do {
-            fileDescriptor = shm_open(tempName.data(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
-        } while (fileDescriptor == -1 && errno == EINTR);
-    }
-
-    if (fileDescriptor != -1)
-        shm_unlink(tempName.data());
-#endif
-
+    const auto name = makeString("/WK2SharedMemory."_s, cryptographicallyRandomNumber<unsigned>());
+    int fileDescriptor = ASharedMemory_create(name.utf8().data(), size);
     return UnixFileDescriptor { fileDescriptor, UnixFileDescriptor::Adopt };
 }
 
 RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
-    auto fileDescriptor = createSharedMemory();
+    auto fileDescriptor = createSharedMemory(size);
     if (!fileDescriptor) {
         WTFLogAlways("Failed to create shared memory: %s", safeStrerror(errno).data());
         return nullptr;
     }
 
-    while (ftruncate(fileDescriptor.value(), size) == -1) {
-        if (errno != EINTR)
-            return nullptr;
+    if (ASharedMemory_setProt(fileDescriptor.value(), PROT_READ | PROT_WRITE) == -1) {
+        WTFLogAlways("Failed to set ASharedMemory protection: %s", safeStrerror(errno).data());
+        return nullptr;
     }
 
     void* data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fileDescriptor.value(), 0);
@@ -176,19 +137,32 @@ SharedMemory::~SharedMemory()
     munmap(m_data, m_size);
 }
 
-auto SharedMemory::createHandle(Protection) -> std::optional<Handle>
+auto SharedMemory::createHandle([[maybe_unused]] Protection protection) -> std::optional<Handle>
 {
-    // FIXME: Handle the case where the passed Protection is ReadOnly.
-    // See https://bugs.webkit.org/show_bug.cgi?id=131542.
-
     UnixFileDescriptor duplicate { m_fileDescriptor.value(), UnixFileDescriptor::Duplicate };
     if (!duplicate) {
         ASSERT_NOT_REACHED();
         return std::nullopt;
     }
+
+    int protectionMode;
+    switch (protection) {
+    case SharedMemory::Protection::ReadOnly:
+        protectionMode = PROT_READ;
+        break;
+    case SharedMemory::Protection::ReadWrite:
+        protectionMode = PROT_WRITE;
+        break;
+    }
+
+    if (ASharedMemory_setProt(duplicate.value(), protectionMode) == -1) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
     return { Handle(WTFMove(duplicate), m_size) };
 }
 
 } // namespace WebCore
 
-#endif // !OS(ANDROID) && USE(UNIX_DOMAIN_SOCKETS)
+#endif // OS(ANDROID)


### PR DESCRIPTION
#### 26eadedcaa761b153ddbbe473d932c240d95cbfe
<pre>
[WPE] Use ASharedMemory when targeting Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=290210">https://bugs.webkit.org/show_bug.cgi?id=290210</a>

Reviewed by Carlos Garcia Campos.

When targeting Android use the ASharedMemory API to create shared memory
buffers and to adjust their protection bits. OS(ANDROID) guards ensure
that only the new implementation gets built.

* Source/WebCore/SourcesWPE.txt: List new SharedMemoryAndroid.cpp source.
* Source/WebCore/platform/android/SharedMemoryAndroid.cpp: Added, based
on the code from SharedMemoryUnix.cpp but using ASharedMemory instead.
(WebCore::SharedMemoryHandle::SharedMemoryHandle):
(WebCore::SharedMemoryHandle::releaseHandle):
(WebCore::accessModeMMap):
(WebCore::createSharedMemory):
(WebCore::SharedMemory::allocate):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::wrapMap):
(WebCore::SharedMemory::~SharedMemory):
(WebCore::SharedMemory::createHandle):
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:

Canonical link: <a href="https://commits.webkit.org/293579@main">https://commits.webkit.org/293579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ecdf72dd06b340372503845f525126e1116f8c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99336 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75600 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32706 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7666 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106824 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26450 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84560 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84072 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21326 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20190 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31590 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->