### PR TITLE
[GTK][WPE][Skia] Stop using finishAcceleratedRenderingAndCreateFence & friends in ImageBuffer

### DIFF
--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -63,6 +63,11 @@
 #include "OffscreenCanvas.h"
 #endif
 
+#if USE(SKIA)
+#include "GLFence.h"
+#include "GraphicsContextSkia.h"
+#endif
+
 namespace WebCore {
 
 
@@ -192,11 +197,12 @@ void ImageBitmap::close()
 void ImageBitmap::prepareForCrossThreadTransfer()
 {
     m_bitmap = ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(WTFMove(m_bitmap));
+    m_fence = m_bitmap->renderingMode() == RenderingMode::Accelerated ? GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded(m_bitmap->surface()) : nullptr;
 }
 
 void ImageBitmap::finalizeCrossThreadTransfer()
 {
-    m_bitmap = ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(WTFMove(m_bitmap));
+    m_bitmap = ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(WTFMove(m_bitmap), WTFMove(m_fence));
 }
 #endif
 

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -46,6 +46,7 @@ class CanvasBase;
 class CSSStyleImageValue;
 class DestinationColorSpace;
 class FloatSize;
+class GLFence;
 class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
@@ -178,6 +179,9 @@ private:
     const bool m_originClean : 1 { false };
     const bool m_premultiplyAlpha : 1 { false };
     const bool m_forciblyPremultiplyAlpha : 1 { false };
+#if USE(SKIA)
+    std::unique_ptr<GLFence> m_fence;
+#endif
 };
 
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -51,9 +51,17 @@
 #if USE(CAIRO)
 #include "ImageBufferUtilitiesCairo.h"
 #endif
+
 #if USE(SKIA)
+#include "GLContext.h"
 #include "ImageBufferSkiaAcceleratedBackend.h"
 #include "ImageBufferUtilitiesSkia.h"
+#include "PlatformDisplay.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 #if HAVE(IOSURFACE)
@@ -358,21 +366,39 @@ RefPtr<ImageBuffer> ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(RefPt
 {
     if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
         return buffer;
-    if (buffer->hasOneRef()) {
-        buffer->finishAcceleratedRenderingAndCreateFence();
+    if (buffer->hasOneRef())
         return buffer;
-    }
-    auto bufferCopy = copyImageBuffer(const_cast<ImageBuffer&>(*buffer), PreserveResolution::Yes, RenderingMode::Accelerated);
-    bufferCopy->finishAcceleratedRenderingAndCreateFence();
-    return bufferCopy;
+    return copyImageBuffer(const_cast<ImageBuffer&>(*buffer), PreserveResolution::Yes, RenderingMode::Accelerated);
 }
 
-RefPtr<ImageBuffer> ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer> buffer)
+RefPtr<ImageBuffer> ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer> buffer, std::unique_ptr<GLFence>&& fence)
 {
     if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
         return buffer;
-    buffer->waitForAcceleratedRenderingFenceCompletion();
-    return buffer->copyAcceleratedImageBufferBorrowingBackendRenderTarget();
+
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+    if (!glContext || !glContext->makeContextCurrent())
+        return nullptr;
+
+    if (fence)
+        fence->serverWait();
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    RELEASE_ASSERT(grContext);
+
+    auto* currentSurface = buffer->surface();
+    RELEASE_ASSERT(currentSurface);
+
+    auto backendRenderTarget = SkSurfaces::GetBackendRenderTarget(currentSurface, SkSurfaces::BackendHandleAccess::kFlushRead);
+
+    const auto& imageInfo = currentSurface->imageInfo();
+    auto surface = SkSurfaces::WrapBackendRenderTarget(grContext, backendRenderTarget, kTopLeft_GrSurfaceOrigin, imageInfo.colorType(), imageInfo.refColorSpace(), &currentSurface->props());
+    if (!surface || !surface->getCanvas())
+        return nullptr;
+
+    auto bufferBackendParameters = ImageBuffer::backendParameters(buffer->parameters());
+    auto backend = ImageBufferSkiaAcceleratedBackend::create(bufferBackendParameters, { }, WTFMove(surface));
+    return ImageBuffer::create<ImageBuffer>(buffer->parameters(), buffer->backendInfo(), { }, WTFMove(backend));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -63,6 +63,7 @@ namespace WebCore {
 class BifurcatedGraphicsContext;
 class DynamicContentScalingDisplayList;
 class Filter;
+class GLFence;
 class GraphicsClient;
 class ScriptExecutionContext;
 class SerializedImageBuffer;
@@ -220,7 +221,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
 #if USE(SKIA)
     static RefPtr<ImageBuffer> sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImageBuffer>);
-    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>);
+    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>, std::unique_ptr<GLFence>&&);
 #endif
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
     WEBCORE_EXPORT static RefPtr<SharedBuffer> sinkIntoPDFDocument(RefPtr<ImageBuffer>);

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -1015,7 +1015,7 @@ void GraphicsContextSkia::drawPattern(NativeImage& nativeImage, const FloatRect&
         } else {
             auto dstRect = SkRect::MakeWH(tileRect.width(), tileRect.height());
             auto clipRect = SkRect::MakeWH(tileFloatRectWithSpacing.width(), tileFloatRectWithSpacing.height());
-            // For raster images we can save creating a copy alltogether, by using SkPicture recording instead.
+            // For raster images we can save creating a copy altogether, by using SkPicture recording instead.
             SkPictureRecorder recorder;
             auto* recordCanvas = recorder.beginRecording(clipRect);
             // The below call effectively extracts a tile from the image thus performing a clipping.
@@ -1041,11 +1041,9 @@ SkiaImageToFenceMap GraphicsContextSkia::endRecording()
     return WTFMove(m_imageToFenceMap);
 }
 
-std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image)
+template<typename T>
+inline std::unique_ptr<GLFence> createAcceleratedRenderingFence(T object)
 {
-    if (!image || !image->isTextureBacked())
-        return nullptr;
-
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())
         return nullptr;
@@ -1053,7 +1051,7 @@ std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFenceIfN
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
 
-    grContext->flush(image);
+    grContext->flush(object);
 
     if (GLFence::isSupported()) {
         grContext->submit(GrSyncCpu::kNo);
@@ -1064,6 +1062,20 @@ std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFenceIfN
 
     grContext->submit(GrSyncCpu::kYes);
     return nullptr;
+}
+
+std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded(SkSurface* surface)
+{
+    if (!surface || !surface->recordingContext())
+        return nullptr;
+    return createAcceleratedRenderingFence<SkSurface*>(surface);
+}
+
+std::unique_ptr<GLFence> GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image)
+{
+    if (!image || !image->isTextureBacked())
+        return nullptr;
+    return createAcceleratedRenderingFence<const sk_sp<SkImage>>(image);
 }
 
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -115,6 +115,7 @@ public:
 
     void drawSkiaText(const sk_sp<SkTextBlob>&, SkScalar, SkScalar, bool, bool);
 
+    static std::unique_ptr<GLFence> createAcceleratedRenderingFenceIfNeeded(SkSurface*);
     static std::unique_ptr<GLFence> createAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>&);
 
 private:


### PR DESCRIPTION
#### f18fd5a7e6383917b8f327f39c700aba6dd96006
<pre>
[GTK][WPE][Skia] Stop using finishAcceleratedRenderingAndCreateFence &amp; friends in ImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=290216">https://bugs.webkit.org/show_bug.cgi?id=290216</a>

Reviewed by Carlos Garcia Campos.

ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer() and
ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer() make use of
finishAcceleratedRenderingAndCreateFence() / waitForAcceleratedRenderingFenceCompletion()
and copyAcceleratedImageBufferBorrowingBackendRenderTarget().

These functions and the Skia-specific DisplayList code still use these methods.
The Skia-specific DisplayList code will be removed in a follow-up PR.

ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer() no longer
creates fences - the caller is responsible to do that (the only
caller is ImageBitmap::prepareForCrossThreadTransfer).

ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer() was extended
to receive a fence as parameter -- ImageBuffer(Backend) is no longer
responsible to hold a fence internally. Switch to explicit fencing, that
is easier to follow.

Covered by existing tests.

* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::prepareForCrossThreadTransfer):
(WebCore::ImageBitmap::finalizeCrossThreadTransfer):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer):
(WebCore::ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::createAcceleratedRenderingFence):
(WebCore::GraphicsContextSkia::createAcceleratedRenderingFenceIfNeeded):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:

Canonical link: <a href="https://commits.webkit.org/292699@main">https://commits.webkit.org/292699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05502a869a9e847802bb9f00298ea6bca7b0c03a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83590 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82179 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28953 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->