### PR TITLE
[webkitscmpy] Add method to retrieve last N commits for a specific file

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -991,6 +991,23 @@ class Git(Scm):
             if log and log.poll() is None:
                 log.kill()
 
+    def last_commits_on(self, path, count=5):
+        """
+        Return the last `count` Commit objects that modified the specified file.
+        """
+        try:
+            output = run(
+                [self.executable(), 'log', f'--max-count={count}', '--follow', '--format=%H', '--', path],
+                cwd=self.root_path, capture_output=True, encoding='utf-8', check=True,
+            )
+            return [
+                self.find(commit_hash.strip())
+                for commit_hash in output.stdout.strip().splitlines()
+                if commit_hash.strip()
+            ]
+        except Exception:
+            return []
+
     def find(self, argument, include_log=True, include_identifier=True):
         if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -375,6 +375,15 @@ nothing to commit, working tree clean
                     ])
                 )
             ), mocks.Subprocess.Route(
+                self.executable, 'log', re.compile(r'--max-count=\d+'), '--follow', '--format=%H', '--', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: mocks.ProcessCompletion(
+                    returncode=0,
+                    stdout='\n'.join([
+                        commit.hash for commit in self.commits[self.branch] if commit.identifier % 2
+                    ][:int(args[2].split('=')[-1])])
+                )
+            ), mocks.Subprocess.Route(
                 self.executable, 'log', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: mocks.ProcessCompletion(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -28,8 +28,7 @@ from unittest.mock import patch
 
 from webkitcorepy import LoggerCapture, OutputCapture, run, testing
 from webkitcorepy.mocks import Time as MockTime
-
-from webkitscmpy import Commit, local, mocks, remote
+from webkitscmpy import Commit, Contributor, local, mocks, remote
 
 
 class TestGit(testing.PathTestCase):
@@ -589,6 +588,24 @@ CommitDate: {time_c}
             self.assertEqual(
                 local.Git(self.path).files_changed('4@main'),
                 ['Source/main.cpp', 'Source/main.h'],
+            )
+
+    def test_last_commits_on(self):
+        with mocks.local.Git(self.path):
+            git = local.Git(self.path)
+            commits = git.last_commits_on('README.md', count=5)
+
+            # Mock environment only produces 3 commits when README.md is requested
+            # because the mock filters to commits with odd-numbered identifiers.
+            self.assertEqual(len(commits), 3)
+            self.assertTrue(all(len(c.hash) == 40 for c in commits))
+            self.assertEqual(
+                [f'{c.identifier}@{c.branch}' for c in commits],
+                [
+                    '1@main',
+                    '3@main',
+                    '5@main',
+                ]
             )
 
     def test_merge_base(self):


### PR DESCRIPTION
#### 875467dc29efa0c369307f968fbbd1c8c23843aa
<pre>
[webkitscmpy] Add method to retrieve last N commits for a specific file
<a href="https://bugs.webkit.org/show_bug.cgi?id=290338">https://bugs.webkit.org/show_bug.cgi?id=290338</a>
<a href="https://rdar.apple.com/147777529">rdar://147777529</a>

Reviewed by Jonathan Bedard.

Add a new method last_commits_on to the Git class in webkitscmpy to return the last N commits that modified

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.last_commits_on):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.last_commits_on):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/294287@main">https://commits.webkit.org/294287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43bfd333af7578258e1e4e12724b86591ef92b40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29514 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34236 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104363 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/16458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91551 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/57540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/100829 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9561 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/100913 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87753 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21809 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/30459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->