### PR TITLE
Extract LayoutRange into its own file

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2174,6 +2174,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/LayerHostingContextIdentifier.h
     platform/graphics/LayerTreeAsTextOptions.h
     platform/graphics/LayoutPoint.h
+    platform/graphics/LayoutRange.h
     platform/graphics/LayoutRect.h
     platform/graphics/LayoutSize.h
     platform/graphics/LegacyCDMSession.h

--- a/Source/WebCore/platform/graphics/LayoutRange.h
+++ b/Source/WebCore/platform/graphics/LayoutRange.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutUnit.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+// This is basically a 1-dimentional LayoutRect.
+class LayoutRange {
+public:
+    LayoutRange() = default;
+    LayoutRange(LayoutUnit location, LayoutUnit size)
+        : m_location(location)
+        , m_size(size)
+    { }
+    LayoutUnit min() const { return m_location; }
+    LayoutUnit max() const { return m_location + m_size; }
+    LayoutUnit size() const { return m_size; }
+
+    inline void set(LayoutUnit location, LayoutUnit size);
+    inline void reset(LayoutUnit size = 0_lu)
+    {
+        m_location = 0_lu;
+        m_size = size;
+    }
+
+    void moveBy(LayoutUnit shift) { m_location += shift; }
+    void moveTo(LayoutUnit target) { m_location = target; }
+
+    inline void shiftMinEdgeBy(LayoutUnit shift);
+    inline void shiftMaxEdgeBy(LayoutUnit shift);
+    inline void shiftMinEdgeTo(LayoutUnit target);
+    inline void shiftMaxEdgeTo(LayoutUnit target);
+
+    inline void sizeFromMinEdge(LayoutUnit size = 0_lu);
+    inline void sizeFromMaxEdge(LayoutUnit size = 0_lu);
+
+    inline void floorMinEdgeTo(LayoutUnit target);
+    inline void floorMaxEdgeTo(LayoutUnit target);
+    inline void capMinEdgeTo(LayoutUnit target);
+    inline void capMaxEdgeTo(LayoutUnit target);
+
+    inline void floorSizeFromMinEdge(LayoutUnit size = 0_lu);
+    inline void floorSizeFromMaxEdge(LayoutUnit size = 0_lu);
+
+private:
+    LayoutUnit m_location;
+    LayoutUnit m_size;
+};
+
+// MARK: - Implementation
+
+inline void LayoutRange::set(LayoutUnit location, LayoutUnit size)
+{
+    m_location = location;
+    m_size = size;
+}
+
+inline void LayoutRange::shiftMinEdgeBy(LayoutUnit shift)
+{
+    m_location += shift;
+    m_size -= shift;
+}
+
+inline void LayoutRange::shiftMaxEdgeBy(LayoutUnit shift)
+{
+    m_size += shift;
+}
+
+inline void LayoutRange::shiftMinEdgeTo(LayoutUnit target) { shiftMinEdgeBy(target - min()); }
+inline void LayoutRange::shiftMaxEdgeTo(LayoutUnit target) { shiftMaxEdgeBy(target - max()); }
+
+inline void LayoutRange::floorMinEdgeTo(LayoutUnit target)
+{
+    if (target > max())
+        shiftMaxEdgeTo(target);
+}
+
+inline void LayoutRange::floorMaxEdgeTo(LayoutUnit target)
+{
+    if (target > max())
+        shiftMaxEdgeTo(target);
+}
+
+inline void LayoutRange::capMinEdgeTo(LayoutUnit target)
+{
+    if (target < min())
+        shiftMinEdgeTo(target);
+}
+
+inline void LayoutRange::capMaxEdgeTo(LayoutUnit target)
+{
+    if (target < max())
+        shiftMaxEdgeTo(target);
+}
+
+inline void LayoutRange::sizeFromMinEdge(LayoutUnit size)
+{
+    m_size = size;
+}
+
+inline void LayoutRange::sizeFromMaxEdge(LayoutUnit size)
+{
+    m_location -= size - m_size;
+    m_size = size;
+}
+
+inline void LayoutRange::floorSizeFromMinEdge(LayoutUnit size)
+{
+    m_size = std::max(m_size, size);
+}
+
+inline void LayoutRange::floorSizeFromMaxEdge(LayoutUnit size)
+{
+    if (size > m_size)
+        sizeFromMaxEdge(size);
+}
+
+inline TextStream& operator<<(TextStream& stream, const LayoutRange& range)
+{
+    if (stream.hasFormattingFlag(TextStream::Formatting::LayoutUnitsAsIntegers))
+        return stream << '[' << range.min().toInt() << ',' << range.max().toInt() << ']';
+
+    return stream << '[' << range.min().toFloat() << ',' << range.max().toFloat() << ']';
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -26,83 +26,11 @@
 #pragma once
 
 #include "BoxSides.h"
+#include "LayoutRange.h"
 #include "RenderBox.h"
 
 namespace WebCore {
 
-// This is basically a 1-dimentional LayoutRect.
-class LayoutRange {
-public:
-    LayoutRange() = default;
-    LayoutRange(LayoutUnit location, LayoutUnit size)
-        : m_location(location)
-        , m_size(size)
-    { }
-    LayoutUnit min() const { return m_location; }
-    LayoutUnit max() const { return m_location + m_size; }
-    LayoutUnit size() const { return m_size; }
-
-    void set(LayoutUnit location, LayoutUnit size)
-    {
-        m_location = location;
-        m_size = size;
-    }
-    void reset(LayoutUnit size = 0_lu)
-    {
-        m_location = 0_lu;
-        m_size = size;
-    }
-    void moveBy(LayoutUnit shift) { m_location += shift; }
-    void moveTo(LayoutUnit location) { m_location = location; }
-
-    void shiftMinEdgeBy(LayoutUnit shift)
-    {
-        m_location += shift;
-        m_size -= shift;
-    }
-    void shiftMaxEdgeBy(LayoutUnit shift) { m_size += shift; }
-    void shiftMinEdgeTo(LayoutUnit target) { shiftMinEdgeBy(target - min()); }
-    void shiftMaxEdgeTo(LayoutUnit target) { shiftMaxEdgeBy(target - max()); }
-    void floorMinEdgeTo(LayoutUnit target)
-    {
-        if (target > max())
-            shiftMaxEdgeTo(target);
-    }
-    void floorMaxEdgeTo(LayoutUnit target)
-    {
-        if (target > max())
-            shiftMaxEdgeTo(target);
-    }
-    void capMinEdgeTo(LayoutUnit target)
-    {
-        if (target < min())
-            shiftMinEdgeTo(target);
-    }
-    void capMaxEdgeTo(LayoutUnit target)
-    {
-        if (target < max())
-            shiftMaxEdgeTo(target);
-    }
-
-    void sizeFromMinEdge(LayoutUnit size = 0_lu) { m_size = size; }
-    void sizeFromMaxEdge(LayoutUnit size = 0_lu)
-    {
-        m_location -= size - m_size;
-        m_size = size;
-    }
-    void floorSizeFromMinEdge(LayoutUnit size = 0_lu) { m_size = std::max(m_size, size); }
-    void floorSizeFromMaxEdge(LayoutUnit size = 0_lu)
-    {
-        if (size > m_size)
-            sizeFromMaxEdge(size);
-    }
-
-private:
-    LayoutUnit m_location;
-    LayoutUnit m_size;
-};
-
-// Convenience struct to package constraints and inputs.
 struct PositionedLayoutConstraints {
 public:
     PositionedLayoutConstraints(const RenderBox&, const RenderStyle&, LogicalBoxAxis);


### PR DESCRIPTION
#### c1583e303bcc671860067ee267b7fa0641a66ae3
<pre>
Extract LayoutRange into its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=290214">https://bugs.webkit.org/show_bug.cgi?id=290214</a>
<a href="https://rdar.apple.com/147607455">rdar://147607455</a>

Reviewed by Alan Baradlay.

Moves LayoutRange definition from PositionedLayoutConstraints.h into
platform/graphics/LayoutRange.h alongside LayoutRect and LayoutPoint.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/LayoutRange.h: Added.
(WebCore::LayoutRange::LayoutRange):
(WebCore::LayoutRange::min const):
(WebCore::LayoutRange::max const):
(WebCore::LayoutRange::size const):
(WebCore::LayoutRange::reset):
(WebCore::LayoutRange::moveBy):
(WebCore::LayoutRange::moveTo):
(WebCore::LayoutRange::set):
(WebCore::LayoutRange::shiftMinEdgeBy):
(WebCore::LayoutRange::shiftMaxEdgeBy):
(WebCore::LayoutRange::shiftMinEdgeTo):
(WebCore::LayoutRange::shiftMaxEdgeTo):
(WebCore::LayoutRange::floorMinEdgeTo):
(WebCore::LayoutRange::floorMaxEdgeTo):
(WebCore::LayoutRange::capMinEdgeTo):
(WebCore::LayoutRange::capMaxEdgeTo):
(WebCore::LayoutRange::sizeFromMinEdge):
(WebCore::LayoutRange::sizeFromMaxEdge):
(WebCore::LayoutRange::floorSizeFromMinEdge):
(WebCore::LayoutRange::floorSizeFromMaxEdge):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::LayoutRange::LayoutRange): Deleted.
(WebCore::LayoutRange::min const): Deleted.
(WebCore::LayoutRange::max const): Deleted.
(WebCore::LayoutRange::size const): Deleted.
(WebCore::LayoutRange::set): Deleted.
(WebCore::LayoutRange::reset): Deleted.
(WebCore::LayoutRange::moveBy): Deleted.
(WebCore::LayoutRange::moveTo): Deleted.
(WebCore::LayoutRange::shiftMinEdgeBy): Deleted.
(WebCore::LayoutRange::shiftMaxEdgeBy): Deleted.
(WebCore::LayoutRange::shiftMinEdgeTo): Deleted.
(WebCore::LayoutRange::shiftMaxEdgeTo): Deleted.
(WebCore::LayoutRange::floorMinEdgeTo): Deleted.
(WebCore::LayoutRange::floorMaxEdgeTo): Deleted.
(WebCore::LayoutRange::capMinEdgeTo): Deleted.
(WebCore::LayoutRange::capMaxEdgeTo): Deleted.
(WebCore::LayoutRange::sizeFromMinEdge): Deleted.
(WebCore::LayoutRange::sizeFromMaxEdge): Deleted.
(WebCore::LayoutRange::floorSizeFromMinEdge): Deleted.
(WebCore::LayoutRange::floorSizeFromMaxEdge): Deleted.

Canonical link: <a href="https://commits.webkit.org/292649@main">https://commits.webkit.org/292649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30637a527f9d5f090af2dd4040207c8f74855ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73573 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53909 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5072 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17200 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82618 "4 flakes 81 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83328 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81993 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23546 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28701 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->