### PR TITLE
AX: Eagerly computing AXProperty::Orientation is extremely expensive and unnecessary

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -761,6 +761,33 @@ bool AXCoreObject::selfOrAncestorLinkHasPopup() const
     return false;
 }
 
+AccessibilityOrientation AXCoreObject::orientation() const
+{
+    if (std::optional orientation = explicitOrientation())
+        return *orientation;
+
+    // In ARIA 1.1, the implicit value of aria-orientation changed from horizontal
+    // to undefined on all roles that don't have their own role-specific values. In
+    // addition, the implicit value of combobox became undefined.
+    if (isComboBox() || isRadioGroup() || isTreeGrid())
+        return AccessibilityOrientation::Undefined;
+
+    if (isScrollbar() || isList() || isListBox() || isMenu() || isTree())
+        return AccessibilityOrientation::Vertical;
+
+    if (isMenuBar() || isSplitter() || isTabList() || isToolbar() || isSlider())
+        return AccessibilityOrientation::Horizontal;
+
+    // Lacking concrete evidence of orientation, horizontal means width > height. vertical is height > width;
+    auto size = this->size();
+    if (size.width() > size.height())
+        return AccessibilityOrientation::Horizontal;
+    if (size.height() > size.width())
+        return AccessibilityOrientation::Vertical;
+
+    return AccessibilityOrientation::Undefined;
+}
+
 AccessibilitySortDirection AXCoreObject::sortDirectionIncludingAncestors() const
 {
     for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentObject()) {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -648,10 +648,10 @@ struct AccessibilityTextOperation {
     AccessibilityTextOperationSmartReplace smartReplace { AccessibilityTextOperationSmartReplace::Yes };
 };
 
-enum class AccessibilityOrientation {
-    Vertical,
-    Horizontal,
+enum class AccessibilityOrientation : uint8_t {
     Undefined,
+    Horizontal,
+    Vertical
 };
 
 enum class TrimWhitespace : bool { No, Yes };
@@ -1255,7 +1255,14 @@ public:
     virtual bool performDismissAction() { return false; }
     virtual void performDismissActionIgnoringResult() = 0;
 
-    virtual AccessibilityOrientation orientation() const = 0;
+    // An object has an "explicit orientation" when its backing entity explicitly provides one,
+    // vs. an "implicit" orientation which is determined inherently by its size or role.
+    //
+    // An example of an explicit orientation is one provided by aria-orientation. Another is scrollbars,
+    // which inherently are horizontal or vertical.
+    virtual std::optional<AccessibilityOrientation> explicitOrientation() const = 0;
+    AccessibilityOrientation orientation() const;
+
     virtual void increment() = 0;
     virtual void decrement() = 0;
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -751,6 +751,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
+    case AXProperty::ExplicitOrientation:
+        stream << "ExplicitOrientation";
+        break;
     case AXProperty::ExtendedDescription:
         stream << "ExtendedDescription";
         break;
@@ -1054,9 +1057,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::NameAttribute:
         stream << "NameAttribute";
-        break;
-    case AXProperty::Orientation:
-        stream << "Orientation";
         break;
     case AXProperty::OuterHTML:
         stream << "OuterHTML";

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4772,7 +4772,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::NameAttribute });
             break;
         case AXNotification::OrientationChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::Orientation });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ExplicitOrientation });
             break;
         case AXNotification::PositionInSetChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::PosInSet, AXProperty::SupportsPosInSet } });

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1066,7 +1066,7 @@ float AccessibilityNodeObject::stepValueForRange() const
     return getAttribute(stepAttr).toFloat();
 }
 
-AccessibilityOrientation AccessibilityNodeObject::orientation() const
+std::optional<AccessibilityOrientation> AccessibilityNodeObject::orientationFromARIA() const
 {
     const AtomString& ariaOrientation = getAttribute(aria_orientationAttr);
     if (equalLettersIgnoringASCIICase(ariaOrientation, "horizontal"_s))
@@ -1076,19 +1076,7 @@ AccessibilityOrientation AccessibilityNodeObject::orientation() const
     if (equalLettersIgnoringASCIICase(ariaOrientation, "undefined"_s))
         return AccessibilityOrientation::Undefined;
 
-    // In ARIA 1.1, the implicit value of aria-orientation changed from horizontal
-    // to undefined on all roles that don't have their own role-specific values. In
-    // addition, the implicit value of combobox became undefined.
-    if (isComboBox() || isRadioGroup() || isTreeGrid())
-        return AccessibilityOrientation::Undefined;
-
-    if (isScrollbar() || isListBox() || isMenu() || isTree())
-        return AccessibilityOrientation::Vertical;
-
-    if (isMenuBar() || isSplitter() || isTabList() || isToolbar() || isSlider())
-        return AccessibilityOrientation::Horizontal;
-
-    return AccessibilityObject::orientation();
+    return std::nullopt;
 }
 
 bool AccessibilityNodeObject::isBusy() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -90,7 +90,8 @@ public:
     float minValueForRange() const override;
     float stepValueForRange() const override;
 
-    AccessibilityOrientation orientation() const override;
+    std::optional<AccessibilityOrientation> orientationFromARIA() const;
+    std::optional<AccessibilityOrientation> explicitOrientation() const override { return orientationFromARIA(); }
 
     AccessibilityButtonState checkboxOrRadioValue() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2580,18 +2580,6 @@ bool AccessibilityObject::insertText(const String& text)
     return editor.insertText(text, nullptr);
 }
 
-// Lacking concrete evidence of orientation, horizontal means width > height. vertical is height > width;
-AccessibilityOrientation AccessibilityObject::orientation() const
-{
-    LayoutRect bounds = elementRect();
-    if (bounds.size().width() > bounds.size().height())
-        return AccessibilityOrientation::Horizontal;
-    if (bounds.size().height() > bounds.size().width())
-        return AccessibilityOrientation::Vertical;
-
-    return AccessibilityOrientation::Undefined;
-}    
-
 using ARIARoleMap = UncheckedKeyHashMap<String, AccessibilityRole, ASCIICaseInsensitiveHash>;
 using ARIAReverseRoleMap = UncheckedKeyHashMap<AccessibilityRole, String, DefaultHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>>;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -520,7 +520,7 @@ public:
     void performDismissActionIgnoringResult() final { performDismissAction(); }
     bool press() override;
 
-    AccessibilityOrientation orientation() const override;
+    std::optional<AccessibilityOrientation> explicitOrientation() const override { return std::nullopt; }
     void increment() override { }
     void decrement() override { }
     virtual bool toggleDetailsAncestor() { return false; }

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
@@ -58,7 +58,7 @@ Document* AccessibilityScrollbar::document() const
     return parent ? parent->document() : nullptr;
 }
 
-AccessibilityOrientation AccessibilityScrollbar::orientation() const
+std::optional<AccessibilityOrientation> AccessibilityScrollbar::explicitOrientation() const
 {
     // ARIA 1.1 Elements with the role scrollbar have an implicit aria-orientation value of vertical.
     if (m_scrollbar->orientation() == ScrollbarOrientation::Horizontal)

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.h
@@ -47,7 +47,7 @@ private:
     LayoutRect elementRect() const final;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ScrollBar; }
-    AccessibilityOrientation orientation() const final;
+    std::optional<AccessibilityOrientation> explicitOrientation() const final;
     Document* document() const final;
     bool isEnabled() const final;
 

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -52,15 +52,10 @@ Ref<AccessibilitySlider> AccessibilitySlider::create(AXID axID, RenderObject& re
     return adoptRef(*new AccessibilitySlider(axID, renderer));
 }
 
-AccessibilityOrientation AccessibilitySlider::orientation() const
+std::optional<AccessibilityOrientation> AccessibilitySlider::explicitOrientation() const
 {
-    auto ariaOrientation = getAttribute(aria_orientationAttr);
-    if (equalLettersIgnoringASCIICase(ariaOrientation, "horizontal"_s))
-        return AccessibilityOrientation::Horizontal;
-    if (equalLettersIgnoringASCIICase(ariaOrientation, "vertical"_s))
-        return AccessibilityOrientation::Vertical;
-    if (equalLettersIgnoringASCIICase(ariaOrientation, "undefined"_s))
-        return AccessibilityOrientation::Undefined;
+    if (std::optional orientation = orientationFromARIA())
+        return orientation;
 
     const auto* style = this->style();
     // Default to horizontal in the unknown case.

--- a/Source/WebCore/accessibility/AccessibilitySlider.h
+++ b/Source/WebCore/accessibility/AccessibilitySlider.h
@@ -56,7 +56,7 @@ private:
     float valueForRange() const final;
     float maxValueForRange() const final;
     float minValueForRange() const final;
-    AccessibilityOrientation orientation() const final;
+    std::optional<AccessibilityOrientation> explicitOrientation() const final;
 };
 
 class AccessibilitySliderThumb final : public AccessibilityMockObject {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -130,7 +130,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     };
 
     // Allocate a capacity based on the minimum properties an object has (based on measurements from a real webpage).
-    constexpr unsigned unignoredSizeToReserve = 11;
+    constexpr unsigned unignoredSizeToReserve = 10;
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     if (object.includeIgnoredInCoreTree()) {
         bool isIgnored = object.isIgnored();
@@ -204,7 +204,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::AccessKey, object.accessKey().isolatedCopy());
     setProperty(AXProperty::AutoCompleteValue, object.autoCompleteValue().isolatedCopy());
     setProperty(AXProperty::ColorValue, object.colorValue());
-    setProperty(AXProperty::Orientation, static_cast<int>(object.orientation()));
+    setProperty(AXProperty::ExplicitOrientation, object.explicitOrientation());
     setProperty(AXProperty::HierarchicalLevel, object.hierarchicalLevel());
     setProperty(AXProperty::LiveRegionStatus, object.liveRegionStatus().isolatedCopy());
     setProperty(AXProperty::LiveRegionRelevant, object.liveRegionRelevant().isolatedCopy());
@@ -640,6 +640,7 @@ void AXIsolatedObject::setProperty(AXProperty propertyName, AXPropertyValueVaria
         [] (WallTime& time) { return !time; },
         [] (TagName& tag) { return tag == TagName::Unknown; },
         [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
+        [] (std::optional<AccessibilityOrientation>& typedValue) { return !typedValue; },
         [](auto&) {
             ASSERT_NOT_REACHED();
             return false;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -349,7 +349,10 @@ private:
 #endif
     AXIsolatedObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
     AXIsolatedObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
-    AccessibilityOrientation orientation() const final { return static_cast<AccessibilityOrientation>(intAttributeValue(AXProperty::Orientation)); }
+    virtual std::optional<AccessibilityOrientation> explicitOrientation() const
+    {
+        return propertyValue<std::optional<AccessibilityOrientation>>(AXProperty::ExplicitOrientation);
+    }
     unsigned hierarchicalLevel() const final { return unsignedAttributeValue(AXProperty::HierarchicalLevel); }
     String language() const final { return stringAttributeValue(AXProperty::Language); }
     void setSelectedChildren(const AccessibilityChildrenVector&) final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -669,6 +669,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::DocumentLinks:
             propertyMap.set(AXProperty::DocumentLinks, axIDs(axObject.documentLinks()));
             break;
+        case AXProperty::ExplicitOrientation:
+            propertyMap.set(AXProperty::ExplicitOrientation, axObject.explicitOrientation());
+            break;
         case AXProperty::ExtendedDescription:
             propertyMap.set(AXProperty::ExtendedDescription, axObject.extendedDescription().isolatedCopy());
             break;
@@ -720,9 +723,6 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
             break;
         case AXProperty::MinValueForRange:
             propertyMap.set(AXProperty::MinValueForRange, axObject.minValueForRange());
-            break;
-        case AXProperty::Orientation:
-            propertyMap.set(AXProperty::Orientation, static_cast<int>(axObject.orientation()));
             break;
         case AXProperty::NameAttribute:
             propertyMap.set(AXProperty::NameAttribute, axObject.nameAttribute().isolatedCopy());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -128,6 +128,7 @@ enum class AXProperty : uint16_t {
     DocumentURI,
     EmbeddedImageDescription,
     ExpandedTextValue,
+    ExplicitOrientation,
     ExtendedDescription,
 #if PLATFORM(COCOA)
     Font,
@@ -232,7 +233,6 @@ enum class AXProperty : uint16_t {
     MaxValueForRange,
     MinValueForRange,
     NameAttribute,
-    Orientation,
     OuterHTML,
     Path,
     PlaceholderValue,
@@ -299,7 +299,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AXProperty);
 using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>, TagName
+using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>, TagName, std::optional<AccessibilityOrientation>
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<id>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1592,9 +1592,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityDisclosingAttribute])
         return [NSNumber numberWithBool:backingObject->isExpanded()];
 
-    if (backingObject->isList() && [attributeName isEqualToString:NSAccessibilityOrientationAttribute])
-        return NSAccessibilityVerticalOrientationValue;
-
     if ([attributeName isEqualToString:NSAccessibilitySelectedTextMarkerRangeAttribute])
         return (id)[self selectedTextMarkerRange];
 


### PR DESCRIPTION
#### 412bf3c1d45cb9473eff5561c62a9d0baa98112b
<pre>
AX: Eagerly computing AXProperty::Orientation is extremely expensive and unnecessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=290228">https://bugs.webkit.org/show_bug.cgi?id=290228</a>
<a href="https://rdar.apple.com/147621116">rdar://147621116</a>

Reviewed by Chris Fleizach.

Eagerly computing AXProperty::Orientation adds 12 seconds of time to the initial build of the accessibility tree
on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a> because for most objects, it requires computing elementRect(), which is very expensive.

This commit resolves the issue by separating &quot;explicit&quot; orientations (e.g. those from aria-orientation, scrollbars, etc)
into a new explicitOrientation() function, leaving orientation() as a fallback to handle any &quot;implicit&quot; orientations
(e.g. those that default from other state, like role value or size).

This greatly reduces the work to cache this property, and saves memory, since we used to store AXProperty::Orientation
for every object, and now only do so in the rare cases we have an explicitly defined orientation.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::orientation const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::orientationFromARIA const):
(WebCore::AccessibilityNodeObject::orientation const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::orientation const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityScrollbar.cpp:
(WebCore::AccessibilityScrollbar::explicitOrientation const):
(WebCore::AccessibilityScrollbar::orientation const): Deleted.
* Source/WebCore/accessibility/AccessibilityScrollbar.h:
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::explicitOrientation const):
(WebCore::AccessibilitySlider::orientation const): Deleted.
* Source/WebCore/accessibility/AccessibilitySlider.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/292616@main">https://commits.webkit.org/292616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba1648c1ac564565377345c6d0f0ca0e529ff5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24356 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73405 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30635 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46155 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103404 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23376 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16750 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->