### PR TITLE
[GTK] Enhanced <input type=color>: support alpha picker

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -160,11 +160,6 @@ fast/history/page-cache-indexed-closed-db.html [ Pass ]
 
 fast/multicol/multicol-with-child-renderLayer-for-input.html [ Pass ]
 
-# Enhanced <input type=color>
-imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html [ Skip ]
-accessibility/color-well.html [ Skip ]
-
 # permessage-deflate WebSocket extension.
 http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-comp-bit-onoff.html [ Pass ]
 http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-parameter.html [ Pass ]

--- a/LayoutTests/platform/gtk/accessibility/color-well-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/color-well-expected.txt
@@ -1,0 +1,13 @@
+This test checks the role of ColorWellRole on an input with type=color
+
+Role of input type=color is: AXRole: AXButton
+Value of empty color well: AXValue: rgb 0.00000 0.00000 0.00000 1
+Value of good color well: AXValue: rgb 1.00000 0.00000 0.00000 1
+Value of bad color well: AXValue: rgb 0.00000 0.00000 0.00000 1
+Value of alpha color well: AXValue: rgb 0.23137 0.23529 0.23137 0.40000
+Value of p3 color well: AXValue: rgb 1.00000 0.26667 0.60000 0.25882
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -900,6 +900,11 @@ webkit.org/b/186262 imported/w3c/web-platform-tests/css/css-text/word-break/word
 webkit.org/b/180645 imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-not-application.html [ Failure ]
 webkit.org/b/180645 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative.html [ Failure ]
 
+# Enhanced <input type=color>
+webkit.org/b/180645 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html [ Skip ]
+webkit.org/b/180645 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html [ Skip ]
+webkit.org/b/180645 accessibility/color-well.html [ Skip ]
+
 webkit.org/b/180645 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/valueMode.html [ Failure ]
 webkit.org/b/180645 accessibility/color-input-value-changes.html [ Timeout ]
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -277,7 +277,10 @@ String AccessibilityObjectAtspi::text() const
 
     if (m_coreObject->roleValue() == AccessibilityRole::ColorWell) {
         auto color = convertColor<SRGBA<float>>(m_coreObject->colorValue()).resolved();
-        GUniquePtr<char> colorString(g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue));
+        GUniquePtr<char> colorString(color.alpha == 1.0f
+            ? g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue)
+            : g_strdup_printf("rgb %7.5f %7.5f %7.5f %7.5f", color.red, color.green, color.blue, color.alpha)
+        );
         return String::fromUTF8(colorString.get());
     }
 

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -306,11 +306,11 @@ Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& pa
 }
 #endif // ENABLE(CONTEXT_MENUS)
 
-RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color& color, const WebCore::IntRect& rect, ColorControlSupportsAlpha, Vector<WebCore::Color>&&)
+RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy& page, const WebCore::Color& color, const WebCore::IntRect& rect, ColorControlSupportsAlpha supportsAlpha, Vector<WebCore::Color>&&)
 {
     if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
-        return WebKitColorChooser::create(page, color, rect);
-    return WebColorPickerGtk::create(page, color, rect);
+        return WebKitColorChooser::create(page, color, rect, supportsAlpha);
+    return WebColorPickerGtk::create(page, color, rect, supportsAlpha);
 }
 
 RefPtr<WebDateTimePicker> PageClientImpl::createDateTimePicker(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
@@ -28,13 +28,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebKitColorChooser> WebKitColorChooser::create(WebPageProxy& page, const WebCore::Color& initialColor, const WebCore::IntRect& rect)
+Ref<WebKitColorChooser> WebKitColorChooser::create(WebPageProxy& page, const WebCore::Color& initialColor, const WebCore::IntRect& rect, WebKit::ColorControlSupportsAlpha supportsAlpha)
 {
-    return adoptRef(*new WebKitColorChooser(page, initialColor, rect));
+    return adoptRef(*new WebKitColorChooser(page, initialColor, rect, supportsAlpha));
 }
 
-WebKitColorChooser::WebKitColorChooser(WebPageProxy& page, const Color& initialColor, const IntRect& rect)
-    : WebColorPickerGtk(page, initialColor, rect)
+WebKitColorChooser::WebKitColorChooser(WebPageProxy& page, const Color& initialColor, const IntRect& rect, WebKit::ColorControlSupportsAlpha supportsAlpha)
+    : WebColorPickerGtk(page, initialColor, rect, supportsAlpha)
     , m_elementRect(rect)
 {
 }

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
@@ -33,13 +33,13 @@ namespace WebKit {
 
 class WebKitColorChooser final : public WebColorPickerGtk {
 public:
-    static Ref<WebKitColorChooser> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&);
+    static Ref<WebKitColorChooser> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, WebKit::ColorControlSupportsAlpha);
     virtual ~WebKitColorChooser();
 
     const WebCore::IntRect& elementRect() const { return m_elementRect; }
 
 private:
-    WebKitColorChooser(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&);
+    WebKitColorChooser(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, WebKit::ColorControlSupportsAlpha);
 
     void endPicker() override;
     void showColorPicker(const WebCore::Color&) override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
@@ -58,6 +58,7 @@ using namespace WebCore;
 enum {
     PROP_0,
     PROP_RGBA,
+    PROP_ALLOW_ALPHA,
     N_PROPERTIES,
 };
 
@@ -73,6 +74,7 @@ struct _WebKitColorChooserRequestPrivate {
     WebKitColorChooser* colorChooser;
     GdkRGBA rgba;
     bool handled;
+    bool allowAlpha;
 };
 
 static std::array<unsigned, LAST_SIGNAL> signals;
@@ -95,6 +97,9 @@ static void webkitColorChooserRequestGetProperty(GObject* object, guint property
     switch (propertyID) {
     case PROP_RGBA:
         g_value_set_boxed(value, &request->priv->rgba);
+        break;
+    case PROP_ALLOW_ALPHA:
+        g_value_set_boxed(value, &request->priv->allowAlpha);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyID, paramSpec);
@@ -133,6 +138,19 @@ static void webkit_color_chooser_request_class_init(WebKitColorChooserRequestCla
             nullptr, nullptr,
             GDK_TYPE_RGBA,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+
+    /**
+     * WebKitColorChooserRequest:allow-alpha:
+     *
+     * The #gboolean allow-alpha of the request
+     *
+     * Since: 2.50
+     */
+    sObjProperties[PROP_ALLOW_ALPHA] =
+        g_param_spec_boolean("allow-alpha",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
 
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
@@ -194,6 +212,21 @@ void webkit_color_chooser_request_get_rgba(WebKitColorChooserRequest* request, G
     g_return_if_fail(rgba);
 
     *rgba = request->priv->rgba;
+}
+
+/**
+ * webkit_color_chooser_request_get_allow_alpha:
+ * @request: a #WebKitColorChooserRequest
+ *
+ * Returns: %TRUE if the request allows alpha, %FALSE otherwise
+ *
+ * Since: 2.50
+ */
+gboolean webkit_color_chooser_request_get_allow_alpha(WebKitColorChooserRequest* request)
+{
+    g_return_val_if_fail(WEBKIT_IS_COLOR_CHOOSER_REQUEST(request), FALSE);
+
+    return request->priv->allowAlpha;
 }
 
 /**
@@ -267,6 +300,7 @@ WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKitColorChooser* c
 {
     WebKitColorChooserRequest* request = WEBKIT_COLOR_CHOOSER_REQUEST(
         g_object_new(WEBKIT_TYPE_COLOR_CHOOSER_REQUEST, "rgba", colorChooser->initialColor(), nullptr));
+    request->priv->allowAlpha = colorChooser->supportsAlpha();
     request->priv->colorChooser = colorChooser;
     return request;
 }

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
@@ -57,6 +57,9 @@ WEBKIT_API void
 webkit_color_chooser_request_set_rgba              (WebKitColorChooserRequest *request,
                                                     const GdkRGBA             *rgba);
 
+WEBKIT_API gboolean
+webkit_color_chooser_request_get_allow_alpha       (WebKitColorChooserRequest *request);
+
 WEBKIT_API void
 webkit_color_chooser_request_get_element_rectangle (WebKitColorChooserRequest *request,
                                                     GdkRectangle              *rect);

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp
@@ -35,16 +35,17 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebColorPickerGtk> WebColorPickerGtk::create(WebPageProxy& page, const Color& initialColor, const IntRect& rect)
+Ref<WebColorPickerGtk> WebColorPickerGtk::create(WebPageProxy& page, const Color& initialColor, const IntRect& rect, WebKit::ColorControlSupportsAlpha supportsAlpha)
 {
-    return adoptRef(*new WebColorPickerGtk(page, initialColor, rect));
+    return adoptRef(*new WebColorPickerGtk(page, initialColor, rect, supportsAlpha));
 }
 
-WebColorPickerGtk::WebColorPickerGtk(WebPageProxy& page, const Color& initialColor, const IntRect&)
+WebColorPickerGtk::WebColorPickerGtk(WebPageProxy& page, const Color& initialColor, const IntRect&, WebKit::ColorControlSupportsAlpha supportsAlpha)
     : WebColorPicker(&page.colorPickerClient())
     , m_initialColor(initialColor)
     , m_webView(page.viewWidget())
     , m_colorChooser(nullptr)
+    , m_supportsAlpha(supportsAlpha)
 {
 }
 
@@ -98,6 +99,7 @@ void WebColorPickerGtk::showColorPicker(const Color& color)
         GtkWidget* toplevel = gtk_widget_get_toplevel(m_webView);
         m_colorChooser = gtk_color_chooser_dialog_new(_("Select Color"), WebCore::widgetIsOnscreenToplevelWindow(toplevel) ? GTK_WINDOW(toplevel) : nullptr);
         gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_colorChooser), &m_initialColor);
+        gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(m_colorChooser), supportsAlpha());
         g_signal_connect(m_colorChooser, "notify::rgba", G_CALLBACK(WebColorPickerGtk::colorChooserDialogRGBAChangedCallback), this);
         g_signal_connect(m_colorChooser, "response", G_CALLBACK(WebColorPickerGtk::colorChooserDialogResponseCallback), this);
     } else

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ColorControlSupportsAlpha.h"
 #include "WebColorPicker.h"
 #include <gdk/gdk.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 
 class WebColorPickerGtk : public WebColorPicker {
 public:
-    static Ref<WebColorPickerGtk> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&);
+    static Ref<WebColorPickerGtk> create(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, WebKit::ColorControlSupportsAlpha);
     virtual ~WebColorPickerGtk();
 
     void endPicker() override;
@@ -48,9 +49,10 @@ public:
     void cancel();
 
     const GdkRGBA* initialColor() const { return &m_initialColor; }
+    bool supportsAlpha() const { return m_supportsAlpha == WebKit::ColorControlSupportsAlpha::Yes; }
 
 protected:
-    WebColorPickerGtk(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&);
+    WebColorPickerGtk(WebPageProxy&, const WebCore::Color&, const WebCore::IntRect&, WebKit::ColorControlSupportsAlpha);
 
     void didChooseColor(const WebCore::Color&);
 
@@ -62,6 +64,7 @@ private:
     static void colorChooserDialogResponseCallback(GtkColorChooser*, int /*responseID*/, WebColorPickerGtk*);
 
     GtkWidget* m_colorChooser;
+    WebKit::ColorControlSupportsAlpha m_supportsAlpha { WebKit::ColorControlSupportsAlpha::No };
 };
 
 } // namespace WebKit

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -458,6 +458,8 @@ static gboolean runColorChooserCallback(WebKitWebView *webView, WebKitColorChoos
     GdkRGBA rgba;
     webkit_color_chooser_request_get_rgba(request, &rgba);
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(colorChooser), &rgba);
+    gboolean allow_alpha = webkit_color_chooser_request_get_allow_alpha(request);
+    gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(colorChooser), allow_alpha);
     g_signal_connect(colorChooser, "notify::rgba", G_CALLBACK(colorChooserRGBAChanged), request);
 #if GTK_CHECK_VERSION(3, 98, 5)
     gtk_popover_set_child(GTK_POPOVER(popover), colorChooser);


### PR DESCRIPTION
#### 04790d591e76c50e57759ee3af70f58f0082fced
<pre>
[GTK] Enhanced &lt;input type=color&gt;: support alpha picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=290266">https://bugs.webkit.org/show_bug.cgi?id=290266</a>

Reviewed by NOBODY (OOPS!).

Enable the GTK color picker to show its alpha slider when
the enhancements preference is enabled and the alpha attribute is used.

Note previously GTK color pickers always showed an alpha slider which never affected
the actual value, this patch also fixes this behaviour.

This adds a new API method webkit_color_chooser_request_get_allow_alpha
so that embedders can choose to update their UI accordingly.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/accessibility/color-well-expected.txt: Added.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::text const):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::createColorPicker):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp:
(WebKit::WebKitColorChooser::create):
(WebKit::WebKitColorChooser::WebKitColorChooser):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp:
(webkitColorChooserRequestGetProperty):
(webkit_color_chooser_request_class_init):
(webkit_color_chooser_request_get_allow_alpha):
(webkitColorChooserRequestCreate):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in:
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp:
(WebKit::WebColorPickerGtk::create):
(WebKit::WebColorPickerGtk::WebColorPickerGtk):
(WebKit::WebColorPickerGtk::showColorPicker):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h:
(WebKit::WebColorPickerGtk::supportsAlpha const):
* Tools/MiniBrowser/gtk/BrowserTab.c:
(runColorChooserCallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04790d591e76c50e57759ee3af70f58f0082fced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96899 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82272 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17470 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29084 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->