### PR TITLE
[Safer CPP] Address UncountedLocalVars warnings under WebProcess/Plugins/PDF/

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -44,9 +44,6 @@ WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
-WebProcess/Plugins/PDF/PDFPluginBase.mm
-WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
-WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/WebPluginInfoProvider.cpp
 WebProcess/Storage/WebSWClientConnection.cpp
 WebProcess/Storage/WebServiceWorkerProvider.cpp

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -141,7 +141,7 @@ PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
 PDFPluginBase::~PDFPluginBase()
 {
 #if ENABLE(PDF_HUD)
-    if (auto* page = m_frame ? m_frame->page() : nullptr)
+    if (RefPtr page = m_frame ? m_frame->page() : nullptr)
         page->removePDFHUD(*this);
 #endif
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -35,6 +35,7 @@
 #import <WebCore/CSSPropertyNames.h>
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
+#import <WebCore/Document.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
 #import <WebCore/HTMLElement.h>
@@ -43,6 +44,7 @@
 #import <WebCore/HTMLTextAreaElement.h>
 #import <WebCore/KeyboardEvent.h>
 #import <WebCore/Page.h>
+#import <wtf/Ref.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -79,11 +81,11 @@ PDFPluginTextAnnotation::~PDFPluginTextAnnotation()
 
 Ref<Element> PDFPluginTextAnnotation::createAnnotationElement()
 {
-    Document& document = parent()->document();
+    Ref document = parent()->document();
     RetainPtr textAnnotation = annotation();
     bool isMultiline = [textAnnotation isMultiline];
 
-    Ref element = downcast<HTMLTextFormControlElement>(document.createElement(isMultiline ? textareaTag : inputTag, false));
+    Ref element = downcast<HTMLTextFormControlElement>(document->createElement(isMultiline ? textareaTag : inputTag, false));
     element->addEventListener(eventNames().keydownEvent, *eventListener(), false);
 
     if (!textAnnotation)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -645,13 +645,13 @@ void UnifiedPDFPlugin::createScrollingNodeIfNecessary()
 #if ENABLE(SCROLLING_THREAD)
     m_scrollContainerLayer->setScrollingNodeID(*m_scrollingNodeID);
 
-    if (auto* layer = layerForHorizontalScrollbar())
+    if (RefPtr layer = layerForHorizontalScrollbar())
         layer->setScrollingNodeID(*m_scrollingNodeID);
 
-    if (auto* layer = layerForVerticalScrollbar())
+    if (RefPtr layer = layerForVerticalScrollbar())
         layer->setScrollingNodeID(*m_scrollingNodeID);
 
-    if (auto* layer = layerForScrollCorner())
+    if (RefPtr layer = layerForScrollCorner())
         layer->setScrollingNodeID(*m_scrollingNodeID);
 #endif
 
@@ -752,8 +752,8 @@ void UnifiedPDFPlugin::didChangeIsInWindow()
     m_presentationController->updateIsInWindow(isInWindow);
 
     if (!isInWindow) {
-        auto& scrollingCoordinator = *page->scrollingCoordinator();
-        scrollingCoordinator.scrollableAreaWillBeDetached(*this);
+        RefPtr scrollingCoordinator = page->scrollingCoordinator();
+        scrollingCoordinator->scrollableAreaWillBeDetached(*this);
     }
 }
 
@@ -1528,11 +1528,11 @@ bool UnifiedPDFPlugin::updateOverflowControlsLayers(bool needsHorizontalScrollba
 
     layersChanged |= createOrDestroyLayer(m_layerForScrollCorner, needsScrollCornerLayer, "scroll corner"_s);
 
-    auto& scrollingCoordinator = *page->scrollingCoordinator();
+    RefPtr scrollingCoordinator = page->scrollingCoordinator();
     if (horizontalScrollbarLayerChanged)
-        scrollingCoordinator.scrollableAreaScrollbarLayerDidChange(*this, ScrollbarOrientation::Horizontal);
+        scrollingCoordinator->scrollableAreaScrollbarLayerDidChange(*this, ScrollbarOrientation::Horizontal);
     if (verticalScrollbarLayerChanged)
-        scrollingCoordinator.scrollableAreaScrollbarLayerDidChange(*this, ScrollbarOrientation::Vertical);
+        scrollingCoordinator->scrollableAreaScrollbarLayerDidChange(*this, ScrollbarOrientation::Vertical);
 
     return layersChanged;
 }
@@ -1546,13 +1546,13 @@ void UnifiedPDFPlugin::positionOverflowControlsLayers()
         layer.setSize(scrollbarRect.size());
     };
 
-    if (auto* layer = layerForHorizontalScrollbar())
+    if (RefPtr layer = layerForHorizontalScrollbar())
         positionScrollbarLayer(*layer, viewRelativeHorizontalScrollbarRect());
 
-    if (auto* layer = layerForVerticalScrollbar())
+    if (RefPtr layer = layerForVerticalScrollbar())
         positionScrollbarLayer(*layer, viewRelativeVerticalScrollbarRect());
 
-    if (auto* layer = layerForScrollCorner()) {
+    if (RefPtr layer = layerForScrollCorner()) {
         auto cornerRect = viewRelativeScrollCornerRect();
         layer->setPosition(cornerRect.location());
         layer->setSize(cornerRect.size());
@@ -1564,7 +1564,7 @@ void UnifiedPDFPlugin::positionOverflowControlsLayers()
 void UnifiedPDFPlugin::invalidateScrollbarRect(WebCore::Scrollbar& scrollbar, const WebCore::IntRect& rect)
 {
     if (&scrollbar == m_verticalScrollbar.get()) {
-        if (auto* layer = layerForVerticalScrollbar()) {
+        if (RefPtr layer = layerForVerticalScrollbar()) {
             layer->setNeedsDisplayInRect(rect);
             return;
         }
@@ -1573,7 +1573,7 @@ void UnifiedPDFPlugin::invalidateScrollbarRect(WebCore::Scrollbar& scrollbar, co
     }
 
     if (&scrollbar == m_horizontalScrollbar.get()) {
-        if (auto* layer = layerForHorizontalScrollbar()) {
+        if (RefPtr layer = layerForHorizontalScrollbar()) {
             layer->setNeedsDisplayInRect(rect);
             return;
         }
@@ -1583,7 +1583,7 @@ void UnifiedPDFPlugin::invalidateScrollbarRect(WebCore::Scrollbar& scrollbar, co
 
 void UnifiedPDFPlugin::invalidateScrollCornerRect(const WebCore::IntRect& rect)
 {
-    if (auto* layer = layerForScrollCorner()) {
+    if (RefPtr layer = layerForScrollCorner()) {
         layer->setNeedsDisplayInRect(rect);
         return;
     }
@@ -1689,8 +1689,8 @@ void UnifiedPDFPlugin::updateScrollingExtents()
         setCurrentScrollType(oldScrollType);
     }
 
-    auto& scrollingCoordinator = *page->scrollingCoordinator();
-    scrollingCoordinator.setScrollingNodeScrollableAreaGeometry(m_scrollingNodeID, *this);
+    RefPtr scrollingCoordinator = page->scrollingCoordinator();
+    scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(m_scrollingNodeID, *this);
 
     m_presentationController->updateForCurrentScrollability(computeScrollability());
 
@@ -1710,8 +1710,8 @@ bool UnifiedPDFPlugin::requestScrollToPosition(const ScrollPosition& position, c
     if (!page)
         return false;
 
-    auto& scrollingCoordinator = *page->scrollingCoordinator();
-    return scrollingCoordinator.requestScrollToPosition(*this, position, options);
+    RefPtr scrollingCoordinator = page->scrollingCoordinator();
+    return scrollingCoordinator->requestScrollToPosition(*this, position, options);
 }
 
 bool UnifiedPDFPlugin::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
@@ -1720,8 +1720,8 @@ bool UnifiedPDFPlugin::requestStartKeyboardScrollAnimation(const KeyboardScroll&
     if (!page)
         return false;
 
-    auto& scrollingCoordinator = *page->scrollingCoordinator();
-    return scrollingCoordinator.requestStartKeyboardScrollAnimation(*this, scrollData);
+    RefPtr scrollingCoordinator = page->scrollingCoordinator();
+    return scrollingCoordinator->requestStartKeyboardScrollAnimation(*this, scrollData);
 }
 
 bool UnifiedPDFPlugin::requestStopKeyboardScrollAnimation(bool immediate)
@@ -1730,8 +1730,8 @@ bool UnifiedPDFPlugin::requestStopKeyboardScrollAnimation(bool immediate)
     if (!page)
         return false;
 
-    auto& scrollingCoordinator = *page->scrollingCoordinator();
-    return scrollingCoordinator.requestStopKeyboardScrollAnimation(*this, immediate);
+    RefPtr scrollingCoordinator = page->scrollingCoordinator();
+    return scrollingCoordinator->requestStopKeyboardScrollAnimation(*this, immediate);
 }
 
 WebCore::OverscrollBehavior UnifiedPDFPlugin::overscrollBehavior() const


### PR DESCRIPTION
#### d13ccffa683f970774402e05df052d9c00be42b1
<pre>
[Safer CPP] Address UncountedLocalVars warnings under WebProcess/Plugins/PDF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=290287">https://bugs.webkit.org/show_bug.cgi?id=290287</a>
<a href="https://rdar.apple.com/147691053">rdar://147691053</a>

Reviewed by Chris Dumez.

* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::~PDFPluginBase):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::createAnnotationElement):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
(WebKit::UnifiedPDFPlugin::updateOverflowControlsLayers):
(WebKit::UnifiedPDFPlugin::positionOverflowControlsLayers):
(WebKit::UnifiedPDFPlugin::invalidateScrollbarRect):
(WebKit::UnifiedPDFPlugin::invalidateScrollCornerRect):
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
(WebKit::UnifiedPDFPlugin::requestScrollToPosition):
(WebKit::UnifiedPDFPlugin::requestStartKeyboardScrollAnimation):
(WebKit::UnifiedPDFPlugin::requestStopKeyboardScrollAnimation):

Canonical link: <a href="https://commits.webkit.org/292583@main">https://commits.webkit.org/292583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6fc3ce8901846f426347f1c49221fba9f02c4ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12086 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103580 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82595 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81967 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28670 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->