### PR TITLE
Address more Safer CPP failures in WebKit/Shared

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -152,7 +152,7 @@ protected:
 #endif
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
-    static id decodePreferenceValue(const std::optional<String>& encodedValue);
+    static RetainPtr<id> decodePreferenceValue(const std::optional<String>& encodedValue);
     static void setPreferenceValue(const String& domain, const String& key, id value);
     virtual void handlePreferenceChange(const String& domain, const String& key, id value);
     virtual void dispatchSimulatedNotificationsForPreferenceChange(const String& key) { }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
@@ -37,8 +37,8 @@ std::optional<CoreIPCCFURL> CoreIPCCFURL::createWithBaseURLAndBytes(std::optiona
         return CoreIPCCFURL { bridge_cast([NSURL URLWithString:@""]) };
     }
 
-    CFURLRef baseCFURL = baseURL ? baseURL->m_cfURL.get() : nullptr;
-    if (RetainPtr newCFURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes.data(), bytes.size(), kCFStringEncodingUTF8, baseCFURL, true)))
+    RetainPtr baseCFURL = baseURL ? baseURL->m_cfURL.get() : nullptr;
+    if (RetainPtr newCFURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes.data(), bytes.size(), kCFStringEncodingUTF8, baseCFURL.get(), true)))
         return CoreIPCCFURL { WTFMove(newCFURL) };
 
     return std::nullopt;
@@ -46,8 +46,8 @@ std::optional<CoreIPCCFURL> CoreIPCCFURL::createWithBaseURLAndBytes(std::optiona
 
 std::optional<CoreIPCCFURL> CoreIPCCFURL::baseURL() const
 {
-    if (CFURLRef baseURL = CFURLGetBaseURL(m_cfURL.get()))
-        return CoreIPCCFURL { baseURL };
+    if (RetainPtr baseURL = CFURLGetBaseURL(m_cfURL.get()))
+        return CoreIPCCFURL { WTFMove(baseURL) };
     return std::nullopt;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.mm
@@ -34,8 +34,8 @@ namespace WebKit {
 using namespace WebCore;
 MachSendRight CoreIPCCVPixelBufferRef::sendRightFromPixelBuffer(const RetainPtr<CVPixelBufferRef>& pixelBuffer)
 {
-    auto surface = CVPixelBufferGetIOSurface(pixelBuffer.get());
-    return MachSendRight::adopt(IOSurfaceCreateMachPort(surface));
+    RetainPtr surface = CVPixelBufferGetIOSurface(pixelBuffer.get());
+    return MachSendRight::adopt(IOSurfaceCreateMachPort(surface.get()));
 }
 
 RetainPtr<CVPixelBufferRef> CoreIPCCVPixelBufferRef::toCF() const

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -40,16 +40,16 @@ CoreIPCDictionary::CoreIPCDictionary(NSDictionary *dictionary)
     m_keyValuePairs.reserveInitialCapacity(dictionary.count);
 
     for (id key in dictionary) {
-        id value = dictionary[key];
+        RetainPtr<id> value = dictionary[key];
         ASSERT(value);
 
         // Ignore values we don't support.
         ASSERT(IPC::isSerializableValue(key));
-        ASSERT(IPC::isSerializableValue(value));
-        if (!IPC::isSerializableValue(key) || !IPC::isSerializableValue(value))
+        ASSERT(IPC::isSerializableValue(value.get()));
+        if (!IPC::isSerializableValue(key) || !IPC::isSerializableValue(value.get()))
             continue;
 
-        m_keyValuePairs.append({ CoreIPCNSCFObject(key), CoreIPCNSCFObject(value) });
+        m_keyValuePairs.append({ CoreIPCNSCFObject(key), CoreIPCNSCFObject(value.get()) });
     }
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -108,9 +108,9 @@ CoreIPCError::CoreIPCError(NSError *nsError)
     : m_domain([nsError domain])
     , m_code([nsError code])
 {
-    NSDictionary *userInfo = [nsError userInfo];
+    RetainPtr<NSDictionary> userInfo = [nsError userInfo];
 
-    RetainPtr<CFMutableDictionaryRef> filteredUserInfo = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, userInfo.count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr<CFMutableDictionaryRef> filteredUserInfo = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, [userInfo count], &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
     [userInfo enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL*) {
         if ([key isEqualToString:@"NSErrorClientCertificateChainKey"]) {

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -522,8 +522,8 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
 
 static inline const NSBundle *webKit2Bundle()
 {
-    const static NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
-    return bundle;
+    const static NeverDestroyed<RetainPtr<NSBundle>> bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+    return bundle.get().get();
 }
 
 static void getSandboxProfileOrProfilePath(const SandboxInitializationParameters& parameters, String& profileOrProfilePath, bool& isProfilePath)
@@ -786,8 +786,8 @@ void AuxiliaryProcess::stopNSAppRunLoop()
     ASSERT([NSApp isRunning]);
     [NSApp stop:nil];
 
-    NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0.0 windowNumber:0 context:nil subtype:0 data1:0 data2:0];
-    [NSApp postEvent:event atStart:true];
+    RetainPtr event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0.0 windowNumber:0 context:nil subtype:0 data1:0 data2:0];
+    [NSApp postEvent:event.get() atStart:true];
 }
 #endif
 

--- a/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
+++ b/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -160,15 +160,15 @@ static std::optional<ScrollingAccelerationCurve> fromIOHIDDevice(IOHIDEventSende
 
 std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fromNativeWheelEvent(const NativeWebWheelEvent& nativeWebWheelEvent)
 {
-    NSEvent *event = nativeWebWheelEvent.nativeEvent();
+    RetainPtr event = nativeWebWheelEvent.nativeEvent();
 
-    auto cgEvent = event.CGEvent;
+    RetainPtr<CGEventRef> cgEvent = event.get().CGEvent;
     if (!cgEvent) {
         RELEASE_LOG(ScrollAnimations, "ScrollingAccelerationCurve::fromNativeWheelEvent did not find CG event");
         return std::nullopt;
     }
 
-    auto hidEvent = adoptCF(CGEventCopyIOHIDEvent(cgEvent));
+    auto hidEvent = adoptCF(CGEventCopyIOHIDEvent(cgEvent.get()));
     if (!hidEvent) {
         RELEASE_LOG(ScrollAnimations, "ScrollingAccelerationCurve::fromNativeWheelEvent did not find HID event");
         return std::nullopt;

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -403,11 +403,11 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(NSEvent *event, NSView *windo
     auto momentumEndType = WebWheelEvent::MomentumEndType::Unknown;
     
     ([&] {
-        auto cgEvent = event.CGEvent;
+        RetainPtr<CGEventRef> cgEvent = event.CGEvent;
         if (!cgEvent)
             return;
 
-        auto ioHIDEvent = adoptCF(CGEventCopyIOHIDEvent(cgEvent));
+        auto ioHIDEvent = adoptCF(CGEventCopyIOHIDEvent(cgEvent.get()));
         if (!ioHIDEvent)
             return;
 

--- a/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
+++ b/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
@@ -96,10 +96,10 @@ size_t WebMemorySampler::sampleProcessCommittedBytes() const
 
 String WebMemorySampler::processName() const
 {
-    NSString *appName = [[NSBundle mainBundle] bundleIdentifier];
+    RetainPtr appName = [[NSBundle mainBundle] bundleIdentifier];
     if (!appName)
         appName = [[NSProcessInfo processInfo] processName];
-    return String(appName);
+    return String(appName.get());
 }
   
 WebMemoryStatistics WebMemorySampler::sampleWebKit() const

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -292,7 +292,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return ax::retrieveValueFromMainThread<RetainPtr<id>>([&attribute, &point, PROTECTED_SELF] () -> RetainPtr<id> {
         if (!protectedSelf->m_page)
             return nil;
-        id value = nil;
+        RetainPtr<id> value;
         if ([attribute isEqualToString:@"AXDataDetectorExistsAtPoint"] || [attribute isEqualToString:@"AXDidShowDataDetectorMenuAtPoint"]) {
             bool boolValue;
             if (protectedSelf->m_page->corePage()->pageOverlayController().copyAccessibilityAttributeBoolValueForPoint(attribute, point, boolValue))


### PR DESCRIPTION
#### 7f3f2fcd9274d69adbb11c845b65e9221ab40b35
<pre>
Address more Safer CPP failures in WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=290337">https://bugs.webkit.org/show_bug.cgi?id=290337</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::disableDowngradeToLayoutManager):
(WebKit::AuxiliaryProcess::registerWithStateDumper):
(WebKit::AuxiliaryProcess::decodePreferenceValue):
(WebKit::AuxiliaryProcess::preferenceDidUpdate):
* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm:
(WebKit::CoreIPCCFURL::createWithBaseURLAndBytes):
(WebKit::CoreIPCCFURL::baseURL const):
* Source/WebKit/Shared/Cocoa/CoreIPCCVPixelBufferRef.mm:
(WebKit::CoreIPCCVPixelBufferRef::sendRightFromPixelBuffer):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::CoreIPCError):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::webKit2Bundle):
(WebKit::AuxiliaryProcess::stopNSAppRunLoop):
* Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm:
(WebKit::ScrollingAccelerationCurve::fromNativeWheelEvent):
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
(WebKit::WebMemorySampler::processName const):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityDataDetectorValue:point:]):

Canonical link: <a href="https://commits.webkit.org/292632@main">https://commits.webkit.org/292632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7cd3fe59396becebb68029512477115f8356de8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73609 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103671 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82658 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83385 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82033 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26686 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17116 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15560 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->