### PR TITLE
REGRESSION(291808@main): [macOS Debug]: ASSERTION FAILED: !index in CSSFontSelector::fallbackFontAt on html5lib/generated/run-entities01-data.html (290012)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2074,9 +2074,6 @@ imported/w3c/web-platform-tests/css/css-position/block-axis-constraint-changes-f
 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-scroller-001.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-scrolled-remove-sibling-002.html [ Pass ImageOnlyFailure ]
 
-# webkit.org/b/290012 REGRESSION(291808@main): [macOS Debug]: ASSERTION FAILED: !index in CSSFontSelector::fallbackFontAt
-[ Debug ] fonts/font-fallback-prefers-pictographs.html [ Skip ]
-
 webkit.org/b/290346 [ arm64 ] gamepad/gamepad-event-handlers.html [ Pass Timeout ]
 
 webkit.org/b/290398 http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass Failure ]

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -119,7 +119,7 @@ FixedElementsLayoutRelativeToFrame:
 
 FontFallbackPrefersPictographs:
   type: bool
-  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  webcoreOnChange: fontFallbackPrefersPictographsChanged
   defaultValue:
     WebCore:
       default: false

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -530,4 +530,14 @@ void SettingsBase::useSystemAppearanceChanged()
         m_page->useSystemAppearanceChanged();
 }
 
+RefPtr<Page> SettingsBase::protectedPage() const
+{
+    return m_page.get();
+}
+
+void SettingsBase::fontFallbackPrefersPictographsChanged()
+{
+    invalidateAfterGenericFamilyChange(protectedPage().get());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -166,6 +166,8 @@ protected:
     void shouldUseModernAVContentKeySessionChanged();
 #endif
     void useSystemAppearanceChanged();
+    void fontFallbackPrefersPictographsChanged();
+    RefPtr<Page> protectedPage() const;
 
     WeakPtr<Page> m_page;
 


### PR DESCRIPTION
#### 0d680136cb51cf449dca3430455b1ffe95be5661
<pre>
REGRESSION(291808@main): [macOS Debug]: ASSERTION FAILED: !index in CSSFontSelector::fallbackFontAt on html5lib/generated/run-entities01-data.html (290012)
<a href="https://rdar.apple.com/147365119">rdar://147365119</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290231">https://bugs.webkit.org/show_bug.cgi?id=290231</a>

Reviewed by Geoffrey Garen.

Settings control how we resolve generic font-family names.

This bug happens because we were setting setFontFallbackPrefersPictographs(true)
from another test, on the same process, before running run-entities01-data.html.

This made the cached FontCascadeFont object to have its m_lastRealizedFallbackIndex
expanded beyound effectiveFamilyCount(), making fontSelectorFallbackIndex turning 1.

When running run-entities01-data.html, m_lastRealizedFallbackIndex is still
retaining that value. However, fontSelector-&gt;fallbackFontCount() that comes from Settings
is now 0 and we won&apos;t pass the check `fontSelectorFallbackIndex == fontSelector-&gt;fallbackFontCount()`.

This lead us to a inconsistent state in which we call fallbackFontAt for resolving the pictographFontFamily,
although we are stating by the index != 0 that we already did.

We should make sure that setting fontFallbackPrefersPictographs invalidates the FontCascadeCache
as we already do for the other related settings as `setSansSerifFontFamily`, `setCursiveFontFamily` and etc.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::protectedPage const):
(WebCore::SettingsBase::fontFallbackPrefersPictographsChanged):
* Source/WebCore/page/SettingsBase.h:

Canonical link: <a href="https://commits.webkit.org/292764@main">https://commits.webkit.org/292764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9342edfbd7065732dd6ddde067772553d14fa896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31092 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87726 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54220 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5565 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104081 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24052 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17554 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82930 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->