### PR TITLE
[SwiftUI] Update the set of supported view modifiers on WebView (part 2)

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
@@ -23,19 +23,12 @@
 
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
-import Foundation
+public import Foundation
 internal import WebKit_Internal
 
-extension WebPage {
-    @MainActor
-    @_spi(Private)
-    public struct ElementInfo: Sendable {
-        init(linkURL: URL?) {
-            self.linkURL = linkURL
-        }
-
-        public let linkURL: URL?
-    }
+@_spi(CrossImportOverlay)
+public struct WKContextMenuElementInfoAdapter {
+    public let linkURL: URL?
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -305,7 +305,7 @@ final public class WebPage {
 
 #if os(macOS)
     @_spi(CrossImportOverlay)
-    public func setMenuBuilder(_ menuBuilder: ((WebPage.ElementInfo) -> NSMenu)?) {
+    public func setMenuBuilder(_ menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)?) {
         backingUIDelegate.menuBuilder = menuBuilder
     }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -44,7 +44,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     weak var owner: WebPage? = nil
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
-    var menuBuilder: ((WebPage.ElementInfo) -> NSMenu)? = nil
+    var menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)? = nil
 #endif
 
     private let dialogPresenter: any WebPage.DialogPresenting
@@ -109,7 +109,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
             return menu
         }
 
-        let info = WebPage.ElementInfo(linkURL: element.hitTestResult.absoluteLinkURL)
+        let info = WKContextMenuElementInfoAdapter(linkURL: element.hitTestResult.absoluteLinkURL)
         return menuBuilder(info)
     }
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */; };
 		074F34812CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		075A9CF326169BAB006DFA3A /* MediaSessionCoordinatorProxyPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */; };
+		075C079A2D92125D00B3E900 /* WKContextMenuElementInfoAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */; };
 		076867FF2D4C283E004DA801 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F72D4C26A8004DA801 /* WebViewRepresentable.swift */; };
 		076868022D4C285B004DA801 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F62D4C26A8004DA801 /* WebView.swift */; };
 		076868032D4C2867004DA801 /* View+WebViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */; };
@@ -173,7 +174,6 @@
 		076E884E1A13CADF005E90FC /* APIContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 076E884D1A13CADF005E90FC /* APIContextMenuClient.h */; };
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */; };
-		0784FFCA2D28B5800032E68C /* WebPage+ElementInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */; };
 		0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */; };
 		078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04432CF1149200B453A6 /* URLSchemeHandler.swift */; };
 		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
@@ -3197,6 +3197,7 @@
 		074E76011DF7075D00D318EC /* MediaDeviceSandboxExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaDeviceSandboxExtensions.h; sourceTree = "<group>"; };
 		074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationDeciding.swift"; sourceTree = "<group>"; };
 		074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceTextEffectCoordinator.h; sourceTree = "<group>"; };
+		075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKContextMenuElementInfoAdapter.swift; sourceTree = "<group>"; };
 		076867F42D4C26A8004DA801 /* CocoaWebViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaWebViewAdapter.swift; sourceTree = "<group>"; };
 		076867F52D4C26A8004DA801 /* PlatformTextSearching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTextSearching.swift; sourceTree = "<group>"; };
 		076867F62D4C26A8004DA801 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
@@ -3207,7 +3208,6 @@
 		076E884F1A13CBC6005E90FC /* APIInjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceReplacementTextEffectCoordinator.swift; sourceTree = "<group>"; };
-		0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+ElementInfo.swift"; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
 		078B04432CF1149200B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
@@ -8987,7 +8987,6 @@
 				078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */,
 				076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */,
 				0718F1142D1B57940060C030 /* WebPage+Download.swift */,
-				0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */,
 				078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
@@ -11976,6 +11975,7 @@
 				DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */,
 				5CE0C369229F2D4A003695F0 /* WKContextMenuElementInfo.h */,
 				5CE0C368229F2D4A003695F0 /* WKContextMenuElementInfo.mm */,
+				075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */,
 				5CE0C36B229F2D4B003695F0 /* WKContextMenuElementInfoInternal.h */,
 				5CE0C36A229F2D4A003695F0 /* WKContextMenuElementInfoPrivate.h */,
 				DF0C5F24252ECB8D00D921DB /* WKDownload.h */,
@@ -20532,7 +20532,6 @@
 				078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */,
 				076897EE2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift in Sources */,
 				0718F1152D1B57940060C030 /* WebPage+Download.swift in Sources */,
-				0784FFCA2D28B5800032E68C /* WebPage+ElementInfo.swift in Sources */,
 				078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,
@@ -20556,6 +20555,7 @@
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
 				2D931169212F61B200044BFE /* WKContentView.mm in Sources */,
 				2D93116A212F61B500044BFE /* WKContentViewInteraction.mm in Sources */,
+				075C079A2D92125D00B3E900 /* WKContextMenuElementInfoAdapter.swift in Sources */,
 				0718F1172D1C73450060C030 /* WKDownloadDelegateAdapter.swift in Sources */,
 				637281A321ADC744009E0DE6 /* WKDownloadProgress.mm in Sources */,
 				5CE9120D2293C219005BEC78 /* WKMain.mm in Sources */,

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -78,15 +78,24 @@ extension View {
         transformEnvironment(\.webViewFindContext) { $0.canReplace = !isDisabled }
     }
 
-    @_spi(Private)
-    public nonisolated func webViewContextMenu<M>(@ViewBuilder menuItems: @escaping (WebPage.ElementInfo) -> M) -> some View where M: View {
+    /// Adds an item-based context menu to a WebView, replacing the default set of context menu items.
+    ///
+    /// - Parameters:
+    ///   - menu: A closure that produces the menu. The single parameter to the closure describes the type of webpage element that was acted upon.
+    /// - Returns: A view that can display an item-based context menu.
+    @available(WK_MAC_TBA, *)
+    @available(iOS, unavailable)
+    @available(visionOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func webViewContextMenu(@ViewBuilder menu: @MainActor @escaping (WebView.ActivatedElementInfo) -> some View) -> some View {
 #if os(macOS)
-        let converted = { (info: WebPage.ElementInfo) in
-            let menuView = menuItems(info)
+        let context = ContextMenuContext { info in
+            let menuView = menu(info)
             return NSHostingMenu(rootView: menuView)
         }
 
-        return environment(\.webViewContextMenuContext, .init(menu: converted))
+        return environment(\.webViewContextMenuContext, context)
 #else
         return self
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -138,4 +138,18 @@ extension WebView {
 
         let value: Value
     }
+
+    /// Contains information about an element the user activated in a webpage, which may be used to configure a context menu for that element.
+    /// For links, the information contains the URL that is linked to.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct ActivatedElementInfo: Hashable, Sendable {
+        init(linkURL: URL?) {
+            self.linkURL = linkURL
+        }
+
+        /// The URL of the link that the user clicked.
+        public let linkURL: URL?
+    }
  }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -26,7 +26,7 @@ internal import SwiftUI
 
 struct ContextMenuContext {
 #if os(macOS)
-    let menu: (WebPage.ElementInfo) -> NSMenu
+    let menu: @MainActor (WebView.ActivatedElementInfo) -> NSMenu
 #endif
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -93,7 +93,13 @@ struct WebViewRepresentable {
         context.coordinator.update(platformView, configuration: self, context: context)
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
-        owner.page.setMenuBuilder(environment.webViewContextMenuContext?.menu)
+        if let menu = environment.webViewContextMenuContext?.menu {
+            owner.page.setMenuBuilder {
+                menu(.init(linkURL: $0.linkURL))
+            }
+        } else {
+            owner.page.setMenuBuilder(nil)
+        }
 #endif
     }
 

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -278,6 +278,7 @@ struct ContentView: View {
                 }
                 .scrollBounceBehavior(scrollBounceBehaviorBasedOnSize == true ? .basedOnSize : .automatic)
                 .webViewContentBackground(backgroundHidden == true ? .hidden : .automatic)
+#if os(macOS)
                 .webViewContextMenu { element in
                     if let url = element.linkURL {
                         Button("Open Link in New Window") {
@@ -309,6 +310,7 @@ struct ContentView: View {
                         }
                     }
                 }
+#endif
                 .toolbar {
                     ToolbarItemGroup(placement: Self.navigationToolbarItemPlacement) {
                         ToolbarBackForwardMenuView(


### PR DESCRIPTION
#### 9bc17785e12e3a4073aa04862f811df982d66802
<pre>
[SwiftUI] Update the set of supported view modifiers on WebView (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290343">https://bugs.webkit.org/show_bug.cgi?id=290343</a>
<a href="https://rdar.apple.com/144668661">rdar://144668661</a>

Reviewed by Aditya Keerthi.

Refine the signature of the WebView context menu view modifier.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
(View.webViewContextMenu(@ViewBuilder menu: @MainActor @escaping (WebView.ActivatedElementInfo) -&gt; some View:)):

- Use `some View` instead of a generic, as opaque types are preferred when possible.
- Annotate the closure as `@MainActor`, since it will be invoked on the main actor.
- Use the new `WebView.ActivatedElementInfo` type instead of the prior `WebPage.ElementInfo` type
- Mark the availability as macOS only.

* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:

Add the new `WebView.ActivatedElementInfo` type, which is effectively the same as `WebPage.ElementInfo` was, just renamed.

* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift: Renamed from Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Since the element info type is now part of WebView and not WebPage, it is only accessible by the cross-import overlay.
As a result, an adapter type is needed to be able to communicate back to WebPage from WebView.

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(setMenuBuilder(_:)):
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter.menuBuilder):
(WKUIDelegateAdapter._webView(_:getContextMenuFromProposedMenu:forElement:userInfo:)):
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):

Update the relevant methods and callsites to use the new types.

Canonical link: <a href="https://commits.webkit.org/292708@main">https://commits.webkit.org/292708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f701accfb71dc4b60f988c3520c83a591750b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73707 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83532 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82142 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26794 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17261 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28902 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->