### PR TITLE
Make it possible to use WKWebView._historyDelegate when using a non-persistent data store

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -140,6 +140,7 @@ Tests/WebKitCocoa/Geolocation.mm
 Tests/WebKitCocoa/GetDisplayMedia.mm
 Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm
 Tests/WebKitCocoa/GetResourceData.mm
+Tests/WebKitCocoa/HistoryDelegate.mm
 Tests/WebKitCocoa/HSTS.mm
 Tests/WebKitCocoa/IDBCheckpointWAL.mm
 Tests/WebKitCocoa/IDBDeleteRecovery.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3040,6 +3040,7 @@
 		63A33C552A339ED500EF94B8 /* WKWebViewInspection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewInspection.mm; sourceTree = "<group>"; };
 		63A61B8A1FAD204D00F06885 /* display-mode.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "display-mode.html"; sourceTree = "<group>"; };
 		63CAD04F2C478A55009CE119 /* GetMatchedCSSRules.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetMatchedCSSRules.mm; sourceTree = "<group>"; };
+		63D138CF2D90B08E0072E181 /* HistoryDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = HistoryDelegate.mm; sourceTree = "<group>"; };
 		63F668201F97C3AA0032EE51 /* ApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplicationManifest.mm; sourceTree = "<group>"; };
 		6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateClickMeasurement.cpp; sourceTree = "<group>"; };
 		6B25A75125DC8D4E0070744F /* EventAttribution.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EventAttribution.mm; sourceTree = "<group>"; };
@@ -4471,6 +4472,7 @@
 				0738012E275EADAB000FA77C /* GetDisplayMediaWindowAndScreen.mm */,
 				2DADF26221CB8F32003D3E3A /* GetResourceData.mm */,
 				465E2806255B2A690063A787 /* GPUProcess.mm */,
+				63D138CF2D90B08E0072E181 /* HistoryDelegate.mm */,
 				5CB5990A269E74EC002A7CFF /* HSTS.mm */,
 				51AF23DE1EF1A3720072F281 /* IconLoadingDelegate.mm */,
 				EB230D3E245E726300C66AD1 /* IDBCheckpointWAL.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestCocoa.h"
+#import "TestNavigationDelegate.h"
+#import <WebKit/WKHistoryDelegatePrivate.h>
+#import <WebKit/WKNavigationData.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WebKit.h>
+#import <wtf/text/MakeString.h>
+
+@interface HistoryDelegate : NSObject <WKHistoryDelegatePrivate> {
+    @public
+    RetainPtr<WKNavigationData> lastNavigationData;
+    RetainPtr<NSString> lastUpdatedTitle;
+    RetainPtr<NSURL> lastRedirectSource;
+    RetainPtr<NSURL> lastRedirectDestination;
+}
+@end
+
+@implementation HistoryDelegate
+
+- (void)_webView:(WKWebView *)webView didNavigateWithNavigationData:(WKNavigationData *)navigationData
+{
+    lastNavigationData = navigationData;
+}
+
+- (void)_webView:(WKWebView *)webView didUpdateHistoryTitle:(NSString *)title forURL:(NSURL *)URL
+{
+    lastUpdatedTitle = title;
+}
+
+- (void)_webView:(WKWebView *)webView didPerformServerRedirectFromURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL
+{
+    lastRedirectSource = sourceURL;
+    lastRedirectDestination = destinationURL;
+}
+
+@end
+
+TEST(HistoryDelegate, NonpersistentDataStoreDoesNotSendHistoryEvents)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "<head><title>Page Title</title></head>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore nonPersistentDataStore] retain]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr historyDelegate = adoptNS([[HistoryDelegate alloc] init]);
+    [webView _setHistoryDelegate:historyDelegate.get()];
+
+    auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:mainURL]];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+    TestWebKitAPI::Util::spinRunLoop();
+
+    EXPECT_NULL(historyDelegate->lastNavigationData.get());
+}
+
+TEST(HistoryDelegate, NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "<head><title>Page Title</title></head>"_s } },
+        { "/server_redirect_source"_s, { 301, { { "Location"_s, "server_redirect_destination"_s } } } },
+        { "/server_redirect_destination"_s, { "<head><title>Target Page</title></head>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore nonPersistentDataStore] retain]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+
+    [configuration preferences]._allowPrivacySensitiveOperationsInNonPersistentDataStores = YES;
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr historyDelegate = adoptNS([[HistoryDelegate alloc] init]);
+    [webView _setHistoryDelegate:historyDelegate.get()];
+
+    auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
+    auto url = [NSURL URLWithString:mainURL];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    [webView loadRequest:request];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastNavigationData && historyDelegate->lastUpdatedTitle;
+    });
+
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request);
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url);
+    EXPECT_NS_EQUAL(historyDelegate->lastUpdatedTitle.get(), @"Page Title");
+
+    auto sourceURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_source"_s);
+    auto destinationURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_destination"_s);
+    url = [NSURL URLWithString:sourceURL];
+    request = [NSURLRequest requestWithURL:url];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+    TestWebKitAPI::Util::spinRunLoop();
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastRedirectSource && historyDelegate->lastRedirectDestination;
+    });
+
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectSource absoluteString], sourceURL);
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectDestination absoluteString], destinationURL);
+}
+
+TEST(HistoryDelegate, PersistentDataStoreSendsHistoryEvents)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { "<head><title>Page Title</title></head>"_s } },
+        { "/server_redirect_source"_s, { 301, { { "Location"_s, "server_redirect_destination"_s } } } },
+        { "/server_redirect_destination"_s, { "<head><title>Target Page</title></head>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore defaultDataStore] retain]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr historyDelegate = adoptNS([[HistoryDelegate alloc] init]);
+    [webView _setHistoryDelegate:historyDelegate.get()];
+
+    auto mainURL = makeString("http://localhost:"_s, server.port(), "/"_s);
+    auto url = [NSURL URLWithString:mainURL];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    [webView loadRequest:request];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastNavigationData && historyDelegate->lastUpdatedTitle;
+    });
+
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request);
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url);
+    EXPECT_NS_EQUAL(historyDelegate->lastUpdatedTitle.get(), @"Page Title");
+
+    auto sourceURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_source"_s);
+    auto destinationURL = makeString("http://localhost:"_s, server.port(), "/server_redirect_destination"_s);
+    url = [NSURL URLWithString:sourceURL];
+    request = [NSURLRequest requestWithURL:url];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+    TestWebKitAPI::Util::spinRunLoop();
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastRedirectSource && historyDelegate->lastRedirectDestination;
+    });
+
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectSource absoluteString], sourceURL);
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectDestination absoluteString], destinationURL);
+}
+

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm
@@ -31,6 +31,7 @@
 #import "Test.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKUserContentControllerPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebScriptWorld.h>
 #import <WebKit/WebViewPrivate.h>
 #import <WebKit/_WKUserStyleSheet.h>


### PR DESCRIPTION
#### f5a6af25e43cc53fd17406f1acf8dc804617c15a
<pre>
Make it possible to use WKWebView._historyDelegate when using a non-persistent data store
<a href="https://bugs.webkit.org/show_bug.cgi?id=290326">https://bugs.webkit.org/show_bug.cgi?id=290326</a>
<a href="https://rdar.apple.com/147764328">rdar://147764328</a>

Reviewed by Brady Eidson.

HistoryController currently skips updates that could end up telling the UI process
about history changes if the page is using an ephemeral data store. While this makes
sense in many cases, not all clients want to keep these two decisions (i.e. whether
they have access to this specific set of callbacks about browsing activity, and
whether WebKit should write website data to disk) tightly coupled. Make it possible
to opt a nonpersistent web view in to history callbacks when opting into other
privacy-sensitive operations, i.e. the &quot;AllowPrivacySensitiveOperationsInNonPersistentDataStores&quot;
setting.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::canRecordHistoryForFrame):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForClientRedirect):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/HistoryDelegate.mm: Added.
(-[HistoryDelegate _webView:didNavigateWithNavigationData:]):
(-[HistoryDelegate _webView:didUpdateHistoryTitle:forURL:]):
(-[HistoryDelegate _webView:didPerformServerRedirectFromURL:toURL:]):
(TEST(HistoryDelegate, NonpersistentDataStoreDoesNotSendHistoryEvents)):
(TEST(HistoryDelegate, NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations)):
(TEST(HistoryDelegate, PersistentDataStoreSendsHistoryEvents)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm:
    Add a missing #import revealed by the shuffling of unified sources as a result
    of adding a new file to TestWebKitAPI.

Canonical link: <a href="https://commits.webkit.org/292628@main">https://commits.webkit.org/292628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5cd77d1b328ef5ee66f923fa3d94d003885d5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24682 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30861 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46482 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23701 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83426 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82066 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26721 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23664 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->