### PR TITLE
Introduce APIWeakPtr

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -27,7 +27,7 @@
 
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 #if PLATFORM(COCOA)
 #include "WKFoundation.h"
@@ -40,11 +40,15 @@
 
 #define DELEGATE_REF_COUNTING_TO_COCOA PLATFORM(COCOA)
 
+#if PLATFORM(COCOA)
+typedef struct objc_object* id;
+#endif
+
 namespace API {
 
 class Object
 #if !DELEGATE_REF_COUNTING_TO_COCOA
-    : public ThreadSafeRefCounted<Object>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Object>
 #endif
 {
     WTF_MAKE_NONCOPYABLE(Object);
@@ -248,6 +252,8 @@ public:
     }
 
     id wrapper() const { return (__bridge id)m_wrapper; }
+#else
+    id wrapper() const { return (id)const_cast<void*>(m_wrapper); }
 #endif
 
     void ref() const;

--- a/Source/WebKit/Shared/API/APIWeakPtr.h
+++ b/Source/WebKit/Shared/API/APIWeakPtr.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIObject.h"
+
+#if PLATFORM(COCOA)
+#include <wtf/WeakObjCPtr.h>
+#else
+#include <wtf/ThreadSafeWeakPtr.h>
+#endif
+
+namespace WebKit {
+
+template<typename T> class APIWeakPtr {
+public:
+    APIWeakPtr(T* ptr)
+#if PLATFORM(COCOA)
+        : m_ptr(ptr ? ptr->wrapper() : nullptr) { }
+#else
+        : m_ptr(ptr) { }
+#endif
+
+    RefPtr<T> get() const
+    {
+#if PLATFORM(COCOA)
+        RetainPtr<CFTypeRef> ptr = m_ptr.get();
+        return downcast<T>(API::Object::unwrap(const_cast<void*>(ptr.get())));
+#else
+        return m_ptr.get();
+#endif
+    }
+
+private:
+#if PLATFORM(COCOA)
+    WeakObjCPtr<id> m_ptr;
+#else
+    ThreadSafeWeakPtr<T> m_ptr;
+#endif
+};
+
+}

--- a/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
@@ -64,7 +64,7 @@ void WKDownloadCancel(WKDownloadRef download, const void* functionContext, WKDow
 
 WKPageRef WKDownloadGetOriginatingPage(WKDownloadRef download)
 {
-    return toAPI(toImpl(download)->originatingPage());
+    return toAPI(toImpl(download)->originatingPage().get());
 }
 
 bool WKDownloadGetWasUserInitiated(WKDownloadRef download)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -110,7 +110,7 @@ void DownloadProxy::processDidClose()
     m_client->processDidCrash(*this);
 }
 
-WebPageProxy* DownloadProxy::originatingPage() const
+RefPtr<WebPageProxy> DownloadProxy::originatingPage() const
 {
     return m_originatingPage.get();
 }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include "APIWeakPtr.h"
 #include "Connection.h"
 #include "DownloadID.h"
 #include "IdentifierTypes.h"
@@ -88,7 +89,7 @@ public:
     void didReceiveDownloadProxyMessage(IPC::Connection&, IPC::Decoder&);
     bool didReceiveSyncDownloadProxyMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
-    WebPageProxy* originatingPage() const;
+    RefPtr<WebPageProxy> originatingPage() const;
 
     void setRedirectChain(Vector<URL>&& redirectChain) { m_redirectChain = WTFMove(redirectChain); }
     const Vector<URL>& redirectChain() const { return m_redirectChain; }
@@ -154,7 +155,7 @@ private:
     String m_suggestedFilename;
     String m_destinationFilename;
 
-    WeakPtr<WebPageProxy> m_originatingPage;
+    APIWeakPtr<WebPageProxy> m_originatingPage;
     Vector<URL> m_redirectChain;
     bool m_wasUserInitiated { true };
     bool m_downloadIsCancelled { false };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8505,6 +8505,7 @@
 		FAC8498B2A9E92DE00D407EF /* WebTransportSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebTransportSession.cpp; path = Network/WebTransportSession.cpp; sourceTree = "<group>"; };
 		FAC8498C2A9E92DE00D407EF /* WebTransportSession.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = WebTransportSession.messages.in; path = Network/WebTransportSession.messages.in; sourceTree = "<group>"; };
 		FAC8498E2A9E92DF00D407EF /* WebTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSession.h; path = Network/WebTransportSession.h; sourceTree = "<group>"; };
+		FADE5EDA2D8F475400057280 /* APIWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIWeakPtr.h; sourceTree = "<group>"; };
 		FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource132.cpp; sourceTree = "<group>"; };
 		FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource134.cpp; sourceTree = "<group>"; };
 		FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource136.cpp; sourceTree = "<group>"; };
@@ -15454,6 +15455,7 @@
 				7AE42B432954E8C200B20510 /* APIURLResponse.serialization.in */,
 				F6113E24126CE1820057D0A7 /* APIUserContentURLPattern.h */,
 				FA9AFA652B224DE400953DC5 /* APIUserContentURLPattern.serialization.in */,
+				FADE5EDA2D8F475400057280 /* APIWeakPtr.h */,
 			);
 			path = API;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### b2385cb603e925ddff2ad7ba7b50246270389601
<pre>
Introduce APIWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=290265">https://bugs.webkit.org/show_bug.cgi?id=290265</a>
<a href="https://rdar.apple.com/147660333">rdar://147660333</a>

Reviewed by NOBODY (OOPS!).

This is an abstraction that works like ThreadSafeWeakPtr, but it works
with API::Object which has different memory management strategies on
different platforms.

* Source/WebKit/Shared/API/APIObject.h:
(API::Object::wrapper const):
* Source/WebKit/Shared/API/APIWeakPtr.h: Added.
(WebKit::APIWeakPtr::APIWeakPtr):
(WebKit::APIWeakPtr::get const):
* Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp:
(WKDownloadGetOriginatingPage):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::originatingPage const):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2385cb603e925ddff2ad7ba7b50246270389601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96378 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15992 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46897 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16288 "Hash b2385cb6 for PR 42884 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24425 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73460 "Failure limit exceed. At least found 109 new test failures: compositing/page-cache-back-crash.html compositing/shared-backing/update-backing-sharing-on-size-change.html compositing/show-composited-iframe-on-back-button.html css3/color-filters/color-filter-apple-invert-lightness.html css3/color-filters/color-filter-backgrounds-borders.html css3/color-filters/color-filter-box-shadow.html css3/color-filters/color-filter-brightness.html css3/color-filters/color-filter-caret-color.html css3/color-filters/color-filter-color-property-list-item.html css3/color-filters/color-filter-color-property.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30690 "Found 60 new test failures: animations/cross-fade-border-image-source.html animations/resume-after-page-cache.html compositing/backing/foreground-layer-no-paints-into-ancestor.html compositing/clipping/border-radius-async-overflow-non-stacking.html compositing/clipping/border-radius-async-overflow-stacking.html compositing/clipping/nested-overflow-with-border-radius.html compositing/geometry/fixed-inside-overflow-scroll.html compositing/geometry/rtl-overflow-scroll.html compositing/layer-creation/overlap-in-scroller.html compositing/overflow/absolute-in-overflow.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99381 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/16288 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53797 "Found 246 new API test failures: /WPE/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/ephemeral, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.ForceRepaint, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /TestWebKit:WebKit.ResizeWindowAfterCrash, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, /WPE/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WPE/TestLoaderClient:/webkit/WebKitWebView/active-uri, /TestWebKit:WebKit.PendingAPIRequestURL, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/16288 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46225 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/16288 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103473 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23445 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17073 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82506 "Failure limit exceed. At least found 87 new test failures: compositing/clipping/border-radius-async-overflow-non-stacking.html compositing/clipping/border-radius-async-overflow-stacking.html compositing/geometry/fixed-inside-overflow-scroll.html compositing/rtl/rtl-overflow-scrolling.html compositing/shared-backing/make-sharing-layer-composited.html compositing/shared-backing/update-backing-sharing-on-size-change.html compositing/show-composited-iframe-on-back-button.html crypto/subtle/rsa-indexeddb-non-exportable-private.html css3/color-filters/color-filter-apple-invert-lightness.html css3/color-filters/color-filter-backgrounds-borders.html ... (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23696 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81881 "Found 280 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/document-loaded-signal, /TestWebKit:WebKit.ForceRepaint, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/options, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/terminate-web-process, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WebKitGTK/TestFrame:/webkit/WebKitFrame/javascript-context, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/progress, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/next ... (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/5989 "Hash b2385cb6 for PR 42884 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16846 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23408 "Hash b2385cb6 for PR 42884 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28563 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23067 "Hash b2385cb6 for PR 42884 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26547 "Hash b2385cb6 for PR 42884 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24808 "Hash b2385cb6 for PR 42884 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->