### PR TITLE
[Screen Time Refactoring] Add API support to WebPage and WebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -43,6 +43,7 @@ extension WKWebViewConfiguration {
         self.allowsInlinePredictions = wrapped.allowsInlinePredictions
         self.supportsAdaptiveImageGlyph = wrapped.supportsAdaptiveImageGlyph
         self._loadsSubresources = wrapped.loadsSubresources
+        self.showsSystemScreenTimeBlockingView = wrapped.showsSystemScreenTimeBlockingView
 
 #if os(iOS)
         self.dataDetectorTypes = wrapped.dataDetectorTypes

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -104,6 +104,13 @@ extension WebPage {
         /// If `true`, they are inserted with the full adaptive sizing behavior.
         public var supportsAdaptiveImageGlyph: Bool = false
 
+        /// Indicates whether the webpage should use the system Screen Time blocking view.
+        ///
+        /// The default value is `true`. If `true`, the system Screen Time blocking view is shown when blocked by Screen Time.
+        /// If `false`, a blurred view of the web content is shown instead.
+        @available(visionOS, unavailable)
+        public var showsSystemScreenTimeBlockingView: Bool = true
+
 #if os(iOS)
         /// The types of data detectors to apply to the webpage's content.
         ///

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -240,6 +240,12 @@ final public class WebPage {
         backingProperty(\.isWritingToolsActive, backedBy: \.isWritingToolsActive)
     }
 
+    /// Indicates whether Screen Time blocking has occurred.
+    @available(visionOS, unavailable)
+    public var isBlockedByScreenTime: Bool {
+        backingProperty(\.isBlockedByScreenTime, backedBy: \.isBlockedByScreenTime)
+    }
+
     /// The fullscreen state the page is currently in.
     public var fullscreenState: WebPage.FullscreenState {
         backingProperty(\.fullscreenState, backedBy: \.fullscreenState) { backingValue in


### PR DESCRIPTION
#### a63d59a94f71d364f23154a5e6c91abd9b05d893
<pre>
[Screen Time Refactoring] Add API support to WebPage and WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=290219">https://bugs.webkit.org/show_bug.cgi?id=290219</a>
<a href="https://rdar.apple.com/147613868">rdar://147613868</a>

Reviewed by Richard Robinson.

Add Screen Time API support to WebPage and WebView.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
(Configuration.showsSystemScreenTimeBlockingView):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(isBlockedByScreenTime):

Canonical link: <a href="https://commits.webkit.org/292533@main">https://commits.webkit.org/292533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c0500387ef3525eabfe4048cc3f8c41773db55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73413 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11936 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46167 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23388 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81833 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16762 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15507 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23351 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->