### PR TITLE
REGRESSION(290813@main) [Cocoa] Videos on bleacherreport.com are muted.

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt
@@ -1,0 +1,8 @@
+
+EVENT(canplaythrough)
+EXPECTED (video.audioTracks.length == '3') OK
+EXPECTED (video.audioTracks[0].language == 'en-US') OK
+EXPECTED (video.audioTracks[1].language == 'fr-FR') OK
+EXPECTED (video.audioTracks[2].language == 'es-US') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../../media-resources/video-test.js></script>
+        <script>
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                testRunner.waitUntilDone();
+            }
+
+            function start() {
+                video = document.getElementById('video');
+                waitForEvent('canplaythrough', canplaythrough);
+                video.src = "../resources/hls/audio-tracks.m3u8";
+            }
+
+            function canplaythrough() {
+                testExpected("video.audioTracks.length", 3);
+                testExpected("video.audioTracks[0].language", "en-US");
+                testExpected("video.audioTracks[1].language", "fr-FR");
+                testExpected("video.audioTracks[2].language", "es-US");
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="start()">
+        <video id="video"></video>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -295,12 +295,18 @@ AtomString AVTrackPrivateAVFObjCImpl::label() const
 
 AtomString AVTrackPrivateAVFObjCImpl::language() const
 {
-    if (m_assetTrack)
-        return AtomString { languageForAVAssetTrack(m_assetTrack.get()) };
-    if (m_mediaSelectionOption)
-        return AtomString { languageForAVMediaSelectionOption(m_mediaSelectionOption->avMediaSelectionOption()) };
+    if (m_assetTrack) {
+        auto language = languageForAVAssetTrack(m_assetTrack.get());
+        if (!language.isEmpty())
+            return AtomString { language };
+    }
 
-    ASSERT_NOT_REACHED();
+    if (m_mediaSelectionOption) {
+        auto language = languageForAVMediaSelectionOption(m_mediaSelectionOption->avMediaSelectionOption());
+        if (!language.isEmpty())
+            return AtomString { language };
+    }
+
     return emptyAtom();
 }
 


### PR DESCRIPTION
#### 39c8c2804ca0b8bf7b956b4e2ed5f8e09526c672
<pre>
REGRESSION(290813@main) [Cocoa] Videos on bleacherreport.com are muted.
<a href="https://rdar.apple.com/147271449">rdar://147271449</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290225">https://bugs.webkit.org/show_bug.cgi?id=290225</a>

Reviewed by Eric Carlson.

In 290813@main, an AVAssetTrack was always added to AVTrackPrivateAVFObjCImpl when
that object was created with an AVMediaSelectionGroup/Option. But because a number
of the functions in AVTrackPrivateAVFObjCImpl check first for the presence of an
AVAssetTrack, this caused a change in behavior where those AudioTracks created with
an AVMediaSelectionGroup/Option no longer had a language.

Reverse the if() check to check for a mediaSelectionOption before an assetTrack.

* LayoutTests/http/tests/media/hls/hls-audio-tracks-language-expected.txt: Added.
* LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html: Added.
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::audioKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::videoKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::textKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::index const):
(WebCore::AVTrackPrivateAVFObjCImpl::id const):
(WebCore::AVTrackPrivateAVFObjCImpl::label const):
(WebCore::AVTrackPrivateAVFObjCImpl::language const):

Canonical link: <a href="https://commits.webkit.org/292648@main">https://commits.webkit.org/292648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dfe1db1541a4bb34fcb729f00bd8e26f5684841

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30876 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103745 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83443 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82090 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4261 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17190 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28834 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->