### PR TITLE
[GStreamer] Change gstStructureGetString and Name to properly handle null terminated strings

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -257,6 +257,8 @@
 		C519C3692D36CE2E0064418F /* SequesteredMalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C519C3682D36CE2B0064418F /* SequesteredMalloc.cpp */; };
 		C805EF39E5F14481A96D39FC /* ASCIILiteral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6F050790D9C432A99085E75 /* ASCIILiteral.cpp */; };
 		CD5497AC15857D0300B5BC30 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5497AA15857D0300B5BC30 /* MediaTime.cpp */; };
+		CDD4AC792D9C309A00D11414 /* CStringView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDD4AC772D9C309A00D11414 /* CStringView.cpp */; };
+		CDD4AC7A2D9C309A00D11414 /* CStringView.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD4AC782D9C309A00D11414 /* CStringView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CEA072AA236FFBF70018839C /* CrashReporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEA072A9236FFBF70018839C /* CrashReporter.cpp */; };
 		DCEE22011CEA7551000C2396 /* BlockObjCExceptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = DCEE21FD1CEA7551000C2396 /* BlockObjCExceptions.mm */; };
 		DD03059327B5DA0D00344002 /* SignedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 862A8D32278DE74A0014120C /* SignedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1669,6 +1671,8 @@
 		CD5497AA15857D0300B5BC30 /* MediaTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTime.cpp; sourceTree = "<group>"; };
 		CD5497AB15857D0300B5BC30 /* MediaTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTime.h; sourceTree = "<group>"; };
 		CDCC9BC422382FCE00FFB51C /* AggregateLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AggregateLogger.h; path = wtf/AggregateLogger.h; sourceTree = SOURCE_ROOT; };
+		CDD4AC772D9C309A00D11414 /* CStringView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CStringView.cpp; sourceTree = "<group>"; };
+		CDD4AC782D9C309A00D11414 /* CStringView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CStringView.h; sourceTree = "<group>"; };
 		CE1132832370634900A8C83B /* AnsiColors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnsiColors.h; sourceTree = "<group>"; };
 		CEA072A8236FFBF70018839C /* CrashReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReporter.h; sourceTree = "<group>"; };
 		CEA072A9236FFBF70018839C /* CrashReporter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CrashReporter.cpp; sourceTree = "<group>"; };
@@ -2840,6 +2844,8 @@
 				0F8F2B9B172F2594007DBDA5 /* ConversionMode.h */,
 				A8A47321151A825B004123FF /* CString.cpp */,
 				A8A47322151A825B004123FF /* CString.h */,
+				CDD4AC772D9C309A00D11414 /* CStringView.cpp */,
+				CDD4AC782D9C309A00D11414 /* CStringView.h */,
 				93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */,
 				50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */,
 				50DE35F4215BB01500B979C7 /* ExternalStringImpl.h */,
@@ -3464,6 +3470,7 @@
 				DD3DC8FC27A4BF8E007E5B61 /* CryptographicallyRandomNumber.h in Headers */,
 				DD3DC8B727A4BF8E007E5B61 /* CryptographicUtilities.h in Headers */,
 				DDF307E127C086DF006A526F /* CString.h in Headers */,
+				CDD4AC7A2D9C309A00D11414 /* CStringView.h in Headers */,
 				DD3DC8E327A4BF8E007E5B61 /* DataLog.h in Headers */,
 				DD4901E927B4748A00D7E50D /* DataMutex.h in Headers */,
 				DD3DC94227A4BF8E007E5B61 /* DataRef.h in Headers */,
@@ -4338,6 +4345,7 @@
 				A8A4739A151A825B004123FF /* CryptographicallyRandomNumber.cpp in Sources */,
 				E15556F518A0CC18006F48FB /* CryptographicUtilities.cpp in Sources */,
 				A8A47439151A825B004123FF /* CString.cpp in Sources */,
+				CDD4AC792D9C309A00D11414 /* CStringView.cpp in Sources */,
 				A8A4739C151A825B004123FF /* CurrentTime.cpp in Sources */,
 				A8A4739E151A825B004123FF /* DataLog.cpp in Sources */,
 				A8A473A0151A825B004123FF /* DateMath.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -459,6 +459,7 @@ set(WTF_PUBLIC_HEADERS
     text/AtomStringTable.h
     text/Base64.h
     text/CString.h
+    text/CStringView.h
     text/CharacterProperties.h
     text/CodePointIterator.h
     text/ConversionMode.h
@@ -648,6 +649,7 @@ set(WTF_SOURCES
     text/AtomStringTable.cpp
     text/Base64.cpp
     text/CString.cpp
+    text/CStringView.cpp
     text/ExternalStringImpl.cpp
     text/LineEnding.cpp
     text/StringBuffer.cpp

--- a/Source/WTF/wtf/text/CStringView.cpp
+++ b/Source/WTF/wtf/text/CStringView.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/text/CStringView.h>
+
+#include <wtf/PrintStream.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+String CStringView::toString() const
+{
+    return String::fromUTF8(span8());
+}
+
+void CStringView::dump(PrintStream& out) const
+{
+    out.print(span8());
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/text/CStringView.h
+++ b/Source/WTF/wtf/text/CStringView.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <string>
+#include <type_traits>
+#include <wtf/Compiler.h>
+#include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Forward.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/SuperFastHash.h>
+
+namespace WTF {
+
+class PrintStream;
+class String;
+
+class CStringView final {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    static CStringView unsafeFromUTF8(const char* string)
+    {
+        if (!string)
+            return CStringView();
+        return CStringView(unsafeMakeSpan(byteCast<char8_t>(string), std::char_traits<char>::length(string) + 1));
+    }
+
+    WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
+
+    CStringView() = default;
+    constexpr CStringView(std::nullptr_t)
+        : CStringView()
+    { }
+    CStringView(ASCIILiteral literal LIFETIME_BOUND)
+    {
+        if (!literal.length())
+            return;
+        m_spanWithNullTerminator = byteCast<char8_t>(literal.spanIncludingNullTerminator());
+    }
+
+    unsigned hash() const;
+    bool isNull() const { return m_spanWithNullTerminator.empty(); }
+
+    const char* rawCharacters() const LIFETIME_BOUND { return reinterpret_cast<const char*>(m_spanWithNullTerminator.data()); }
+    size_t length() const { return m_spanWithNullTerminator.size() > 0 ? m_spanWithNullTerminator.size() - 1 : 0; }
+    std::span<const char8_t> span8() const LIFETIME_BOUND { return m_spanWithNullTerminator.first(length()); }
+    std::span<const char8_t> spanIncludingNullTerminator() const LIFETIME_BOUND { return m_spanWithNullTerminator; }
+    size_t isEmpty() const { return m_spanWithNullTerminator.size() <= 1; }
+    WTF_EXPORT_PRIVATE String toString() const;
+
+    explicit operator bool() const { return !isEmpty(); }
+    bool operator!() const { return isEmpty(); }
+
+private:
+    explicit CStringView(std::span<const char8_t> spanWithNullTerminator LIFETIME_BOUND)
+        : m_spanWithNullTerminator(spanWithNullTerminator)
+    {
+    }
+
+    std::span<const char8_t> m_spanWithNullTerminator;
+};
+
+inline bool operator==(CStringView a, CStringView b)
+{
+    if (!a || !b)
+        return a.rawCharacters() == b.rawCharacters();
+    return equalSpans(a.span8(), b.span8());
+}
+
+inline bool operator==(CStringView a, ASCIILiteral b)
+{
+    if (!a || !b)
+        return a.rawCharacters() == b.characters();
+    return equalSpans(a.span8(), b.span());
+}
+
+// CStringView is null terminated
+inline const char* safePrintfType(const CStringView& string) { return string.rawCharacters(); }
+
+} // namespace WTF
+
+using WTF::CStringView;

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -60,6 +60,7 @@ public:
     void append(const String&);
     void append(StringView);
     void append(ASCIILiteral);
+    void append(CStringView);
     void append(const char*) = delete; // Pass ASCIILiteral or span instead.
     void append(char16_t);
     void append(LChar);
@@ -223,6 +224,11 @@ inline void StringBuilder::append(StringView string)
 }
 
 inline void StringBuilder::append(ASCIILiteral string)
+{
+    append(string.span8());
+}
+
+inline void StringBuilder::append(CStringView string)
 {
     append(string.span8());
 }

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -37,6 +37,7 @@
 #include <wtf/UnalignedAccess.h>
 #include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/CStringView.h>
 
 namespace WTF {
 
@@ -133,8 +134,10 @@ template<typename StringClassA, typename StringClassB> bool equalIgnoringASCIICa
 
 template<typename CharacterType> bool equalLettersIgnoringASCIICase(std::span<const CharacterType>, std::span<const LChar> lowercaseLetters);
 template<typename CharacterType> bool equalLettersIgnoringASCIICase(std::span<const CharacterType>, ASCIILiteral);
+template<typename CharacterType> bool equalLettersIgnoringASCIICase(std::span<const CharacterType>, CStringView);
 
 template<typename StringClass> bool equalLettersIgnoringASCIICaseCommon(const StringClass&, ASCIILiteral);
+template<typename StringClass> bool equalLettersIgnoringASCIICaseCommon(const StringClass&, CStringView);
 
 bool equalIgnoringASCIICase(const char*, const char*);
 
@@ -791,6 +794,11 @@ template<typename CharacterType> inline bool equalLettersIgnoringASCIICase(std::
     return equalLettersIgnoringASCIICase(characters, lowercaseLetters.span8());
 }
 
+template<typename CharacterType> inline bool equalLettersIgnoringASCIICase(std::span<const CharacterType> characters, CStringView lowercaseLetters)
+{
+    return equalLettersIgnoringASCIICase(characters, lowercaseLetters.span8());
+}
+
 template<typename StringClass> bool inline hasPrefixWithLettersIgnoringASCIICaseCommon(const StringClass& string, std::span<const LChar> lowercaseLetters)
 {
 #if ASSERT_ENABLED
@@ -832,6 +840,16 @@ template<typename StringClass> inline bool startsWithLettersIgnoringASCIICaseCom
     return startsWithLettersIgnoringASCIICaseCommon(string, literal.span8());
 }
 
+template<typename StringClass> inline bool equalLettersIgnoringASCIICaseCommon(const StringClass& string, CStringView view)
+{
+    return equalLettersIgnoringASCIICaseCommon(string, view.span8());
+}
+
+template<typename StringClass> inline bool startsWithLettersIgnoringASCIICaseCommon(const StringClass& string, CStringView view)
+{
+    return startsWithLettersIgnoringASCIICaseCommon(string, view.span8());
+}
+
 inline bool equalIgnoringASCIICase(const char* a, const char* b)
 {
     return equalIgnoringASCIICase(unsafeSpan8(a), unsafeSpan8(b));
@@ -848,6 +866,31 @@ inline bool equalIgnoringASCIICase(const char* string, ASCIILiteral literal)
 }
 
 inline bool equalIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
+{
+    return equalIgnoringASCIICase(a.span8(), b.span8());
+}
+
+inline bool equalIgnoringASCIICase(const char* string, CStringView view)
+{
+    return equalIgnoringASCIICase(unsafeSpan8(string), view.span8());
+}
+
+inline bool equalIgnoringASCIICase(CStringView a, CStringView b)
+{
+    return equalIgnoringASCIICase(a.span8(), b.span8());
+}
+
+inline bool equalLettersIgnoringASCIICase(CStringView a, ASCIILiteral b)
+{
+    return equalLettersIgnoringASCIICase(a.span8(), b.span8());
+}
+
+inline bool equalIgnoringASCIICase(CStringView a, ASCIILiteral b)
+{
+    return equalIgnoringASCIICase(a.span8(), b.span8());
+}
+
+inline bool equalIgnoringASCIICase(ASCIILiteral a, CStringView b)
 {
     return equalIgnoringASCIICase(a.span8(), b.span8());
 }

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -297,6 +297,14 @@ public:
     }
 };
 
+template<> class StringTypeAdapter<CStringView, void> : public StringTypeAdapter<std::span<const char8_t>, void> {
+public:
+    StringTypeAdapter(CStringView characters)
+        : StringTypeAdapter<std::span<const char8_t>, void> { characters.span8() }
+    {
+    }
+};
+
 template<typename... StringTypes> class StringTypeAdapter<std::tuple<StringTypes...>, void> {
 public:
     StringTypeAdapter(const std::tuple<StringTypes...>& tuple)

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -143,6 +143,12 @@ TextStream& TextStream::operator<<(ASCIILiteral string)
     return *this;
 }
 
+TextStream& TextStream::operator<<(CStringView string)
+{
+    m_text.append(string);
+    return *this;
+}
+
 TextStream& TextStream::operator<<(StringView string)
 {
     m_text.append(string);

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -82,6 +82,7 @@ public:
     WTF_EXPORT_PRIVATE TextStream& operator<<(const String&);
     WTF_EXPORT_PRIVATE TextStream& operator<<(ASCIILiteral);
     WTF_EXPORT_PRIVATE TextStream& operator<<(StringView);
+    WTF_EXPORT_PRIVATE TextStream& operator<<(CStringView);
     WTF_EXPORT_PRIVATE TextStream& operator<<(const HexNumberBuffer&);
     WTF_EXPORT_PRIVATE TextStream& operator<<(const FormattedCSSNumber&);
     // Deprecated. Use the NumberRespectingIntegers FormattingFlag instead.
@@ -107,6 +108,15 @@ public:
 
     template<typename T>
     void dumpProperty(ASCIILiteral name, const T& value)
+    {
+        TextStream& ts = *this;
+        ts.startGroup();
+        ts << name << ' ' << value;
+        ts.endGroup();
+    }
+
+    template<typename T>
+    void dumpProperty(CStringView name, const T& value)
     {
         TextStream& ts = *this;
         ts.startGroup();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1127,7 +1127,7 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
         }
         std::optional<int> payloadType;
         if (auto encodingName = gstStructureGetString(structure, "encoding-name"_s))
-            payloadType = payloadTypeForEncodingName(encodingName);
+            payloadType = payloadTypeForEncodingName(encodingName.toString());
 
         if (!payloadType) {
             if (availablePayloadType < 128)
@@ -1441,7 +1441,7 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
     GST_DEBUG_OBJECT(m_pipeline.get(), "Connecting incoming track with mid '%s' and caps %" GST_PTR_FORMAT, data.mid.ascii().data(), caps.get());
     if (!gst_caps_is_empty(caps.get()) && !gst_caps_is_any(caps.get())) [[likely]] {
         const auto structure = gst_caps_get_structure(caps.get(), 0);
-        if (auto encodingName = gstStructureGetString(structure, "encoding-name")) {
+        if (auto encodingName = gstStructureGetString(structure, "encoding-name"_s)) {
             if (encodingName == "TELEPHONE-EVENT"_s) {
                 GST_DEBUG_OBJECT(pipeline(), "Starting incoming DTMF stream");
                 gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
@@ -2375,7 +2375,7 @@ GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<G
                 gst_structure_set(structure.get(), "frame-height", G_TYPE_UINT, *frameHeight, nullptr);
             auto trackIdentifier = gstStructureGetString(additionalStats.get(), "track-identifier"_s);
             if (!trackIdentifier.isEmpty())
-                gst_structure_set(structure.get(), "track-identifier", G_TYPE_STRING, trackIdentifier.toStringWithoutCopying().utf8().data(), nullptr);
+                gst_structure_set(structure.get(), "track-identifier", G_TYPE_STRING, trackIdentifier.rawCharacters(), nullptr);
             auto kind = gstStructureGetString(structure.get(), "kind"_s);
             if (kind == "audio"_s)
                 hasInboundAudioStats = true;
@@ -2415,9 +2415,9 @@ GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<G
                 gst_structure_set(structure.get(), "frames-per-second", G_TYPE_DOUBLE, *framesPerSecond, nullptr);
 
             if (auto midValue = gstStructureGetString(ssrcStats.get(), "mid"_s))
-                gst_structure_set(structure.get(), "mid", G_TYPE_STRING, midValue.toString().ascii().data(), nullptr);
+                gst_structure_set(structure.get(), "mid", G_TYPE_STRING, midValue.rawCharacters(), nullptr);
             if (auto ridValue = gstStructureGetString(ssrcStats.get(), "rid"_s))
-                gst_structure_set(structure.get(), "rid", G_TYPE_STRING, ridValue.toString().ascii().data(), nullptr);
+                gst_structure_set(structure.get(), "rid", G_TYPE_STRING, ridValue.rawCharacters(), nullptr);
             auto kind = gstStructureGetString(structure.get(), "kind"_s);
             if (kind == "audio"_s)
                 hasOutboundAudioStats = true;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
@@ -75,8 +75,8 @@ RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
 
         auto media = gstStructureGetString(structure, "media"_s);
         auto encodingName = gstStructureGetString(structure, "encoding-name"_s);
-        if (media && encodingName)
-            codec.mimeType = makeString(media, '/', encodingName.convertToASCIILowercase());
+        if (!media.isEmpty() && !encodingName.isEmpty())
+            codec.mimeType = makeString(media, '/', encodingName.toString().convertToASCIILowercase());
 
         if (auto clockRate = gstStructureGet<uint64_t>(structure, "clock-rate"_s))
             codec.clockRate = *clockRate;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -227,7 +227,7 @@ RTCStatsReport::TransportStats::TransportStats(const GstStructure* structure)
     // stats.srtpCipher =
 }
 
-static inline RTCIceCandidateType iceCandidateType(StringView type)
+static inline RTCIceCandidateType iceCandidateType(CStringView type)
 {
     if (type == "host"_s)
         return RTCIceCandidateType::Host;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -585,7 +585,7 @@ uint32_t UniqueSSRCGenerator::generateSSRC()
     return std::numeric_limits<uint32_t>::max();
 }
 
-std::optional<int> payloadTypeForEncodingName(StringView encodingName)
+std::optional<int> payloadTypeForEncodingName(const String& encodingName)
 {
     static HashMap<String, int> staticPayloadTypes = {
         { "PCMU"_s, 0 },
@@ -593,9 +593,8 @@ std::optional<int> payloadTypeForEncodingName(StringView encodingName)
         { "G722"_s, 9 },
     };
 
-    const auto key = encodingName.toStringWithoutCopying();
-    if (staticPayloadTypes.contains(key))
-        return staticPayloadTypes.get(key);
+    if (staticPayloadTypes.contains(encodingName))
+        return staticPayloadTypes.get(encodingName);
     return { };
 }
 
@@ -618,7 +617,7 @@ GRefPtr<GstCaps> capsFromRtpCapabilities(const RTCRtpCapabilities& capabilities,
             gst_structure_set(codecStructure, "encoding-params", G_TYPE_STRING, makeString(*codec.channels).ascii().data(), nullptr);
 
         if (auto encodingName = gstStructureGetString(codecStructure, "encoding-name"_s)) {
-            if (auto payloadType = payloadTypeForEncodingName(encodingName))
+            if (auto payloadType = payloadTypeForEncodingName(encodingName.toString()))
                 gst_structure_set(codecStructure, "payload", G_TYPE_INT, *payloadType, nullptr);
         }
 
@@ -691,7 +690,7 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
                 "a-sendonly", "a-recvonly", "a-end-of-candidates", nullptr);
 
             if (auto name = gstStructureGetString(structure, "encoding-name"_s)) {
-                auto encodingName = name.convertToASCIIUppercase();
+                auto encodingName = name.toString().convertToASCIIUppercase();
                 gst_structure_set(structure, "encoding-name", G_TYPE_STRING, encodingName.ascii().data(), nullptr);
             }
 
@@ -1016,19 +1015,20 @@ GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer& buffer,
         gst_sdp_media_attributes_to_caps(media, mediaCaps.get());
         auto s = gst_caps_get_structure(mediaCaps.get(), 0);
         for (int ii = 0; ii < gst_structure_n_fields(s); ii++) {
-            auto name = StringView::fromLatin1(gst_structure_nth_field_name(s, ii));
-            if (!name.startsWith("extmap-"_s))
+            auto name = CStringView::unsafeFromUTF8(gst_structure_nth_field_name(s, ii));
+            auto nameAsString = name.toString();
+            if (!nameAsString.startsWith("extmap-"_s))
                 continue;
 
             auto value = gstStructureGetString(s, name);
-            if (value == StringView::fromLatin1(GST_RTP_HDREXT_BASE "sdes:mid")) {
-                auto id = parseInteger<uint8_t>(name.substring(7));
+            if (value == CStringView::unsafeFromUTF8(GST_RTP_HDREXT_BASE "sdes:mid")) {
+                auto id = parseInteger<uint8_t>(nameAsString.substring(7));
                 if (!id) [[unlikely]]
                     continue;
                 if (*id && *id < 15)
                     midExtID = *id;
-            } else if (value == StringView::fromLatin1(GST_RTP_HDREXT_BASE "sdes:rtp-stream-id")) {
-                auto id = parseInteger<uint8_t>(name.substring(7));
+            } else if (value == CStringView::unsafeFromUTF8(GST_RTP_HDREXT_BASE "sdes:rtp-stream-id")) {
+                auto id = parseInteger<uint8_t>(nameAsString.substring(7));
                 if (!id) [[unlikely]]
                     continue;
                 if (*id && *id < 15)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -284,7 +284,7 @@ private:
     Vector<uint32_t> m_knownIds WTF_GUARDED_BY_LOCK(m_lock);
 };
 
-std::optional<int> payloadTypeForEncodingName(StringView encodingName);
+std::optional<int> payloadTypeForEncodingName(const String& encodingName);
 
 WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(const RTCRtpCapabilities&, Function<void(GstStructure*)> supplementCapsCallback);
 

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -64,7 +64,7 @@ Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::disable()
 
 String PageHeapAgent::heapSnapshotBuilderOverrideClassName(JSC::HeapSnapshotBuilder& builder, JSC::JSCell* cell, const String& currentClassName)
 {
-    if (currentClassName == "HTMLElement") {
+    if (currentClassName == "HTMLElement"_s) {
         if (auto* jsElement = jsDynamicCast<JSElement*>(cell)) {
             Ref element = jsElement->wrapped();
             if (element->isDefinedCustomElement()) {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3233,7 +3233,7 @@ String FrameLoader::userAgent(const URL& url) const
             auto topFullURLPath = topFullURL.path();
             if (RegistrableDomain(topFullURL).string() == "easyjet.com"_s && topFullURLPath.contains("routemap"_s)) {
                 auto urlDomainString = RegistrableDomain(url).string();
-                if (urlDomainString == "bing.com") {
+                if (urlDomainString == "bing.com"_s) {
                     // FIXME: Move this to a proper UA override singular mechanism
                     // https://bugs.webkit.org/show_bug.cgi?id=274374
                     userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/135.0"_s;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -121,15 +121,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCoreLogObserver);
 
 static GstClockTime s_webkitGstInitTime;
 
-WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTemplate, ASCIILiteral name, GstPad* target)
+WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTemplate, CStringView name, GstPad* target)
 {
     GstPad* pad;
     GRefPtr padTemplate = gst_static_pad_template_get(staticPadTemplate);
 
     if (target)
-        pad = gst_ghost_pad_new_from_template(name.characters(), target, padTemplate.get());
+        pad = gst_ghost_pad_new_from_template(name.rawCharacters(), target, padTemplate.get());
     else
-        pad = gst_ghost_pad_new_no_target_from_template(name.characters(), padTemplate.get());
+        pad = gst_ghost_pad_new_no_target_from_template(name.rawCharacters(), padTemplate.get());
 
     return pad;
 }
@@ -295,7 +295,7 @@ std::optional<TrackID> parseStreamId(StringView stringId)
     return parseIntegerAllowingTrailingJunk<TrackID>(stringId.substring(position + 1));
 }
 
-StringView capsMediaType(const GstCaps* caps)
+CStringView capsMediaType(const GstCaps* caps)
 {
     ASSERT(caps);
     GstStructure* structure = gst_caps_get_structure(caps, 0);
@@ -320,7 +320,7 @@ bool doCapsHaveType(const GstCaps* caps, ASCIILiteral type)
         GST_WARNING("Failed to get MediaType");
         return false;
     }
-    return mediaType.startsWith(type);
+    return mediaType.toString().startsWith(type);
 }
 
 bool areEncryptedCaps(const GstCaps* caps)
@@ -1161,13 +1161,7 @@ static ASCIILiteral webrtcIceTcpCandidateTypeName(int value)
 #endif // USE(GSTREAMER_WEBRTC)
 
 template<typename T>
-std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key)
-{
-    return gstStructureGet<T>(structure, StringView { key });
-}
-
-template<typename T>
-std::optional<T> gstStructureGet(const GstStructure* structure, StringView key)
+std::optional<T> gstStructureGet(const GstStructure* structure, CStringView key)
 {
     if (!structure) {
         ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
@@ -1175,25 +1169,24 @@ std::optional<T> gstStructureGet(const GstStructure* structure, StringView key)
     }
 
     T value;
-    auto strKey = key.toStringWithoutCopying();
     if constexpr(std::is_same_v<T, int>) {
-        if (gst_structure_get_int(structure, strKey.ascii().data(), &value))
+        if (gst_structure_get_int(structure, key.rawCharacters(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, int64_t>) {
-        if (gst_structure_get_int64(structure, strKey.ascii().data(), &value))
+        if (gst_structure_get_int64(structure, key.rawCharacters(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, unsigned>) {
-        if (gst_structure_get_uint(structure, strKey.ascii().data(), &value))
+        if (gst_structure_get_uint(structure, key.rawCharacters(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, uint64_t>) {
-        if (gst_structure_get_uint64(structure, strKey.ascii().data(), &value))
+        if (gst_structure_get_uint64(structure, key.rawCharacters(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, double>) {
-        if (gst_structure_get_double(structure, strKey.ascii().data(), &value))
+        if (gst_structure_get_double(structure, key.rawCharacters(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, bool>) {
         gboolean gstValue;
-        if (gst_structure_get_boolean(structure, strKey.ascii().data(), &gstValue)) {
+        if (gst_structure_get_boolean(structure, key.rawCharacters(), &gstValue)) {
             value = gstValue;
             return value;
         }
@@ -1202,60 +1195,45 @@ std::optional<T> gstStructureGet(const GstStructure* structure, StringView key)
     return std::nullopt;
 }
 
-template std::optional<int> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template std::optional<int64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template std::optional<unsigned> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template std::optional<uint64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template std::optional<double> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template std::optional<bool> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<int> gstStructureGet(const GstStructure*, CStringView key);
+template std::optional<int64_t> gstStructureGet(const GstStructure*, CStringView key);
+template std::optional<unsigned> gstStructureGet(const GstStructure*, CStringView key);
+template std::optional<uint64_t> gstStructureGet(const GstStructure*, CStringView key);
+template std::optional<double> gstStructureGet(const GstStructure*, CStringView key);
+template std::optional<bool> gstStructureGet(const GstStructure*, CStringView key);
 
-template std::optional<int> gstStructureGet(const GstStructure*, StringView key);
-template std::optional<int64_t> gstStructureGet(const GstStructure*, StringView key);
-template std::optional<unsigned> gstStructureGet(const GstStructure*, StringView key);
-template std::optional<uint64_t> gstStructureGet(const GstStructure*, StringView key);
-template std::optional<double> gstStructureGet(const GstStructure*, StringView key);
-template std::optional<bool> gstStructureGet(const GstStructure*, StringView key);
-
-StringView gstStructureGetString(const GstStructure* structure, ASCIILiteral key)
+CStringView gstStructureGetString(const GstStructure* structure, CStringView key)
 {
     if (!structure) {
         ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
         return { };
     }
 
-    return gstStructureGetString(structure, StringView { key });
+    const GValue* value = gst_structure_get_value(structure, key.rawCharacters());
+    if (!value || !G_VALUE_HOLDS_STRING(value))
+        return { };
+    return CStringView::unsafeFromUTF8(g_value_get_string(value));
 }
 
-StringView gstStructureGetString(const GstStructure* structure, StringView key)
+CStringView gstStructureGetName(const GstStructure* structure)
 {
     if (!structure) {
         ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
         return { };
     }
 
-    auto utf8String = key.utf8();
-    return StringView::fromLatin1(gst_structure_get_string(structure, utf8String.data()));
-}
-
-StringView gstStructureGetName(const GstStructure* structure)
-{
-    if (!structure) {
-        ASSERT_NOT_REACHED_WITH_MESSAGE("tried to access a field of a null GstStructure");
-        return { };
-    }
-
-    return StringView::fromLatin1(gst_structure_get_name(structure));
+    return CStringView::unsafeFromUTF8(gst_structure_get_name(structure));
 }
 
 template<typename T>
-Vector<T> gstStructureGetArray(const GstStructure* structure, ASCIILiteral key)
+Vector<T> gstStructureGetArray(const GstStructure* structure, CStringView key)
 {
     static_assert(std::is_same_v<T, int> || std::is_same_v<T, int64_t> || std::is_same_v<T, unsigned>
         || std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, const GstStructure*>);
     Vector<T> result;
     if (!structure)
         return result;
-    const GValue* array = gst_structure_get_value(structure, key.characters());
+    const GValue* array = gst_structure_get_value(structure, key.rawCharacters());
     if (!GST_VALUE_HOLDS_ARRAY (array))
         return result;
     unsigned size = gst_value_array_get_size(array);
@@ -1277,20 +1255,20 @@ Vector<T> gstStructureGetArray(const GstStructure* structure, ASCIILiteral key)
     return result;
 }
 
-template Vector<const GstStructure*> gstStructureGetArray(const GstStructure*, ASCIILiteral key);
+template Vector<const GstStructure*> gstStructureGetArray(const GstStructure*, CStringView key);
 
 template<typename T>
-Vector<T> gstStructureGetList(const GstStructure* structure, ASCIILiteral key)
+Vector<T> gstStructureGetList(const GstStructure* structure, CStringView key)
 {
     static_assert(std::is_same_v<T, int> || std::is_same_v<T, int64_t> || std::is_same_v<T, unsigned>
         || std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, const GstStructure*>);
     Vector<T> result;
     if (!structure)
         return result;
-    const GValue* list = gst_structure_get_value(structure, key.characters());
+    const GValue* list = gst_structure_get_value(structure, key.rawCharacters());
     RELEASE_ASSERT(GST_VALUE_HOLDS_LIST(list));
     if (!GST_VALUE_HOLDS_LIST(list)) {
-        GST_WARNING("Structure field %s does not hold a list", key.characters());
+        GST_WARNING("Structure field %s does not hold a list", key.rawCharacters());
         return result;
     }
     unsigned size = gst_value_list_get_size(list);
@@ -1317,12 +1295,12 @@ Vector<T> gstStructureGetList(const GstStructure* structure, ASCIILiteral key)
     return result;
 }
 
-template Vector<int> gstStructureGetList(const GstStructure*, ASCIILiteral key);
-template Vector<int64_t> gstStructureGetList(const GstStructure*, ASCIILiteral key);
-template Vector<unsigned> gstStructureGetList(const GstStructure*, ASCIILiteral key);
-template Vector<uint64_t> gstStructureGetList(const GstStructure*, ASCIILiteral key);
-template Vector<double> gstStructureGetList(const GstStructure*, ASCIILiteral key);
-template Vector<const GstStructure*> gstStructureGetList(const GstStructure*, ASCIILiteral key);
+template Vector<int> gstStructureGetList(const GstStructure*, CStringView key);
+template Vector<int64_t> gstStructureGetList(const GstStructure*, CStringView key);
+template Vector<unsigned> gstStructureGetList(const GstStructure*, CStringView key);
+template Vector<uint64_t> gstStructureGetList(const GstStructure*, CStringView key);
+template Vector<double> gstStructureGetList(const GstStructure*, CStringView key);
+template Vector<const GstStructure*> gstStructureGetList(const GstStructure*, CStringView key);
 
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -74,13 +74,13 @@ inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
 #define GST_AUDIO_CAPS_TYPE_PREFIX  "audio/"_s
 #define GST_TEXT_CAPS_TYPE_PREFIX   "text/"_s
 
-WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate*, ASCIILiteral name, GstPad* target);
+WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate*, CStringView name, GstPad* target);
 #if ENABLE(VIDEO)
 bool getVideoSizeAndFormatFromCaps(const GstCaps*, WebCore::IntSize&, GstVideoFormat&, int& pixelAspectRatioNumerator, int& pixelAspectRatioDenominator, int& stride, double& frameRate, PlatformVideoColorSpace&);
 std::optional<FloatSize> getVideoResolutionFromCaps(const GstCaps*);
 bool getSampleVideoInfo(GstSample*, GstVideoInfo&);
 #endif
-StringView capsMediaType(const GstCaps*);
+CStringView capsMediaType(const GstCaps*);
 std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>&);
 std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>&);
 std::optional<TrackID> parseStreamId(StringView stringId);
@@ -280,20 +280,17 @@ GstBuffer* gstBufferNewWrappedFast(void* data, size_t length);
 GstElement* makeGStreamerElement(ASCIILiteral factoryName, const String& name = emptyString());
 
 template<typename T>
-std::optional<T> gstStructureGet(const GstStructure*, ASCIILiteral key);
-template<typename T>
-std::optional<T> gstStructureGet(const GstStructure*, StringView key);
+std::optional<T> gstStructureGet(const GstStructure*, CStringView key);
 
-StringView gstStructureGetString(const GstStructure*, ASCIILiteral key);
-StringView gstStructureGetString(const GstStructure*, StringView key);
+CStringView gstStructureGetString(const GstStructure*, CStringView key);
 
-StringView gstStructureGetName(const GstStructure*);
+CStringView gstStructureGetName(const GstStructure*);
 
 template<typename T>
-Vector<T> gstStructureGetArray(const GstStructure*, ASCIILiteral key);
+Vector<T> gstStructureGetArray(const GstStructure*, CStringView key);
 
 template<typename T>
-Vector<T> gstStructureGetList(const GstStructure*, ASCIILiteral key);
+Vector<T> gstStructureGetList(const GstStructure*, CStringView key);
 
 String gstStructureToJSONString(const GstStructure*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -884,9 +884,8 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
                 continue;
             }
             auto structure = gst_caps_get_structure(codecCaps.get(), 0);
-            auto nameView = gstStructureGetName(structure);
-            auto name = nameView.utf8();
-            auto caps = adoptGRef(gst_caps_new_simple("application/x-webm-enc", "original-media-type", G_TYPE_STRING, name.data(), nullptr));
+            auto name = gstStructureGetName(structure);
+            auto caps = adoptGRef(gst_caps_new_simple("application/x-webm-enc", "original-media-type", G_TYPE_STRING, name.rawCharacters(), nullptr));
             if (!factories.hasElementForCaps(ElementFactories::Type::Decryptor, caps))
                 return SupportsType::IsNotSupported;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -214,9 +214,9 @@ IGNORE_WARNINGS_END
     auto structure = gst_caps_get_structure(destinationCaps.get(), 0);
     auto width = gstStructureGet<int>(structure, "width"_s);
     auto height = gstStructureGet<int>(structure, "height"_s);
-    auto formatStringView = gstStructureGetString(structure, "format"_s);
-    if (width && height && !formatStringView.isEmpty()) {
-        auto format = gst_video_format_from_string(formatStringView.toStringWithoutCopying().ascii().data());
+    auto formatString = gstStructureGetString(structure, "format"_s);
+    if (width && height && !formatString.isEmpty()) {
+        auto format = gst_video_format_from_string(formatString.rawCharacters());
         gst_buffer_add_video_meta(writableBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, *width, *height);
     }
     gst_sample_set_buffer(convertedSample.get(), writableBuffer.get());

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2265,7 +2265,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
                     // handle it here, until we remove the webkit+ protocol
                     // prefix from webkitwebsrc.
                     if (auto contentLengthValue = gstStructureGetString(responseHeaders.get(), contentLengthHeaderName)) {
-                        if (auto parsedContentLength = parseInteger<uint64_t>(contentLengthValue))
+                        if (auto parsedContentLength = parseInteger<uint64_t>(contentLengthValue.toString()))
                             contentLength = *parsedContentLength;
                     }
                 } else
@@ -3019,7 +3019,7 @@ bool MediaPlayerPrivateGStreamer::loadNextLocation()
         return false;
 
     const GValue* locations = gst_structure_get_value(m_mediaLocations.get(), "locations");
-    StringView newLocation;
+    CStringView newLocation;
 
     if (!locations) {
         // Fallback on new-location string.
@@ -3028,7 +3028,7 @@ bool MediaPlayerPrivateGStreamer::loadNextLocation()
             return false;
     }
 
-    if (!newLocation) {
+    if (newLocation.isEmpty()) {
         if (m_mediaLocationCurrentIndex < 0) {
             m_mediaLocations.reset();
             return false;
@@ -3045,7 +3045,7 @@ bool MediaPlayerPrivateGStreamer::loadNextLocation()
         newLocation = gstStructureGetString(structure, "new-location"_s);
     }
 
-    if (newLocation) {
+    if (!newLocation.isEmpty()) {
         // Found a candidate. new-location is not always an absolute url
         // though. We need to take the base of the current url and
         // append the value of new-location to it.

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -189,9 +189,8 @@ static std::optional<unsigned> retrieveTemporalIndex(const GRefPtr<GstSample>& s
         return gstStructureGet<unsigned>(metaStructure, "layer-id"_s);
     }
 #ifndef GST_DISABLE_GST_DEBUG
-    auto nameView = gstStructureGetName(structure);
-    auto name = nameView.utf8();
-    GST_TRACE("Retrieval of temporal index from encoded format %s is not yet supported.", name.data());
+    auto name = gstStructureGetName(structure);
+    GST_TRACE("Retrieval of temporal index from encoded format %s is not yet supported.", name.rawCharacters());
 #endif
 #endif
     return { };

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -92,7 +92,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
                 return GST_PAD_PROBE_OK;
 
             auto structure = gst_caps_get_structure(caps, 0);
-            auto sampleRate = gstStructureGet<int>(structure, "rate");
+            auto sampleRate = gstStructureGet<int>(structure, "rate"_s);
             if (!sampleRate) [[unlikely]]
                 return GST_PAD_PROBE_OK;
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -155,10 +155,9 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
             outgoingStructure = GUniquePtr<GstStructure>(gst_structure_copy(incomingStructure));
 
             if (!canDoPassthrough) {
-                auto originalMediaTypeView = WebCore::gstStructureGetString(outgoingStructure.get(), "original-media-type"_s);
-                RELEASE_ASSERT(originalMediaTypeView);
-                auto originalMediaType = originalMediaTypeView.utf8();
-                gst_structure_set_name(outgoingStructure.get(), originalMediaType.data());
+                auto originalMediaType = WebCore::gstStructureGetString(outgoingStructure.get(), "original-media-type"_s);
+                RELEASE_ASSERT(originalMediaType);
+                gst_structure_set_name(outgoingStructure.get(), originalMediaType.rawCharacters());
             }
 
             // Filter out the DRM related fields from the down-stream caps.
@@ -171,10 +170,9 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
                 // can cause caps negotiation failures with adaptive bitrate streams.
                 gst_structure_remove_fields(outgoingStructure.get(), "base-profile", "codec_data", "height", "framerate", "level", "pixel-aspect-ratio", "profile", "rate", "width", nullptr);
 
-                auto nameView = WebCore::gstStructureGetName(incomingStructure);
-                auto name = nameView.utf8();
+                auto name = WebCore::gstStructureGetName(incomingStructure);
                 gst_structure_set(outgoingStructure.get(), "protection-system", G_TYPE_STRING, klass->protectionSystemId(self),
-                    "original-media-type", G_TYPE_STRING, name.data() , nullptr);
+                    "original-media-type", G_TYPE_STRING, name.rawCharacters() , nullptr);
 
                 // GST_PROTECTION_UNSPECIFIED_SYSTEM_ID was added in the GStreamer
                 // developement git master which will ship as version 1.16.0.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -236,12 +236,12 @@ AppendPipeline::AppendPipeline(SourceBufferPrivateGStreamer& sourceBufferPrivate
             if (demuxerElementName.isNull()) {
                 GST_ELEMENT_ERROR(appendPipeline->pipeline(), STREAM, WRONG_TYPE,
                     ("Unsupported caps for audio/mpeg mimetype: %s",
-                    gstStructureGetName(capsStructure).toStringWithoutCopying().utf8().data()), (nullptr));
+                    gstStructureGetName(capsStructure).rawCharacters()), (nullptr));
                 return;
             }
 
             GST_DEBUG_OBJECT(appendPipeline->pipeline(), "Creating %s demuxer for caps: %s",
-                demuxerElementName.characters(), gstStructureGetName(capsStructure).toStringWithoutCopying().utf8().data());
+                demuxerElementName.characters(), gstStructureGetName(capsStructure).rawCharacters());
             appendPipeline->m_demux = makeGStreamerElement(demuxerElementName);
             ASSERT(appendPipeline->m_demux);
 
@@ -456,14 +456,10 @@ void AppendPipeline::appsinkCapsChanged(Track& track)
     // If this is not the first time we're parsing an initialization segment, fail if the track
     // has a different codec or type (e.g. if we were previously demuxing an audio stream and
     // someone appends a video stream).
-    auto currentMediaTypeView = capsMediaType(caps.get());
-    auto trackMediaTypeView = capsMediaType(track.finalCaps.get());
-    if (track.finalCaps && currentMediaTypeView != trackMediaTypeView) {
-#ifndef GST_DISABLE_GST_DEBUG
-        auto currentMediaType = currentMediaTypeView.utf8();
-        auto trackMediaType = trackMediaTypeView.utf8();
-        GST_WARNING_OBJECT(pipeline(), "Track received incompatible caps, received '%s' for a track previously handling '%s'. Erroring out.", currentMediaType.data(), trackMediaType.data());
-#endif
+    auto currentMediaType = capsMediaType(caps.get());
+    auto trackMediaType = capsMediaType(track.finalCaps.get());
+    if (track.finalCaps && currentMediaType != trackMediaType) {
+        GST_WARNING_OBJECT(pipeline(), "Track received incompatible caps, received '%s' for a track previously handling '%s'. Erroring out.", currentMediaType.rawCharacters(), trackMediaType.rawCharacters());
         m_sourceBufferPrivate.appendParsingFailed();
         return;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -59,7 +59,7 @@ String GStreamerMediaDescription::extractCodecName(const GRefPtr<GstCaps>& caps)
 
         auto originalMediaType = WebCore::gstStructureGetString(structure, "original-media-type"_s);
         RELEASE_ASSERT(originalMediaType);
-        gst_structure_set_name(structure, originalMediaType.toStringWithoutCopying().ascii().data());
+        gst_structure_set_name(structure, originalMediaType.rawCharacters());
 
         // Remove the DRM related fields from the caps.
         gstStructureFilterAndMapInPlace(structure, [](GstId id, GValue*) -> bool {

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -673,7 +673,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             const auto& encodedCaps = self->priv->encodedCaps;
             if (!gst_caps_is_any(encodedCaps.get()) && !gst_caps_is_empty(encodedCaps.get())) [[likely]] {
                 auto structure = gst_caps_get_structure(encodedCaps.get(), 0);
-                auto profile = gstStructureGetString(structure, "profile"_s);
+                auto profile = gstStructureGetString(structure, "profile"_s).toString();
 
                 if (profile.findIgnoringASCIICase("high"_s) != notFound)
                     gst_preset_load_preset(GST_PRESET(self->priv->encoder.get()), "Profile High");

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -43,8 +43,9 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
     GST_DEBUG("Creating packetizer for codec: %" GST_PTR_FORMAT " and encoding parameters %" GST_PTR_FORMAT, codecParameters, encodingParameters.get());
     String encoding;
-    if (auto encodingName = gstStructureGetString(codecParameters, "encoding-name"_s))
-        encoding = encodingName.convertToASCIILowercase();
+    auto encodingName = gstStructureGetString(codecParameters, "encoding-name"_s);
+    if (encodingName)
+        encoding = encodingName.toString().convertToASCIILowercase();
     else {
         GST_ERROR("encoding-name not found");
         return nullptr;
@@ -92,7 +93,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
         if (gst_caps_is_any(inputCaps.get())) {
             if (auto encodingParameters = gstStructureGetString(structure.get(), "encoding-params"_s)) {
-                if (auto channels = parseIntegerAllowingTrailingJunk<int>(encodingParameters))
+                if (auto channels = parseIntegerAllowingTrailingJunk<int>(encodingParameters.toString()))
                     inputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "channels", G_TYPE_INT, *channels, nullptr));
             }
         }
@@ -120,7 +121,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
     g_object_set(payloader.get(), "auto-header-extension", TRUE, "mtu", 1200, nullptr);
 
     if (auto minPTime = gstStructureGetString(structure.get(), "minptime"_s)) {
-        if (auto value = parseIntegerAllowingTrailingJunk<int64_t>(minPTime)) {
+        if (auto value = parseIntegerAllowingTrailingJunk<int64_t>(minPTime.toString())) {
             if (gstObjectHasProperty(payloader.get(), "min-ptime"_s))
                 g_object_set(payloader.get(), "min-ptime", *value * GST_MSECOND, nullptr);
             else

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -224,7 +224,11 @@ std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::captureDevi
     auto label = makeString(isDefault ? "default: "_s : ""_s, deviceName.span());
 
     auto nodeName = gstStructureGetString(properties.get(), "node.name"_s);
-    auto identifier = makeString(nodeName.isEmpty() ? deviceName.span() : nodeName);
+    String identifier;
+    if (nodeName.isEmpty())
+        identifier = makeString(deviceName.span());
+    else
+        identifier = nodeName.toString();
 
     bool isMock = false;
     if (auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s)) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1276,7 +1276,7 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
     GST_DEBUG_OBJECT(self, "%s Ghosting %" GST_PTR_FORMAT, objectPath.get(), pad.get());
 #endif
 
-    auto* ghostPad = webkitGstGhostPadFromStaticTemplate(padTemplate, ASCIILiteral::fromLiteralUnsafe(padName.ascii().data()), pad.get());
+    auto* ghostPad = webkitGstGhostPadFromStaticTemplate(padTemplate, CStringView::unsafeFromUTF8(padName.utf8().data()), pad.get());
     gst_pad_store_sticky_event(ghostPad, stickyStreamStartEvent.get());
     gst_pad_set_active(ghostPad, TRUE);
     gst_element_add_pad(GST_ELEMENT_CAST(self), ghostPad);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -79,7 +79,7 @@ void webkitGstMockDeviceProviderSwitchDefaultDevice(const CaptureDevice& oldDevi
     for (GList* it = devices; it; it = it->next) {
         auto device = GST_DEVICE_CAST(it->data);
         GUniquePtr<GstStructure> properties(gst_device_get_properties(device));
-        auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s);
+        auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s).toString();
         if (persistentId == oldDevice.persistentId())
             oldGstDevice = device;
         else if (persistentId == newDevice.persistentId())

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -48,8 +48,9 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
     GUniquePtr<GstStructure> codecParameters(gst_structure_copy(parameters));
     GST_DEBUG("Creating packetizer for codec: %" GST_PTR_FORMAT " and encoding parameters %" GST_PTR_FORMAT, codecParameters.get(), encodingParameters.get());
     String encoding;
-    if (auto encodingName = gstStructureGetString(codecParameters.get(), "encoding-name"_s))
-        encoding = encodingName.convertToASCIILowercase();
+    auto encodingName = gstStructureGetString(codecParameters.get(), "encoding-name"_s);
+    if (encodingName)
+        encoding = encodingName.toString().convertToASCIILowercase();
     else {
         GST_ERROR("encoding-name not found");
         return nullptr;
@@ -77,7 +78,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
         VPCodecConfigurationRecord record;
         record.codecName = "vp09"_s;
         if (auto vp9Profile = gstStructureGetString(codecParameters.get(), "profile-id"_s)) {
-            if (auto profile = parseInteger<uint8_t>(vp9Profile))
+            if (auto profile = parseInteger<uint8_t>(vp9Profile.toString()))
                 record.profile = *profile;
         }
         codec = createVPCodecParametersString(record);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -69,14 +69,14 @@ void RealtimeOutgoingAudioSourceGStreamer::initialize()
 void RealtimeOutgoingAudioSourceGStreamer::setInitialParameters(GUniquePtr<GstStructure>&& parameters)
 {
     for (const auto& codec : gstStructureGetList<const GstStructure*>(parameters.get(), "codecs"_s)) {
-        auto encodingName = gstStructureGetString(codec, "mime-type");
+        auto encodingName = gstStructureGetString(codec, "mime-type"_s);
         if (encodingName.isEmpty() || encodingName.isNull())
             continue;
 
         if (encodingName != "audio/telephone-event"_s)
             continue;
 
-        auto pt = gstStructureGet<unsigned>(codec, "pt");
+        auto pt = gstStructureGet<unsigned>(codec, "pt"_s);
         if (!pt) [[unlikely]]
             continue;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -433,7 +433,7 @@ void RealtimeOutgoingMediaSourceGStreamer::setParameters(GUniquePtr<GstStructure
         if (!rid)
             continue;
 
-        auto packetizer = getPacketizerForRid(rid);
+        auto packetizer = getPacketizerForRid(rid.toString());
         if (!packetizer)
             continue;
 
@@ -442,7 +442,7 @@ void RealtimeOutgoingMediaSourceGStreamer::setParameters(GUniquePtr<GstStructure
     m_parameters = WTFMove(parameters);
 }
 
-RefPtr<GStreamerRTPPacketizer> RealtimeOutgoingMediaSourceGStreamer::getPacketizerForRid(StringView rid)
+RefPtr<GStreamerRTPPacketizer> RealtimeOutgoingMediaSourceGStreamer::getPacketizerForRid(const String& rid)
 {
     for (auto& packetizer : m_packetizers) {
         if (packetizer->rtpStreamId() == rid)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -145,7 +145,7 @@ private:
     void startUpdatingStats();
     void stopUpdatingStats();
 
-    RefPtr<GStreamerRTPPacketizer> getPacketizerForRid(StringView);
+    RefPtr<GStreamerRTPPacketizer> getPacketizerForRid(const String&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -77,7 +77,7 @@ public:
     GstElement* makeElement(ASCIILiteral factoryName)
     {
         static Atomic<uint32_t> elementId;
-        auto name = makeString(ASCIILiteral::fromLiteralUnsafe(Name()), "-dec-"_s, factoryName, "-"_s, elementId.exchangeAdd(1));
+        auto name = makeString(Name(), "-dec-"_s, factoryName, "-"_s, elementId.exchangeAdd(1));
         return makeGStreamerElement(factoryName, name);
     }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -663,7 +663,7 @@ TextStream& operator<<(TextStream& ts, const PlatformCAAnimationRemote::Properti
     ts.dumpProperty("fillMode"_s, animation.fillMode);
     ts.dumpProperty("valueFunction"_s, animation.valueFunction);
     if (animation.timingFunction)
-        ts.dumpProperty<const TimingFunction&>("timing function", Ref { *animation.timingFunction });
+        ts.dumpProperty<const TimingFunction&>("timing function"_s, Ref { *animation.timingFunction });
 
     if (animation.autoReverses)
         ts.dumpProperty("autoReverses"_s, animation.autoReverses);
@@ -697,7 +697,7 @@ TextStream& operator<<(TextStream& ts, const PlatformCAAnimationRemote::Properti
             ts.dumpProperty("time"_s, animation.keyTimes[i]);
 
         if (i < animation.timingFunctions.size())
-            ts.dumpProperty<const TimingFunction&>("timing function", animation.timingFunctions[i]);
+            ts.dumpProperty<const TimingFunction&>("timing function"_s, animation.timingFunctions[i]);
 
         if (i < animation.keyValues.size()) {
             ts.startGroup();

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TestWTF_SOURCES
     Tests/WTF/BoxPtr.cpp
     Tests/WTF/BumpPointerAllocator.cpp
     Tests/WTF/CString.cpp
+    Tests/WTF/CStringView.cpp
     Tests/WTF/CharacterProperties.cpp
     Tests/WTF/CheckedArithmeticOperations.cpp
     Tests/WTF/CompactPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1311,6 +1311,7 @@
 		CD27A1C123C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */; };
 		CD48A87324C8A66F00F5800C /* Observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD48A87224C8A66F00F5800C /* Observer.cpp */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
+		CD930D7E2D9EAC9F00507B6B /* CStringView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD930D7D2D9EAC9F00507B6B /* CStringView.cpp */; };
 		CDA315981ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDA315961ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm */; };
 		CDB213BD24EF522800FDE301 /* FullscreenFocus.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDB213BC24EF522800FDE301 /* FullscreenFocus.mm */; };
 		CDBFCC451A9FF45300A7B691 /* FullscreenZoomInitialFrame.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDBFCC431A9FF44800A7B691 /* FullscreenZoomInitialFrame.mm */; };
@@ -3936,6 +3937,7 @@
 		CD7FC5D82CDAF7160032C1FC /* FullscreenScrollAndResize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenScrollAndResize.mm; sourceTree = "<group>"; };
 		CD8394DE232AF15E00149495 /* media-loading.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "media-loading.html"; sourceTree = "<group>"; };
 		CD89D0381C4EDB2A00040A04 /* WebCoreNSURLSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCoreNSURLSession.mm; sourceTree = "<group>"; };
+		CD930D7D2D9EAC9F00507B6B /* CStringView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CStringView.cpp; sourceTree = "<group>"; };
 		CD9E292B1C90A71F000BB800 /* RequiresUserActionForPlayback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RequiresUserActionForPlayback.mm; sourceTree = "<group>"; };
 		CD9E292D1C90C1BA000BB800 /* audio-only.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "audio-only.html"; sourceTree = "<group>"; };
 		CDA29B2820FD2A9900F15CED /* ExitFullscreenOnEnterPiP.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExitFullscreenOnEnterPiP.mm; sourceTree = "<group>"; };
@@ -6288,6 +6290,7 @@
 				278DE64B22B8D611004E0E7A /* CrossThreadCopierTests.cpp */,
 				51714EB91D087416004723C4 /* CrossThreadTask.cpp */,
 				26A2C72E15E2E73C005B1A14 /* CString.cpp */,
+				CD930D7D2D9EAC9F00507B6B /* CStringView.cpp */,
 				7AA021BA1AB09EA70052953F /* DateMath.cpp */,
 				1A3524A91D627BD40031729B /* DeletedAddressOfOperator.h */,
 				E4A757D3178AEA5B00B5D7A4 /* Deque.cpp */,
@@ -7466,6 +7469,7 @@
 				5C2C01A82734883600F89D37 /* CrossThreadCopierTests.cpp in Sources */,
 				45F3A5F72D822261002B4550 /* CrossThreadTask.cpp in Sources */,
 				7C83DEA91D0A590C00FEBCF3 /* CString.cpp in Sources */,
+				CD930D7E2D9EAC9F00507B6B /* CStringView.cpp in Sources */,
 				45F3A5E52D81F955002B4550 /* DateMath.cpp in Sources */,
 				7C83DEAD1D0A590C00FEBCF3 /* Deque.cpp in Sources */,
 				FFD3FF372AF9BD8F0057C508 /* DragonBoxTest.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/text/CStringView.h>
+
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF, CStringViewNullAndEmpty)
+{
+    CStringView string;
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.rawCharacters(), nullptr);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    string = CStringView(nullptr);
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.rawCharacters(), nullptr);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    string = CStringView(""_s);
+    EXPECT_TRUE(string.isNull());
+    EXPECT_TRUE(string.isEmpty());
+    EXPECT_EQ(string.rawCharacters(), nullptr);
+    EXPECT_TRUE(!string);
+    EXPECT_FALSE(string);
+
+    string = CStringView("test"_s);
+    EXPECT_FALSE(string.isNull());
+    EXPECT_FALSE(string.isEmpty());
+    EXPECT_TRUE(string.rawCharacters());
+    EXPECT_FALSE(!string);
+    EXPECT_TRUE(string);
+}
+
+TEST(WTF, CStringViewLength)
+{
+    CStringView string;
+    EXPECT_EQ(string.length(), static_cast<size_t>(0));
+    EXPECT_EQ(string.span8().size(), static_cast<size_t>(0));
+
+    string = CStringView("test"_s);
+    EXPECT_EQ(string.length(), static_cast<size_t>(4));
+    EXPECT_EQ(string.span8().size(), static_cast<size_t>(4));
+}
+
+TEST(WTF, CStringViewFrom)
+{
+    const char* stringPtr = "test";
+    CStringView string = CStringView::unsafeFromUTF8(stringPtr);
+    EXPECT_EQ(string.length(), static_cast<size_t>(4));
+    EXPECT_TRUE(string);
+    EXPECT_EQ(string.rawCharacters(), stringPtr);
+
+    stringPtr = "";
+    string = CStringView::unsafeFromUTF8(stringPtr);
+    EXPECT_EQ(string.length(), static_cast<size_t>(0));
+    EXPECT_FALSE(string);
+    EXPECT_EQ(string.rawCharacters(), stringPtr);
+}
+
+TEST(WTF, CStringViewEquality)
+{
+    CStringView string("Test"_s);
+    CStringView sameString("Test"_s);
+    CStringView anotherString("another test"_s);
+    CStringView emptyString;
+    CStringView nullString(nullptr);
+    CStringView mixedCaseString("test"_s);
+    EXPECT_TRUE(string != emptyString);
+    EXPECT_EQ(string, string);
+    EXPECT_EQ(string, sameString);
+    EXPECT_TRUE(string != anotherString);
+    EXPECT_EQ(emptyString, nullString);
+    EXPECT_TRUE(string != mixedCaseString);
+    EXPECT_TRUE(equalIgnoringASCIICase(string, mixedCaseString));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 34d309e31ff8bca46c3b9f877916d0b34d4592a1
<pre>
[GStreamer] Change gstStructureGetString and Name to properly handle null terminated strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=290306">https://bugs.webkit.org/show_bug.cgi?id=290306</a>

Reviewed by NOBODY (OOPS!).

Created a new CStringView type to wrap a C String and be able to recover, without copies, the original string while
taking advantage of some other string niceties likes comparisons and the like. This class handles UTF8 strings only, so
if you need to compare or interface with any other WebKit strings, you have to convert to String.

I used that on gstStructureGetString and Name and updated the rest of the code accordingly.

Tests: Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/CStringView.cpp: Added.
(WTF::CStringView::toString const):
(WTF::CStringView::dump const):
* Source/WTF/wtf/text/CStringView.h: Added.
(WTF::operator==):
(WTF::safePrintfType):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::requestPad):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
(WebCore::GStreamerMediaEndpoint::preprocessStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp:
(WebCore::GStreamerRtpReceiverBackend::getParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::iceCandidateType):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCEncodingParameters):
(WebCore::toRTCRtpSendParameters):
(WebCore::payloadTypeForEncodingName):
(WebCore::capsFromRtpCapabilities):
(WebCore::capsFromSDPMedia):
(WebCore::extractMidAndRidFromRTPBuffer):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
(WebCore::PageHeapAgent::heapSnapshotBuilderOverrideClassName):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::userAgent const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::webkitGstGhostPadFromStaticTemplate):
(WebCore::capsMediaType):
(WebCore::doCapsHaveType):
(WebCore::gstStructureGet):
(WebCore::gstStructureGetString):
(WebCore::gstStructureGetName):
(WebCore::gstStructureGetArray):
(WebCore::gstStructureGetList):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isContentTypeSupported const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp:
(WebCore::GStreamerVideoFrameConverter::convert):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::retrieveTemporalIndex):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformCaps):
(transformInPlace):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::AppendPipeline):
(WebCore::AppendPipeline::appsinkCapsChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp:
(WebCore::GStreamerMediaDescription::extractCodecName const):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::describeCaps):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
(WebCore::GStreamerAudioRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::configure):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcAddTrack):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
(webkitGstMockDeviceProviderSwitchDefaultDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setInitialParameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setParameters):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::getPacketizerForRid):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::makeElement):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::operator&lt;&lt;):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp: Added.
(TestWebKitAPI::TEST(WTF, CStringViewNullAndEmpty)):
(TestWebKitAPI::TEST(WTF, CStringViewLength)):
(TestWebKitAPI::TEST(WTF, CStringViewFrom)):
(TestWebKitAPI::TEST(WTF, CStringViewEquality)):
</pre>