### PR TITLE
Inputs with type=color cannot be focused using keyboard tabs.

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt
+++ b/LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt
@@ -1,0 +1,5 @@
+Tests that pressing the tab key focuses a color input.
+
+PASS focused the color input.
+
+

--- a/LayoutTests/fast/forms/color/color-input-keyboard-focus.html
+++ b/LayoutTests/fast/forms/color/color-input-keyboard-focus.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>Tests that pressing the tab key focuses a color input.</p>
+<p id="result">FAIL did not focus the color input.</p>
+<input type="text" id="firstField"><input type="color" id="secondField" onfocus="passed()">
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    async function runTest()
+    {
+        if (!window.testRunner || !testRunner.runUIScript)
+            return;
+        await UIHelper.activateFormControl(document.getElementById("firstField"));
+        await UIHelper.keyDown("\t");
+    }
+
+    function passed()
+    {
+        document.getElementById("result").textContent = "PASS focused the color input.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+
+    runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1054,7 +1054,6 @@ input:is([type="checkbox"], [type="radio"]):checked:disabled {
 input[type="color"] {
     appearance: auto;
     box-sizing: border-box;
-    outline: none;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     width: 28px;
     height: 28px;

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -156,11 +156,7 @@ bool ColorInputType::isMouseFocusable() const
 bool ColorInputType::isKeyboardFocusable(KeyboardEvent*) const
 {
     ASSERT(element());
-#if PLATFORM(IOS_FAMILY)
-    return element()->isTextFormControlFocusable();
-#else
-    return false;
-#endif
+    return protectedElement()->isTextFormControlFocusable();
 }
 
 bool ColorInputType::isPresentingAttachedView() const


### PR DESCRIPTION
#### ceaa50e0a560b9d37f5de1b1abd1f820ecbc15f5
<pre>
Inputs with type=color cannot be focused using keyboard tabs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266285">https://bugs.webkit.org/show_bug.cgi?id=266285</a>
<a href="https://rdar.apple.com/problem/119557550">rdar://problem/119557550</a>

Reviewed by NOBODY (OOPS!).

Removed the platform specific conditional for the ::isKeyboardFocusable (returned false for non-IOS)
Removed the `outline: none` from the html.css, to restore the visual indicator for the focus state

* LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt: Added.
* LayoutTests/fast/forms/color/color-input-keyboard-focus.html: Added.
* Source/WebCore/css/html.css:
(#endif):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::isKeyboardFocusable const):
(WebCore::ColorInputType::showPicker):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceaa50e0a560b9d37f5de1b1abd1f820ecbc15f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73955 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46940 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82644 "Found 10 new API test failures: TestWebKitAPI.ProcessSwap.NavigatingToLockdownMode, TestWebKitAPI.LockdownMode.NotAllowedFont, TestWebKitAPI.ServiceWorkers.LockdownModeInServiceWorkerProcess, TestWebKitAPI.LockdownMode.SVGFonts, TestWebKitAPI.LockdownMode.AllowedFont, TestWebKitAPI.ProcessSwap.LockdownModeSystemSettingChange, TestWebKitAPI.LockdownMode.NotSupportedFontLoadingAPI, TestWebKitAPI.LockdownMode.AllowedFontLoadingAPI, TestWebKitAPI.ProcessSwap.CannotDisableLockdownModeWithoutBrowserEntitlement, TestWebKitAPI.LockdownMode.NotAllowedFontLoadingAPI (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83006 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82407 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4638 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17664 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->