### PR TITLE
[SwiftUI] Remove `load(fileURL:allowingReadAccessTo:)` and `load(fileRequest:allowingReadAccessTo:)` APIs on WebPage

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -386,39 +386,6 @@ final public class WebPage {
         backingWebView.loadHTMLString(html, baseURL: baseURL).map(NavigationID.init(_:))
     }
 
-    /// Loads the web content from the specified file and navigates to it.
-    ///
-    /// - Parameters:
-    ///   - fileURL: The URL of a file that contains web content. This URL must be a file-based URL.
-    ///   - readAccessURL: The URL of a file or directory containing web content that you grant the system permission
-    ///   to read. This URL must be a file-based URL and must not be empty. To prevent WebKit from reading any other
-    ///   content, specify the same value as the URL parameter. To read additional files related to the content file,
-    ///   specify a directory.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
-    @discardableResult
-    public func load(fileURL url: URL, allowingReadAccessTo readAccessURL: URL) -> NavigationID? {
-        backingWebView.loadFileURL(url, allowingReadAccessTo: readAccessURL).map(NavigationID.init(_:))
-    }
-
-    /// Loads the web content from the file the URL request object specifies and navigates to that content.
-    ///
-    /// Provide the source of this load request for app activity data by setting the `attribution` parameter on your request.
-    ///
-    /// - Parameters:
-    ///   - request: A URL request that specifies the file to display. The URL in this request must be a file-based URL.
-    ///   - readAccessURL: The URL of a file or directory containing web content that you grant the system permission
-    ///   to read. This URL must be a file-based URL and must not be empty. To prevent WebKit from reading any other
-    ///   content, specify the same value as the URL parameter. To read additional files related to the content file,
-    ///   specify a directory.
-    /// - Returns: A navigation identifier you use to track the loading progress of the request.
-    @discardableResult
-    public func load(fileRequest request: URLRequest, allowingReadAccessTo readAccessURL: URL) -> NavigationID? {
-        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
-
-        let navigation = backingWebView.loadFileRequest(request, allowingReadAccessTo: readAccessURL) as WKNavigation?
-        return navigation.map(NavigationID.init(_:))
-    }
-
     /// Loads the web content from the data you provide as if the data were the response to the request.
     ///
     /// - Parameters:

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -131,7 +131,8 @@ final class BrowserViewModel {
     func openURL(_ url: URL) {
         assert(url.isFileURL)
 
-        page.load(fileURL: url, allowingReadAccessTo: url.deletingLastPathComponent())
+        let data = try! Data(contentsOf: url)
+        page.load(data, mimeType: "text/html", characterEncoding: .utf8, baseURL: URL(string: "about:blank")!)
     }
 
     func didReceiveNavigationEvent(_ event: WebPage.NavigationEvent) {


### PR DESCRIPTION
#### 49ef75665309c974a2c50b42923c58f898652d7f
<pre>
[SwiftUI] Remove `load(fileURL:allowingReadAccessTo:)` and `load(fileRequest:allowingReadAccessTo:)` APIs on WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=290242">https://bugs.webkit.org/show_bug.cgi?id=290242</a>
<a href="https://rdar.apple.com/147631415">rdar://147631415</a>

Reviewed by Wenson Hsieh.

The new plan of record is to not include API on WebPage to load file URLs; instead, clients should use
the `URLSchemeHandler` API. The latter is preferred because with URL scheme handlers, clients:

* Cannot accidentally expose paths on disk they didn&apos;t mean to
* Cannot accidentally allow navigations to files on disk they didn&apos;t mean to
* Have flexibility to easily show any file their app has access to that might not be doable with file urls directly
* Can mix custom scheme content with other custom schemes, or http
* Can very easily serve dynamically generated content

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(load(fileURL:allowingReadAccessTo:)): Deleted.
(load(fileRequest:allowingReadAccessTo:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/292598@main">https://commits.webkit.org/292598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e71d1071732317907800f8a1d146bd866a8c95f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30653 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82464 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81841 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16776 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15542 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->