### PR TITLE
WebCore::ReadableStream should have a virtual destructor

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ public:
     static ExceptionOr<Ref<ReadableStream>> create(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
     static Ref<ReadableStream> create(Ref<InternalReadableStream>&&);
 
-    ~ReadableStream() = default;
+    virtual ~ReadableStream() = default;
 
     void lock() { m_internalReadableStream->lock(); }
     bool isLocked() const { return m_internalReadableStream->isLocked(); }

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,9 +33,11 @@ class DeferredPromise;
 
 struct WebTransportReceiveStreamStats;
 
-class WebTransportReceiveStream : public ReadableStream {
+class WebTransportReceiveStream final : public ReadableStream {
 public:
     static ExceptionOr<Ref<WebTransportReceiveStream>> create(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
+
+    ~WebTransportReceiveStream() final = default;
 
     void getStats(Ref<DeferredPromise>&&);
 private:

--- a/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations
@@ -1,4 +1,3 @@
-Modules/webtransport/WebTransportReceiveStream.h
 css/CSSAppleColorFilterPropertyValue.h
 css/CSSAttrValue.h
 css/CSSBackgroundRepeatValue.h


### PR DESCRIPTION
#### 5cd38aa5746a75bd4cf23bd48f2792f0bbe09c34
<pre>
WebCore::ReadableStream should have a virtual destructor
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=290236">https://bugs.webkit.org/show_bug.cgi?id=290236</a>&gt;
&lt;<a href="https://rdar.apple.com/147627336">rdar://147627336</a>&gt;

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/streams/ReadableStream.h:
(WebCore::ReadableStream::~ReadableStream):
- Make destructor virtual.
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h:
- Mark WebCore::WebTransportReceiveStream as final.
(WebCore::WebTransportReceiveStream::~WebTransportReceiveStream):
- Declare default constructor as final.
* Source/WebCore/SaferCPPExpectations/RefCntblBaseVirtualDtorExpectations:
- Update expectations file after fixing the warning.

Canonical link: <a href="https://commits.webkit.org/292537@main">https://commits.webkit.org/292537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c957eeb1bc9edfc2ebf5a275822bc26418b22097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53752 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4776 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81834 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16764 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15510 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28508 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->