### PR TITLE
[SwiftUI] After using `.scrollTo` on a ScrollPosition bound to a WebView, natural scrolling may stop working and/or get reset

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -144,11 +144,17 @@ final class WebViewCoordinator {
         // FIXME: Use the binding to update the `isPositionedByUser` property when applicable.
 
         let scrollPosition = environment.webViewScrollPositionContext
+
+        let scrollPositionDidNotChange = view.scrollPosition?.position?.wrappedValue == scrollPosition.position?.wrappedValue
+        guard !scrollPositionDidNotChange else {
+            return
+        }
+
         view.scrollPosition = scrollPosition
 
-        if let point = environment.webViewScrollPositionContext.position?.wrappedValue.point {
+        if let point = scrollPosition.position?.wrappedValue.point {
             webView.setContentOffset(point, animated: context.transaction.isAnimated)
-        } else if let edge = environment.webViewScrollPositionContext.position?.wrappedValue.edge {
+        } else if let edge = scrollPosition.position?.wrappedValue.edge {
             webView.scrollTo(edge: NSDirectionalRectEdge(edge), animated: context.transaction.isAnimated)
         }
     }


### PR DESCRIPTION
#### b12ed39572951123a4b5a99c471e0262e9481001
<pre>
[SwiftUI] After using `.scrollTo` on a ScrollPosition bound to a WebView, natural scrolling may stop working and/or get reset
<a href="https://bugs.webkit.org/show_bug.cgi?id=290240">https://bugs.webkit.org/show_bug.cgi?id=290240</a>
<a href="https://rdar.apple.com/146719277">rdar://146719277</a>

Reviewed by Aditya Keerthi.

When the `.scrollTo` view modifier was attached to a `WebView`, user-driven scrolling would effectively
become non-functional in some cases. This is because when the view representable receives an update / gets re-computed,
part of the update logic included checking if there was a ScrollPosition set by the API client, and if so, scroll to
that position. Therefore, after user-driven scrolling, the actual scroll position would always get reset back to the
API-client specified position since there was nothing to avoid running that logic.

The solution to this issue requires two fixes:

1. If the current `ScrollPosition` hasn&apos;t changed, this indicates that the API client has not used `.scrollTo` again.
Therefore, the webpage should only be scrolled to the `ScrollPosition` position only once, and not repeatedly.

2. When a user-driven scroll happens, the `ScrollPosition` binding should have its `isPositionedByUser` property set
to `true`, which sets the other properties to `nil`.

By fixing (1), the functional issue is solved. Fixing (2) fixes the correctness issue. This PR only addresses (1) for
now, since the fix to (2) is significantly more complex and risky.

Fix (1) by checking if the `ScrollPosition` is equal to the prior one, and if so, early return. This works because the
`ScrollPosition` type has a seed value, which gets updated when `scrollTo` is called on it, which then changes the value&apos;s
identity.

* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewCoordinator.updateScrollPosition(_:context:)):

Canonical link: <a href="https://commits.webkit.org/292534@main">https://commits.webkit.org/292534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94eecd1183b7543ab0b6a61d1b3d15cf520f8d97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24373 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53754 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11941 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103421 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81837 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26477 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/3914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16768 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15508 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23356 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->