### PR TITLE
Add CF_BRIDGED_TYPE annotation on DDHighlightRef

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
@@ -110,7 +110,8 @@ WTF_EXTERN_C_BEGIN
 CFTypeID DDResultGetCFTypeID(void);
 WTF_EXTERN_C_END
 
-typedef struct __DDHighlight *DDHighlightRef;
+// FIXME: See rdar://147779798 for adding CF_BRIDGED_TYPE annotation in DDHighlightDrawing.h.
+typedef struct CF_BRIDGED_TYPE(id) __DDHighlight *DDHighlightRef;
 typedef NSUInteger DDHighlightStyle;
 
 #if !HAVE(DATA_DETECTORS_MAC_ACTION)


### PR DESCRIPTION
#### ea71212028bb99161c8e9e05719df52d627998f9
<pre>
Add CF_BRIDGED_TYPE annotation on DDHighlightRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=290340">https://bugs.webkit.org/show_bug.cgi?id=290340</a>

Reviewed by Geoffrey Garen.

Added CF_BRIDGED_TYPE to DDHighlightRef since it&apos;s a CF type.

* Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h:

Canonical link: <a href="https://commits.webkit.org/292624@main">https://commits.webkit.org/292624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f1a2902b72e31ff26f4c3db85a7540ea82eb2cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73620 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30842 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83408 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82045 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4229 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15556 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28784 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->