### PR TITLE
subtitle tracks with no `srclang` show up as " (label)" instead of just "label"

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-expected.txt
+++ b/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-expected.txt
@@ -15,6 +15,7 @@ Subtitles: [
   "Spanish Captions",
   "Spanish",
   "Spanish Descriptions",
+  "no-srclang",
   "Chinese (China mainland)",
   "French Captions (label-fr)",
   "French (label-fr)",

--- a/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html
+++ b/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html
@@ -16,7 +16,8 @@
     <track src="../../lorem-ipsum.vtt" kind="subtitles"    srclang="fr" label="label-fr">
     <track src="../../lorem-ipsum.vtt" kind="descriptions" srclang="es" label="Descriptions">
     <track src="../../lorem-ipsum.vtt" kind="captions"     srclang="es">
-    <track src="../../lorem-ipsum.vtt" kind="subtitles"    srclang="es">
+    <track src="../../lorem-ipsum.vtt" kind="subtitles"    srclang="es" label=" ">
+    <track src="../../lorem-ipsum.vtt" kind="subtitles"                 label="no-srclang">
     <track src="../../lorem-ipsum.vtt" kind="subtitles"    srclang="zh-CN">
 </video>
 <script type="text/javascript">

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -217,11 +217,11 @@ static String trackDisplayName(TextTrack* track)
     if (track == &TextTrack::captionMenuAutomaticItem())
         return textTrackAutomaticMenuItemText();
 
-    if (track->label().isEmpty() && track->validBCP47Language().isEmpty())
-        return trackNoLabelText();
-    if (!track->label().isEmpty())
+    if (auto label = track->label().string().trim(isASCIIWhitespace); !label.isEmpty())
         return track->label();
-    return track->validBCP47Language();
+    if (auto languageIdentifier = track->validBCP47Language(); !languageIdentifier.isEmpty())
+        return languageIdentifier;
+    return trackNoLabelText();
 }
 
 String CaptionUserPreferences::displayNameForTrack(TextTrack* track) const
@@ -286,11 +286,11 @@ Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTra
 
 static String trackDisplayName(AudioTrack* track)
 {
-    if (track->label().isEmpty() && track->validBCP47Language().isEmpty())
-        return trackNoLabelText();
-    if (!track->label().isEmpty())
+    if (auto label = track->label().string().trim(isASCIIWhitespace); !label.isEmpty())
         return track->label();
-    return track->validBCP47Language();
+    if (auto languageIdentifier = track->validBCP47Language(); !languageIdentifier.isEmpty())
+        return languageIdentifier;
+    return trackNoLabelText();
 }
 
 String CaptionUserPreferences::displayNameForTrack(AudioTrack* track) const

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -735,7 +735,7 @@ static String trackDisplayName(const TrackBase& track)
 
     String result;
 
-    String label = track.label();
+    String label = track.label().string().trim(isASCIIWhitespace);
     String trackLanguageIdentifier = track.validBCP47Language();
 
     auto preferredLanguages = userPreferredLanguages(ShouldMinimizeLanguages::No);
@@ -761,8 +761,12 @@ static String trackDisplayName(const TrackBase& track)
 
         result = addTrackKindDisplayNameIfNeeded(track, result);
 
-        if (!label.isEmpty() && !result.contains(label))
-            result = addTrackLabelAsSuffix(result, label);
+        if (!label.isEmpty()) {
+            if (result.isEmpty())
+                result = label;
+            else if (!result.contains(label))
+                result = addTrackLabelAsSuffix(result, label);
+        }
     }
 
     if (result.isEmpty())


### PR DESCRIPTION
#### 83905fa0a630452ecbf7abf7b79d1aca8965c8cc
<pre>
subtitle tracks with no `srclang` show up as &quot; (label)&quot; instead of just &quot;label&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=290226">https://bugs.webkit.org/show_bug.cgi?id=290226</a>

Reviewed by Eric Carlson.

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::trackDisplayName):
Only use the localized format string if both parts are valid.

* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::trackDisplayName):
Strip any leading/trailing whitespace from the `label` before deciding whether to use it.

* LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages.html:
* LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-expected.txt:

Canonical link: <a href="https://commits.webkit.org/292577@main">https://commits.webkit.org/292577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f136dbc1e2bff8b493ec978f46e05d84a51af8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24504 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73526 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99460 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12301 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53862 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4963 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82167 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5081 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23524 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17160 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23775 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83242 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20571 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26589 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4100 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->