### PR TITLE
ResourceLoadInfo: fix compilation if VIDEO or is not enabled

### DIFF
--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -87,8 +87,10 @@ OptionSet<ResourceType> toResourceType(CachedResource::Type type, ResourceReques
 #endif
         return { ResourceType::Other };
 
+#if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
         return { ResourceType::Media };
+#endif
 
     };
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 120eef401f7c2e88f6b976a9316149d838a74004
<pre>
ResourceLoadInfo: fix compilation if VIDEO or is not enabled

<a href="https://bugs.webkit.org/show_bug.cgi?id=290259">https://bugs.webkit.org/show_bug.cgi?id=290259</a>

Reviewed by Adrian Perez de Castro.

/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/webkitgtk-2.48.0/Source/WebCore/loader/ResourceLoadInfo.cpp:88:32: error: ‘TextTrackResource’ is not a member of ‘WebCore::CachedResource::Type’
   88 |     case CachedResource::Type::TextTrackResource:
      |                                ^~~~~~~~~~~~~~~~~

Commit <a href="https://github.com/WebKit/WebKit/commit/951a118e17cd92adc3aa31129af7cd348fac91e9">https://github.com/WebKit/WebKit/commit/951a118e17cd92adc3aa31129af7cd348fac91e9</a>
&quot;Fix missing includes and guards when certain features are disabled&quot;,
added guards to TextTrackResource in CachedResource, but forgot to
add this one.

Signed-off-by: Thomas Devoogdt &lt;thomas@devoogdt.com&gt;
Canonical link: <a href="https://commits.webkit.org/292680@main">https://commits.webkit.org/292680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a82d1f12693c58f0dd49a50073096e6ac6d61f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24409 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73448 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81868 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3962 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16827 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15595 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23051 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->