### PR TITLE
Address safer CPP failures in WebViewImpl.h

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -27,7 +27,6 @@ UIProcess/Cocoa/WebPageProxyCocoa.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
 UIProcess/WebProcessPool.h
-UIProcess/mac/WebViewImpl.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/InjectedBundle/InjectedBundle.h
 WebProcess/Inspector/WebInspectorClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,6 +1,5 @@
 UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
 UIProcess/DisplayLink.h
 UIProcess/mac/PageClientImplMac.h
-UIProcess/mac/WebViewImpl.h
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 WebProcess/InjectedBundle/InjectedBundle.h

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1705,7 +1705,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     if (!_impl)
         return nil;
-    return _impl->thumbnailView();
+    return _impl->thumbnailView().autorelease();
 }
 
 - (void)_setIgnoresAllEvents:(BOOL)ignoresAllEvents

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -161,7 +161,7 @@ NSView *PageClientImpl::activeView() const
 NSWindow *PageClientImpl::activeWindow() const
 {
     if (m_impl && m_impl->thumbnailView())
-        return m_impl->thumbnailView().window;
+        return [m_impl->thumbnailView() window];
     if (m_impl && m_impl->targetWindowForMovePreparation())
         return m_impl->targetWindowForMovePreparation();
     return m_view.window;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -36,6 +36,7 @@
 #include "WKTextAnimationType.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/FocusDirection.h>
+#include <WebCore/KeypressCommand.h>
 #include <WebCore/PlatformPlaybackSessionInterface.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ShareableBitmap.h>
@@ -184,7 +185,6 @@ enum class ReplacementBehavior : uint8_t;
 
 namespace WebCore {
 struct DragItem;
-struct KeypressCommand;
 #if ENABLE(DIGITAL_CREDENTIALS_UI)
 struct DigitalCredentialsRequestData;
 #endif
@@ -527,7 +527,7 @@ public:
     CALayer *acceleratedCompositingRootLayer() const { return m_rootLayer.get(); }
 
     void setThumbnailView(_WKThumbnailView *);
-    _WKThumbnailView *thumbnailView() const { return m_thumbnailView; }
+    RetainPtr<_WKThumbnailView> thumbnailView() const { return m_thumbnailView.get(); }
 
     void setHeaderBannerLayer(CALayer *);
     CALayer *headerBannerLayer() const { return m_headerBannerLayer.get(); }
@@ -985,7 +985,7 @@ private:
     RetainPtr<CALayer> m_headerBannerLayer;
     RetainPtr<CALayer> m_footerBannerLayer;
 
-    _WKThumbnailView *m_thumbnailView { nullptr };
+    WeakObjCPtr<_WKThumbnailView> m_thumbnailView;
 
     RetainPtr<_WKRemoteObjectRegistry> m_remoteObjectRegistry;
 
@@ -1012,7 +1012,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // the application to distinguish the case of a new event from one
     // that has been already sent to WebCore.
     RetainPtr<NSEvent> m_keyDownEventBeingResent;
-    Vector<WebCore::KeypressCommand>* m_collectedKeypressCommands { nullptr };
+
+    struct CheckedCommands : public CanMakeCheckedPtr<CheckedCommands> {
+        WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedCommands);
+    public:
+        Vector<WebCore::KeypressCommand> commands;
+    };
+    CheckedPtr<CheckedCommands> m_collectedKeypressCommands;
 
     String m_lastStringForCandidateRequest;
     NSInteger m_lastCandidateRequestSequenceNumber;


### PR DESCRIPTION
#### e6c5f910dd55a6b5b3687c8c61e5c1986ebcf065
<pre>
Address safer CPP failures in WebViewImpl.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=290220">https://bugs.webkit.org/show_bug.cgi?id=290220</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::collectKeyboardLayoutCommandsForEvent):
(WebKit::WebViewImpl::doCommandBySelector):
(WebKit::WebViewImpl::insertText):

Canonical link: <a href="https://commits.webkit.org/292563@main">https://commits.webkit.org/292563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7608b92208b4ebfc9ce02ce5516579e3b4e36ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24494 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12292 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12048 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82158 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103542 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23514 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23765 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/83207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81936 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26580 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16959 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28632 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->