### PR TITLE
AX: Adopt AXTextMarkerRange::toString() as the canonical way to extract text from a range.

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1338,7 +1338,6 @@ public:
     virtual AXTextMarkerRange selectedTextMarkerRange() const = 0;
 #endif
 
-    virtual String stringForRange(const SimpleRange&) const = 0;
     virtual IntRect boundsForRange(const SimpleRange&) const = 0;
     virtual void setSelectedVisiblePositionRange(const VisiblePositionRange&) const = 0;
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -486,6 +486,100 @@ bool AXTextMarkerRange::isConfinedTo(std::optional<AXID> objectID) const
         && LIKELY(m_start.treeID() == m_end.treeID());
 }
 
+String AXTextMarkerRange::toString() const
+{
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (!isMainThread() && AXObjectCache::useAXThreadTextApis()) {
+        // Traverses from m_start to m_end, collecting all text along the way.
+        auto start = m_start.toTextRunMarker();
+        if (!start.isValid())
+            return emptyString();
+        auto end = m_end.toTextRunMarker();
+        if (!end.isValid())
+            return emptyString();
+
+        StringBuilder result;
+        RefPtr startObject = start.isolatedObject();
+        RefPtr listItemAncestor = Accessibility::findAncestor(*startObject, /* includeSelf */ true, [] (const auto& object) {
+            return object.isListItem();
+        });
+        if (listItemAncestor) {
+            if (RefPtr listMarker = findUnignoredDescendant(*listItemAncestor, /* includeSelf */ false, [] (const auto& object) {
+                return object.roleValue() == AccessibilityRole::ListMarker;
+            })) {
+                auto lineID = listMarker->listMarkerLineID();
+                if (lineID && lineID == start.lineID())
+                    result.append(listMarker->listMarkerText());
+            }
+        }
+
+        if (startObject.get() == end.isolatedObject()) {
+            size_t minOffset = std::min(start.offset(), end.offset());
+            size_t maxOffset = std::max(start.offset(), end.offset());
+            result.append(start.runs()->substring(minOffset, maxOffset - minOffset));
+            return result.toString();
+        }
+
+        auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
+            // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
+            auto behavior = object.textEmissionBehavior();
+            if (behavior != TextEmissionBehavior::Newline && behavior != TextEmissionBehavior::DoubleNewline)
+                return;
+
+            // Like TextIterator, don't emit a newline if the most recently emitted character was already a newline.
+            if (result.length() && result[result.length() - 1] != '\n') {
+                result.append('\n');
+                if (behavior == TextEmissionBehavior::DoubleNewline)
+                    result.append('\n');
+            }
+        };
+
+        result.append(start.runs()->substring(start.offset()));
+
+        // FIXME: If we've been given reversed markers, i.e. the end marker actually comes before the start marker,
+        // we may want to detect this and try searching AXDirection::Previous?
+        RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitNewlineOnExit);
+        while (current && current->objectID() != end.objectID()) {
+            const auto* runs = current->textRuns();
+            for (unsigned i = 0; i < runs->size(); i++)
+                result.append(runs->at(i).text);
+            current = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitNewlineOnExit);
+        }
+        result.append(end.runs()->substring(0, end.offset()));
+        return result.toString();
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
+    return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
+        auto range = simpleRange();
+        if (!range)
+            return { };
+
+        TextIterator it = TextIterator(*range, { TextIteratorBehavior::IgnoresFullSizeKana });
+        if (it.atEnd())
+            return { };
+
+        StringBuilder builder;
+        for (; !it.atEnd(); it.advance()) {
+            // non-zero length means textual node, zero length means replaced node (AKA "attachments" in AX)
+            if (it.text().length()) {
+                // If this is in a list item, we need to add the text for the list marker
+                // because a RenderListMarker does not have a Node equivalent and thus does not appear
+                // when iterating text.
+                // Don't add list marker text for new line character.
+                if (it.text().length() != 1 || !isASCIIWhitespace(it.text()[0]))
+                    builder.append(AccessibilityObject::listMarkerTextForNodeAndPosition(it.node(), makeDeprecatedLegacyPosition(it.range().start)));
+                it.appendTextToStringBuilder(builder);
+            } else {
+                if (AccessibilityObject::replacedNodeNeedsCharacter(*it.node()))
+                    builder.append(objectReplacementCharacter);
+            }
+        }
+
+        return builder.toString().isolatedCopy();
+    });
+}
+
 #if ENABLE(AX_THREAD_TEXT_APIS)
 AXTextMarker AXTextMarker::convertToDomOffset() const
 {
@@ -898,68 +992,6 @@ AXTextMarkerRange AXTextMarkerRange::convertToDomOffsetRange() const
         m_start.convertToDomOffset(),
         m_end.convertToDomOffset()
     };
-}
-
-String AXTextMarkerRange::toString() const
-{
-    RELEASE_ASSERT(!isMainThread());
-
-    auto start = m_start.toTextRunMarker();
-    if (!start.isValid())
-        return emptyString();
-    auto end = m_end.toTextRunMarker();
-    if (!end.isValid())
-        return emptyString();
-
-    StringBuilder result;
-    RefPtr startObject = start.isolatedObject();
-    RefPtr listItemAncestor = Accessibility::findAncestor(*startObject, /* includeSelf */ true, [] (const auto& object) {
-        return object.isListItem();
-    });
-    if (listItemAncestor) {
-        if (RefPtr listMarker = findUnignoredDescendant(*listItemAncestor, /* includeSelf */ false, [] (const auto& object) {
-            return object.roleValue() == AccessibilityRole::ListMarker;
-        })) {
-            auto lineID = listMarker->listMarkerLineID();
-            if (lineID && lineID == start.lineID())
-                result.append(listMarker->listMarkerText());
-        }
-    }
-
-    if (startObject.get() == end.isolatedObject()) {
-        size_t minOffset = std::min(start.offset(), end.offset());
-        size_t maxOffset = std::max(start.offset(), end.offset());
-        result.append(start.runs()->substring(minOffset, maxOffset - minOffset));
-        return result.toString();
-    }
-
-    auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
-        // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
-        auto behavior = object.textEmissionBehavior();
-        if (behavior != TextEmissionBehavior::Newline && behavior != TextEmissionBehavior::DoubleNewline)
-            return;
-
-        // Like TextIterator, don't emit a newline if the most recently emitted character was already a newline.
-        if (result.length() && result[result.length() - 1] != '\n') {
-            result.append('\n');
-            if (behavior == TextEmissionBehavior::DoubleNewline)
-                result.append('\n');
-        }
-    };
-
-    result.append(start.runs()->substring(start.offset()));
-
-    // FIXME: If we've been given reversed markers, i.e. the end marker actually comes before the start marker,
-    // we may want to detect this and try searching AXDirection::Previous?
-    RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitNewlineOnExit);
-    while (current && current->objectID() != end.objectID()) {
-        const auto* runs = current->textRuns();
-        for (unsigned i = 0; i < runs->size(); i++)
-            result.append(runs->at(i).text);
-        current = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitNewlineOnExit);
-    }
-    result.append(end.runs()->substring(0, end.offset()));
-    return result.toString();
 }
 
 const AXTextRuns* AXTextMarker::runs() const

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -419,10 +419,9 @@ public:
     bool isCollapsed() const { return m_start.isEqual(m_end); }
     bool isConfinedTo(std::optional<AXID>) const;
     bool isConfined() const;
+    String toString() const;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    // Traverses from m_start to m_end, collecting all text along the way.
-    String toString() const;
     // Returns the bounds (frame) of the text in this range relative to the viewport.
     // Analagous to AXCoreObject::relativeFrame().
     FloatRect viewportRelativeFrame() const;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -602,7 +602,6 @@ public:
     AXTextMarkerRange selectedTextMarkerRange() const final;
 #endif
     static String stringForVisiblePositionRange(const VisiblePositionRange&);
-    String stringForRange(const SimpleRange&) const final;
     virtual IntRect boundsForVisiblePositionRange(const VisiblePositionRange&) const { return IntRect(); }
     IntRect boundsForRange(const SimpleRange&) const final;
     void setSelectedVisiblePositionRange(const VisiblePositionRange&) const override { }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2246,9 +2246,7 @@ static RenderObject* rendererForView(WAKView* view)
     AXTextMarkerRange axRange { markers };
     if (!axRange)
         return nil;
-
-    auto range = axRange.simpleRange();
-    return range ? self.axBackingObject->stringForRange(*range) : String();
+    return axRange.toString();
 }
 
 // This method is intended to return an array of strings and accessibility elements that
@@ -2387,7 +2385,7 @@ static RenderObject* rendererForView(WAKView* view)
     auto webRange = makeDOMRange(self.axBackingObject->document(), range);
     if (!webRange)
         return nil;
-    return self.axBackingObject->stringForRange(*webRange);
+    return AXTextMarkerRange { webRange }.toString();
 }
 
 - (NSAttributedString *)attributedStringForRange:(NSRange)range

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1282,13 +1282,6 @@ AXTextMarkerRange AXIsolatedObject::selectedTextMarkerRange() const
 }
 #endif // PLATFORM(MAC)
 
-String AXIsolatedObject::stringForRange(const SimpleRange& range) const
-{
-    ASSERT(isMainThread());
-    auto* axObject = associatedAXObject();
-    return axObject ? axObject->stringForRange(range).isolatedCopy() : String();
-}
-
 IntRect AXIsolatedObject::boundsForRange(const SimpleRange& range) const
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -415,7 +415,6 @@ private:
 #if PLATFORM(MAC)
     AXTextMarkerRange selectedTextMarkerRange() const final;
 #endif
-    String stringForRange(const SimpleRange&) const final;
     IntRect boundsForRange(const SimpleRange&) const final;
     VisiblePosition visiblePositionForPoint(const IntPoint&) const final;
     VisiblePosition nextLineEndPosition(const VisiblePosition&) const final;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3220,23 +3220,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:NSAccessibilityStringForTextMarkerRangeAttribute]) {
-#if ENABLE(AX_THREAD_TEXT_APIS)
-        if (AXObjectCache::useAXThreadTextApis()) {
-            AXTextMarkerRange range = { textMarkerRange };
-            return range.toString();
-        }
-#endif
-        return Accessibility::retrieveValueFromMainThread<String>([textMarkerRange = retainPtr(textMarkerRange), protectedSelf = retainPtr(self)] () -> String {
-            auto* backingObject = protectedSelf.get().axBackingObject;
-            if (!backingObject)
-                return String();
-
-            AXTextMarkerRange markerRange { textMarkerRange.get() };
-            auto range = markerRange.simpleRange();
-            return range ? backingObject->stringForRange(*range) : String();
-        });
-    }
+    if ([attribute isEqualToString:NSAccessibilityStringForTextMarkerRangeAttribute])
+        return AXTextMarkerRange { textMarkerRange }.toString();
 
     if ([attribute isEqualToString:NSAccessibilityTextMarkerForPositionAttribute]) {
         if (!pointSet)
@@ -3324,9 +3309,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             auto start = cache->characterOffsetForIndex(range.location, backingObject);
             auto end = cache->characterOffsetForIndex(range.location + range.length, backingObject);
             auto range = cache->rangeForUnorderedCharacterOffsets(start, end);
-            if (!range)
-                return { };
-            return backingObject->stringForRange(*range);
+            return AXTextMarkerRange { range }.toString();
         });
     }
 


### PR DESCRIPTION
#### 2231639e2fa41c6dda2ab2fe990fe005d80bbcac
<pre>
AX: Adopt AXTextMarkerRange::toString() as the canonical way to extract text from a range.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290330">https://bugs.webkit.org/show_bug.cgi?id=290330</a>
&lt;<a href="https://rdar.apple.com/problem/147770908">rdar://problem/147770908</a>&gt;

Reviewed by Tyler Wilcock.

As part of the work to support text APIs on the AX thread, we added the method AXTextMarkerRange::toString. This change extends the implementation of this method to be used in all cases, whether on the AX or main thread. This functionality is removed from the AXCoreObject interface and implementations, and is now part of the AXTextMarkerRange class where it belongs. This simplifies the platform layer code and allows for a consistent and unified interface for this functionality.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::textContentPrefixFromListMarker const):
(WebCore::AccessibilityObject::textContent const):
(WebCore::AccessibilityObject::stringForRange const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper stringForTextMarkers:]):
(-[WebAccessibilityObjectWrapper stringForRange:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::stringForRange const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/292623@main">https://commits.webkit.org/292623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f111f461ce9a812d5754eb593642991db94d91d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87328 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53938 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46412 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82650 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83372 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82025 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20602 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4199 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28749 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->