### PR TITLE
AX: [AX Thread Text APIs] Cache text run character widths up front to more accurately serve bounds APIs

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -53,7 +53,6 @@ accessibility/mac/attributed-string-with-listitem-multiple-lines.html [ Failure 
 accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html [ Failure ]
 accessibility/mac/attributed-string/attributed-string-for-range-with-options.html [ Failure ]
 accessibility/mac/attributed-string/attributed-string-for-range.html [ Failure ]
-accessibility/mac/bounds-for-range.html [ Failure ]
 accessibility/mac/character-offset-from-upstream-position.html [ Failure ]
 accessibility/mac/content-editable-attributed-string.html [ Failure ]
 accessibility/mac/insertion-point-line-number.html [ Failure ]

--- a/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
@@ -77,7 +77,7 @@ AXTextOperation
 ----------------------
 PASS: textChild.boundsForRange(6, 10) was equal or approximately equal to (x: -1, y: -1, w: 60, h: 18).
 PASS: textChild.boundsForRange(1, 35) was equal or approximately equal to (x: -1, y: -1, w: 221, h: 18).
-PASS: textChild.boundsForRange(0, 1) was equal to (x: -1, y: -1, w: 11, h: 18).
+PASS: textChild.boundsForRange(0, 1) was equal or approximately equal to (x: -1, y: -1, w: 11, h: 18).
 PASS: textChild.boundsForRange(0, 100000) was equal to (x: -1, y: -1, w: 731, h: 36).
 PASS: textChild.boundsForRange(5, 0) was equal or approximately equal to (x: -1, y: -1, w: 2, h: 18).
 

--- a/LayoutTests/accessibility/mac/bounds-for-range-multiline-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-multiline-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that text marker range bounds for ranges that span across soft line breaks are correct.
+
+PASS: textChild.boundsForRange(0, 3) was equal or approximately equal to (x: -1, y: -1, w: 31, h: 23).
+PASS: textChild.boundsForRange(0, 19) was equal or approximately equal to (x: -1, y: -1, w: 168, h: 23).
+PASS: textChild.boundsForRange(16, 8) was equal or approximately equal to (x: -1, y: -1, w: 168, h: 46).
+PASS: textChild.boundsForRange(0, 42) was equal or approximately equal to (x: -1, y: -1, w: 168, h: 69).
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The quick brown fox jumped over the lazy dog.

--- a/LayoutTests/accessibility/mac/bounds-for-range-multiline.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range-multiline.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+Wraps like the following:
+```
+The quick brown fox
+jumps over the lazy
+dog.
+```
+!-->
+
+<p id="content" style="width: 200px; font-size: 20px;">
+The quick brown fox jumped over the lazy dog.
+</p>
+    
+<script>
+if (window.accessibilityController) {
+    let output = "This test verifies that text marker range bounds for ranges that span across soft line breaks are correct.\n\n";
+    var textChild = accessibilityController.accessibleElementById("content").childAtIndex(0);
+
+    output += expectRectWithVariance("textChild.boundsForRange(0, 3)", -1, -1, 31, 23, 1); // "The"
+    output += expectRectWithVariance("textChild.boundsForRange(0, 19)", -1, -1, 168, 23, 1); // "The quick brown fox" (full width)
+    output += expectRectWithVariance("textChild.boundsForRange(16, 8)", -1, -1, 168, 46, 1); // "fox jumps" (full width)
+    output += expectRectWithVariance("textChild.boundsForRange(0, 42)", -1, -1, 168, 69, 1); // "The quick brown fox jumped over the lazy dog." (full width)
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/accessibility/mac/bounds-for-range-vertical-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-vertical-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that text marker range bounds for vertical text orientations are correct.
+
+PASS: mixedText.boundsForRange(0, 5) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 45).
+PASS: mixedText.boundsForRange(6, 6) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 52).
+PASS: mixedText.boundsForRange(0, 12) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 102).
+PASS: uprightText.boundsForRange(0, 5) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 101).
+PASS: uprightText.boundsForRange(6, 6) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 121).
+PASS: uprightText.boundsForRange(0, 12) was equal or approximately equal to (x: -1, y: -1, w: 23, h: 226).
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world.
+
+Hello world.

--- a/LayoutTests/accessibility/mac/bounds-for-range-vertical.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range-vertical.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="mixed" style="font-size: 20px; writing-mode: vertical-lr; text-orientation: mixed;">
+Hello world.
+</p>
+
+<p id="upright" style="font-size: 20px; writing-mode: vertical-lr; text-orientation: upright;">
+Hello world.
+</p>
+
+<script>
+if (window.accessibilityController) {
+    let output = "This test verifies that text marker range bounds for vertical text orientations are correct.\n\n";
+    var mixedText = accessibilityController.accessibleElementById("mixed").childAtIndex(0);
+    var uprightText = accessibilityController.accessibleElementById("upright").childAtIndex(0);
+
+    // Mixed (rendered sideways)
+    output += expectRectWithVariance("mixedText.boundsForRange(0, 5)", -1, -1, 23, 45, 1); // "Hello"
+    output += expectRectWithVariance("mixedText.boundsForRange(6, 6)", -1, -1, 23, 52, 1); // "world."
+    output += expectRectWithVariance("mixedText.boundsForRange(0, 12)", -1, -1, 23, 102, 1); // "Hello world." (full width)
+
+    // Upright
+    output += expectRectWithVariance("uprightText.boundsForRange(0, 5)", -1, -1, 23, 101, 1); // "Hello"
+    output += expectRectWithVariance("uprightText.boundsForRange(6, 6)", -1, -1, 23, 121, 1); // "world."
+    output += expectRectWithVariance("uprightText.boundsForRange(0, 12)", -1, -1, 23, 226, 1); // "Hello world." (full width)
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/accessibility/mac/bounds-for-range.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range.html
@@ -26,7 +26,7 @@ if (window.accessibilityController) {
 
     output += expectRectWithVariance("textChild.boundsForRange(6, 10)", -1, -1, 60, 18, 1);
     output += expectRectWithVariance("textChild.boundsForRange(1, 35)", -1, -1, 221, 18, 1);
-    output += expectRectWithVariance("textChild.boundsForRange(0, 1)", -1, -1, 11, 18, 0);
+    output += expectRectWithVariance("textChild.boundsForRange(0, 1)", -1, -1, 11, 18, 2);
     output += expectRectWithVariance("textChild.boundsForRange(0, 100000)", -1, -1, 731, 36, 0);
     output += expectRectWithVariance("textChild.boundsForRange(5, 0)", -1, -1, 2, 18, 1);
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -934,17 +934,11 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
         return relativeFrame;
     }
 
-    float estimatedLineHeight = relativeFrame.height() / runs->size();
-    if (auto fontRef = object->font()) {
-        auto runsLocalRect = runs->localRect(start, end, estimatedLineHeight, relativeFrame, fontRef.get(), object->fontOrientation());
-        // The rect we got above is a "local" rect, relative to nothing else. Move it to be
-        // anchored at this object's relative frame.
-        runsLocalRect.move(relativeFrame.x(), relativeFrame.y());
-        return runsLocalRect;
-    }
-
-    // This means we had no font information, so fallback to the object's relative frame.
-    return relativeFrame;
+    auto runsLocalRect = runs->localRect(start, end, object->fontOrientation());
+    // The rect we got above is a "local" rect, relative to nothing else. Move it to be
+    // anchored at this object's relative frame.
+    runsLocalRect.move(relativeFrame.x(), relativeFrame.y());
+    return runsLocalRect;
 }
 
 static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, unsigned offset)

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -76,10 +76,18 @@ struct AXTextRun {
     // This Vector would then have values: [[2, 10], [11, 16]]
     Vector<std::array<uint16_t, 2>> textRunDomOffsets;
 
-    AXTextRun(size_t lineIndex, String&& text, Vector<std::array<uint16_t, 2>>&& domOffsets)
+    // An array the size of the run, where each value is the width/advance of each character in the run (in the direction
+    // of the writing mode: horizontal or vertical).
+    Vector<uint16_t> characterAdvances;
+
+    float lineHeight;
+
+    AXTextRun(size_t lineIndex, String&& text, Vector<std::array<uint16_t, 2>>&& domOffsets, Vector<uint16_t> characterAdvances, float lineHeight)
         : lineIndex(lineIndex)
         , text(WTFMove(text))
         , textRunDomOffsets(WTFMove(domOffsets))
+        , characterAdvances(WTFMove(characterAdvances))
+        , lineHeight(lineHeight)
     { }
 
     String debugDescription(void* containingBlock) const
@@ -88,6 +96,7 @@ struct AXTextRun {
         return makeString(lineID.debugDescription(), ": |"_s, makeStringByReplacingAll(text, '\n', "{newline}"_s), "|(len "_s, text.length(), ")"_s);
     }
     const Vector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }
+    const Vector<uint16_t>& advances() const { return characterAdvances; }
 
     // Convenience methods for TextUnit movement.
     bool startsWithLineBreak() const { return text.startsWith('\n'); }
@@ -166,7 +175,7 @@ struct AXTextRuns {
     //   b|bb|b
     // The local rect would be:
     //   {x: width_of_single_b, y: |lineHeight| * 1, width: width_of_two_b, height: |lineHeight * 1|}
-    FloatRect localRect(unsigned start, unsigned end, float lineHeight, FloatRect, CTFontRef, FontOrientation) const;
+    FloatRect localRect(unsigned start, unsigned end, FontOrientation) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1625,6 +1625,16 @@ float FontCascade::widthForComplexText(const TextRun& run, SingleThreadWeakHashS
     return controller.totalAdvance().width();
 }
 
+float FontCascade::widthForCharacterInRun(const TextRun& run, unsigned characterPosition) const
+{
+    auto shortenedRun = run.subRun(characterPosition, 1);
+    auto codePathToUse = codePath(run);
+    if (codePathToUse == CodePath::Complex)
+        return widthForComplexText(shortenedRun);
+
+    return widthForSimpleText(shortenedRun);
+}
+
 void FontCascade::adjustSelectionRectForSimpleText(const TextRun& run, LayoutRect& selectionRect, unsigned from, unsigned to) const
 {
     GlyphBuffer glyphBuffer;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -152,6 +152,7 @@ public:
     WEBCORE_EXPORT float width(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
     float widthForTextUsingSimplifiedMeasuring(StringView text, TextDirection = TextDirection::LTR) const;
     WEBCORE_EXPORT float widthForSimpleTextWithFixedPitch(StringView text, bool whitespaceIsCollapsed) const;
+    float widthForCharacterInRun(const TextRun&, unsigned) const;
 
     std::unique_ptr<TextLayout, TextLayoutDeleter> createLayout(RenderText&, float xPos, bool collapseWhiteSpace) const;
     float widthOfSpaceString() const


### PR DESCRIPTION
#### f7f3e11543724542dd187070c0cd5709ae8892d1
<pre>
AX: [AX Thread Text APIs] Cache text run character widths up front to more accurately serve bounds APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=290315">https://bugs.webkit.org/show_bug.cgi?id=290315</a>
<a href="https://rdar.apple.com/147752500">rdar://147752500</a>

Reviewed by Tyler Wilcock.

In the quest to improve the accuracy of the text marker bounds that are served off of the main thread,
this new approach caches the widths of each character in a run up-front. We do this a new method in
FontCascade to compute the width, and storing these widths in the text run. Then, when we serve the
bounds for a given range, we can sum up these advances (in the direction of the text orientation) to
build a more accurate bounds. This adds the extra benefit of more gracefully handling Horizontal and
Vertical text orientations.

Two new tests were added with this change. One test verifies bounds calculations when they span across
soft line breaks. The other tests bounds with mixed/upright vertical text.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/mac/bounds-for-range-expected.txt:
* LayoutTests/accessibility/mac/bounds-for-range-multiline-expected.txt: Added.
* LayoutTests/accessibility/mac/bounds-for-range-multiline.html: Added.
* LayoutTests/accessibility/mac/bounds-for-range-vertical-expected.txt: Added.
* LayoutTests/accessibility/mac/bounds-for-range-vertical.html: Added.
* LayoutTests/accessibility/mac/bounds-for-range.html:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::viewportRelativeFrameFromRuns):
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
(WebCore::AXTextRun::advances const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForCharacterInRun const):
* Source/WebCore/platform/graphics/FontCascade.h:

Canonical link: <a href="https://commits.webkit.org/292675@main">https://commits.webkit.org/292675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfcc1aea7ec65d4e8391a7b2024bd45fb0c32b4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30923 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46555 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83528 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82158 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17249 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28892 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->