### PR TITLE
[WTF] Use dataLogLnIf and if constexpr for cleaner debug logging in NaturalLoops

### DIFF
--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/DataLog.h>
 #include <wtf/Dominators.h>
 
 namespace WTF {
@@ -128,8 +129,8 @@ public:
     
         static constexpr bool verbose = false;
     
-        if (verbose) {
-            dataLog("Dominators:\n");
+        if constexpr (verbose) {
+            dataLogLn("Dominators:");
             dominators.dump(WTF::dataFile());
         }
     
@@ -161,9 +162,8 @@ public:
                 m_loops.append(loop);
             }
         }
-    
-        if (verbose)
-            dataLog("After bootstrap: ", *this, "\n");
+
+        dataLogLnIf(verbose, "After bootstrap: ", *this);
     
         FastBitVector seenBlocks;
         Vector<typename Graph::Node, 4> blockWorklist;
@@ -175,8 +175,7 @@ public:
             seenBlocks.clearAll();
             ASSERT(blockWorklist.isEmpty());
         
-            if (verbose)
-                dataLog("Dealing with loop ", loop, "\n");
+            dataLogLnIf(verbose, "Dealing with loop ", loop);
         
             for (unsigned j = loop.size(); j--;) {
                 seenBlocks[graph.index(loop[j])] = true;
@@ -186,8 +185,7 @@ public:
             while (!blockWorklist.isEmpty()) {
                 typename Graph::Node block = blockWorklist.takeLast();
             
-                if (verbose)
-                    dataLog("    Dealing with ", graph.dump(block), "\n");
+                dataLogLnIf(verbose, "    Dealing with ", graph.dump(block));
             
                 if (block == loop.header())
                     continue;
@@ -263,8 +261,7 @@ public:
             }
         }
     
-        if (verbose)
-            dataLog("Results: ", *this, "\n");
+        dataLogLnIf(verbose, "Results: ", *this);
     }
     
     Graph& graph() { return m_graph; }
@@ -287,10 +284,10 @@ public:
             return nullptr;
         if (loop->header() == block)
             return loop;
-        if (ASSERT_ENABLED) {
-            for (; loop; loop = innerMostOuterLoop(*loop))
-                ASSERT(loop->header() != block);
-        }
+#if ASSERT_ENABLED
+        for (; loop; loop = innerMostOuterLoop(*loop))
+            ASSERT(loop->header() != block);
+#endif
         return nullptr;
     }
     


### PR DESCRIPTION
#### 7aef9de3174653eff3bfc019eac2e3321cc8aff8
<pre>
[WTF] Use dataLogLnIf and if constexpr for cleaner debug logging in NaturalLoops
<a href="https://bugs.webkit.org/show_bug.cgi?id=290351">https://bugs.webkit.org/show_bug.cgi?id=290351</a>
<a href="https://rdar.apple.com/147789431">rdar://147789431</a>

Reviewed by Yusuke Suzuki.

Refactors verbose debug logging in NaturalLoops to use dataLogLnIf(...) and
if constexpr for improved clarity and potential compile-time dead-code elimination.

1. Replaces if (verbose) with if constexpr (verbose) or dataLogLnIf(verbose, ...) as appropriate.
2. Improves readability of debug logic while maintaining existing behavior.
3. Replaces if (ASSERT_ENABLED) with #if ASSERT_ENABLED for better clarity and dead-code pruning.

* Source/WTF/wtf/DataLog.h:
(WTF::dataLogLnIfConstexpr):
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoops::NaturalLoops):
(WTF::NaturalLoops::headerOf const):

Canonical link: <a href="https://commits.webkit.org/292635@main">https://commits.webkit.org/292635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d612493dab89dd8da01bb01509cd2a0815c845e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24712 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99664 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/12226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/5215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46509 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89334 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103757 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95282 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23979 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/83468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/26748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15563 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23691 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118908 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23350 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->