### PR TITLE
RemoteMediaRecorderPrivateWriterManager should adopt MESSAGE_CHECKS over ASSERTs

### DIFF
--- a/LayoutTests/ipc/invalid-mediarecorder-identifier-expected.txt
+++ b/LayoutTests/ipc/invalid-mediarecorder-identifier-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-mediarecorder-identifier.html
+++ b/LayoutTests/ipc/invalid-mediarecorder-identifier.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+  if (!window.IPC)
+      return window.testRunner?.notifyDone();
+
+  const { CoreIPC } = await import('./coreipc.js');
+  
+  CoreIPC.GPU.RemoteMediaRecorderPrivateWriterManager.AllTracksAdded(0, {
+        identifier: 0x41, // Shouldn't exist
+  }, ()=>{
+    window.testRunner?.notifyDone();
+  });
+
+}, 20);
+</script>


### PR DESCRIPTION
#### 53c0d8bf9d1eda3feb9ef5094f6685001691c725
<pre>
RemoteMediaRecorderPrivateWriterManager should adopt MESSAGE_CHECKS over ASSERTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=290314">https://bugs.webkit.org/show_bug.cgi?id=290314</a>
<a href="https://rdar.apple.com/147740435">rdar://147740435</a>

Reviewed by Jean-Yves Avenard.

Add MESSAGE_CHECK support to RemoteMediaRecorderPrivateWriterManager and move existing indentifier
checks from ASSERTS to MESSAGE_CHECKS.

* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.cpp:
(WebKit::RemoteMediaRecorderPrivateWriterManager::create):
(WebKit::RemoteMediaRecorderPrivateWriterManager::addAudioTrack):
(WebKit::RemoteMediaRecorderPrivateWriterManager::addVideoTrack):
(WebKit::RemoteMediaRecorderPrivateWriterManager::allTracksAdded):
(WebKit::RemoteMediaRecorderPrivateWriterManager::writeFrames):

Canonical link: <a href="https://commits.webkit.org/292865@main">https://commits.webkit.org/292865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7870c92b6083f225ceb56c5e8316cbf0ab22f4f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47083 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73601 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30826 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99566 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12389 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17229 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17104 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->