### PR TITLE
[ARMv7] Fix --32-bit with gcc 11

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2845,14 +2845,22 @@ sub generateBuildSystemFromCMakeProject
         $ENV{"LDFLAGS"} = "-m32" . ($ENV{"LDFLAGS"} || "");
     }
     if (architecture() eq "arm64" && shouldBuild32Bit()) {
+        my $compiler = "";
+        $compiler = $ENV{'CC'} if (defined($ENV{'CC'}));
         # CMAKE_LIBRARY_ARCHITECTURE is needed to get the right .pc
         # files in Debian-based systems, for the others
         # CMAKE_PREFIX_PATH will get us /usr/lib, which should be the
         # right path for 32bit. See FindPkgConfig.cmake.
         push @cmakeArgs, '-DFORCE_32BIT=ON -DCMAKE_PREFIX_PATH="/usr" -DCMAKE_LIBRARY_ARCHITECTURE=armv7-a+fp ';
-        $ENV{"CFLAGS"} =  "-m32 -march=armv7-a+fp " . ($ENV{"CFLAGS"} || "");
-        $ENV{"CXXFLAGS"} = "-m32 -march=armv7-a+fp " . ($ENV{"CXXFLAGS"} || "");
-        $ENV{"LDFLAGS"} = "-m32 -march=armv7-a+fp " . ($ENV{"LDFLAGS"} || "");
+        $ENV{"CFLAGS"} =  " -march=armv7-a+fp " . ($ENV{"CFLAGS"} || "");
+        $ENV{"CXXFLAGS"} = " -march=armv7-a+fp " . ($ENV{"CXXFLAGS"} || "");
+        $ENV{"LDFLAGS"} = " -march=armv7-a+fp " . ($ENV{"LDFLAGS"} || "");
+
+        if ($compiler =~ /clang/) {
+            $ENV{"CFLAGS"} =  " -m32 " . ($ENV{"CFLAGS"} || "");
+            $ENV{"CXXFLAGS"} = " -m32 " . ($ENV{"CXXFLAGS"} || "");
+            $ENV{"LDFLAGS"} = " -m32 " . ($ENV{"LDFLAGS"} || "");
+        }
     }
     push @args, @cmakeArgs if @cmakeArgs;
 


### PR DESCRIPTION
#### 82d24cdebc0ba7b073d133ad16f3b70432984902
<pre>
[ARMv7] Fix --32-bit with gcc 11
<a href="https://bugs.webkit.org/show_bug.cgi?id=290316">https://bugs.webkit.org/show_bug.cgi?id=290316</a>

Reviewed by Adrian Perez de Castro.

* Tools/Scripts/webkitdirs.pm:
(generateBuildSystemFromCMakeProject):

Canonical link: <a href="https://commits.webkit.org/292739@main">https://commits.webkit.org/292739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faaa403979777fdb1c5275b05e200a0bad4ba0eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73849 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5512 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46780 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89605 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104029 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95553 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24000 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23962 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119180 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23789 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->