### PR TITLE
WebFullScreenManager{Proxy,Manager}: add missing includes

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -30,6 +30,7 @@
 #include "FullScreenMediaDetails.h"
 #include "MessageReceiver.h"
 #include <WebCore/BoxExtents.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/ProcessIdentifier.h>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -28,6 +28,8 @@
 #if ENABLE(FULLSCREEN_API)
 
 #include <WebCore/EventListener.h>
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/IntRect.h>


### PR DESCRIPTION
#### 03cfc67d38c5899f4bfc881c920d68cf80f15279
<pre>
WebFullScreenManager{Proxy,Manager}: add missing includes

<a href="https://bugs.webkit.org/show_bug.cgi?id=290261">https://bugs.webkit.org/show_bug.cgi?id=290261</a>

Reviewed by Adrian Perez de Castro.

/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/webkitgtk-2.48.0/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:69:140: error: ‘ExceptionOr’ is not a member of ‘WebCore’
   69 |     void enterFullScreenForElement(WebCore::Element&amp;, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler&lt;void(WebCore::ExceptionOr&lt;void&gt;)&gt;&amp;&amp;, CompletionHandler&lt;bool(bool)&gt;&amp;&amp;);
      |                                                                                                                                            ^~~~~~~~~~~

/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/webkitgtk-2.48.0/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:79:42: error: ‘WebCore::FrameIdentifier’ has not been declared
   79 |     void enterFullScreenForOwnerElements(WebCore::FrameIdentifier, CompletionHandler&lt;void()&gt;&amp;&amp;);
      |                                          ^~~~~~~

/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/webkitgtk-2.48.0/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:104:58: error: ‘WebCore::FrameIdentifier’ has not been declared
  104 |     void enterFullScreenForOwnerElementsInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler&lt;void()&gt;&amp;&amp;);
      |                                                          ^~~~~~~

Signed-off-by: Thomas Devoogdt &lt;thomas@devoogdt.com&gt;
Canonical link: <a href="https://commits.webkit.org/292681@main">https://commits.webkit.org/292681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbfa600d085245f6d13f19b13302683619817435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46885 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73451 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30680 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11975 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23433 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17063 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82496 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3967 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16833 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15596 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28551 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->