### PR TITLE
[WebGPU] radians(f16variable) / degrees(f16variable) should return f16 type

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_290328-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_290328-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Pass: no validation error
+

--- a/LayoutTests/fast/webgpu/regression/repro_290328.html
+++ b/LayoutTests/fast/webgpu/regression/repro_290328.html
@@ -1,0 +1,34 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({requiredFeatures: ['shader-f16']});
+    device.pushErrorScope('validation');
+    let module = device.createShaderModule({
+      code: `
+enable f16;
+
+@compute @workgroup_size(1)
+fn c() {
+  let m = 1h;
+  let n = modf(radians(m));
+  let o = modf(degrees(m));
+}
+`,
+    });
+    device.createComputePipeline({
+      layout: 'auto',
+      compute: {module},
+    });
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('Pass: no validation error');
+    }
+    globalThis.testRunner?.dumpAsText();
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1911,7 +1911,9 @@ static void emitLength(FunctionDefinitionWriter* writer, AST::CallExpression& ca
 
 static void emitDegrees(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append('(');
+    writer->stringBuilder().append("static_cast<"_s);
+    writer->visit(call.inferredType());
+    writer->stringBuilder().append(">("_s);
     writer->visit(call.arguments()[0]);
     writer->stringBuilder().append(" * "_s, String::number(180 / std::numbers::pi), ')');
 }
@@ -2002,7 +2004,9 @@ static void emitQuantizeToF16(FunctionDefinitionWriter* writer, AST::CallExpress
 
 static void emitRadians(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append('(');
+    writer->stringBuilder().append("static_cast<"_s);
+    writer->visit(call.inferredType());
+    writer->stringBuilder().append(">("_s);
     writer->visit(call.arguments()[0]);
     writer->stringBuilder().append(" * "_s, String::number(std::numbers::pi / 180), ')');
 }


### PR DESCRIPTION
#### 2007fd0e73a03b2bef787340595106f0ebfca766
<pre>
[WebGPU] radians(f16variable) / degrees(f16variable) should return f16 type
<a href="https://bugs.webkit.org/show_bug.cgi?id=290328">https://bugs.webkit.org/show_bug.cgi?id=290328</a>
<a href="https://rdar.apple.com/147754153">rdar://147754153</a>

Reviewed by Tadeu Zagallo.

Cast the result of degrees / radians back to the origin type.

* LayoutTests/fast/webgpu/regression/repro_290328-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_290328.html: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitDegrees):
(WGSL::Metal::emitRadians):

Canonical link: <a href="https://commits.webkit.org/292801@main">https://commits.webkit.org/292801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3436f5d16fd727f49b81916e36ae2564f67cc0b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104194 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24165 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17627 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83010 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20740 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29281 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->