### PR TITLE
Address safer CPP failures in PageClientImplMac.h

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,1 +1,0 @@
-UIProcess/mac/PageClientImplMac.h

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -33,6 +33,7 @@
 #include <WebCore/DOMPasteAccess.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakObjCPtr.h>
 
 @class WKEditorUndoTarget;
 @class WKView;
@@ -327,7 +328,7 @@ private:
     void didCleanupFullscreen() final { }
 #endif
 
-    NSView *m_view;
+    WeakObjCPtr<NSView> m_view;
     WeakPtr<WebViewImpl> m_impl;
 #if USE(AUTOCORRECTION_PANEL)
     CorrectionPanel m_correctionPanel;

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
@@ -29,6 +29,7 @@
 
 #import "WebDataListSuggestionsDropdown.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS WKDataListSuggestionsController;
 
@@ -50,7 +51,7 @@ private:
 
     void selectOption();
 
-    NSView *m_view;
+    WeakObjCPtr<NSView> m_view;
     RetainPtr<WKDataListSuggestionsController> m_dropdownUI;
 };
 

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -88,7 +88,7 @@ void WebDataListSuggestionsDropdownMac::show(WebCore::DataListSuggestionInformat
         return;
     }
 
-    m_dropdownUI = adoptNS([[WKDataListSuggestionsController alloc] initWithInformation:WTFMove(information) inView:m_view]);
+    m_dropdownUI = adoptNS([[WKDataListSuggestionsController alloc] initWithInformation:WTFMove(information) inView:m_view.get().get()]);
     [m_dropdownUI showSuggestionsDropdown:*this];
 }
 


### PR DESCRIPTION
#### f92ac66b5bca402bb8688b208955fb7795386aed
<pre>
Address safer CPP failures in PageClientImplMac.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=290217">https://bugs.webkit.org/show_bug.cgi?id=290217</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::activeView const):
(WebKit::PageClientImpl::activeWindow const):
(WebKit::PageClientImpl::assistiveTechnologyMakeFirstResponder):
(WebKit::PageClientImpl::makeFirstResponder):
(WebKit::PageClientImpl::setCursor):
(WebKit::PageClientImpl::screenToRootView):
(WebKit::PageClientImpl::rootViewToScreen):
(WebKit::PageClientImpl::createPopupMenuProxy):
(WebKit::PageClientImpl::createContextMenuProxy):
(WebKit::PageClientImpl::createColorPicker):
(WebKit::PageClientImpl::createDataListSuggestionsDropdown):
(WebKit::PageClientImpl::createDateTimePicker):
(WebKit::PageClientImpl::createValidationBubble):
(WebKit::PageClientImpl::didPerformDictionaryLookup):
(WebKit::PageClientImpl::showCorrectionPanel):
(WebKit::PageClientImpl::showDictationAlternativeUI):
(WebKit::PageClientImpl::didFinishNavigation):
(WebKit::PageClientImpl::didFailNavigation):
(WebKit::PageClientImpl::boundsOfLayerInLayerBackedWindowCoordinates const):
(WebKit::PageClientImpl::showPlatformContextMenu):
(WebKit::PageClientImpl::refView):
(WebKit::PageClientImpl::derefView):
(WebKit::PageClientImpl::userInterfaceLayoutDirection):
(WebKit::PageClientImpl::handleContextMenuWritingTools):

Canonical link: <a href="https://commits.webkit.org/292568@main">https://commits.webkit.org/292568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2d53418398c4a4f5fbe60f8074577a5308dee1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30764 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99468 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12066 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4975 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46312 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82175 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23532 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23783 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/83229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81950 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20567 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26597 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16985 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->