### PR TITLE
[GTK][WPE][Skia] Remove obsolete fencing related methods from ImageBuffer/NativeImage & their backends

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -484,39 +484,6 @@ RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 }
 #endif
 
-#if USE(SKIA)
-bool ImageBuffer::finishAcceleratedRenderingAndCreateFence()
-{
-    if (auto* backend = ensureBackend())
-        return backend->finishAcceleratedRenderingAndCreateFence();
-    return false;
-}
-
-void ImageBuffer::waitForAcceleratedRenderingFenceCompletion()
-{
-    if (auto* backend = ensureBackend())
-        backend->waitForAcceleratedRenderingFenceCompletion();
-}
-
-const GrDirectContext* ImageBuffer::skiaGrContext() const
-{
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-    return backend->skiaGrContext();
-}
-
-RefPtr<ImageBuffer> ImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget() const
-{
-    ASSERT(renderingMode() == RenderingMode::Accelerated);
-
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-    return backend->copyAcceleratedImageBufferBorrowingBackendRenderTarget(*this);
-}
-#endif
-
 RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBuffer::layerContentsDisplayDelegate()
 {
     if (auto* backend = ensureBackend())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -50,7 +50,6 @@
 #endif
 
 #if USE(SKIA)
-class GrDirectContext;
 class SkSurface;
 #endif
 
@@ -196,12 +195,6 @@ public:
 
 #if USE(SKIA)
     SkSurface* surface() const;
-
-    // FIXME: Remove the obsolete Skia specific methods below.
-    bool finishAcceleratedRenderingAndCreateFence();
-    void waitForAcceleratedRenderingFenceCompletion();
-    const GrDirectContext* skiaGrContext() const;
-    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget() const;
 #endif
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -181,13 +181,6 @@ AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& par
     return baseTransform;
 }
 
-#if USE(SKIA)
-RefPtr<ImageBuffer> ImageBufferBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const
-{
-    return nullptr;
-}
-#endif
-
 TextStream& operator<<(TextStream& ts, VolatilityState state)
 {
     switch (state) {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -51,7 +51,6 @@
 #endif
 
 #if USE(SKIA)
-class GrDirectContext;
 class SkSurface;
 #endif
 
@@ -145,12 +144,6 @@ public:
 
 #if USE(SKIA)
     virtual SkSurface* surface() const { return nullptr; }
-
-    // FIXME: Remove the obsolete Skia specific methods below.
-    virtual bool finishAcceleratedRenderingAndCreateFence() { return false; }
-    virtual void waitForAcceleratedRenderingFenceCompletion() { }
-    virtual const GrDirectContext* skiaGrContext() const { return nullptr; }
-    WEBCORE_EXPORT virtual RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const;
 #endif
 
     virtual bool isInUse() const { return false; }

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -32,15 +32,10 @@
 #include "IntSize.h"
 #include "PlatformImage.h"
 #include "RenderingResource.h"
-#include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
-
-#if USE(SKIA)
-class GLFence;
-#endif
 
 class GraphicsContext;
 class NativeImageBackend;
@@ -90,22 +85,6 @@ public:
     virtual DestinationColorSpace colorSpace() const = 0;
     virtual Headroom headroom() const = 0;
     WEBCORE_EXPORT virtual bool isRemoteNativeImageBackendProxy() const;
-
-#if USE(SKIA)
-    // During DisplayList recording a fence is created, so that we can wait until the SkImage finished rendering
-    // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
-    virtual bool finishAcceleratedRenderingAndCreateFence() { return false; }
-    virtual void waitForAcceleratedRenderingFenceCompletion() { }
-
-    virtual const GrDirectContext* skiaGrContext() const { return nullptr; }
-
-    // Use to copy an accelerated NativeImage, cloning the PlatformImageNativeImageBackend, creating
-    // a new SkImage tied to the current thread (and thus the thread-local GrDirectContext), but re-using
-    // the existing backend texture, of this NativeImage. This avoids any GPU->GPU copies and has the
-    // sole purpose to abe able to access an accelerated NativeImage from another thread, that is not
-    // the creation thread.
-    virtual RefPtr<NativeImage> copyAcceleratedNativeImageBorrowingBackendTexture() const { return nullptr; }
-#endif
 };
 
 class PlatformImageNativeImageBackend final : public NativeImageBackend {
@@ -117,20 +96,8 @@ public:
     WEBCORE_EXPORT bool hasAlpha() const final;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const final;
     WEBCORE_EXPORT Headroom headroom() const final;
-
-#if USE(SKIA)
-    // FIXME: Remove the obsolete Skia specific methods and members below.
-    bool finishAcceleratedRenderingAndCreateFence() final;
-    void waitForAcceleratedRenderingFenceCompletion() final;
-    const GrDirectContext* skiaGrContext() const final;
-    RefPtr<NativeImage> copyAcceleratedNativeImageBorrowingBackendTexture() const final;
-#endif
 private:
     PlatformImagePtr m_platformImage;
-#if USE(SKIA)
-    std::unique_ptr<GLFence> m_fence WTF_GUARDED_BY_LOCK(m_fenceLock);
-    Lock m_fenceLock;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -28,12 +28,9 @@
 #if USE(SKIA)
 #include "ImageBuffer.h"
 #include "ImageBufferSkiaSurfaceBackend.h"
-#include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class GLFence;
 
 class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBackend
 {
@@ -57,21 +54,11 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
-    // FIXME: Remove the obsolete Skia specific methods and members below.
-    bool finishAcceleratedRenderingAndCreateFence() final;
-    void waitForAcceleratedRenderingFenceCompletion() final;
-    const GrDirectContext* skiaGrContext() const final { return m_skiaGrContext; }
-    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const final;
-
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 #endif
-
-    const GrDirectContext* m_skiaGrContext { nullptr };
-    std::unique_ptr<GLFence> m_fence WTF_GUARDED_BY_LOCK(m_fenceLock);
-    Lock m_fenceLock;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -28,80 +28,13 @@
 
 #if USE(SKIA)
 #include "GLContext.h"
-#include "GLFence.h"
 #include "GraphicsContextSkia.h"
 #include "PlatformDisplay.h"
-#include <skia/core/SkData.h>
-#include <skia/core/SkImage.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN // GLib/Win ports
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/private/chromium/SkImageChromium.h>
 #include <skia/core/SkPixmap.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
-
-bool PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence()
-{
-    Locker locker { m_fenceLock };
-    if (m_fence)
-        return true;
-
-    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-    if (!glContext || !glContext->makeContextCurrent())
-        return false;
-
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    RELEASE_ASSERT(grContext);
-
-    grContext->flush(m_platformImage);
-
-    if (GLFence::isSupported()) {
-        grContext->submit(GrSyncCpu::kNo);
-        m_fence = GLFence::create();
-    }
-
-    if (!m_fence)
-        grContext->submit(GrSyncCpu::kYes);
-
-    return true;
-}
-
-void PlatformImageNativeImageBackend::waitForAcceleratedRenderingFenceCompletion()
-{
-    Locker locker { m_fenceLock };
-    if (!m_fence)
-        return;
-
-    m_fence->serverWait();
-    m_fence = nullptr;
-}
-
-const GrDirectContext* PlatformImageNativeImageBackend::skiaGrContext() const
-{
-    return SkImages::GetContext(platformImage());
-}
-
-RefPtr<NativeImage> PlatformImageNativeImageBackend::copyAcceleratedNativeImageBorrowingBackendTexture() const
-{
-    auto image = platformImage();
-    if (!image)
-        return nullptr;
-
-    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-    if (!glContext || !glContext->makeContextCurrent())
-        return nullptr;
-
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    RELEASE_ASSERT(grContext);
-
-    GrBackendTexture backendTexture;
-    if (!SkImages::GetBackendTextureFromImage(image, &backendTexture, false))
-        return nullptr;
-
-    return NativeImage::create(SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace()));
-}
 
 IntSize PlatformImageNativeImageBackend::size() const
 {


### PR DESCRIPTION
#### f2876d34b120e11098f4190b4a3189c4548a0271
<pre>
[GTK][WPE][Skia] Remove obsolete fencing related methods from ImageBuffer/NativeImage &amp; their backends
<a href="https://bugs.webkit.org/show_bug.cgi?id=290283">https://bugs.webkit.org/show_bug.cgi?id=290283</a>

Reviewed by Carlos Garcia Campos.

Remove Skia specific methods from ImageBuffer / NativeImage, that
got obsoleted by the switch from DisplayList to SkPictureRecorder, for
the WPE/Gtk ports, namely:

- bool finishAcceleratedRenderingAndCreateFence()
- void waitForAcceleratedRenderingFenceCompletion()
- const GrDirectContext* skiaGrContext() const
- RefPtr&lt;ImageBuffer&gt; copyAcceleratedImageBufferBorrowingBackendRenderTarget() const

No change in behavior, just removing obsolete code.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::ImageBuffer::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::ImageBuffer::skiaGrContext const): Deleted.
(WebCore::ImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget const): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::surface const):
(WebCore::ImageBufferBackend::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::ImageBufferBackend::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::ImageBufferBackend::skiaGrContext const): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImageBackend::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::NativeImageBackend::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::NativeImageBackend::skiaGrContext const): Deleted.
(WebCore::NativeImageBackend::copyAcceleratedNativeImageBorrowingBackendTexture const): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::ImageBufferSkiaAcceleratedBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget const): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::PlatformImageNativeImageBackend::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::PlatformImageNativeImageBackend::skiaGrContext const): Deleted.
(WebCore::PlatformImageNativeImageBackend::copyAcceleratedNativeImageBorrowingBackendTexture const): Deleted.

Canonical link: <a href="https://commits.webkit.org/292701@main">https://commits.webkit.org/292701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83c20725dd611e66859c77332d3c38edb82ba528

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24907 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99851 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5425 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82475 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17450 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83679 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17412 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29033 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->