### PR TITLE
Optimize single-segment Path::fastBoundingRect()

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -629,7 +629,7 @@ bool Path::hasSubpaths() const
 FloatRect Path::fastBoundingRect() const
 {
     if (auto* segment = asSingle())
-        return PathStream::computeFastBoundingRect(singleElementSpan(*segment));
+        return segment->fastBoundingRect();
 
     if (auto* impl = asImpl())
         return impl->fastBoundingRect();

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -51,6 +51,22 @@ std::optional<FloatPoint> PathSegment::tryGetEndPointWithoutContext() const
     });
 }
 
+FloatRect PathSegment::fastBoundingRect() const
+{
+    FloatPoint currentPoint;
+    FloatPoint lastMoveToPoint;
+
+    auto boundingRect = FloatRect::smallestRect();
+    extendFastBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
+
+    if (boundingRect.isSmallest()) {
+        currentPoint = calculateEndPoint(currentPoint, lastMoveToPoint);
+        boundingRect.extend(currentPoint);
+    }
+
+    return boundingRect;
+}
+
 void PathSegment::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
     WTF::switchOn(m_data, [&](auto& data) {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -66,6 +66,8 @@ public:
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
     std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    FloatRect fastBoundingRect() const;
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 


### PR DESCRIPTION
#### 190edbac90b933190f5879106a7893020f56e4bb
<pre>
Optimize single-segment Path::fastBoundingRect()
<a href="https://bugs.webkit.org/show_bug.cgi?id=290234">https://bugs.webkit.org/show_bug.cgi?id=290234</a>
<a href="https://rdar.apple.com/147623819">rdar://147623819</a>

Reviewed by Cameron McCormack.

`PathStream::computeFastBoundingRect()` has some overhead we can remove if we just have
a single segment; the loop, and the call to `calculateEndPoint()`. So implement in
`Path::fastBoundingRect()` in a way that works for single segment paths.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::fastBoundingRect const):

Canonical link: <a href="https://commits.webkit.org/292543@main">https://commits.webkit.org/292543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e54d21951f60b5577be612baab71d53438d5d99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30677 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20543 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->