### PR TITLE
Address more NoUnretainedMemberChecker warnings in WebCore/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -154,7 +154,6 @@ platform/mac/DataDetectorHighlight.mm
 platform/mediarecorder/MediaRecorderPrivateEncoder.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.h
-platform/network/ResourceHandleInternal.h
 platform/network/cocoa/CredentialCocoa.h
 platform/network/cocoa/ProtectionSpaceCocoa.h
 platform/network/mac/FormDataStreamMac.mm

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -3,13 +3,6 @@ PAL/pal/spi/mac/NSGraphicsSPI.h
 accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 page/EventHandler.h
-page/cocoa/ResourceUsageOverlayCocoa.mm
-page/mac/TextIndicatorWindow.h
-platform/ValidationBubble.h
-platform/graphics/FontPlatformData.h
-platform/graphics/cg/CGContextStateSaver.h
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
-platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
-platform/network/ResourceHandleInternal.h
 platform/network/cf/FormDataStreamCFNet.cpp

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -373,7 +373,7 @@ static void drawMemHistory(CGContextRef context, float x1, float y1, float y2, H
     CGContextSetLineWidth(context, 1);
 
     struct ColorAndSize {
-        CGColorRef color;
+        RetainPtr<CGColorRef> color;
         size_t size;
     };
 
@@ -396,7 +396,7 @@ static void drawMemHistory(CGContextRef context, float x1, float y1, float y2, H
             CGContextBeginPath(context);
             CGContextMoveToPoint(context, x1 + i, currentY2);
             CGContextAddLineToPoint(context, x1 + i, nextY2);
-            CGContextSetStrokeColorWithColor(context, colorAndSize.color);
+            CGContextSetStrokeColorWithColor(context, colorAndSize.color.get());
             CGContextStrokePath(context);
             currentY2 = nextY2;
         }

--- a/Source/WebCore/page/mac/TextIndicatorWindow.h
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.h
@@ -32,6 +32,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSView;
 OBJC_CLASS WebTextIndicatorLayer;
@@ -58,7 +59,7 @@ private:
 
     void startFadeOut();
 
-    NSView *m_targetView;
+    WeakObjCPtr<NSView> m_targetView;
     RefPtr<TextIndicator> m_textIndicator;
     RetainPtr<NSWindow> m_textIndicatorWindow;
     RetainPtr<NSView> m_textIndicatorView;

--- a/Source/WebCore/platform/ValidationBubble.h
+++ b/Source/WebCore/platform/ValidationBubble.h
@@ -96,7 +96,11 @@ private:
     WEBCORE_EXPORT ValidationBubble(PlatformView*, const String& message, const Settings&);
 #endif
 
+#if PLATFORM(COCOA)
+    WeakObjCPtr<PlatformView> m_view;
+#else
     PlatformView* m_view;
+#endif
     String m_message;
     double m_fontSize { 0 };
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -510,12 +510,12 @@ public:
         : m_context(context)
         , m_textMatrix(CGContextGetTextMatrix(context))
     {
-        CGContextSetTextMatrix(m_context, newMatrix);
+        CGContextSetTextMatrix(m_context.get(), newMatrix);
     }
 
     ~ScopedTextMatrix()
     {
-        CGContextSetTextMatrix(m_context, m_textMatrix);
+        CGContextSetTextMatrix(m_context.get(), m_textMatrix);
     }
 
     CGAffineTransform savedMatrix() const
@@ -524,7 +524,7 @@ public:
     }
 
 private:
-    CGContextRef m_context;
+    RetainPtr<CGContextRef> m_context;
     CGAffineTransform m_textMatrix;
 };
 

--- a/Source/WebCore/platform/graphics/cg/CGContextStateSaver.h
+++ b/Source/WebCore/platform/graphics/cg/CGContextStateSaver.h
@@ -36,26 +36,26 @@ public:
         , m_saveAndRestore(saveAndRestore)
     {
         if (m_saveAndRestore)
-            CGContextSaveGState(m_context);
+            CGContextSaveGState(m_context.get());
     }
     
     ~CGContextStateSaver()
     {
         if (m_saveAndRestore)
-            CGContextRestoreGState(m_context);
+            CGContextRestoreGState(m_context.get());
     }
     
     void save()
     {
         ASSERT(!m_saveAndRestore);
-        CGContextSaveGState(m_context);
+        CGContextSaveGState(m_context.get());
         m_saveAndRestore = true;
     }
 
     void restore()
     {
         ASSERT(m_saveAndRestore);
-        CGContextRestoreGState(m_context);
+        CGContextRestoreGState(m_context.get());
         m_saveAndRestore = false;
     }
     
@@ -65,7 +65,7 @@ public:
     }
     
 private:
-    CGContextRef m_context;
+    RetainPtr<CGContextRef> m_context;
     bool m_saveAndRestore;
 };
 

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -137,7 +137,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
 
 struct ProviderInfo {
     std::span<const UChar> cp;
-    CFDictionaryRef attributes;
+    RetainPtr<CFDictionaryRef> attributes;
 };
 
 static const UniChar* provideStringAndAttributes(CFIndex stringIndex, CFIndex* charCount, CFDictionaryRef* attributes, void* refCon)
@@ -147,7 +147,7 @@ static const UniChar* provideStringAndAttributes(CFIndex stringIndex, CFIndex* c
         return 0;
 
     *charCount = info->cp.size() - stringIndex;
-    *attributes = info->attributes;
+    *attributes = info->attributes.get();
     return reinterpret_cast<const UniChar*>(info->cp.subspan(stringIndex).data());
 }
 

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -218,8 +218,9 @@ static UIViewController *fallbackViewController(UIView *view)
 
 void ValidationBubble::setAnchorRect(const IntRect& anchorRect, UIViewController *presentingViewController)
 {
+    RetainPtr view = m_view.get();
     if (!presentingViewController)
-        presentingViewController = fallbackViewController(m_view);
+        presentingViewController = fallbackViewController(view.get());
 
     if (!presentingViewController)
         return;
@@ -227,8 +228,8 @@ void ValidationBubble::setAnchorRect(const IntRect& anchorRect, UIViewController
     UIPopoverPresentationController *presentationController = [m_popoverController popoverPresentationController];
     m_popoverDelegate = adoptNS([[WebValidationBubbleDelegate alloc] init]);
     presentationController.delegate = m_popoverDelegate.get();
-    presentationController.passthroughViews = @[ presentingViewController.view, m_view ];
-    presentationController.sourceView = m_view;
+    presentationController.passthroughViews = @[ presentingViewController.view, view.get() ];
+    presentationController.sourceView = view.get();
     presentationController.sourceRect = CGRectMake(anchorRect.x(), anchorRect.y(), anchorRect.width(), anchorRect.height());
     m_presentingViewController = presentingViewController;
 }

--- a/Source/WebCore/platform/mac/ValidationBubbleMac.mm
+++ b/Source/WebCore/platform/mac/ValidationBubbleMac.mm
@@ -87,11 +87,12 @@ ValidationBubble::~ValidationBubble()
 void ValidationBubble::showRelativeTo(const IntRect& anchorRect)
 {
     // Passing an unparented view to [m_popover showRelativeToRect:ofView:preferredEdge:] crashes.
-    if (![m_view window])
+    RetainPtr view = m_view.get();
+    if (![view window])
         return;
 
     NSRect rect = NSMakeRect(anchorRect.x(), anchorRect.y(), anchorRect.width(), anchorRect.height());
-    [m_popover showRelativeToRect:rect ofView:m_view preferredEdge:NSMinYEdge];
+    [m_popover showRelativeToRect:rect ofView:view.get() preferredEdge:NSMinYEdge];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -34,6 +34,8 @@
 #include <wtf/MonotonicTime.h>
 
 #if PLATFORM(COCOA)
+#include <wtf/WeakObjCPtr.h>
+
 OBJC_CLASS NSURLAuthenticationChallenge;
 OBJC_CLASS NSURLConnection;
 
@@ -94,7 +96,7 @@ public:
 
     // We need to keep a reference to the original challenge to be able to cancel it.
     // It is almost identical to m_currentWebChallenge.nsURLAuthenticationChallenge(), but has a different sender.
-    NSURLAuthenticationChallenge *m_currentMacChallenge { nil };
+    WeakObjCPtr<NSURLAuthenticationChallenge> m_currentMacChallenge;
 #endif
     Box<NetworkLoadMetrics> m_networkLoadMetrics;
     MonotonicTime m_startTime;


### PR DESCRIPTION
#### dbbcfa7f0320b8db48905deee66e5605975ba43a
<pre>
Address more NoUnretainedMemberChecker warnings in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=290277">https://bugs.webkit.org/show_bug.cgi?id=290277</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::drawMemHistory):
* Source/WebCore/page/mac/TextIndicatorWindow.h:
* Source/WebCore/platform/ValidationBubble.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::ScopedTextMatrix::ScopedTextMatrix):
(WebCore::ScopedTextMatrix::~ScopedTextMatrix):
* Source/WebCore/platform/graphics/cg/CGContextStateSaver.h:
(WebCore::CGContextStateSaver::CGContextStateSaver):
(WebCore::CGContextStateSaver::~CGContextStateSaver):
(WebCore::CGContextStateSaver::save):
(WebCore::CGContextStateSaver::restore):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::provideStringAndAttributes):
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::ValidationBubble::setAnchorRect):
* Source/WebCore/platform/mac/ValidationBubbleMac.mm:
(WebCore::ValidationBubble::showRelativeTo):
* Source/WebCore/platform/network/ResourceHandleInternal.h:
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::cancel):
(WebCore::ResourceHandle::didReceiveAuthenticationChallenge):
(WebCore::ResourceHandle::receivedCredential):
(WebCore::ResourceHandle::receivedRequestToContinueWithoutCredential):
(WebCore::ResourceHandle::receivedRequestToPerformDefaultHandling):
(WebCore::ResourceHandle::receivedChallengeRejection):

Canonical link: <a href="https://commits.webkit.org/292560@main">https://commits.webkit.org/292560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87351eeb08b9c71444e7422314e7cdec6b77499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87132 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53853 "Build is in progress. Recent messages:") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4902 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81910 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16903 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15522 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23101 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->