### PR TITLE
Dark mode does not work in SVGImages

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -71,6 +71,8 @@ imported/w3c/web-platform-tests/css/css-properties-values-api/ [ Skip ]
 css-custom-properties-api [ Skip ]
 css-typedom [ Skip ]
 css-dark-mode [ Skip ]
+svg/custom/svg-image-dark-mode-dynamic.html [ Skip ]
+svg/custom/svg-image-dark-mode-initial.html [ Skip ]
 
 media/audioSession [ Skip ]
 

--- a/LayoutTests/svg/custom/resources/light-dark-red-green.svg
+++ b/LayoutTests/svg/custom/resources/light-dark-red-green.svg
@@ -1,0 +1,3 @@
+<svg style="color-scheme: light dark;" xmlns="http://www.w3.org/2000/svg" fill="light-dark(red, green)">
+    <rect width="100%" height="100%"/>
+</svg>

--- a/LayoutTests/svg/custom/resources/prefers-color-scheme-dark-red-green.svg
+++ b/LayoutTests/svg/custom/resources/prefers-color-scheme-dark-red-green.svg
@@ -1,0 +1,9 @@
+<svg style="color-scheme: light dark;" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        rect { fill: red; }
+            @media (prefers-color-scheme: dark) {
+                rect { fill: green; }
+        }
+    </style>
+    <rect width="100%" height="100%"/>
+</svg>

--- a/LayoutTests/svg/custom/svg-image-dark-mode-dynamic-expected.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-dynamic-expected.html
@@ -1,0 +1,41 @@
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        background-color: green;
+    }  
+    .centered {
+        text-align: center;
+    }
+</style>
+<body>
+    <table>
+        <tr>
+             <td colspan="3"><h3>light-dark() CSS function</h3></td>
+        </tr>
+        <tr>
+            <td><div></div></td>
+            <td><div></div></td>
+            <td><div></div></td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+        <tr>
+             <td colspan="3"><h3>prefers-color-scheme media query</h3></td>
+        </tr>
+        <tr>
+            <td><div></div></td>
+            <td><div></div></td>
+            <td><div></div></td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+    </table>
+</body>

--- a/LayoutTests/svg/custom/svg-image-dark-mode-dynamic.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-dynamic.html
@@ -1,0 +1,81 @@
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-400" />
+<style>
+    svg, img, div {
+        width: 200px;
+        height: 200px;
+    }  
+    .light-dark {
+        display: inline-block;
+        background-image: url("resources/light-dark-red-green.svg");
+    }
+    .prefers-color-scheme {
+        display: inline-block;
+        background-image: url("resources/prefers-color-scheme-dark-red-green.svg");
+    }
+    .centered {
+        text-align: center;
+    }
+</style>
+<body>
+    <table>
+        <tr>
+             <td colspan="3"><h3>light-dark() CSS function</h3></td>
+        </tr>
+        <tr>
+            <td>
+                <svg style="color-scheme: light dark;" fill="light-dark(red, green)">
+                    <rect width="100%" height="100%"/>
+                </svg>
+            </td>
+            <td>
+                <img src="resources/light-dark-red-green.svg">
+            </td>
+            <td>
+                <div class="light-dark"></div>
+            </td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+        <tr>
+             <td colspan="3"><h3>prefers-color-scheme media query</h3></td>
+        </tr>
+        <tr>
+            <td>
+                <svg style="color-scheme: light dark;">
+                    <style>
+                        rect { fill: red; }
+                        @media (prefers-color-scheme: dark) {
+                            rect { fill: green; }
+                        }
+                    </style>
+                    <rect width="100%" height="100%"/>
+                </svg>
+            </td>
+            <td>
+                <img src="resources/prefers-color-scheme-dark-red-green.svg">
+            </td>
+            <td>
+                <div class="prefers-color-scheme"></div>
+            </td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+    </table>
+    <script>
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    window.testRunner.setUseDarkAppearanceForTesting(true);
+                    window.testRunner.notifyDone();
+                });
+            });
+    </script>
+</body>

--- a/LayoutTests/svg/custom/svg-image-dark-mode-initial-expected.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-initial-expected.html
@@ -1,0 +1,41 @@
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        display: inline-block;
+        background-color: green;
+    }  
+    .centered {
+        text-align: center;
+    }
+</style>
+<body>
+    <table>
+        <tr>
+             <td colspan="3"><h3>light-dark() CSS function</h3></td>
+        </tr>
+        <tr>
+            <td><div></div></td>
+            <td><div></div></td>
+            <td><div></div></td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+        <tr>
+             <td colspan="3"><h3>prefers-color-scheme media query</h3></td>
+        </tr>
+        <tr>
+            <td><div></div></td>
+            <td><div></div></td>
+            <td><div></div></td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+    </table>
+</body>

--- a/LayoutTests/svg/custom/svg-image-dark-mode-initial.html
+++ b/LayoutTests/svg/custom/svg-image-dark-mode-initial.html
@@ -1,0 +1,74 @@
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-400" />
+<style>
+    svg, img, div {
+        width: 200px;
+        height: 200px;
+    }  
+    .light-dark {
+        display: inline-block;
+        background-image: url("resources/light-dark-red-green.svg");
+    }
+    .prefers-color-scheme {
+        display: inline-block;
+        background-image: url("resources/prefers-color-scheme-dark-red-green.svg");
+    }
+    .centered {
+        text-align: center;
+    }
+</style>
+<body>
+    <table>
+        <tr>
+             <td colspan="3"><h3>light-dark() CSS function</h3></td>
+        </tr>
+        <tr>
+            <td>
+                <svg style="color-scheme: light dark;" fill="light-dark(red, green)">
+                    <rect width="100%" height="100%"/>
+                </svg>
+            </td>
+            <td>
+                <img src="resources/light-dark-red-green.svg">
+            </td>
+            <td>
+                <div class="light-dark"></div>
+            </td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+        <tr>
+             <td colspan="3"><h3>prefers-color-scheme media query</h3></td>
+        </tr>
+        <tr>
+            <td>
+                <svg style="color-scheme: light dark;">
+                    <style>
+                        rect { fill: red; }
+                        @media (prefers-color-scheme: dark) {
+                            rect { fill: green; }
+                        }
+                    </style>
+                    <rect width="100%" height="100%"/>
+                </svg>
+            </td>
+            <td>
+                <img src="resources/prefers-color-scheme-dark-red-green.svg">
+            </td>
+            <td>
+                <div class="prefers-color-scheme"></div>
+            </td>
+        </tr>
+        <tr>
+            <td><span class="centered">inline SVG</span></td>
+            <td><span class="centered">&lt;img&gt; src</span></td>
+            <td><span class="centered"> CSS background-image</span></td>
+        </tr>
+    </table>
+    <script>
+        if (window.testRunner)
+            window.testRunner.setUseDarkAppearanceForTesting(true);
+    </script>
+</body>

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -746,6 +746,14 @@ void CachedImage::scheduleRenderingUpdate(const Image& image)
         client->scheduleRenderingUpdateForImage(*this);
 }
 
+bool CachedImage::useSystemDarkAppearance() const
+{
+    CachedResourceClientWalker<CachedImageClient> walker(*this);
+    if (RefPtr client = walker.next())
+        return client->useSystemDarkAppearance();
+    return false;
+}
+
 bool CachedImage::allowsAnimation(const Image& image) const
 {
     if (&image != m_image)

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -173,6 +173,7 @@ private:
 
         bool allowsAnimation(const Image&) const final;
         const Settings* settings() final { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).m_settings.get() : nullptr; }
+        bool useSystemDarkAppearance() const final { return !m_cachedImages.isEmptyIgnoringNullReferences() && m_cachedImages.begin()->useSystemDarkAppearance(); }
 
         WeakHashSet<CachedImage> m_cachedImages;
     };
@@ -185,6 +186,7 @@ private:
     void changedInRect(const Image&, const IntRect*);
     void imageContentChanged(const Image&);
     void scheduleRenderingUpdate(const Image&);
+    bool useSystemDarkAppearance() const;
 
     void updateBufferInternal(const FragmentedSharedBuffer&);
 

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -46,6 +46,7 @@ public:
     virtual void imageChanged(CachedImage*, const IntRect* = nullptr) { }
 
     virtual bool canDestroyDecodedData() const { return true; }
+    virtual bool useSystemDarkAppearance() const { return false; }
 
     // Called when a new decoded frame for a large image is available or when an animated image is ready to advance to the next frame.
     WEBCORE_EXPORT virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4392,6 +4392,13 @@ void Page::setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInt
 
     appearanceDidChange();
 #endif
+
+    forEachRenderableDocument([useDarkAppearance, useElevatedUserInterfaceLevel] (Document& document) {
+        for (auto& image : document.protectedCachedResourceLoader()->allCachedSVGImages()) {
+            if (RefPtr page = image->internalPage())
+                page->setUseColorAppearance(useDarkAppearance, useElevatedUserInterfaceLevel);
+        }
+    });
 }
 
 bool Page::useDarkAppearance() const

--- a/Source/WebCore/platform/graphics/ImageObserver.h
+++ b/Source/WebCore/platform/graphics/ImageObserver.h
@@ -60,6 +60,7 @@ public:
 
     virtual bool allowsAnimation(const Image&) const { return true; }
     virtual const Settings* settings() { return nullptr; }
+    virtual bool useSystemDarkAppearance() const { return false; }
 
 protected:
     ImageObserver() = default;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1696,6 +1696,13 @@ bool RenderElement::isVisibleInViewport() const
     return isVisibleInDocumentRect(visibleRect);
 }
 
+bool RenderElement::useSystemDarkAppearance() const
+{
+    if (RefPtr page = document().page())
+        return page->useDarkAppearance();
+    return false;
+}
+
 VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)
 {
     bool isVisible = isVisibleInViewport();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -423,6 +423,7 @@ private:
     StyleDifference adjustStyleDifference(StyleDifference, OptionSet<StyleDifferenceContextSensitiveProperty>) const;
 
     bool canDestroyDecodedData() const final { return !isVisibleInViewport(); }
+    bool useSystemDarkAppearance() const final;
     VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect* changeRect) final;
     VisibleInViewportState imageVisibleInViewport(const Document&) const final;
     void didRemoveCachedImageClient(CachedImage&) final;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -3028,6 +3028,13 @@ bool RenderObject::CachedImageListener::allowsAnimation() const
     return true;
 }
 
+bool RenderObject::CachedImageListener::useSystemDarkAppearance() const
+{
+    if (CheckedPtr renderer = m_renderer.get())
+        return renderer->useSystemDarkAppearance();
+    return false;
+}
+
 bool RenderObject::CachedImageListener::canDestroyDecodedData() const
 {
     if (CheckedPtr renderer = m_renderer.get())

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1062,6 +1062,7 @@ public:
     virtual void imageChanged(WrappedImagePtr, const IntRect* = nullptr) { }
     virtual bool allowsAnimation() const { return true; }
     virtual bool canDestroyDecodedData() const { return true; }
+    virtual bool useSystemDarkAppearance() const { return false; }
     virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
     virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
     virtual void didRemoveCachedImageClient(CachedImage&) { }
@@ -1153,6 +1154,7 @@ private:
         void imageChanged(CachedImage*, const IntRect* = nullptr) final;
         bool allowsAnimation() const final;
         bool canDestroyDecodedData() const final;
+        bool useSystemDarkAppearance() const final;
         VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*) final;
         VisibleInViewportState imageVisibleInViewport(const Document&) const final;
         void didRemoveCachedImageClient(CachedImage&) final;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -496,6 +496,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
                 m_page->settings().fontGenericFamilies() = parentSettings->fontGenericFamilies();
                 m_page->settings().setCSSDPropertyEnabled(parentSettings->cssDPropertyEnabled());
             }
+            m_page->setUseColorAppearance(observer->useSystemDarkAppearance(), false);
         }
 
         RefPtr localMainFrame = m_page->localMainFrame();


### PR DESCRIPTION
#### 702c47ccd9244a4f95caddb607cdb2b638c0fa77
<pre>
Dark mode does not work in SVGImages
<a href="https://bugs.webkit.org/show_bug.cgi?id=283489">https://bugs.webkit.org/show_bug.cgi?id=283489</a>
<a href="https://rdar.apple.com/140661763">rdar://140661763</a>

Reviewed by Simon Fraser.

Page::useColorAppearance() is not propagated to the Page of the SVGImage when it
is first created. To fix this issue, SVGImage will query the container Page
useSystemDarkAppearance() through the ImageObserver and set it in its Page.

Also if the dark mode changes after the SVGImage is loaded, the SVGImage does not
recalculate its style colors. To sync the setUseColorAppearance() of all the
SVGImages when the system appearance changes, Page::setUseColorAppearance() needs
to scan all the SVGImages in all Documents and call setUseColorAppearance() of
the Pages of these Documents.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/svg/custom/resources/light-dark-red-green.svg: Added.
* LayoutTests/svg/custom/resources/prefers-color-scheme-dark-red-green.svg: Added.
* LayoutTests/svg/custom/svg-image-dark-mode-dynamic-expected.html: Added.
* LayoutTests/svg/custom/svg-image-dark-mode-dynamic.html: Added.
* LayoutTests/svg/custom/svg-image-dark-mode-initial-expected.html: Added.
* LayoutTests/svg/custom/svg-image-dark-mode-initial.html: Added.
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::useSystemDarkAppearance const):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedImageClient.h:
(WebCore::CachedImageClient::useSystemDarkAppearance const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setUseColorAppearance):
* Source/WebCore/platform/graphics/ImageObserver.h:
(WebCore::ImageObserver::useSystemDarkAppearance const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::useSystemDarkAppearance const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::CachedImageListener::useSystemDarkAppearance const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::useSystemDarkAppearance const):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):

Canonical link: <a href="https://commits.webkit.org/303920@main">https://commits.webkit.org/303920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd913e24bcc5b771cc9ea5191c93f7bf9dd719b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/6445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/141514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85995 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e80d2069-a4d5-4ef7-89ed-3cf73b0102f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/6309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102469 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/444050dd-ef27-450c-a894-127de42215a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4780 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/2400 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144159 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110815 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4637 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/116327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59862 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6167 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/6013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->