### PR TITLE
[css-anchor-position-1] Adjust anchor()/anchor-size() for viewport and CSS zoom

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-page-zoom-expected.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-page-zoom-expected.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 150px;
+        height: 150px;
+    }
+
+    .cell {
+        width: 50px;
+        height: 50px;
+    }
+
+    #anchor-cell {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+
+        background: green;
+    }
+
+    .anchor-positioned-cell {
+        position: absolute;
+    }
+
+    #top-left {
+        top: 0;
+        left: 0;
+
+        background: cyan;
+    }
+
+    #top-right {
+        top: 0;
+        right: 0;
+
+        background: magenta;
+    }
+
+    #bottom-left {
+        bottom: 0;
+        left: 0;
+
+        background: yellow;
+    }
+
+    #bottom-right {
+        bottom: 0;
+        right: 0;
+
+        background: black;
+    }
+</style>
+
+<body>
+    <div class="containing-block">
+        <div class="cell" id="anchor-cell"></div>
+
+        <div class="cell anchor-positioned-cell" id="top-left"></div>
+        <div class="cell anchor-positioned-cell" id="top-right"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-left"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-right"></div>
+    </div>
+
+    <script>
+        if (window.internals)
+            window.internals.setPageZoomFactor(2);
+    </script>
+</body>

--- a/LayoutTests/fast/css/css-anchor-position/anchor-page-zoom.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-page-zoom.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 150px;
+        height: 150px;
+    }
+
+    .cell {
+        width: 50px;
+        height: 50px;
+    }
+
+    #anchor-cell {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+
+        anchor-name: --anchor;
+
+        background: green;
+    }
+
+    .anchor-positioned-cell {
+        position: absolute;
+        position-anchor: --anchor;
+    }
+
+    #top-left {
+        top: 0;
+        right: anchor(left);
+
+        background: cyan;
+    }
+
+    #top-right {
+        top: 0;
+        left: anchor(right);
+
+        background: magenta;
+    }
+
+    #bottom-left {
+        bottom: 0;
+        right: anchor(left);
+
+        background: yellow;
+    }
+
+    #bottom-right {
+        bottom: 0;
+        left: anchor(right);
+
+        background: black;
+    }
+</style>
+
+<body>
+    <!--
+        The boxes below are arranged like this:
+        (the outside box is .containing-block)
+
+        -------------
+        | 1 |   | 2 |
+        |---|---|---|
+        |   | A |   |
+        |---|---|---|
+        | 3 |   | 4 |
+        -------------
+    -->
+
+    <div class="containing-block">
+        <!-- Box A -->
+        <div class="cell" id="anchor-cell"></div>
+
+        <!-- Box 1 -->
+        <div class="cell anchor-positioned-cell" id="top-left"></div>
+
+        <!-- Box 2 -->
+        <div class="cell anchor-positioned-cell" id="top-right"></div>
+
+        <!-- Box 3 -->
+        <div class="cell anchor-positioned-cell" id="bottom-left"></div>
+
+        <!-- Box 4 -->
+        <div class="cell anchor-positioned-cell" id="bottom-right"></div>
+    </div>
+
+    <script>
+        if (window.internals)
+            window.internals.setPageZoomFactor(2);
+    </script>
+</body>

--- a/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom-expected.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<style>
+    #containing-block {
+        position: relative;
+    }
+
+    #anchor {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: red;
+    }
+
+    #anchor-positioned {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: green;
+
+        z-index: 1;
+    }
+</style>
+
+Test passes if no red is visible.
+
+<div id="containing-block">
+    <div id="anchor"></div>
+    <div id="anchor-positioned"></div>
+</div>
+
+<script>
+    if (window.internals)
+        window.internals.setPageZoomFactor(2);
+</script>

--- a/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<style>
+    #containing-block {
+        position: relative;
+    }
+
+    #anchor {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        anchor-name: --anchor;
+
+        background: red;
+    }
+
+    #anchor-positioned {
+        position: absolute;
+
+        width: anchor-size(--anchor width);
+        height: anchor-size(--anchor height);
+
+        background: green;
+
+        z-index: 1;
+    }
+</style>
+
+Test passes if no red is visible.
+
+<div id="containing-block">
+    <!--
+        Both rectangles below overlaps.
+        #anchor is red, #anchor-positioned is green and above #anchor in Z order.
+        If no red is visible then #anchor-positioned has fully covered #anchor.
+    -->
+    <div id="anchor"></div>
+    <div id="anchor-positioned"></div>
+</div>
+
+<script>
+    if (window.internals)
+        window.internals.setPageZoomFactor(2);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom-expected.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 150px;
+        height: 150px;
+
+        zoom: 2;
+    }
+
+    .cell {
+        width: 50px;
+        height: 50px;
+    }
+
+    #anchor-cell {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+
+        background: green;
+    }
+
+    .anchor-positioned-cell {
+        position: absolute;
+    }
+
+    #top-left {
+        top: 0;
+        left: 0;
+
+        background: cyan;
+    }
+
+    #top-right {
+        top: 0;
+        right: 0;
+
+        background: magenta;
+    }
+
+    #bottom-left {
+        bottom: 0;
+        left: 0;
+
+        background: yellow;
+    }
+
+    #bottom-right {
+        bottom: 0;
+        right: 0;
+
+        background: black;
+    }
+</style>
+
+<body>
+    <div class="containing-block">
+        <div class="cell" id="anchor-cell"></div>
+
+        <div class="cell anchor-positioned-cell" id="top-left"></div>
+        <div class="cell anchor-positioned-cell" id="top-right"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-left"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-right"></div>
+    </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+
+<title>CSS Anchor Positioning: tests that anchor() works with CSS zoom property</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/anchor-css-zoom-ref.html">
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 150px;
+        height: 150px;
+
+        zoom: 2;
+    }
+
+    .cell {
+        width: 50px;
+        height: 50px;
+    }
+
+    #anchor-cell {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+
+        anchor-name: --anchor;
+
+        background: green;
+    }
+
+    .anchor-positioned-cell {
+        position: absolute;
+        position-anchor: --anchor;
+    }
+
+    #top-left {
+        top: 0;
+        right: anchor(left);
+
+        background: cyan;
+    }
+
+    #top-right {
+        top: 0;
+        left: anchor(right);
+
+        background: magenta;
+    }
+
+    #bottom-left {
+        bottom: 0;
+        right: anchor(left);
+
+        background: yellow;
+    }
+
+    #bottom-right {
+        bottom: 0;
+        left: anchor(right);
+
+        background: black;
+    }
+</style>
+
+<body>
+    <!--
+        The boxes below are arranged like this:
+        (the outside box is .containing-block)
+
+        -------------
+        | 1 |   | 2 |
+        |---|---|---|
+        |   | A |   |
+        |---|---|---|
+        | 3 |   | 4 |
+        -------------
+    -->
+
+    <div class="containing-block">
+        <!-- Box A -->
+        <div class="cell" id="anchor-cell"></div>
+
+        <!-- Box 1 -->
+        <div class="cell anchor-positioned-cell" id="top-left"></div>
+
+        <!-- Box 2 -->
+        <div class="cell anchor-positioned-cell" id="top-right"></div>
+
+        <!-- Box 3 -->
+        <div class="cell anchor-positioned-cell" id="bottom-left"></div>
+
+        <!-- Box 4 -->
+        <div class="cell anchor-positioned-cell" id="bottom-right"></div>
+    </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+<style>
+    #containing-block {
+        position: relative;
+
+        zoom: 2;
+    }
+
+    #anchor {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: red;
+    }
+
+    #anchor-positioned {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: green;
+
+        z-index: 1;
+    }
+</style>
+
+Test passes if no red is visible.
+
+<div id="containing-block">
+    <div id="anchor"></div>
+    <div id="anchor-positioned"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+<title>CSS Anchor Positioning: tests that anchor-size() works with CSS zoom property</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/anchor-size-css-zoom-ref.html">
+
+<style>
+    #containing-block {
+        position: relative;
+
+        zoom: 2;
+    }
+
+    #anchor {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        anchor-name: --anchor;
+
+        background: red;
+    }
+
+    #anchor-positioned {
+        position: absolute;
+
+        width: anchor-size(--anchor width);
+        height: anchor-size(--anchor height);
+
+        background: green;
+
+        z-index: 1;
+    }
+</style>
+
+Test passes if no red is visible.
+
+<div id="containing-block">
+    <!--
+        Both rectangles below overlaps.
+        #anchor is red, #anchor-positioned is green and above #anchor in Z order.
+        If no red is visible then #anchor-positioned has fully covered #anchor.
+    -->
+    <div id="anchor"></div>
+    <div id="anchor-positioned"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-css-zoom-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-css-zoom-ref.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 150px;
+        height: 150px;
+
+        zoom: 2;
+    }
+
+    .cell {
+        width: 50px;
+        height: 50px;
+    }
+
+    #anchor-cell {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+
+        background: green;
+    }
+
+    .anchor-positioned-cell {
+        position: absolute;
+    }
+
+    #top-left {
+        top: 0;
+        left: 0;
+
+        background: cyan;
+    }
+
+    #top-right {
+        top: 0;
+        right: 0;
+
+        background: magenta;
+    }
+
+    #bottom-left {
+        bottom: 0;
+        left: 0;
+
+        background: yellow;
+    }
+
+    #bottom-right {
+        bottom: 0;
+        right: 0;
+
+        background: black;
+    }
+</style>
+
+<body>
+    <div class="containing-block">
+        <div class="cell" id="anchor-cell"></div>
+
+        <div class="cell anchor-positioned-cell" id="top-left"></div>
+        <div class="cell anchor-positioned-cell" id="top-right"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-left"></div>
+        <div class="cell anchor-positioned-cell" id="bottom-right"></div>
+    </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-size-css-zoom-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-size-css-zoom-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+<style>
+    #containing-block {
+        position: relative;
+
+        zoom: 2;
+    }
+
+    #anchor {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: red;
+    }
+
+    #anchor-positioned {
+        position: absolute;
+
+        width: 200px;
+        height: 100px;
+
+        background: green;
+
+        z-index: 1;
+    }
+</style>
+
+Test passes if no red is visible.
+
+<div id="containing-block">
+    <div id="anchor"></div>
+    <div id="anchor-positioned"></div>
+</div>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -581,7 +581,10 @@ std::optional<double> AnchorPositionEvaluator::evaluate(BuilderState& builderSta
 
     // Proceed with computing the inset value for the specified inset property.
     CheckedRef anchorBox = downcast<RenderBoxModelObject>(*anchorRenderer);
-    return computeInsetValue(propertyID, anchorBox, *anchorPositionedRenderer, side, builderState.positionTryFallback());
+    double insetValue = computeInsetValue(propertyID, anchorBox, *anchorPositionedRenderer, side, builderState.positionTryFallback());
+
+    // Adjust for CSS `zoom` property and page zoom.
+    return insetValue / style.usedZoom();
 }
 
 // Returns the default anchor size dimension to use when it is not specified in
@@ -710,11 +713,13 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
     CheckedRef anchorBox = downcast<RenderBoxModelObject>(*anchorRenderer);
     auto anchorBorderBoundingBox = anchorBox->borderBoundingBox();
 
+    // Adjust for CSS `zoom` property and page zoom.
+
     switch (physicalDimension) {
     case BoxAxis::Horizontal:
-        return anchorBorderBoundingBox.width();
+        return anchorBorderBoundingBox.width() / style.usedZoom();
     case BoxAxis::Vertical:
-        return anchorBorderBoundingBox.height();
+        return anchorBorderBoundingBox.height() / style.usedZoom();
     }
 
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 27cdd2696cac96e278f244f3594911fbc5766554
<pre>
[css-anchor-position-1] Adjust anchor()/anchor-size() for viewport and CSS zoom
<a href="https://rdar.apple.com/146806814">rdar://146806814</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289578">https://bugs.webkit.org/show_bug.cgi?id=289578</a>

Reviewed by Antti Koivisto.

The value returned by anchor()/anchor-size() is calculated at 1x viewport zoom,
which is wrong if either:
* the viewport is zoomed using Ctrl+/Ctrl-, or
* CSS zoom property is used.

This patch fixes this by adjusting the returned value by the zoom factor.

* LayoutTests/fast/css/css-anchor-position/anchor-page-zoom-expected.html: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-page-zoom.html: Added.
    - Added test for anchor() + viewport zoom. This test can&apos;t be added to WPT,
      as WPT does not support changing viewport zoom factor.

* LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom-expected.html: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html: Added.
    - Added test for anchor-size() + viewport zoom. This test can&apos;t be added to WPT,
      as WPT does not support changing viewport zoom factor.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-css-zoom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-css-zoom-ref.html: Added.
    - Added test for anchor() + CSS zoom.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-css-zoom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-size-css-zoom-ref.html: Added.
    - Added test for anchor-size() + CSS zoom.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):

Canonical link: <a href="https://commits.webkit.org/292985@main">https://commits.webkit.org/292985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db66aa2a2e5c1d7e5ace2fa88997bab88a631a3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5722 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47033 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83047 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17725 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->