### PR TITLE
FRAME and FRAMESET should always be in-flow (and non-floating)

### DIFF
--- a/LayoutTests/fast/frames/abspos-display-none-frameset-crash-expected.txt
+++ b/LayoutTests/fast/frames/abspos-display-none-frameset-crash-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS No crash or ASSERT failure.
+

--- a/LayoutTests/fast/frames/abspos-display-none-frameset-crash.html
+++ b/LayoutTests/fast/frames/abspos-display-none-frameset-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+  frameset { display:none; position:absolute; }
+  frame { float:right; }
+</style>
+<div id="container"></div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  var frameset = document.createElement("frameset")
+  var frame = document.createElement("frame");
+  var container = document.getElementById("container");
+  frameset.appendChild(frame);
+  container.appendChild(frameset);
+  test(() => { }, "No crash or ASSERT failure.");
+</script>

--- a/LayoutTests/fast/multicol/abspos-display-none-frameset-crash-expected.txt
+++ b/LayoutTests/fast/multicol/abspos-display-none-frameset-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS No crash or ASSERT failure.
+

--- a/LayoutTests/fast/multicol/abspos-display-none-frameset-crash.html
+++ b/LayoutTests/fast/multicol/abspos-display-none-frameset-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+  frameset { display:none; position:absolute; }
+  frame { float:right; }
+</style>
+<div id="multicol" style="columns:1;">
+  <div></div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  var frameset = document.createElement("frameset")
+  var frame = document.createElement("frame");
+  frameset.appendChild(frame);
+  multicol.appendChild(frameset);
+  document.body.offsetTop;
+  multicol.style.display = "none";
+  test(() => { }, "No crash or ASSERT failure.");
+</script>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -483,9 +483,10 @@ void Adjuster::adjust(RenderStyle& style) const
         adjustDisplayContentsStyle(style);
 
     if (m_element && (m_element->hasTagName(frameTag) || m_element->hasTagName(framesetTag))) {
-        // Framesets ignore display and position properties.
+        // Framesets ignore display, position and float properties.
         style.setPosition(PositionType::Static);
         style.setEffectiveDisplay(DisplayType::Block);
+        style.setFloating(Float::None);
     }
 
     if (style.display() != DisplayType::None && style.display() != DisplayType::Contents) {


### PR DESCRIPTION
#### c3c083fd58975d9243b017b9384fcff76be88ec6
<pre>
FRAME and FRAMESET should always be in-flow (and non-floating)

<a href="https://bugs.webkit.org/show_bug.cgi?id=248088">https://bugs.webkit.org/show_bug.cgi?id=248088</a>
<a href="https://rdar.apple.com/102670652">rdar://102670652</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/f47b628e85e5195efc1f152c2bc7a19d20c85fa0">https://chromium.googlesource.com/chromium/src.git/+/f47b628e85e5195efc1f152c2bc7a19d20c85fa0</a>

Frames and framesets ignore display:none, and will render no matter
what. The style adjuster would check for display != none, before
attempting to adjust, and would therefore just do nothing and accept
whatever.

We only used to override display and position (force to &quot;block&quot; and
&quot;static&quot;, respectively). Additionally force &quot;float&quot; to &quot;none&quot;, as
framesets are really unsuitable containing blocks. It aligns with
other browser engines as well.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* LayoutTests/fast/multicol/abspos-display-none-frameset-crash.html:
* LayoutTests/fast/multicol/abspos-display-none-frameset-crash-expected.txt:
* LayoutTests/fast/frames/abspos-display-none-frameset-crash.html:
* LayoutTests/fast/frames/abspos-display-none-frameset-crash-expected.txt:

Canonical link: <a href="https://commits.webkit.org/296236@main">https://commits.webkit.org/296236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a245c3974f2a188ea42ae89ec65f443c29f9a7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81412 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57225 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90454 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->