### PR TITLE
Address safer CPP failures in DisplayLink.h

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,5 +1,4 @@
 UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-UIProcess/DisplayLink.h
 UIProcess/mac/PageClientImplMac.h
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
 WebProcess/InjectedBundle/InjectedBundle.h

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -48,6 +48,17 @@
 struct wpe_playstation_display;
 #endif
 
+namespace WTF {
+#if PLATFORM(MAC)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+template<> struct DefaultRefDerefTraits<__CVDisplayLink> {
+    static CVDisplayLinkRef refIfNotNull(CVDisplayLinkRef displayLink) { return CVDisplayLinkRetain(displayLink); }
+    static void derefIfNotNull(CVDisplayLinkRef displayLink) { CVDisplayLinkRelease(displayLink); }
+};
+ALLOW_DEPRECATED_DECLARATIONS_END
+#endif // PLATFORM(MAC)
+}
+
 namespace WebKit {
 
 class DisplayLink {
@@ -113,7 +124,7 @@ private:
     };
 
 #if PLATFORM(MAC)
-    CVDisplayLinkRef m_displayLink { nullptr };
+    RefPtr<__CVDisplayLink> m_displayLink;
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
     std::unique_ptr<DisplayVBlankMonitor> m_vblankMonitor;


### PR DESCRIPTION
#### 0ecadc10b54efff6ed6a4626a815dc5563f56b45
<pre>
Address safer CPP failures in DisplayLink.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=290238">https://bugs.webkit.org/show_bug.cgi?id=290238</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/UIProcess/DisplayLink.h:
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::derefIfNotNull):
* Source/WebKit/UIProcess/mac/DisplayLinkMac.cpp:
(WebKit::createDisplayLinkWithDisplay):
(WebKit::DisplayLink::platformInitialize):
(WebKit::DisplayLink::platformFinalize):
(WebKit::DisplayLink::platformIsRunning const):
(WebKit::DisplayLink::platformStart):
(WebKit::DisplayLink::platformStop):

Canonical link: <a href="https://commits.webkit.org/292565@main">https://commits.webkit.org/292565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec5232ca91d40a29daaa5c301ce9936cd92ffa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46968 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73520 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99452 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12293 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12049 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17135 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82566 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20561 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26581 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16961 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28634 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->