### PR TITLE
Move off of staging SPI for _setNeedsDropPreviewUpdate.

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1207,10 +1207,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @property (nonatomic, readonly) CGRect _selectionClipRect;
 @end
 
-@interface UIDragItem (Staging_117702233)
-- (void)_setNeedsDropPreviewUpdate;
-@end
-
 @interface UIDevice ()
 @property (nonatomic, setter=_setBacklightLevel:) float _backlightLevel;
 @end

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -207,12 +207,6 @@ UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *it
     return m_finalDropPreviews.get(item).get();
 }
 
-inline static bool dragItemSupportsAsynchronousUpdates()
-{
-    static bool hasSupport = [UIDragItem instancesRespondToSelector:@selector(_setNeedsDropPreviewUpdate)];
-    return hasSupport;
-}
-
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, const WebCore::TextIndicatorData& indicator)
 {
     auto textIndicatorImage = uiImageForImage(indicator.contentImage.get());
@@ -222,8 +216,7 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UI
 
     for (auto item : m_defaultDropPreviews.keys()) {
         m_finalDropPreviews.add(item, preview.get());
-        if (dragItemSupportsAsynchronousUpdates())
-            [item _setNeedsDropPreviewUpdate];
+        [item setNeedsDropPreviewUpdate];
     }
 }
 
@@ -248,8 +241,7 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, CG
             // simply retarget the default preview.
             auto target = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:contentView center:placeholderRect.center()]);
             m_finalDropPreviews.add(item, [defaultPreview retargetedPreviewWithTarget:target.get()]);
-            if (dragItemSupportsAsynchronousUpdates())
-                [item _setNeedsDropPreviewUpdate];
+            [item setNeedsDropPreviewUpdate];
             continue;
         }
 
@@ -271,8 +263,7 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, CG
         auto target = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:contentView center:previewIntersectionRect.center() transform:transform]);
         [defaultPreview parameters].visiblePath = [UIBezierPath bezierPathWithRect:insetPreviewBounds];
         m_finalDropPreviews.add(item, adoptNS([[UITargetedDragPreview alloc] initWithView:[defaultPreview view] parameters:[defaultPreview parameters] target:target.get()]));
-        if (dragItemSupportsAsynchronousUpdates())
-            [item _setNeedsDropPreviewUpdate];
+        [item setNeedsDropPreviewUpdate];
     }
 }
 


### PR DESCRIPTION
#### c0a251fb19f37c15cc686a148f2e7a4a6c6513dd
<pre>
Move off of staging SPI for _setNeedsDropPreviewUpdate.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290222">https://bugs.webkit.org/show_bug.cgi?id=290222</a>
<a href="https://rdar.apple.com/147610111">rdar://147610111</a>

Reviewed by Wenson Hsieh.

Move onto the now existing API for consistency.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::dragItemSupportsAsynchronousUpdates): Deleted.
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[DragAndDropSimulator initWithWebView:]):
(-[UIDragItem _setNeedsDropPreviewUpdate]): Deleted.

Canonical link: <a href="https://commits.webkit.org/292678@main">https://commits.webkit.org/292678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ea327dbbe6f672830094b56e880a0400a1eac64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73423 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30654 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46179 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82466 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28518 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->