### PR TITLE
Sync `css-tables` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
@@ -22,8 +22,8 @@ This should be a 50x50 cyan square:
 Table-layout:fixed does apply to width:min-content tables
 
 min-content
-This should be a 100x50 cyan rectangle:
-Table-layout:fixed does NOT apply to width:max-content tables
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:max-content tables
 
 max-content
 This should be a 50x50 cyan square:
@@ -34,12 +34,12 @@ This should be a 50x50 cyan square:
 Table-layout:fixed does apply to width:-webkit-fill-available tables
 
 -webkit-fill-available
-This should be a 100x50 cyan rectangle:
-Table-layout:fixed does NOT apply to width:intrinsic tables
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:intrinsic tables
 
 intrinsic
-This should be a 100x50 cyan rectangle:
-Table-layout:fixed does NOT apply to width:min-intrinsic tables
+This should be a 50x50 cyan square:
+Table-layout:fixed does apply to width:min-intrinsic tables
 
 min-intrinsic
 
@@ -48,9 +48,9 @@ PASS 100%
 PASS calc(10px + 100%)
 PASS auto
 PASS min-content
-PASS max-content
+FAIL max-content assert_equals: Table is in fixed mode expected 50 but got 100
 PASS fit-content
 PASS -webkit-fill-available
-PASS intrinsic
-PASS min-intrinsic
+FAIL intrinsic assert_equals: Table is in fixed mode expected 50 but got 100
+FAIL min-intrinsic assert_equals: Table is in fixed mode expected 50 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#in-fixed-mode">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10937">
+<meta name="assert" content="Fixed table layout is triggered except when inline-size is auto.">
 <link rel="stylesheet" href="./support/base.css">
 
 <style>
@@ -52,26 +53,25 @@ x-td > div {
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-let sizeData = {
-  "10px": true,
-  "100%": true,
-  "calc(10px + 100%)": true,
-  "auto": false,
-  "min-content": true,
-  "max-content": false,
-  "fit-content": true,
-  "calc-size(any, 10px + 100%)": true,
+let sizes = [
+  "10px",
+  "100%",
+  "calc(10px + 100%)",
+  "auto",
+  "min-content",
+  "max-content",
+  "fit-content",
+  "calc-size(any, 10px + 100%)",
+  "fit-content(0)",
+  "stretch",
+  "contain",
 
-  // These expectations are tentative, see https://github.com/w3c/csswg-drafts/issues/10937
-  "fit-content(0)": true,
-  "stretch": true,
-
-  // These are non-standard, expect the most popular behavior among the supporting implementations.
-  "-moz-available": true,
-  "-webkit-fill-available": true,
-  "intrinsic": false,
-  "min-intrinsic": false,
-};
+  // These are non-standard sizes.
+  "-moz-available",
+  "-webkit-fill-available",
+  "intrinsic",
+  "min-intrinsic",
+];
 
 function checkSize(size, allowsFixed) {
   let fragment = template.content.cloneNode(true);
@@ -101,15 +101,16 @@ function checkSize(size, allowsFixed) {
   }, size);
 }
 
-for (let [size, allowsFixed] of Object.entries(sizeData)) {
+for (let size of sizes) {
   if (CSS.supports("width", size)) {
+    let allowsFixed = size !== "auto";
     checkSize(size, allowsFixed);
 
-    // calc-size() should have the same behavior as its basis.
+    // calc-size() should trigger fixed table layout.
     // https://drafts.csswg.org/css-values-5/#calc-size
     let calcSize = "calc-size(" + size + ", size)";
     if (CSS.supports("width", calcSize)) {
-      checkSize(calcSize, allowsFixed);
+      checkSize(calcSize, true);
     }
   }
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="display: table;">
+  <div style="display: table-cell; height: 50px;">
+    <div></div>
+    <canvas width=1 height=1 style="height: 200%; background: green;"></canvas>
+  </div>
+  <div style="display: table-cell;">
+    <div style="height: 100px;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="display: table;">
+  <div style="display: table-cell; height: 50px;">
+    <span>
+      <canvas width=1 height=1 style="display: block; height: 200%; background: green;"></canvas>
+    </span>
+  </div>
+  <div style="display: table-cell;">
+    <div style="height: 100px;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/w3c-import.log
@@ -192,6 +192,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-overflow-auto-in-unrestricted-block-size-cell.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-002-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell.tentative-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-table-cell-child-expected.xht


### PR DESCRIPTION
#### 3388eabffbdf9dc6b76a132ac46e5d3530023986
<pre>
Sync `css-tables` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=290221">https://bugs.webkit.org/show_bug.cgi?id=290221</a>
<a href="https://rdar.apple.com/147616971">rdar://147616971</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/24b0a3ae223a95ad7c3f11e42cb74018ad9c3ffe">https://github.com/web-platform-tests/wpt/commit/24b0a3ae223a95ad7c3f11e42cb74018ad9c3ffe</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/percent-height-replaced-in-percent-cell-004.html:

Canonical link: <a href="https://commits.webkit.org/292532@main">https://commits.webkit.org/292532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b1e657ba5e4b6485e20f24444e194873e8c5598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46818 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24346 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73396 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30623 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99302 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12160 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17010 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82436 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81814 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26450 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23329 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->