### PR TITLE
AX: It's not necessary to cache AXProperty::TextContentPrefixFromListMarker when ENABLE(AX_THREAD_TEXT_APIS)

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -5,7 +5,6 @@ accessibility/isolated-tree [ Pass ]
 # Potentially caused by: https://github.com/WebKit/WebKit/commit/2517a540e6f5a2037c6843102f3a9cb753f2f9f0
 accessibility/content-editable-set-inner-text-generates-axvalue-notification.html [ Failure Pass ]
 accessibility/dynamically-ignored-canvas.html [ Failure ]
-accessibility/frame-disconnect-textmarker-cache-crash.html [ Failure ]
 accessibility/keyevents-for-actions-mimic-real-key-events.html [ Failure ]
 accessibility/keyevents-posted-for-increment-actions.html [ Failure ]
 accessibility/mac/document-attributes.html [ Failure ]
@@ -34,7 +33,7 @@ accessibility/element-reflection-ariaactivedescendant.html [ Failure ]
 # accessibility/mac/text-marker-from-typing-notification.html
 
 # Used to be a timeout until https://github.com/WebKit/WebKit/commit/c69e4c0caaf5368db791652eee3a057ed2751144, now is a text failure.
-accessibility/frame-disconnect-textmarker-cache-crash.html [ Failure ]
+accessibility/frame-disconnect-textmarker-cache-crash.html [ Pass Failure ]
 
 # Test times out without ITM, so we need to reconcile behavior here.
 accessibility/mac/style-range.html [ Pass ]
@@ -57,11 +56,9 @@ accessibility/mac/character-offset-from-upstream-position.html [ Failure ]
 accessibility/mac/content-editable-attributed-string.html [ Failure ]
 accessibility/mac/insertion-point-line-number.html [ Failure ]
 accessibility/mac/line-index-for-textmarker.html [ Failure ]
-accessibility/mac/line-text-marker-range-in-list-item.html [ Failure ]
 accessibility/mac/misspelled-attributed-string.html [ Failure ]
 accessibility/mac/object-replacement-with-no-rendered-children-at-node-start.html [ Failure ]
 accessibility/mac/object-replacement-with-rendered-children-at-node-start.html [ Failure ]
-accessibility/mac/range-for-line-index.html [ Failure ]
 accessibility/mac/spellcheck-with-voiceover.html [ Failure ]
 accessibility/mac/text-marker-for-index.html [ Failure ]
 accessibility/mac/text-marker-p-tags.html [ Failure ]

--- a/LayoutTests/accessibility/aria-labelledby-on-password-input.html
+++ b/LayoutTests/accessibility/aria-labelledby-on-password-input.html
@@ -30,8 +30,8 @@ if (window.accessibilityController) {
     document.getElementById("password-1").value = "hello";
     setTimeout(async function() {
         await waitFor(() => password1.stringValue === "AXValue: \u2022\u2022\u2022\u2022\u2022");
-        output += expect("button1.description", "'AXDescription: \u2022\u2022\u2022\u2022\u2022'");
-        output += expect("button1.title", "'AXTitle: \u2022\u2022\u2022\u2022\u2022'");
+        output += await expectAsync("button1.description", "'AXDescription: \u2022\u2022\u2022\u2022\u2022'");
+        output += await expectAsync("button1.title", "'AXTitle: \u2022\u2022\u2022\u2022\u2022'");
 
         output += "Update aria-labelledby to text-1 for #button-2\n";
         document.getElementById("button-2").setAttribute("aria-labelledby", "text-1");

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -347,6 +347,8 @@ public:
     // The index of the line this text marker is on relative to the nearest editable ancestor (or start of the page if there are no editable ancestors).
     // Returns -1 if the line couldn't be computed (i.e. because `this` is invalid).
     int lineIndex() const;
+    // After resolving this marker to a text-run marker, what line does the offset point to?
+    AXTextRunLineID lineID() const;
     // Returns the line number for the character index within the descendants of this marker's object.
     // Returns -1 if the index is out of bounds, or this marker isn't valid.
     int lineNumberForIndex(unsigned) const;
@@ -359,8 +361,6 @@ public:
 private:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     const AXTextRuns* runs() const;
-    // After resolving this marker to a text-run marker, what line does the offset point to?
-    AXTextRunLineID lineID() const;
     // Are we at the start or end of a line?
     bool atLineBoundaryForDirection(AXDirection) const;
     // Fast path to calcuate line boundary when a callsite already has the runs and runIndex available.
@@ -477,6 +477,10 @@ inline bool operator>=(const AXTextMarkerRange& range1, const AXTextMarkerRange&
 {
     return range1 == range2 || range1 > range2;
 }
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+String listMarkerTextOnSameLine(const AXTextMarker&);
+#endif
 
 namespace Accessibility {
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1766,7 +1766,7 @@ Vector<RetainPtr<id>> AccessibilityObject::modelElementChildren()
 static RenderListItem* renderListItemContainer(Node* node)
 {
     for (; node; node = node->parentNode()) {
-        if (auto* listItem = dynamicDowncast<RenderListItem>(node->renderBoxModelObject()))
+        if (auto* listItem = dynamicDowncast<RenderListItem>(node->renderer()))
             return listItem;
     }
     return nullptr;
@@ -1804,6 +1804,11 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
 
 String AccessibilityObject::textContentPrefixFromListMarker() const
 {
+    // The code below creates a VisiblePosition, which is very expensive. Only do this if there's
+    // any chance we're actually associated with a list marker.
+    if (!renderListItemContainer(node()))
+        return { };
+
     // Get the attributed string for range (0, 1) and then delete the last character,
     // in order to extract the list marker that was added as a prefix to the text content.
     std::optional<SimpleRange> firstCharacterRange = rangeForCharacterRange({ 0, 1 });

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1473,7 +1473,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
     auto domOffset = [] (unsigned value) -> uint16_t {
         // It shouldn't be possible for any textbox to have more than 65535 characters.
-        RELEASE_ASSERT(value <= std::numeric_limits<uint16_t>::max());
+        ASSERT(value <= std::numeric_limits<uint16_t>::max());
         return static_cast<uint16_t>(value);
     };
 

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -84,15 +84,17 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject
     if (!end.isValid())
         return nil;
 
+    String listMarkerText = listMarkerTextOnSameLine(start);
+
     if (start.isolatedObject() == end.isolatedObject()) {
         size_t minOffset = std::min(start.offset(), end.offset());
         size_t maxOffset = std::max(start.offset(), end.offset());
         // FIXME: createAttributedString takes a StringView, but we create a full-fledged String. Could we create a
         // new substringView method that returns a StringView?
-        return start.isolatedObject()->createAttributedString(start.runs()->substring(minOffset, maxOffset - minOffset), spellCheck).autorelease();
+        return start.isolatedObject()->createAttributedString(makeString(listMarkerText, start.runs()->substring(minOffset, maxOffset - minOffset)), spellCheck).autorelease();
     }
 
-    RetainPtr<NSMutableAttributedString> result = start.isolatedObject()->createAttributedString(start.runs()->substring(start.offset()), spellCheck);
+    RetainPtr<NSMutableAttributedString> result = start.isolatedObject()->createAttributedString(makeString(listMarkerText, start.runs()->substring(start.offset())), spellCheck);
     auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
         // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
         auto behavior = object.textEmissionBehavior();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -219,12 +219,12 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::HasPlainText, object.hasPlainText());
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     setProperty(AXProperty::HasUnderline, object.hasUnderline());
+    setProperty(AXProperty::TextContentPrefixFromListMarker, object.textContentPrefixFromListMarker());
 #endif
     setProperty(AXProperty::IsKeyboardFocusable, object.isKeyboardFocusable());
     setProperty(AXProperty::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
     setProperty(AXProperty::BrailleLabel, object.brailleLabel().isolatedCopy());
     setProperty(AXProperty::IsNonLayerSVGObject, object.isNonLayerSVGObject());
-    setProperty(AXProperty::TextContentPrefixFromListMarker, object.textContentPrefixFromListMarker());
 
     bool isWebArea = axObject->isWebArea();
     bool isScrollArea = axObject->isScrollView();

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -336,7 +336,7 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     if (!nsRange)
         return nil;
 
-    // If the range spans the beginning of the node, account for the length of the text marker prefix, if any.
+    // If the range spans the beginning of the node, account for the length of the list marker prefix, if any.
     if (!nsRange->location)
         nsRange->length += textContentPrefixFromListMarker().length();
 


### PR DESCRIPTION
#### 59d9f4cbb1bb7aa208717e7a058e57f7e783f2e8
<pre>
AX: It&apos;s not necessary to cache AXProperty::TextContentPrefixFromListMarker when ENABLE(AX_THREAD_TEXT_APIS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290339">https://bugs.webkit.org/show_bug.cgi?id=290339</a>
<a href="https://rdar.apple.com/147780583">rdar://147780583</a>

Reviewed by Chris Fleizach.

We already handled including list marker text as part of AXTextMarkerRange::toString() — this patch extends that to
AXTextMarkerRange::toAttributedString(), fixing accessibility/mac/line-text-marker-range-in-list-item.html. This test
failed after ENABLE(AX_THREAD_TEXT_APIS) was enabled because we didn&apos;t make use of AXProperty::TextContentPrefixFromListMarker.
It&apos;s better to determine this information on-demand off the main-thread rather than eagerly computing it, so this property
is now only cached when !ENABLE(AX_THREAD_TEXT_APIS).

AccessibilityObject::textContentPrefixFromListMarker was also more expensive than it needed to be in the common case
where there is no list marker prefix (e.g. non-list-item text). Specifically, it is expensive because it creates a
VisiblePosition. This function now checks whether we have a RenderListItem ancestor first, then only doing the expensive
work if that&apos;s true. Based on timings gathered from <a href="https://html.spec.whatwg.org">https://html.spec.whatwg.org</a> when we used to try to cache this for
every object, this new implementation is 4.6x times faster.

This commit also has a drive-by change to downgrade a RELEASE_ASSERT in AccessibilityRenderObject::textRuns() to an
ASSERT, since we can probably still continue safely with incorrect behavior in the given condition happens.

The change to stop caching this property saves 2 seconds from building the accessibility tree on <a href="https://html.spec.whatwg.org.">https://html.spec.whatwg.org.</a>

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::textContentPrefixFromListMarker const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
* LayoutTests/accessibility/aria-labelledby-on-password-input.html:
Make this test slightly more async. This test should&apos;ve been more async friendly all along, but we got away with it
based on lucky timing. This patch alters the timing so the test starts failing due to the lack of asynchronously waiting
for the expected changes.

Canonical link: <a href="https://commits.webkit.org/292723@main">https://commits.webkit.org/292723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3cb1ac6f9827c074c029823602ac20ce5ebb920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73735 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82784 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83574 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82171 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4360 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17299 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28938 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->