### PR TITLE
Address more Safer CPP failures in WebKit/NetworkProcess

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1006,8 +1006,8 @@ $(PROJECT_DIR)/Modules/webauthn/AuthenticatorAttestationResponse.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorResponse.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorSelectionCriteria.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorTransport.idl
-$(PROJECT_DIR)/Modules/webauthn/CurrentUserDetailsOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/CredentialPropertiesOutput.idl
+$(PROJECT_DIR)/Modules/webauthn/CurrentUserDetailsOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredential.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.idl
@@ -1023,8 +1023,8 @@ $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialUserEntity.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl
 $(PROJECT_DIR)/Modules/webauthn/RegistrationResponseJSON.idl
 $(PROJECT_DIR)/Modules/webauthn/ResidentKeyRequirement.idl
-$(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
 $(PROJECT_DIR)/Modules/webauthn/UnknownCredentialOptions.idl
+$(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
 $(PROJECT_DIR)/Modules/webcodecs/AacEncoderConfig.idl
 $(PROJECT_DIR)/Modules/webcodecs/AudioSampleFormat.idl
 $(PROJECT_DIR)/Modules/webcodecs/AvcEncoderConfig.idl
@@ -1286,8 +1286,8 @@ $(PROJECT_DIR)/css/CSSScopeRule.idl
 $(PROJECT_DIR)/css/CSSStartingStyleRule.idl
 $(PROJECT_DIR)/css/CSSStyleDeclaration.idl
 $(PROJECT_DIR)/css/CSSStyleProperties.idl
-$(PROJECT_DIR)/css/CSSStyleRule.idl
 $(PROJECT_DIR)/css/CSSStyleRule+Typedom.idl
+$(PROJECT_DIR)/css/CSSStyleRule.idl
 $(PROJECT_DIR)/css/CSSStyleSheet.idl
 $(PROJECT_DIR)/css/CSSSupportsRule.idl
 $(PROJECT_DIR)/css/CSSValueKeywords.in
@@ -1307,8 +1307,8 @@ $(PROJECT_DIR)/css/DeprecatedCSSOMRGBColor.idl
 $(PROJECT_DIR)/css/DeprecatedCSSOMRect.idl
 $(PROJECT_DIR)/css/DeprecatedCSSOMValue.idl
 $(PROJECT_DIR)/css/DeprecatedCSSOMValueList.idl
-$(PROJECT_DIR)/css/ElementCSSInlineStyle.idl
 $(PROJECT_DIR)/css/ElementCSSInlineStyle+Typedom.idl
+$(PROJECT_DIR)/css/ElementCSSInlineStyle.idl
 $(PROJECT_DIR)/css/FontFace.idl
 $(PROJECT_DIR)/css/FontFaceSet.idl
 $(PROJECT_DIR)/css/FontFaceSource.idl
@@ -1451,6 +1451,7 @@ $(PROJECT_DIR)/dom/Element+DOMParsing.idl
 $(PROJECT_DIR)/dom/Element+Fullscreen.idl
 $(PROJECT_DIR)/dom/Element+PointerEvents.idl
 $(PROJECT_DIR)/dom/Element+PointerLock.idl
+$(PROJECT_DIR)/dom/Element+Typedom.idl
 $(PROJECT_DIR)/dom/Element.idl
 $(PROJECT_DIR)/dom/ElementContentEditable.idl
 $(PROJECT_DIR)/dom/ElementCreationOptions.idl

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -169,9 +169,9 @@ bool LegacyCustomProtocolManager::supportsScheme(const String& scheme)
 
 static inline void dispatchOnInitializationRunLoop(WKCustomProtocol* protocol, void (^block)())
 {
-    CFRunLoopRef runloop = protocol.initializationRunLoop;
-    CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, block);
-    CFRunLoopWakeUp(runloop);
+    RetainPtr<CFRunLoopRef> runloop = protocol.initializationRunLoop;
+    CFRunLoopPerformBlock(runloop.get(), kCFRunLoopDefaultMode, block);
+    CFRunLoopWakeUp(runloop.get());
 }
 
 void LegacyCustomProtocolManager::didFailWithError(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceError& error)

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -53,13 +53,13 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
     auto& cocoaSession = downcast<NetworkSessionCocoa>(*networkSession);
     RetainPtr nsData = toNSData(resumeData);
 
-    NSMutableDictionary *dictionary = [NSPropertyListSerialization propertyListWithData:nsData.get() options:NSPropertyListMutableContainersAndLeaves format:0 error:nullptr];
+    RetainPtr dictionary = [NSPropertyListSerialization propertyListWithData:nsData.get() options:NSPropertyListMutableContainersAndLeaves format:0 error:nullptr];
     [dictionary setObject:static_cast<NSString*>(path) forKey:@"NSURLSessionResumeInfoLocalPath"];
-    NSData *updatedData = [NSPropertyListSerialization dataWithPropertyList:dictionary format:NSPropertyListXMLFormat_v1_0 options:0 error:nullptr];
+    RetainPtr updatedData = [NSPropertyListSerialization dataWithPropertyList:dictionary.get() format:NSPropertyListXMLFormat_v1_0 options:0 error:nullptr];
 
     // FIXME: Use nsData instead of updatedData once we've migrated from _WKDownload to WKDownload
     // because there's no reason to set the local path we got from the data back into the data.
-    m_downloadTask = [cocoaSession.sessionWrapperForDownloadResume().session downloadTaskWithResumeData:updatedData];
+    m_downloadTask = [cocoaSession.sessionWrapperForDownloadResume().session downloadTaskWithResumeData:updatedData.get()];
     if (!m_downloadTask) {
         RELEASE_LOG_ERROR(Network, "Could not create download task from resume data");
         return;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -408,8 +408,8 @@ bool NetworkConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connect
     MESSAGE_CHECK_WITH_RETURN_VALUE(decoder.messageReceiverName() != Messages::NetworkProcess::messageReceiverName(), false);
 
     if (decoder.messageReceiverName() == Messages::WebSWServerConnection::messageReceiverName()) {
-        if (m_swConnection)
-            return m_swConnection->didReceiveSyncMessage(connection, decoder, reply);
+        if (RefPtr swConnection = m_swConnection.get())
+            return swConnection->didReceiveSyncMessage(connection, decoder, reply);
         return false;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -130,8 +130,8 @@ void NetworkLoad::updateRequestAfterRedirection(WebCore::ResourceRequest& newReq
 void NetworkLoad::reprioritizeRequest(ResourceLoadPriority priority)
 {
     m_currentRequest.setPriority(priority);
-    if (m_task)
-        m_task->setPriority(priority);
+    if (RefPtr task = m_task)
+        task->setPriority(priority);
 }
 
 bool NetworkLoad::shouldCaptureExtraNetworkLoadMetrics() const
@@ -358,8 +358,8 @@ void NetworkLoad::setH2PingCallback(const URL& url, CompletionHandler<void(Expec
 
 void NetworkLoad::setTimingAllowFailedFlag()
 {
-    if (m_task)
-        m_task->setTimingAllowFailedFlag();
+    if (RefPtr task = m_task)
+        task->setTimingAllowFailedFlag();
 }
 
 String NetworkLoad::attributedBundleIdentifier(WebPageProxyIdentifier pageID)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -554,7 +554,7 @@ void ServiceWorkerFetchTask::loadBodyFromPreloader()
             protectedThis->didFinish(protectedThis->m_preloader->networkLoadMetrics());
             return;
         }
-        protectedThis->didReceiveDataFromPreloader(const_cast<WebCore::FragmentedSharedBuffer&>(*chunk), length);
+        protectedThis->didReceiveDataFromPreloader(*chunk, length);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -109,8 +109,8 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
 
 void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    auto dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+    RetainPtr dispatchData = data.dispatchData();
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
         if (!done) {
             RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
             return;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -66,15 +66,15 @@ namespace WebKit {
 
 inline static bool shouldBlockTrackersForThirdPartyCloaking(NSURLRequest *request)
 {
-    auto requestURL = request.URL;
-    auto mainDocumentURL = request.mainDocumentURL;
+    RetainPtr<NSURL> requestURL = request.URL;
+    RetainPtr<NSURL> mainDocumentURL = request.mainDocumentURL;
     if (!requestURL || !mainDocumentURL)
         return false;
 
-    if (!WebCore::areRegistrableDomainsEqual(requestURL, mainDocumentURL))
+    if (!WebCore::areRegistrableDomainsEqual(requestURL.get(), mainDocumentURL.get()))
         return false;
 
-    if ([requestURL.host isEqualToString:mainDocumentURL.host])
+    if ([[requestURL host] isEqualToString:[mainDocumentURL host]])
         return false;
 
     return true;
@@ -171,15 +171,15 @@ void NetworkDataTaskCocoa::updateFirstPartyInfoForSession(const URL& requestURL)
 
     auto* session = networkSession();
     auto cnameDomain = [this]() {
-        if (auto* lastResolvedCNAMEInChain = [[m_task _resolvedCNAMEChain] lastObject])
-            return lastCNAMEDomain(lastResolvedCNAMEInChain);
+        if (RetainPtr lastResolvedCNAMEInChain = [[m_task _resolvedCNAMEChain] lastObject])
+            return lastCNAMEDomain(lastResolvedCNAMEInChain.get());
         return WebCore::RegistrableDomain { };
     }();
     if (!cnameDomain.isEmpty())
         session->setFirstPartyHostCNAMEDomain(requestURL.host().toString(), WTFMove(cnameDomain));
 
-    if (NSString *ipAddress = lastRemoteIPAddress(m_task.get()); ipAddress.length)
-        session->setFirstPartyHostIPAddress(requestURL.host().toString(), ipAddress);
+    if (RetainPtr ipAddress = lastRemoteIPAddress(m_task.get()); [ipAddress length])
+        session->setFirstPartyHostIPAddress(requestURL.host().toString(), ipAddress.get());
 }
 
 NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -161,9 +161,9 @@ void NetworkProcess::deleteHSTSCacheForHostNames(PAL::SessionID sessionID, const
 void NetworkProcess::clearHSTSCache(PAL::SessionID sessionID, WallTime modifiedSince)
 {
     NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();
-    NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
+    RetainPtr date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
     if (auto* networkSession = downcast<NetworkSessionCocoa>(this->networkSession(sessionID)))
-        [networkSession->hstsStorage() resetHSTSHostsSinceDate:date];
+        [networkSession->hstsStorage() resetHSTSHostsSinceDate:date.get()];
 }
 
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
@@ -171,8 +171,8 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
     if (!m_clearCacheDispatchGroup)
         m_clearCacheDispatchGroup = adoptOSObject(dispatch_group_create());
 
-    auto group = m_clearCacheDispatchGroup.get();
-    dispatch_group_async(group, dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
+    RetainPtr group = m_clearCacheDispatchGroup.get();
+    dispatch_group_async(group.get(), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
         auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
         forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
             if (RefPtr cache = session.cache())

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -126,9 +126,9 @@ void WebSocketTask::resume()
 void WebSocketTask::didConnect(const String& protocol)
 {
     String extensionsValue;
-    auto response = [m_task response];
-    if (auto *httpResponse  = dynamic_objc_cast<NSHTTPURLResponse>(response))
-        extensionsValue = [httpResponse  valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
+    RetainPtr response = [m_task response];
+    if (RetainPtr httpResponse  = dynamic_objc_cast<NSHTTPURLResponse>(response.get()))
+        extensionsValue = [httpResponse valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
 
     m_receivedDidConnect = true;
     RefPtr channel = m_channel.get();

--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -58,8 +58,8 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), (NSString *)parameters.uiProcessName];
-    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
+    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), (NSString *)parameters.uiProcessName];
+    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
 #endif
 }
 
@@ -75,7 +75,7 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
 
 void NetworkProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)
 {
-    auto webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+    RetainPtr webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
 
     sandboxParameters.setOverrideSandboxProfilePath(makeString(String([webKitBundle resourcePath]), "/com.apple.WebKit.NetworkProcess.sb"_s));
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -35,6 +35,7 @@
 #include <dispatch/dispatch.h>
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/cocoa/VectorCocoa.h>
@@ -49,12 +50,12 @@ using namespace WebCore;
 
 static dispatch_queue_t tcpSocketQueue()
 {
-    static dispatch_queue_t queue;
+    static LazyNeverDestroyed<RetainPtr<dispatch_queue_t>> queue;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        queue = dispatch_queue_create("WebRTC TCP socket queue", DISPATCH_QUEUE_CONCURRENT);
+        queue.construct(adoptNS(dispatch_queue_create("WebRTC TCP socket queue", DISPATCH_QUEUE_CONCURRENT)));
     });
-    return queue;
+    return queue.get().get();
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkRTCTCPSocketCocoa);

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -10,8 +10,6 @@ GPUProcess/media/RemoteTextTrackProxy.h
 GPUProcess/media/RemoteVideoTrackProxy.cpp
 GPUProcess/media/RemoteVideoTrackProxy.h
 GeneratedSerializers.mm
-NetworkProcess/NetworkConnectionToWebProcess.cpp
-NetworkProcess/NetworkLoad.cpp
 NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/IPC/Connection.cpp


### PR DESCRIPTION
#### efa46b8ae5c8934c48fd886aff63c1663f0f8c31
<pre>
Address more Safer CPP failures in WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=290320">https://bugs.webkit.org/show_bug.cgi?id=290320</a>

Reviewed by Darin Adler and Per Arne Vollan.

* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(WebKit::dispatchOnInitializationRunLoop):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::resume):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::reprioritizeRequest):
(WebKit::NetworkLoad::setTimingAllowFailedFlag):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::statelessSessionWithoutRedirects):
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::loadBodyFromPreloader):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::shouldBlockTrackersForThirdPartyCloaking):
(WebKit::NetworkDataTaskCocoa::updateFirstPartyInfoForSession):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::clearHSTSCache):
(WebKit::NetworkProcess::clearDiskCache):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(downgradeRequest):
(updateIgnoreStrictTransportSecuritySetting):
(-[WKNetworkSessionDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:_schemeUpgraded:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(-[WKNetworkSessionDelegate URLSession:task:didFinishCollectingMetrics:]):
(-[WKNetworkSessionDelegate URLSession:task:_didReceiveInformationalResponse:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
(WebKit::configurationForSessionID):
(WebKit::NetworkSessionCocoa::hstsStorage const):
(WebKit::NetworkSessionCocoa::nsCredentialStorage const):
(WebKit::SessionWrapper::recreateSessionWithUpdatedProxyConfigurations):
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::SessionSet::initializeEphemeralStatelessSessionIfNeeded):
(WebKit::NetworkSessionCocoa::originsWithCredentials):
(WebKit::NetworkSessionCocoa::removeCredentialsForOrigins):
(WebKit::NetworkSessionCocoa::clearCredentials):
(WebKit::NetworkSessionCocoa::dataTaskWithRequest):
(WebKit::NetworkSessionCocoa::hostNamesWithAlternativeServices const):
(WebKit::NetworkSessionCocoa::deleteAlternativeServicesForHostNames):
(WebKit::NetworkSessionCocoa::clearAlternativeServices):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::cookiesByCappingExpiry):
(WebKit::NetworkTaskCocoa::setCookieTransformForFirstPartyRequest):
(WebKit::NetworkTaskCocoa::updateTaskWithFirstPartyForSameSiteCookies):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::didConnect):
* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::initializeProcessName):
(WebKit::NetworkProcess::initializeSandbox):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::tcpSocketQueue):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::udpSocketQueue):
(WebKit::NetworkRTCUDPSocketCocoaConnections::sendTo):

Canonical link: <a href="https://commits.webkit.org/292629@main">https://commits.webkit.org/292629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0adde8f6fef632167e11fed1aa5b048f437d50bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96597 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73619 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30845 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103693 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17255 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82669 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83401 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82068 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17138 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15557 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->