### PR TITLE
Add OS_OBJECT_RETURNS_RETAINED to a couple of SPIs defined in NetworkSPI.h

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -37,7 +37,7 @@ void nw_parameters_set_account_id(nw_parameters_t, const char * account_id);
 void nw_parameters_set_source_application(nw_parameters_t, audit_token_t);
 void nw_parameters_set_source_application_by_bundle_id(nw_parameters_t, const char*);
 void nw_parameters_set_attributed_bundle_identifier(nw_parameters_t, const char*);
-nw_endpoint_t nw_endpoint_create_host_with_numeric_port(const char* hostname, uint16_t port_host_order);
+OS_OBJECT_RETURNS_RETAINED nw_endpoint_t nw_endpoint_create_host_with_numeric_port(const char* hostname, uint16_t port_host_order);
 const char* nw_endpoint_get_known_tracker_name(nw_endpoint_t);
 bool nw_nat64_does_interface_index_support_nat64(uint32_t ifindex);
 
@@ -53,14 +53,14 @@ void nw_parameters_allow_sharing_port_with_listener(nw_parameters_t, nw_listener
 void nw_connection_reset_traffic_class(nw_connection_t, uint32_t traffic_class);
 void nw_parameters_set_traffic_class(nw_parameters_t, uint32_t traffic_class);
 
-nw_interface_t nw_interface_create_with_name(const char *interface_name);
-nw_interface_t nw_path_copy_interface(nw_path_t);
+OS_OBJECT_RETURNS_RETAINED nw_interface_t nw_interface_create_with_name(const char *interface_name);
+OS_OBJECT_RETURNS_RETAINED nw_interface_t nw_path_copy_interface(nw_path_t);
 
 bool nw_settings_get_unified_http_enabled(void);
 
 void nw_parameters_set_server_mode(nw_parameters_t, bool);
-nw_parameters_t nw_parameters_create_webtransport_http(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
-nw_protocol_options_t nw_webtransport_create_options(void);
+OS_OBJECT_RETURNS_RETAINED nw_parameters_t nw_parameters_create_webtransport_http(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);
+OS_OBJECT_RETURNS_RETAINED nw_protocol_options_t nw_webtransport_create_options(void);
 bool nw_protocol_options_is_webtransport(nw_protocol_options_t);
 void nw_webtransport_options_set_is_unidirectional(nw_protocol_options_t, bool);
 void nw_webtransport_options_set_is_datagram(nw_protocol_options_t, bool);


### PR DESCRIPTION
#### 573316834d1624213420b8e82ab872cc6601e3b4
<pre>
Add OS_OBJECT_RETURNS_RETAINED to a couple of SPIs defined in NetworkSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=290232">https://bugs.webkit.org/show_bug.cgi?id=290232</a>

Reviewed by David Kilzer.

Add OS_OBJECT_RETURNS_RETAINED to a couple of functions in this SPI header.

* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:

Canonical link: <a href="https://commits.webkit.org/292530@main">https://commits.webkit.org/292530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61e768862b458346d3820d6bf0feca124e560b81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73406 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46158 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81832 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16753 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23342 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->