### PR TITLE
Fixed table layout should only be triggered when inline-size is not auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt
@@ -48,9 +48,9 @@ PASS 100%
 PASS calc(10px + 100%)
 PASS auto
 PASS min-content
-FAIL max-content assert_equals: Table is in fixed mode expected 50 but got 100
+PASS max-content
 PASS fit-content
 PASS -webkit-fill-available
-FAIL intrinsic assert_equals: Table is in fixed mode expected 50 but got 100
-FAIL min-intrinsic assert_equals: Table is in fixed mode expected 50 but got 100
+PASS intrinsic
+PASS min-intrinsic
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -570,7 +570,7 @@ constexpr bool RenderStyle::isDisplayListItemType(DisplayType display) { return 
 constexpr bool RenderStyle::isDisplayTableOrTablePart() const { return isDisplayTableOrTablePart(display()); }
 constexpr bool RenderStyle::isInternalTableBox() const { return isInternalTableBox(display()); }
 constexpr bool RenderStyle::isRubyContainerOrInternalRubyBox() const { return isRubyContainerOrInternalRubyBox(display()); }
-inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isFillAvailable() || logicalWidth().isMinContent()); }
+inline bool RenderStyle::isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && !logicalWidth().isAuto(); }
 inline bool RenderStyle::isFloating() const { return floating() != Float::None; }
 inline bool RenderStyle::isGridAutoFlowAlgorithmDense() const { return m_nonInheritedData->rareData->grid->gridAutoFlow & InternalAutoFlowAlgorithmDense; }
 inline bool RenderStyle::isGridAutoFlowAlgorithmSparse() const { return m_nonInheritedData->rareData->grid->gridAutoFlow & InternalAutoFlowAlgorithmSparse; }


### PR DESCRIPTION
#### 7dc7304c93eb91190d7c4206103213778cc8b578
<pre>
Fixed table layout should only be triggered when inline-size is not auto

<a href="https://bugs.webkit.org/show_bug.cgi?id=290247">https://bugs.webkit.org/show_bug.cgi?id=290247</a>
<a href="https://rdar.apple.com/problem/147636653">rdar://problem/147636653</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with CSSWG Resolution [1]:

[1] <a href="https://github.com/w3c/csswg-drafts/issues/10937#issuecomment-2669150397">https://github.com/w3c/csswg-drafts/issues/10937#issuecomment-2669150397</a>

&quot;Fixed table layout is triggered except when inline-size is auto&quot;.

In this patch, we remove `allow-list` we had for different length types
and keep it to just `isAuto()`.`

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isFixedTableLayout const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/fixed-layout-2-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/292536@main">https://commits.webkit.org/292536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db8f14f8ce88440537e06d4bbcb73c65af0ed2d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73433 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30664 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16791 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28529 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->