### PR TITLE
Stop using IOChannel in NetworkCache

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -39,6 +39,18 @@
 namespace WebKit {
 namespace NetworkCache {
 
+#if !USE(GLIB) && USE(CURL)
+Data::Data(Vector<uint8_t>&& data)
+    : Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTFMove(data) })
+{
+}
+#elif !PLATFORM(COCOA)
+Data::Data(Vector<uint8_t>&& data)
+    : Data(data.span())
+{
+}
+#endif
+
 Data Data::mapToFile(const String& path) const
 {
     FileSystem::FileHandle handle;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -32,6 +32,7 @@
 #include <wtf/MappedFileData.h>
 #include <wtf/SHA1.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
@@ -59,6 +60,7 @@ class Data {
 public:
     Data() { }
     Data(std::span<const uint8_t>);
+    Data(Vector<uint8_t>&& data);
 
     ~Data() { }
 
@@ -73,7 +75,6 @@ public:
     Data(GRefPtr<GBytes>&&, FileSystem::FileHandle&& = { });
 #elif USE(CURL)
     Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData>&&);
-    Data(Vector<uint8_t>&& data) : Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTFMove(data) }) { }
 #endif
     bool isNull() const;
     bool isEmpty() const { return !size(); }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -32,6 +32,7 @@
 #import <sys/stat.h>
 #import <wtf/FileHandle.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 namespace NetworkCache {
@@ -44,6 +45,11 @@ Data::Data(std::span<const uint8_t> data)
 Data::Data(OSObjectPtr<dispatch_data_t>&& dispatchData, Backing backing)
     : m_dispatchData(WTFMove(dispatchData))
     , m_isMap(backing == Backing::Map && dispatch_data_get_size(m_dispatchData.get()))
+{
+}
+
+Data::Data(Vector<uint8_t>&& data)
+    : Data(makeDispatchData(WTFMove(data)).get(), Backing::Buffer)
 {
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -103,7 +103,7 @@ public:
     void retrieve(const Key&, unsigned priority, RetrieveCompletionHandler&&);
 
     using MappedBodyHandler = Function<void (const Data& mappedBody)>;
-    void store(const Record&, MappedBodyHandler&&, CompletionHandler<void(int)>&& = { });
+    void store(const Record&, MappedBodyHandler&&);
 
     void remove(const Key&);
     void remove(const Vector<Key>&, CompletionHandler<void()>&&);
@@ -166,13 +166,13 @@ private:
     void dispatchPendingWriteOperations();
     void addWriteOperationActivity(WriteOperationIdentifier);
     bool removeWriteOperationActivity(WriteOperationIdentifier);
-    void finishWriteOperationActivity(WriteOperationIdentifier, int error = 0);
+    void finishWriteOperationActivity(WriteOperationIdentifier);
 
     bool shouldStoreBodyAsBlob(const Data& bodyData);
     std::optional<BlobStorage::Blob> storeBodyAsBlob(WriteOperationIdentifier, const Storage::Record&);
     Data encodeRecord(const Record&, std::optional<BlobStorage::Blob>);
     Record readRecord(const Data&);
-    void readRecordFromData(Storage::ReadOperationIdentifier, MonotonicTime, Data&&, int error);
+    void readRecordFromData(Storage::ReadOperationIdentifier, MonotonicTime, std::optional<Vector<uint8_t>>&&);
     void readBlobIfNecessary(Storage::ReadOperationIdentifier, const String& blobPath);
 
     void updateFileModificationTime(String&& path);


### PR DESCRIPTION
#### 0b589ff5c2f2066348731a0f48c271c63dd43ad7
<pre>
Stop using IOChannel in NetworkCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=290211">https://bugs.webkit.org/show_bug.cgi?id=290211</a>
<a href="https://rdar.apple.com/142645876">rdar://142645876</a>

Reviewed by Per Arne Vollan.

This is a speculative fix for a hard-to-repro issue where page loads sometimes hang for minutes
while the system is under heavy load.

What we see in logs is that the disk network cache lookup ends up on a pri 4 default overcommit
dispatch queue. That thread is parked in a pread and gets preempted for minutes while other higher
pri work is occurring. The thing that is enqueuing the pread on to that dispatch queue is
`dispatch_io_read`, which enqueues that block on to a queue that it controls. We think that probably
something is going wrong with the priority propagation to that queue sometimes, as the network cache
lookup hops from main thread =&gt; network cache I/O queue =&gt; dispatch_io private queue and back.

As a speculative fix:

- Stop using `dispatch_io` / `IOChannel` altogether. It buys us nothing other than adding extra
  thread hops, making things harder to debug, and perhaps exposing some latent bug in priority
  propagation. Instead, just do the I/O directly on the network cache&apos;s I/O queues.

- Change the priority of the read-only I/O queue from default to UserInteractive, since it&apos;s on the
  blocking path for resource fetching.

- Change the priority of the write I/O queues from Background to Utility, since Background is very
  punitive (capped at max pri 4), and if we get anything wrong, getting capped at max pri 4 can
  cause minutes of starvation.

WriteOperations also had an completion handler that received an integer errno as an argument. This
was unused, so I removed it.

* Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp:
(WebKit::NetworkCache::Data::Data):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::Data):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::WriteOperation::WriteOperation):
(WebKit::NetworkCache::Storage::WriteOperation::~WriteOperation):
(WebKit::NetworkCache::Storage::Storage):
(WebKit::NetworkCache::Storage::dispatchReadOperation):
(WebKit::NetworkCache::Storage::readRecordFromData):
(WebKit::NetworkCache::Storage::dispatchWriteOperation):
(WebKit::NetworkCache::Storage::finishWriteOperationActivity):
(WebKit::NetworkCache::Storage::store):
(WebKit::NetworkCache::Storage::WriteOperation::invokeCompletionHandler): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
(WebKit::NetworkCache::Storage::store): Deleted.

Canonical link: <a href="https://commits.webkit.org/292576@main">https://commits.webkit.org/292576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95cf059d1197a8a8c4f1646e2d0fc0b1821e7869

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30627 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11917 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46148 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103397 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28487 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->