### PR TITLE
Address more Safer CPP failures in UIProcess/Cocoa

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,7 +1,4 @@
 UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
-UIProcess/Cocoa/AutomationClient.h
-UIProcess/Cocoa/DiagnosticLoggingClient.h
-UIProcess/Cocoa/FullscreenClient.h
 UIProcess/DisplayLink.h
 UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
 UIProcess/mac/PageClientImplMac.h

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
@@ -56,7 +56,7 @@ private:
     String browserName() const final;
     String browserVersion() const final;
 
-    WKProcessPool *m_processPool;
+    WeakObjCPtr<WKProcessPool> m_processPool;
     WeakObjCPtr<id <_WKAutomationDelegate>> m_delegate;
 
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -73,7 +73,7 @@ void AutomationClient::didRequestAutomationSession(WebKit::WebProcessPool*, cons
 bool AutomationClient::remoteAutomationAllowed() const
 {
     if (m_delegateMethods.allowsRemoteAutomation)
-        return [m_delegate.get() _processPoolAllowsRemoteAutomation:m_processPool];
+        return [m_delegate.get() _processPoolAllowsRemoteAutomation:m_processPool.get().get()];
 
     return false;
 }
@@ -94,7 +94,7 @@ void AutomationClient::requestAutomationSession(const String& sessionIdentifier,
     NSString *requestedSessionIdentifier = sessionIdentifier;
     RunLoop::protectedMain()->dispatch([this, requestedSessionIdentifier = retainPtr(requestedSessionIdentifier), configuration = WTFMove(configuration)] {
         if (m_delegateMethods.requestAutomationSession)
-            [m_delegate.get() _processPool:m_processPool didRequestAutomationSessionWithIdentifier:requestedSessionIdentifier.get() configuration:configuration.get()];
+            [m_delegate.get() _processPool:m_processPool.get().get() didRequestAutomationSessionWithIdentifier:requestedSessionIdentifier.get() configuration:configuration.get()];
     });
 }
 
@@ -104,14 +104,14 @@ void AutomationClient::requestedDebuggablesToWakeUp()
 {
     RunLoop::protectedMain()->dispatch([this] {
         if (m_delegateMethods.requestedDebuggablesToWakeUp)
-            [m_delegate.get() _processPoolDidRequestInspectorDebuggablesToWakeUp:m_processPool];
+            [m_delegate.get() _processPoolDidRequestInspectorDebuggablesToWakeUp:m_processPool.get().get()];
     });
 }
 
 String AutomationClient::browserName() const
 {
     if (m_delegateMethods.browserNameForAutomation)
-        return [m_delegate _processPoolBrowserNameForAutomation:m_processPool];
+        return [m_delegate _processPoolBrowserNameForAutomation:m_processPool.get().get()];
 
     // Fall back to using the unlocalized app name (i.e., 'Safari').
     NSBundle *appBundle = [NSBundle mainBundle];
@@ -123,7 +123,7 @@ String AutomationClient::browserName() const
 String AutomationClient::browserVersion() const
 {
     if (m_delegateMethods.browserVersionForAutomation)
-        return [m_delegate _processPoolBrowserVersionForAutomation:m_processPool];
+        return [m_delegate _processPoolBrowserVersionForAutomation:m_processPool.get().get()];
 
     // Fall back to using the app short version (i.e., '11.1.1').
     NSBundle *appBundle = [NSBundle mainBundle];

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
@@ -54,7 +54,7 @@ private:
 
     bool isWebKitDiagnosticLoggingClient() const final { return true; }
 
-    WKWebView *m_webView;
+    WeakObjCPtr<WKWebView> m_webView;
     WeakObjCPtr<id <_WKDiagnosticLoggingDelegate>> m_delegate;
 
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -61,7 +61,7 @@ void DiagnosticLoggingClient::setDelegate(id <_WKDiagnosticLoggingDelegate> dele
 void DiagnosticLoggingClient::logDiagnosticMessage(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessage)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessage:message description:description];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message description:description];
 }
 
 static _WKDiagnosticLoggingResultType toWKDiagnosticLoggingResultType(WebCore::DiagnosticLoggingResultType result)
@@ -87,31 +87,31 @@ static _WKDiagnosticLoggingDomain toWKDiagnosticLoggingDomain(WebCore::Diagnosti
 void DiagnosticLoggingClient::logDiagnosticMessageWithResult(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description, WebCore::DiagnosticLoggingResultType result)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithResult)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessageWithResult:message description:description result:toWKDiagnosticLoggingResultType(result)];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithResult:message description:description result:toWKDiagnosticLoggingResultType(result)];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithValue(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description, const WTF::String& value)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithValue)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessageWithValue:message description:description value:value];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithValue:message description:description value:value];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithEnhancedPrivacy)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessageWithEnhancedPrivacy:message description:description];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithEnhancedPrivacy:message description:description];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary(WebPageProxy*, const String& message, const String& description, Ref<API::Dictionary>&& valueDictionary)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithValueDictionary)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessage:message description:description valueDictionary:static_cast<NSDictionary*>(valueDictionary->wrapper())];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message description:description valueDictionary:static_cast<NSDictionary*>(valueDictionary->wrapper())];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithDomain(WebPageProxy*, const String& message, WebCore::DiagnosticLoggingDomain domain)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithDomain)
-        [m_delegate.get() _webView:m_webView logDiagnosticMessageWithDomain:message domain:toWKDiagnosticLoggingDomain(domain)];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessageWithDomain:message domain:toWKDiagnosticLoggingDomain(domain)];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.h
@@ -55,7 +55,7 @@ private:
 
     bool isWebKitFindClient() const final { return true; }
     
-    WKWebView *m_webView;
+    WeakObjCPtr<WKWebView> m_webView;
     WeakObjCPtr<id <_WKFindDelegate>> m_delegate;
     
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -57,31 +57,31 @@ void FindClient::setDelegate(id <_WKFindDelegate> delegate)
 void FindClient::didCountStringMatches(WebPageProxy*, const String& string, uint32_t matchCount)
 {
     if (m_delegateMethods.webviewDidCountStringMatches)
-        [m_delegate.get() _webView:m_webView didCountMatches:matchCount forString:string];
+        [m_delegate.get() _webView:m_webView.get().get() didCountMatches:matchCount forString:string];
 }
 
 void FindClient::didFindString(WebPageProxy*, const String& string, const Vector<WebCore::IntRect>&, uint32_t matchCount, int32_t matchIndex, bool)
 {
     if (m_delegateMethods.webviewDidFindString)
-        [m_delegate.get() _webView:m_webView didFindMatches:matchCount forString:string withMatchIndex:matchIndex];
+        [m_delegate.get() _webView:m_webView.get().get() didFindMatches:matchCount forString:string withMatchIndex:matchIndex];
 }
 
 void FindClient::didFailToFindString(WebPageProxy*, const String& string)
 {
     if (m_delegateMethods.webviewDidFailToFindString)
-        [m_delegate.get() _webView:m_webView didFailToFindString:string];
+        [m_delegate.get() _webView:m_webView.get().get() didFailToFindString:string];
 }
 
 void FindClient::didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer* layer)
 {
     if (m_delegateMethods.webviewDidAddLayerForFindOverlay)
-        [m_delegate _webView:m_webView didAddLayerForFindOverlay:layer];
+        [m_delegate _webView:m_webView.get().get() didAddLayerForFindOverlay:layer];
 }
 
 void FindClient::didRemoveLayerForFindOverlay(WebKit::WebPageProxy*)
 {
     if (m_delegateMethods.webviewDidRemoveLayerForFindOverlay)
-        [m_delegate _webViewDidRemoveLayerForFindOverlay:m_webView];
+        [m_delegate _webViewDidRemoveLayerForFindOverlay:m_webView.get().get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -58,7 +58,7 @@ public:
 #endif
 
 private:
-    WKWebView *m_webView;
+    WeakObjCPtr<WKWebView> m_webView;
     WeakObjCPtr<id <_WKFullscreenDelegate> > m_delegate;
 
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -67,61 +67,65 @@ void FullscreenClient::setDelegate(id <_WKFullscreenDelegate> delegate)
 
 void FullscreenClient::willEnterFullscreen(WebPageProxy*)
 {
-    [m_webView willChangeValueForKey:@"fullscreenState"];
-    [m_webView didChangeValueForKey:@"fullscreenState"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"fullscreenState"];
+    [webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)
     if (m_delegateMethods.webViewWillEnterFullscreen)
-        [m_delegate.get() _webViewWillEnterFullscreen:m_webView];
+        [m_delegate.get() _webViewWillEnterFullscreen:webView.get()];
 #else
     if (m_delegateMethods.webViewWillEnterElementFullscreen)
-        [m_delegate.get() _webViewWillEnterElementFullscreen:m_webView];
+        [m_delegate.get() _webViewWillEnterElementFullscreen:webView.get()];
 #endif
 }
 
 void FullscreenClient::didEnterFullscreen(WebPageProxy*)
 {
-    [m_webView willChangeValueForKey:@"fullscreenState"];
-    [m_webView didChangeValueForKey:@"fullscreenState"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"fullscreenState"];
+    [webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)
     if (m_delegateMethods.webViewDidEnterFullscreen)
-        [m_delegate.get() _webViewDidEnterFullscreen:m_webView];
+        [m_delegate.get() _webViewDidEnterFullscreen:webView.get()];
 #else
     if (m_delegateMethods.webViewDidEnterElementFullscreen)
-        [m_delegate.get() _webViewDidEnterElementFullscreen:m_webView];
+        [m_delegate.get() _webViewDidEnterElementFullscreen:webView.get()];
 #endif
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (auto fullScreenController = [m_webView fullScreenWindowController]) {
+    if (auto fullScreenController = [webView fullScreenWindowController]) {
         CGSize imageDimensions = fullScreenController.imageDimensions;
         if (fullScreenController.isUsingQuickLook && m_delegateMethods.webViewDidFullscreenImageWithQuickLook)
-            [m_delegate.get() _webView:m_webView didFullscreenImageWithQuickLook:imageDimensions];
+            [m_delegate.get() _webView:webView.get() didFullscreenImageWithQuickLook:imageDimensions];
     }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 }
 
 void FullscreenClient::willExitFullscreen(WebPageProxy*)
 {
-    [m_webView willChangeValueForKey:@"fullscreenState"];
-    [m_webView didChangeValueForKey:@"fullscreenState"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"fullscreenState"];
+    [webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)
     if (m_delegateMethods.webViewWillExitFullscreen)
-        [m_delegate.get() _webViewWillExitFullscreen:m_webView];
+        [m_delegate.get() _webViewWillExitFullscreen:webView.get()];
 #else
     if (m_delegateMethods.webViewWillExitElementFullscreen)
-        [m_delegate.get() _webViewWillExitElementFullscreen:m_webView];
+        [m_delegate.get() _webViewWillExitElementFullscreen:webView.get()];
 #endif
 }
 
 void FullscreenClient::didExitFullscreen(WebPageProxy*)
 {
-    [m_webView willChangeValueForKey:@"fullscreenState"];
-    [m_webView didChangeValueForKey:@"fullscreenState"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"fullscreenState"];
+    [webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)
     if (m_delegateMethods.webViewDidExitFullscreen)
-        [m_delegate.get() _webViewDidExitFullscreen:m_webView];
+        [m_delegate.get() _webViewDidExitFullscreen:webView.get()];
 #else
     if (m_delegateMethods.webViewDidExitElementFullscreen)
-        [m_delegate.get() _webViewDidExitElementFullscreen:m_webView];
+        [m_delegate.get() _webViewDidExitElementFullscreen:webView.get()];
 #endif
 }
 
@@ -131,7 +135,7 @@ void FullscreenClient::requestPresentingViewController(CompletionHandler<void(UI
     if (!m_delegateMethods.webViewRequestPresentingViewController)
         return completionHandler(nil, nil);
 
-    [m_delegate _webView:m_webView requestPresentingViewControllerWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+    [m_delegate _webView:m_webView.get().get() requestPresentingViewControllerWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
@@ -63,7 +63,7 @@ private:
         CheckedRef<IconLoadingDelegate> m_iconLoadingDelegate;
     };
 
-    WKWebView *m_webView;
+    WeakObjCPtr<WKWebView> m_webView;
     WeakObjCPtr<id <_WKIconLoadingDelegate> > m_delegate;
 
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -96,7 +96,7 @@ void IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon(const WebCor
 
     RetainPtr<_WKLinkIconParameters> parameters = adoptNS([[_WKLinkIconParameters alloc] _initWithLinkIcon:linkIcon]);
 
-    [delegate webView:m_iconLoadingDelegate->m_webView shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (IconLoadCompletionHandler loadCompletionHandler) mutable {
+    [delegate webView:m_iconLoadingDelegate->m_webView.get().get() shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (IconLoadCompletionHandler loadCompletionHandler) mutable {
         ASSERT(RunLoop::isMain());
         if (loadCompletionHandler) {
             completionHandler([loadCompletionHandler = makeBlockPtr(loadCompletionHandler)](API::Data* data) {


### PR DESCRIPTION
#### bf2a64f8e55b24ab264a304bdcef677d5e532038
<pre>
Address more Safer CPP failures in UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=290272">https://bugs.webkit.org/show_bug.cgi?id=290272</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
(WebKit::AutomationClient::remoteAutomationAllowed const):
(WebKit::AutomationClient::requestAutomationSession):
(WebKit::AutomationClient::requestedDebuggablesToWakeUp):
(WebKit::AutomationClient::browserName const):
(WebKit::AutomationClient::browserVersion const):
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
(WebKit::DiagnosticLoggingClient::logDiagnosticMessage):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithResult):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithValue):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary):
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithDomain):
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::willEnterFullscreen):
(WebKit::FullscreenClient::didEnterFullscreen):
(WebKit::FullscreenClient::willExitFullscreen):
(WebKit::FullscreenClient::didExitFullscreen):
(WebKit::FullscreenClient::requestPresentingViewController):

Canonical link: <a href="https://commits.webkit.org/292559@main">https://commits.webkit.org/292559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f047fbcc91f4ec41ef21da7243f3c3f78a25639f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46925 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12009 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81905 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16889 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28591 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->