### PR TITLE
[JSC] Use normal ImpureNaN propagation for Negation / Abs / Rounding

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -855,7 +855,9 @@ SpeculatedType typeOfDoubleNegation(SpeculatedType value)
 {
     // Changing bits can make pure NaN impure and vice versa:
     // 0xefff000000000000 (pure) - 0xffff000000000000 (impure)
-    if (value & SpecDoubleNaN)
+    // But we don't allow such pure NaN patterns. Thus we don't
+    // need any special handling for those pure NaNs
+    if (value & SpecDoubleImpureNaN)
         value |= SpecDoubleNaN;
     // We could get negative zero, which mixes SpecAnyIntAsDouble and SpecNotIntAsDouble.
     // We could also overflow a large negative int into something that is no longer
@@ -872,9 +874,8 @@ SpeculatedType typeOfDoubleAbs(SpeculatedType value)
 
 SpeculatedType typeOfDoubleRounding(SpeculatedType value)
 {
-    // Double Pure NaN can becomes impure when converted back from Float.
-    // and vice versa.
-    if (value & SpecDoubleNaN)
+    // Impure NaN can become pure when rounding but none of the pure NaNs we produce will convert to an impure NaN.
+    if (value & SpecDoubleImpureNaN)
         value |= SpecDoubleNaN;
     // We might lose bits, which leads to a value becoming integer-representable.
     if (value & SpecNonIntAsDouble)

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -477,8 +477,8 @@ public:
 
     // This value is 2^49, used to encode doubles such that the encoded value will begin
     // with a 15-bit pattern within the range 0x0002..0xFFFC.
-    static constexpr size_t DoubleEncodeOffsetBit = 49;
-    static constexpr int64_t DoubleEncodeOffset = 1ll << DoubleEncodeOffsetBit;
+    static constexpr size_t DoubleEncodeOffsetBit = JSValueDoubleEncodeOffsetBit;
+    static constexpr int64_t DoubleEncodeOffset = JSValueDoubleEncodeOffset;
 
     // If all bits in the mask are set, this indicates an integer number,
     // if any but not all are set this value is a double precision number.

--- a/Source/JavaScriptCore/runtime/PureNaN.h
+++ b/Source/JavaScriptCore/runtime/PureNaN.h
@@ -71,17 +71,27 @@ namespace JSC {
 // the docs appear to imply that quiet_NaN could even return a double with the
 // signaling bit set on hardware that doesn't do signaling. That would probably
 // never happen, but it's healthy to be paranoid.
-static constexpr uint64_t PNaNAsBits { 0x7ff8000000000000ll };
+static constexpr uint64_t PNaNAsBits { 0x7ff8000000000000ULL };
 static constexpr double PNaN { std::bit_cast<double>(PNaNAsBits) };
 static constexpr uint64_t ImpureNaNAsBits { 0xffff000000000000ULL };
 static constexpr double ImpureNaN { std::bit_cast<double>(ImpureNaNAsBits) };
+static constexpr size_t JSValueDoubleEncodeOffsetBit { 49 };
+static constexpr uint64_t JSValueDoubleEncodeOffset { 1ULL << JSValueDoubleEncodeOffsetBit };
+static constexpr uint64_t JSValueNumberTag { 0xfffe000000000000ULL };
 
 inline constexpr bool isImpureNaN(double value)
 {
-    // Tests if the double value would break JSVALUE64 encoding, which is the most
-    // aggressive kind of encoding that we currently use.
-    return std::bit_cast<uint64_t>(value) >= 0xfffe000000000000llu;
+    // Impure when encoded double is not recognized as double.
+    uint64_t bits = std::bit_cast<uint64_t>(value);
+    bits += JSValueDoubleEncodeOffset;
+    uint64_t mask = bits & JSValueNumberTag;
+    return !mask || mask == JSValueNumberTag;
 }
+
+static_assert(!isImpureNaN(std::numeric_limits<double>::quiet_NaN()));
+static_assert(!isImpureNaN(-std::numeric_limits<double>::quiet_NaN()));
+static_assert(!isImpureNaN(PNaN));
+static_assert(!isImpureNaN(-PNaN));
 
 // If the given value is NaN then return a NaN that is known to be pure.
 inline constexpr double purifyNaN(double value)


### PR DESCRIPTION
#### 4b5c73a50f805ea1bb49c5dba2634d7d22222e19
<pre>
[JSC] Use normal ImpureNaN propagation for Negation / Abs / Rounding
<a href="https://bugs.webkit.org/show_bug.cgi?id=290275">https://bugs.webkit.org/show_bug.cgi?id=290275</a>
<a href="https://rdar.apple.com/147666753">rdar://147666753</a>

Reviewed by Keith Miller.

We can just follow to the rule we are using in C++. Negation, Abs,
Rounding should pollute the result only when we can see ImpureNaN.

* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::typeOfDoubleNegation):
(JSC::typeOfDoubleRounding):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/PureNaN.h:
(JSC::isImpureNaN):

Canonical link: <a href="https://commits.webkit.org/292606@main">https://commits.webkit.org/292606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8a01b5d21ed6f99fc387099cc433979dc1c990d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6270 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/101630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99561 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/101630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/12150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/5110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/46406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/89231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103654 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95179 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/23625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/23876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/83365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15546 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23588 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118805 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/23247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/26727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->