### PR TITLE
[iOS] The user preferred camera is not always selected with getUserMedia({ video: true })

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
@@ -49,7 +49,7 @@ class AVCaptureDeviceManager final : public CaptureDeviceManager {
 public:
     static AVCaptureDeviceManager& singleton();
 
-    void refreshCaptureDevices() { refreshCaptureDevicesInternal([] { }, ShouldSetUserPreferredCamera::No); };
+    void refreshCaptureDevices(CompletionHandler<void()>&& = [] { });
 
 private:
     static bool isAvailable();
@@ -59,15 +59,14 @@ private:
 
     void computeCaptureDevices(CompletionHandler<void()>&&) final;
     const Vector<CaptureDevice>& captureDevices() final;
+    void processRefreshedCaptureDevices(CompletionHandler<void()>&&, Vector<CaptureDevice>&&);
 
     void registerForDeviceNotifications();
     void updateCachedAVCaptureDevices();
     Vector<CaptureDevice> retrieveCaptureDevices();
     RetainPtr<NSArray> currentCameras();
 
-    enum class ShouldSetUserPreferredCamera : bool { No, Yes };
-    void refreshCaptureDevicesInternal(CompletionHandler<void()>&&, ShouldSetUserPreferredCamera);
-    void setUserPreferredCamera();
+    void setUserPreferredCamera(CompletionHandler<void()>&&);
 
     RetainPtr<WebCoreAVCaptureDeviceManagerObserver> m_objcObserver;
     Vector<CaptureDevice> m_devices;


### PR DESCRIPTION
#### 446489af2a2667464dc05a162ce1e4b686335d52
<pre>
[iOS] The user preferred camera is not always selected with getUserMedia({ video: true })
<a href="https://bugs.webkit.org/show_bug.cgi?id=290321">https://bugs.webkit.org/show_bug.cgi?id=290321</a>
<a href="https://rdar.apple.com/147524488">rdar://147524488</a>

Reviewed by Eric Carlson.

When initializing, we set the user preferred camera to the front camera and we immediately compute the camera list in a preferred order.
Later on, if the system preferred camera changes to due to setting the user preferred camera, we update the camera list.

In case of the first getUserMedia call, getUserMedia may use the list before the user preferred camera is taken into account.
To prevent this, we add a hop to main thread before computing the camera list at initialization time.

A future change will make sure to compute the ordered camera list (based on getUserMedia constraints) once the user grants permission.
This future change is tracked in <a href="https://bugs.webkit.org/show_bug.cgi?id=290324.">https://bugs.webkit.org/show_bug.cgi?id=290324.</a>

We do a small refactoring to make the code more readable and to have lambdas not take raw pointers.
Manually tested.

* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
(WebCore::AVCaptureDeviceManager::computeCaptureDevices):
(WebCore::AVCaptureDeviceManager::retrieveCaptureDevices):
(WebCore::AVCaptureDeviceManager::processRefreshedCaptureDevices):
(WebCore::AVCaptureDeviceManager::refreshCaptureDevices):
(WebCore::AVCaptureDeviceManager::setUserPreferredCamera):
(WebCore::AVCaptureDeviceManager::refreshCaptureDevicesInternal): Deleted.

Canonical link: <a href="https://commits.webkit.org/292755@main">https://commits.webkit.org/292755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbc98098bd1746fd07ff200abf369205b1bd51f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73590 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30820 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99546 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12375 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53926 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5100 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46391 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83356 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82012 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17084 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28728 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->