### PR TITLE
[JSC] Remove remaining hard coded test loop count for JSTests/stress

### DIFF
--- a/JSTests/stress/iterator-open-throw-for-non-objects.js
+++ b/JSTests/stress/iterator-open-throw-for-non-objects.js
@@ -3,10 +3,8 @@ function shouldBe(actual, expected) {
         throw new Error(`expected ${expected} but got ${actual}`);
 }
 
-const runs = 1e5;
-
 let count = 0;
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return 3; };
@@ -15,10 +13,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return "foo"; };
@@ -27,10 +25,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return true; };
@@ -39,10 +37,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return null; };
@@ -51,10 +49,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return undefined; };
@@ -63,10 +61,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return Symbol("foo"); };
@@ -75,10 +73,10 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;
 
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
     try {
         const arr = [101, 101];
         arr[Symbol.iterator] = function () { return 3n; };
@@ -87,5 +85,5 @@ for (let i = 0; i < runs; i++) {
         count++;
     }
 }
-shouldBe(count, runs);
+shouldBe(count, testLoopCount);
 count = 0;

--- a/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js
+++ b/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js
@@ -10,16 +10,14 @@ function numberToString(thisValue) {
 }
 
 (function() {
-    const runs = 1e6;
-
-    for (let i = 0; i < runs; i++) {
+    for (let i = 0; i < testLoopCount; i++) {
         numberToString({});
         numberToString(i);
     }
 
-    if (successCount !== runs)
+    if (successCount !== testLoopCount)
         throw new Error(`Bad value: ${successCount}!`);
 
-    if (errorCount !== runs)
+    if (errorCount !== testLoopCount)
         throw new Error(`Bad value: ${errorCount}!`);
 })();

--- a/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js
+++ b/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js
@@ -10,16 +10,14 @@ function numberToString(thisValue) {
 }
 
 (function() {
-    const runs = 1e6;
-
-    for (let i = 0; i < runs; i++) {
+    for (let i = 0; i < testLoopCount; i++) {
         numberToString({});
         numberToString(i);
     }
 
-    if (successCount !== runs)
+    if (successCount !== testLoopCount)
         throw new Error(`Bad value: ${successCount}!`);
 
-    if (errorCount !== runs)
+    if (errorCount !== testLoopCount)
         throw new Error(`Bad value: ${errorCount}!`);
 })();

--- a/JSTests/stress/putDirectWithReify-JSFinalObject.js
+++ b/JSTests/stress/putDirectWithReify-JSFinalObject.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const runs = 1e5;
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`Bad value: ${actual}!`);
@@ -31,7 +29,7 @@ function shouldThrow(func, errorMessage) {
         foo = 1;
     }
 
-    for (var i = 0; i < runs; i++) {
+    for (var i = 0; i < testLoopCount; i++) {
         shouldThrow(() => { new TestFinalObjectDontDelete(); }, "TypeError: Attempting to change configurable attribute of unconfigurable property.");
     }
 
@@ -47,7 +45,7 @@ function shouldThrow(func, errorMessage) {
         foo = 42;
     }
 
-    for (var i = 0; i < runs; i++) {
+    for (var i = 0; i < testLoopCount; i++) {
         var object = new TestFinalObjectReadOnly();
         shouldBe(object.foo, 42);
 
@@ -70,7 +68,7 @@ function shouldThrow(func, errorMessage) {
         foo = 42;
     }
 
-    for (var i = 0; i < runs; i++) {
+    for (var i = 0; i < testLoopCount; i++) {
         shouldThrow(() => { new TestFinalObjectNonExtendable(); }, "TypeError: Attempting to define property on object that is not extensible.");
     }
 })();
@@ -86,7 +84,7 @@ function shouldThrow(func, errorMessage) {
         dontEnum = 42;
     }
 
-    for (var i = 0; i < runs; i++) {
+    for (var i = 0; i < testLoopCount; i++) {
         var object = new TestNonReifiedStaticDontEnum();
         shouldBe(object.dontEnum, 42);
 
@@ -101,7 +99,7 @@ function shouldThrow(func, errorMessage) {
         dontDelete = "foo";
     }
 
-    for (var i = 0; i < runs; i++) {
+    for (var i = 0; i < testLoopCount; i++) {
         shouldThrow(() => { new TestNonReifiedStaticDontDelete(); }, "TypeError: Attempting to change configurable attribute of unconfigurable property.");
     }
 })();

--- a/JSTests/stress/regexp-exec-consistent-error-message.js
+++ b/JSTests/stress/regexp-exec-consistent-error-message.js
@@ -3,13 +3,12 @@ function shouldBe(a, b) {
         throw new Error(`expected ${b} but got ${a}`);
 }
 
-const runs = 1e5;
 const regExpPrototype = RegExp.prototype;
 
 function test(propertyName) {
     let count = 0;
     let message = null;
-    for (let i = 0; i < runs; i++) {
+    for (let i = 0; i < testLoopCount; i++) {
         try {
             regExpPrototype[propertyName]();
         } catch (error) {
@@ -19,7 +18,7 @@ function test(propertyName) {
                 count++;
         }
     }
-    shouldBe(count, runs);
+    shouldBe(count, testLoopCount);
 }
 
 noInline(test);

--- a/JSTests/stress/regexp-split-side-effects-via-hasIndices-and-dotAll.js
+++ b/JSTests/stress/regexp-split-side-effects-via-hasIndices-and-dotAll.js
@@ -20,11 +20,9 @@ Object.defineProperty(re, "dotAll", {
   }
 });
 
-const runs = 1e6;
-
-for (let i = 0; i < runs; i++) {
+for (let i = 0; i < testLoopCount; i++) {
   re[Symbol.split]("abc");
 }
 
-sameValue(dotAllCount, runs);
-sameValue(hasIndicesCount, runs);
+sameValue(dotAllCount, testLoopCount);
+sameValue(hasIndicesCount, testLoopCount);

--- a/JSTests/stress/string-prototype-at.js
+++ b/JSTests/stress/string-prototype-at.js
@@ -8,10 +8,9 @@ function stringAt(string, index) {
 }
 noInline(stringAt);
 
-const runs = 1e6;
 function test(str, index, expected) {
     let count = 0;
-    for (let i = 0; i < runs; i++) {
+    for (let i = 0; i < testLoopCount; i++) {
         if (stringAt(str, index) === expected)
           count++;
     }
@@ -22,14 +21,14 @@ noInline(test);
 const string8 = "hello, world";
 const string16 = "こんにちは、世界";
 
-shouldBe(test(string16, 0, "こ"), runs);
-shouldBe(test(string16, 2, "に"), runs);
-shouldBe(test(string16, 20, undefined), runs);
-shouldBe(test(string16, -2, "世"), runs);
-shouldBe(test(string16, -40, undefined), runs);
+shouldBe(test(string16, 0, "こ"), testLoopCount);
+shouldBe(test(string16, 2, "に"), testLoopCount);
+shouldBe(test(string16, 20, undefined), testLoopCount);
+shouldBe(test(string16, -2, "世"), testLoopCount);
+shouldBe(test(string16, -40, undefined), testLoopCount);
 
-shouldBe(test(string8, 0, "h"), runs);
-shouldBe(test(string8, 2, "l"), runs);
-shouldBe(test(string8, 20, undefined), runs);
-shouldBe(test(string8, -2, "l"), runs);
-shouldBe(test(string8, -40, undefined), runs);
+shouldBe(test(string8, 0, "h"), testLoopCount);
+shouldBe(test(string8, 2, "l"), testLoopCount);
+shouldBe(test(string8, 20, undefined), testLoopCount);
+shouldBe(test(string8, -2, "l"), testLoopCount);
+shouldBe(test(string8, -40, undefined), testLoopCount);


### PR DESCRIPTION
#### 409c9304985790d3e024131fadd7841c6fa95706
<pre>
[JSC] Remove remaining hard coded test loop count for JSTests/stress
<a href="https://bugs.webkit.org/show_bug.cgi?id=290255">https://bugs.webkit.org/show_bug.cgi?id=290255</a>

Reviewed by Yusuke Suzuki.

<a href="https://commits.webkit.org/289981@main">https://commits.webkit.org/289981@main</a> introduced `testLoopCount` for JS
tests. But loop counts written as `runs = value` are remaining.

This patch fixes it.

* JSTests/stress/iterator-open-throw-for-non-objects.js:
* JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js:
* JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js:
* JSTests/stress/putDirectWithReify-JSFinalObject.js:
* JSTests/stress/regexp-exec-consistent-error-message.js:
(test):
* JSTests/stress/regexp-split-side-effects-via-hasIndices-and-dotAll.js:
* JSTests/stress/string-prototype-at.js:
(test):

Canonical link: <a href="https://commits.webkit.org/292553@main">https://commits.webkit.org/292553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aa122150811bcbeceadf2cafaca097dfc2c3b2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24402 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73441 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11966 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46202 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89028 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94976 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16814 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23385 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118453 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23044 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->