### PR TITLE
[visionOS] Remove obsolete canImport(LinearMediaKit, _version: ...) checks

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/LinearMediaKit.swiftinterface
+++ b/Source/WebKit/Platform/spi/visionos/LinearMediaKit.swiftinterface
@@ -1,18 +1,23 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -library-level spi -enable-bare-slash-regex -user-module-version 199.100.12 -module-name LinearMediaKit
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -library-level spi -enable-bare-slash-regex -user-module-version 211.60.12 -module-name LinearMediaKit
 
 import _Concurrency
 import Combine
+import CoreMedia
 import Foundation
-@_spi(RealityKit) @_spi(Private) import RealityFoundation
+import QuartzCore
+import RealityFoundation
 import Swift
 import UIKit
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+//import XPC
 
 @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(LMPlayableViewController) @_Concurrency.MainActor(unsafe) public class PlayableViewController : UIKit.UIViewController {
-@_Concurrency.MainActor(unsafe) public var prefersAutoDimming: Swift.Bool {
-  get
-  set
-}
+  public var playable: (any LinearMediaKit.Playable)? { get set }
+  public var prefersAutoDimming: Swift.Bool { get set }
+  public var automaticallyDockOnFullScreenPresentation: Swift.Bool { get set }
+  public var dismissFullScreenOnExitingDocking: Swift.Bool { get set }
+  public var environmentPickerButtonViewController: UIKit.UIViewController? { get }
 }
 public enum ContentType : Swift.Equatable, Swift.CaseIterable, Swift.Codable, Swift.Sendable {
  case immersive
@@ -30,6 +35,8 @@ public enum ContentType : Swift.Equatable, Swift.CaseIterable, Swift.Codable, Sw
    get
  }
  public init(from decoder: any Swift.Decoder) throws
+ public static func makeEntity(captionLayer: QuartzCore.CALayer) -> RealityFoundation.Entity?
+ public static func makeSpatialEntity(videoMetadata: LinearMediaKit.SpatialVideoMetadata?, extruded: Swift.Bool = true) -> (any RealityFoundation.Entity & LinearMediaKit.Peculiarable)?
 }
 public enum PresentationMode {
  case inline
@@ -69,6 +76,21 @@ public enum ViewingMode {
    get
  }
 }
+public struct SeekMetadata {
+  public enum Origin {
+    case user
+    public static func == (a: LinearMediaKit.SeekMetadata.Origin, b: LinearMediaKit.SeekMetadata.Origin) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public let origin: LinearMediaKit.SeekMetadata.Origin
+  public init(origin: LinearMediaKit.SeekMetadata.Origin)
+}
+public protocol Track : AnyObject {
+  var localizedDisplayName: Swift.String { get }
+}
 public enum PeculiarMode {
  case portal
  case immersive
@@ -78,6 +100,15 @@ public enum PeculiarMode {
    get
  }
 }
+public struct SpatialVideoMetadata {
+  public init(width: Swift.Int32, height: Swift.Int32, horizontalFOVDegrees: Swift.Float, baseline: Swift.Float, disparityAdjustment: Swift.Float, isRecommendedForImmersive: Swift.Bool)
+  public var width: Swift.Int32
+  public var height: Swift.Int32
+  public var horizontalFOVDegrees: Swift.Float
+  public var baseline: Swift.Float
+  public var disparityAdjustment: Swift.Float
+  public var isRecommendedForImmersive: Swift.Bool
+}
 public protocol Peculiarable {
  func setScreen(width: Swift.Float, height: Swift.Float)
  var screenMode: LinearMediaKit.PeculiarMode { get set }
@@ -85,6 +116,9 @@ public protocol Peculiarable {
  var screenGUIDPublisher: Combine.AnyPublisher<Swift.UInt64?, Swift.Never> { get }
  var shouldDisplayThumbnail: Swift.Bool { get }
  var preferStereoPlayback: Swift.Bool { get set }
+ func setVideoMetaData(to: LinearMediaKit.SpatialVideoMetadata?)
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+// var videoReceiverEndpointPublisher: Combine.AnyPublisher<XPC.xpc_object_t?, Swift.Never> { get }
 }
 public typealias PeculiarEntity = RealityFoundation.Entity & LinearMediaKit.Peculiarable
 public enum ContentMode : Swift.Int, Swift.CaseIterable {
@@ -149,4 +183,113 @@ public struct FullscreenBehaviors : Swift.OptionSet, Swift.CustomStringConvertib
  public typealias ArrayLiteralElement = LinearMediaKit.FullscreenBehaviors
  public typealias Element = LinearMediaKit.FullscreenBehaviors
  public typealias RawValue = Swift.Int
+}
+public protocol Playable : AnyObject {
+ var presentationModePublisher: Combine.AnyPublisher<LinearMediaKit.PresentationMode, Swift.Never> { get }
+ func makeDefaultEntity() -> RealityFoundation.Entity?
+ func updateRenderingConfiguration(_ config: LinearMediaKit.RenderingConfiguration)
+ var errorPublisher: Combine.AnyPublisher<(any Swift.Error)?, Swift.Never> { get }
+ var isLoadingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ @available(*, deprecated, message: "Replaced by 'playbackRatePublisher'")
+ var isPlayingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var playbackRatePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ var selectedPlaybackRatePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ var playbackRatesPublisher: Combine.AnyPublisher<[Swift.Double], Swift.Never> { get }
+ var requiresLinearPlaybackPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var canTogglePlaybackPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var showsPlaybackControlsPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func play()
+ func pause()
+ func togglePlayback()
+ func setPlaybackRate(_ rate: Swift.Double)
+ var interstitialRangesPublisher: Combine.AnyPublisher<[Swift.Range<Foundation.TimeInterval>], Swift.Never> { get }
+ var isInterstitialActivePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func skipActiveInterstitial()
+ var currentTimePublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ var remainingTimePublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ var durationPublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ func setTimeResolverInterval(_ interval: Foundation.TimeInterval)
+ func setTimeResolverResolution(_ resolution: Swift.Double)
+ var thumbnailLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ var thumbnailMaterialPublisher: Combine.AnyPublisher<RealityFoundation.VideoMaterial?, Swift.Never> { get }
+ func setThumbnailSize(_ size: CoreFoundation.CGSize)
+ func seekThumbnail(to time: Foundation.TimeInterval)
+ var captionLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ @available(*, deprecated, message: "Use captionContentInsetsPublisher and setCaptionContentInsets instead.")
+ var captionContentInsets: UIKit.UIEdgeInsets { get set }
+ var captionContentInsetsPublisher: Combine.AnyPublisher<UIKit.UIEdgeInsets, Swift.Never> { get }
+ func setCaptionContentInsets(_ insets: UIKit.UIEdgeInsets)
+ var isSeekingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var canSeekPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var seekableTimeRangesPublisher: Combine.AnyPublisher<[Swift.ClosedRange<Foundation.TimeInterval>], Swift.Never> { get }
+ @available(*, deprecated, message: "Replace with seek(to:from:metadata:)")
+ func seek(to time: Foundation.TimeInterval)
+ @available(*, deprecated, message: "Replace with seek(to:from:metadata:)")
+ func seek(delta: Foundation.TimeInterval)
+ func seek(to destination: Foundation.TimeInterval, from source: Foundation.TimeInterval, metadata: LinearMediaKit.SeekMetadata) -> Foundation.TimeInterval
+ func beginScrubbing()
+ func endScrubbing()
+ var canScanForwardPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func beginScanningForward()
+ func endScanningForward()
+ var canScanBackwardPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func beginScanningBackward()
+ func endScanningBackward()
+ var isTrimmingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var forwardPlaybackEndTimePublisher: Combine.AnyPublisher<CoreMedia.CMTime?, Swift.Never> { get }
+ var reversePlaybackEndTimePublisher: Combine.AnyPublisher<CoreMedia.CMTime?, Swift.Never> { get }
+ var trimViewPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ func completeTrimming(commitChanges: Swift.Bool)
+ func updateStartTime(_ time: Foundation.TimeInterval)
+ func updateEndTime(_ time: Foundation.TimeInterval)
+ var contentTypePublisher: Combine.AnyPublisher<LinearMediaKit.ContentType?, Swift.Never> { get }
+ var contentMetadataPublisher: Combine.AnyPublisher<LinearMediaKit.ContentMetadataContainer, Swift.Never> { get }
+ var artworkPublisher: Combine.AnyPublisher<Foundation.Data?, Swift.Never> { get }
+ var isPlayableOfflinePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var contentInfoViewControllersPublisher: Combine.AnyPublisher<[UIKit.UIViewController], Swift.Never> { get }
+ var contextualActionsPublisher: Combine.AnyPublisher<[UIKit.UIAction], Swift.Never> { get }
+ var contextualActionsInfoViewPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ var transportBarIncludesTitleViewPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var contentDimensionsPublisher: Combine.AnyPublisher<CoreFoundation.CGSize, Swift.Never> { get }
+ var contentModePublisher: Combine.AnyPublisher<LinearMediaKit.ContentMode, Swift.Never> { get }
+ var videoLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ var videoMaterialPublisher: Combine.AnyPublisher<RealityFoundation.VideoMaterial?, Swift.Never> { get }
+ @available(*, deprecated, message: "Will be removed during seed -1")
+ var peculiarEntityPublisher: Combine.AnyPublisher<(any RealityFoundation.Entity & LinearMediaKit.Peculiarable)?, Swift.Never> { get }
+ func updateVideoBounds(_ bounds: CoreFoundation.CGRect)
+ var anticipatedViewingModePublisher: Combine.AnyPublisher<LinearMediaKit.ViewingMode?, Swift.Never> { get }
+ func updateViewingMode(_ viewingMode: LinearMediaKit.ViewingMode?)
+ var contentOverlayPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ var contentOverlayViewControllerPublisher: Combine.AnyPublisher<UIKit.UIViewController?, Swift.Never> { get }
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+// func setVideoReceiverEndpoint(_ endpoint: XPC.xpc_object_t)
+ var volumePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ func setVolume(_ volume: Swift.Double)
+ func beginEditingVolume()
+ func endEditingVolume()
+ var isMutedPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func setIsMuted(_ value: Swift.Bool)
+ var sessionDisplayTitlePublisher: Combine.AnyPublisher<Swift.String?, Swift.Never> { get }
+ var sessionThumbnailPublisher: Combine.AnyPublisher<UIKit.UIImage?, Swift.Never> { get }
+ var isSessionExtendedPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var hasAudioContentPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var currentAudioTrackPublisher: Combine.AnyPublisher<(any LinearMediaKit.Track)?, Swift.Never> { get }
+ var audioTracksPublisher: Combine.AnyPublisher<[any LinearMediaKit.Track]?, Swift.Never> { get }
+ func setAudioTrack(_ newTrack: (any LinearMediaKit.Track)?)
+ var currentLegibleTrackPublisher: Combine.AnyPublisher<(any LinearMediaKit.Track)?, Swift.Never> { get }
+ var legibleTracksPublisher: Combine.AnyPublisher<[any LinearMediaKit.Track]?, Swift.Never> { get }
+ func setLegibleTrack(_ newTrack: (any LinearMediaKit.Track)?)
+ var allowPipPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func togglePip()
+ func toggleInlineMode()
+ var allowFullScreenFromInlinePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var isLiveStreamPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var startDatePublisher: Combine.AnyPublisher<Foundation.Date, Swift.Never> { get }
+ var endDatePublisher: Combine.AnyPublisher<Foundation.Date, Swift.Never> { get }
+ var recommendedViewingRatioPublisher: Combine.AnyPublisher<Swift.Double?, Swift.Never> { get }
+ var fullscreenSceneBehaviorsPublisher: Combine.AnyPublisher<[LinearMediaKit.FullscreenBehaviors], Swift.Never> { get }
+ func willEnterFullscreen()
+ func didCompleteEnterFullscreen(result: Swift.Result<Swift.Void, any Swift.Error>)
+ func willExitFullscreen()
+ func didCompleteExitFullscreen(result: Swift.Result<Swift.Void, any Swift.Error>)
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7230,6 +7230,8 @@
 		A188D2E22B6B0F4E00E65A08 /* WKVisibilityPropagationView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKVisibilityPropagationView.h; path = ios/WKVisibilityPropagationView.h; sourceTree = "<group>"; };
 		A188D2E32B6B0F4E00E65A08 /* WKVisibilityPropagationView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVisibilityPropagationView.mm; path = ios/WKVisibilityPropagationView.mm; sourceTree = "<group>"; };
 		A19DD3BF1D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebViewPrintFormatterInternal.h; sourceTree = "<group>"; };
+		A1A207432D8A7A92003B1A13 /* LinearMediaKit.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = LinearMediaKit.swiftinterface; sourceTree = "<group>"; };
+		A1A207442D8A7A92003B1A13 /* QuickLook_SPI.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = QuickLook_SPI.swiftinterface; sourceTree = "<group>"; };
 		A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownload.h; sourceTree = "<group>"; };
 		A1A4FE5818DCE9FA00B5EA8A /* _WKDownload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKDownload.mm; sourceTree = "<group>"; };
 		A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadInternal.h; sourceTree = "<group>"; };
@@ -16292,7 +16294,9 @@
 		E5BF52E02A44A5D9005B2848 /* visionos */ = {
 			isa = PBXGroup;
 			children = (
+				A1A207432D8A7A92003B1A13 /* LinearMediaKit.swiftinterface */,
 				E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */,
+				A1A207442D8A7A92003B1A13 /* QuickLook_SPI.swiftinterface */,
 				E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */,
 				DD6E58C42BE004DE0000C264 /* RealitySystemSupportSPI.h */,
 			);

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
@@ -34,40 +34,24 @@ import UIKit
 @objc extension PlayableViewController {
     var wks_automaticallyDockOnFullScreenPresentation: Bool {
         get {
-#if canImport(LinearMediaKit, _version: 211.0.2)
             self.automaticallyDockOnFullScreenPresentation
-#else
-            false
-#endif
         }
         set {
-#if canImport(LinearMediaKit, _version: 211.0.2)
             self.automaticallyDockOnFullScreenPresentation = newValue
-#endif
         }
     }
 
     var wks_dismissFullScreenOnExitingDocking: Bool {
         get {
-#if canImport(LinearMediaKit, _version: 211.0.2)
             self.dismissFullScreenOnExitingDocking
-#else
-            false
-#endif
         }
         set {
-#if canImport(LinearMediaKit, _version: 211.0.2)
             self.dismissFullScreenOnExitingDocking = newValue
-#endif
         }
     }
 
     var wks_environmentPickerButtonViewController: UIViewController? {
-#if canImport(LinearMediaKit, _version: 211.0.2)
         self.environmentPickerButtonViewController
-#else
-        nil
-#endif
     }
 }
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -132,9 +132,7 @@ enum LinearMediaPlayerErrors: Error {
         get { swiftOnlyData.spatialVideoMetadata }
         set {
             swiftOnlyData.spatialVideoMetadata = newValue
-#if canImport(LinearMediaKit, _version: 211.60.3)
             swiftOnlyData.peculiarEntity?.setVideoMetaData(to: swiftOnlyData.spatialVideoMetadata?.metadata)
-#endif
         }
     }
     var isImmersiveVideo: Bool {
@@ -194,9 +192,7 @@ enum LinearMediaPlayerErrors: Error {
         Logger.linearMediaPlayer.log("\(#function)")
 
         let viewController = PlayableViewController()
-#if canImport(LinearMediaKit, _version: 205)
         viewController.playable = self
-#endif
         viewController.prefersAutoDimming = true
         return viewController
     }
@@ -298,7 +294,6 @@ extension WKSLinearMediaPlayer {
     }
 
     private func maybeCreateSpatialOrImmersiveEntity() {
-#if canImport(LinearMediaKit, _version: 211.60.3)
         if swiftOnlyData.enteredFromInline || swiftOnlyData.peculiarEntity != nil || contentType == .immersive { return }
         if swiftOnlyData.isImmersiveVideo {
             contentType = .immersive
@@ -307,12 +302,14 @@ extension WKSLinearMediaPlayer {
         guard let metadata = swiftOnlyData.spatialVideoMetadata else { return }
         swiftOnlyData.peculiarEntity = ContentType.makeSpatialEntity(videoMetadata: metadata.metadata, extruded: true)
         swiftOnlyData.peculiarEntity?.screenMode = spatialImmersive ? .immersive : .portal;
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+#if canImport(XPC)
         swiftOnlyData.videoReceiverEndpointObserver = swiftOnlyData.peculiarEntity?.videoReceiverEndpointPublisher.sink {
             [weak self] in guard let endpoint = $0 else { return }
             self?.setVideoReceiverEndpoint(endpoint)
         }
-        contentType = .spatial
 #endif
+        contentType = .spatial
     }
 
     private func maybeClearSpatialOrImmersiveEntity() {
@@ -320,16 +317,12 @@ extension WKSLinearMediaPlayer {
             contentType = .none
             return
         }
-#if canImport(LinearMediaKit, _version: 211.60.3)
         if swiftOnlyData.peculiarEntity == nil { return }
         swiftOnlyData.videoReceiverEndpointObserver = nil;
         swiftOnlyData.peculiarEntity = nil;
         contentType = .none; // this causes a call to makeDefaultEntity
-#endif
     }
 }
-
-#if canImport(LinearMediaKit, _version: 205)
 
 @_spi(Internal) extension WKSLinearMediaPlayer: @retroactive Playable {
     public var selectedPlaybackRatePublisher: AnyPublisher<Double, Never> {
@@ -758,7 +751,6 @@ extension WKSLinearMediaPlayer {
     public func makeDefaultEntity() -> Entity? {
         Logger.linearMediaPlayer.log("\(#function)")
 
-#if canImport(LinearMediaKit, _version: 211.60.3)
         // This gets called from maybeCreateSpatialOrImmersiveEntity through the KVO when setting
         // peculiarEntity. As such, we can't check if the peculiarEntity is set or not.
         // We will return nil here on the first call and will get call back again once
@@ -766,7 +758,6 @@ extension WKSLinearMediaPlayer {
         if swiftOnlyData.spatialVideoMetadata != nil && !swiftOnlyData.enteredFromInline {
             return swiftOnlyData.peculiarEntity
         }
-#endif
         if let captionLayer {
             let entity = ContentType.makeEntity(captionLayer: captionLayer)
             swiftOnlyData.defaultEntity = entity
@@ -838,12 +829,13 @@ extension WKSLinearMediaPlayer {
         delegate?.linearMediaPlayer?(self, setMuted: value)
     }
 
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+#if canImport(XPC)
     public func setVideoReceiverEndpoint(_ endpoint: xpc_object_t) {
         Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayer?(self, setVideoReceiverEndpoint: endpoint)
     }
+#endif
 }
-
-#endif // canImport(LinearMediaKit, _version: 205)
 
 #endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -235,17 +235,13 @@ extension WKSLinearMediaTimeRange {
     }
 }
 
-#if canImport(LinearMediaKit, _version: 205)
 @_spi(Internal) extension WKSLinearMediaTrack: @retroactive Track {
 }
-#endif
 
 extension WKSLinearMediaSpatialVideoMetadata {
-#if canImport(LinearMediaKit, _version: 211.60.3)
     var metadata: SpatialVideoMetadata {
         return SpatialVideoMetadata(width: self.width, height: self.height, horizontalFOVDegrees: self.horizontalFOVDegrees, baseline: self.baseline, disparityAdjustment: self.disparityAdjustment, isRecommendedForImmersive: true)
     }
-#endif
 }
 
 #endif // os(visionOS)

--- a/WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd
+++ b/WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd
@@ -96,5 +96,14 @@ exports:
                 _$s14LinearMediaKit8PlayablePAAE18overScenePublisher7Combine03AnyG0VySo7UISceneCSgSgs5NeverOGvg, _$s14LinearMediaKit8PlayablePAAE19videoAssetPublisher7Combine03AnyG0Vys13OpaquePointerVSgs5NeverOGvg,
                 _$s14LinearMediaKit8PlayablePAAE28fullscreenPlacementPublisher7Combine03AnyG0VyAA010FullscreenF0Os5NeverOGvg,
                 _$s14LinearMediaKit8PlayablePAAE29allowSceneAdjustmentPublisher7Combine03AnyH0VySbs5NeverOGvg, _$s14LinearMediaKit8PlayablePAAE35interstitialTimelineRangesPublisher7Combine03AnyH0VySaySNySdGGs5NeverOGvg,
-                _$s14LinearMediaKit8PlayablePAAE8setMuted_8metadataySb_AA12MuteMetadataVtF]
+                _$s14LinearMediaKit8PlayablePAAE8setMuted_8metadataySb_AA12MuteMetadataVtF,
+                _$s14LinearMediaKit11ContentTypeO17makeSpatialEntity13videoMetadata8extrudedAA12Peculiarable_07RealityC00H0CXcSgAA0g5VideoJ0VSg_SbtFZ,
+                _$s14LinearMediaKit12PeculiarModeO6portalyA2CmFWC,
+                _$s14LinearMediaKit12PeculiarModeO9immersiveyA2CmFWC,
+                _$s14LinearMediaKit12PeculiarModeOMa,
+                _$s14LinearMediaKit12PeculiarableP10screenModeAA08PeculiarF0OvsTj,
+                _$s14LinearMediaKit12PeculiarableP16setVideoMetaData2toyAA07SpatialF8MetadataVSg_tFTj,
+                _$s14LinearMediaKit20SpatialVideoMetadataVMa,
+                _$s14LinearMediaKit20SpatialVideoMetadataVMn,
+                _$s14LinearMediaKit20SpatialVideoMetadataV5width6height20horizontalFOVDegrees8baseline19disparityAdjustment25isRecommendedForImmersiveACs5Int32V_AKS3fSbtcfC]
 ...


### PR DESCRIPTION
#### d524e6a77542baff543f1c3f3ec895f81c67b5e6
<pre>
[visionOS] Remove obsolete canImport(LinearMediaKit, _version: ...) checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=290349">https://bugs.webkit.org/show_bug.cgi?id=290349</a>
<a href="https://rdar.apple.com/147787761">rdar://147787761</a>

Reviewed by Jer Noble.

The earliest version of visionOS supported by main is visionOS 2.2, whose SDK contains all
LinearMediaKit symbols currently used by WebKit. As such, this PR removes all
canImport(LinearMediaKit, _version: ...) checks and declares the interfaces and symbols we use in
LinearMediaKit.swiftinterface and LinearMediaKit.tbd, respectively.

Since LinearMediaKit uses private symbols from XPC on visionOS, this also adds FIXMEs for
introducing an XPC module that can be imported in Public SDK builds.

* Source/WebKit/Platform/spi/visionos/LinearMediaKit.swiftinterface:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift:
(PlayableViewController.wks_automaticallyDockOnFullScreenPresentation):
(PlayableViewController.wks_dismissFullScreenOnExitingDocking):
(PlayableViewController.wks_environmentPickerButtonViewController):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.spatialVideoMetadata):
(WKSLinearMediaPlayer.makeViewController):
(WKSLinearMediaPlayer.maybeCreateSpatialOrImmersiveEntity):
(WKSLinearMediaPlayer.maybeClearSpatialOrImmersiveEntity):
(WKSLinearMediaPlayer.makeDefaultEntity):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSLinearMediaSpatialVideoMetadata.metadata):
* WebKitLibraries/SDKs/xros2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd:

Canonical link: <a href="https://commits.webkit.org/292765@main">https://commits.webkit.org/292765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732a4c9b14982188a229b5e0a6394e26cb8971c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47146 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24674 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73634 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30857 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12193 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82685 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24056 "Hash 732a4c9b for PR 42964 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83420 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82060 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20718 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28811 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->