### PR TITLE
[WebDriver][BiDi] Add support to relay commands with new processBidiMessage and bidiMessageSent in Source/WebDriver

### DIFF
--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -49,7 +49,7 @@ class SessionHost;
 
 class Session :
 #if ENABLE(WEBDRIVER_BIDI)
-public BiDiEventHandler // Inherits RefCounted
+public BidiMessageHandler // Inherits RefCounted
 #else
 public RefCounted<Session>
 #endif
@@ -159,7 +159,8 @@ public:
 #if ENABLE(WEBDRIVER_BIDI)
     void enableGlobalEvent(const String&);
     void disableGlobalEvent(const String&);
-    void dispatchEvent(RefPtr<JSON::Object>&&);
+    void dispatchBidiMessage(RefPtr<JSON::Object>&&);
+    void relayBidiCommand(const String&, unsigned commandId, Function<void(WebSocketMessageHandler::Message&&)>&&);
 #endif
 
 private:

--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SessionHost.h"
 
+#include "Logging.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Observer.h>
 #include <wtf/WeakHashSet.h>
@@ -78,6 +79,7 @@ long SessionHost::sendCommandToBackend(const String& command, RefPtr<JSON::Objec
 
 void SessionHost::dispatchMessage(const String& message)
 {
+    LOG(SessionHost, "SessionHost::dispatchMessage: %s", message.utf8().data());
     auto messageValue = JSON::Value::parseJSON(message);
     if (!messageValue)
         return;
@@ -88,8 +90,15 @@ void SessionHost::dispatchMessage(const String& message)
 
     auto sequenceID = messageObject->getInteger("id"_s);
     if (!sequenceID) {
+        auto method = messageObject->getString("method"_s);
+        if (method == "Automation.browsingContextCleared"_s)
+            return;
 #if ENABLE(WEBDRIVER_BIDI)
-        dispatchEvent(WTFMove(messageObject));
+        if (method != "Automation.bidiMessageSent"_s)
+            return;
+        dispatchBidiMessage(WTFMove(messageObject));
+#else
+        RELEASE_LOG_ERROR(SessionHost, "Received from browser message without id: %s", message.utf8().data());
 #endif
         return;
     }
@@ -126,10 +135,13 @@ void SessionHost::removeBrowserTerminatedObserver(const BrowserTerminatedObserve
     browserTerminatedObservers().remove(observer);
 }
 
-void SessionHost::dispatchEvent(RefPtr<JSON::Object>&& event)
+void SessionHost::dispatchBidiMessage(RefPtr<JSON::Object>&& event)
 {
-    if (m_eventHandler)
-        m_eventHandler->dispatchEvent(WTFMove(event));
+    LOG(WebDriverBiDi, "SessionHost::dispatchBidiMessage: %s", event->toJSONString().utf8().data());
+    if (m_bidiHandler)
+        m_bidiHandler->dispatchBidiMessage(WTFMove(event));
+    else
+        RELEASE_LOG(SessionHost, "No bidi message handler to dispatch message %s", event->toJSONString().utf8().data());
 }
 #endif
 

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -50,10 +50,10 @@ namespace WebDriver {
 struct ConnectToBrowserAsyncData;
 
 #if ENABLE(WEBDRIVER_BIDI)
-class BiDiEventHandler : public CanMakeWeakPtr<BiDiEventHandler>, public RefCounted<BiDiEventHandler> {
+class BidiMessageHandler : public CanMakeWeakPtr<BidiMessageHandler>, public RefCounted<BidiMessageHandler> {
 public:
-    virtual ~BiDiEventHandler() = default;
-    virtual void dispatchEvent(RefPtr<JSON::Object>&&) = 0;
+    virtual ~BidiMessageHandler() = default;
+    virtual void dispatchBidiMessage(RefPtr<JSON::Object>&&) = 0;
 };
 #endif
 
@@ -97,7 +97,7 @@ public:
     long sendCommandToBackend(const String&, RefPtr<JSON::Object>&& parameters, Function<void (CommandResponse&&)>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    void addEventHandler(WeakPtr<BiDiEventHandler>&& handler) { m_eventHandler = WTFMove(handler); }
+    void setBidiHandler(WeakPtr<BidiMessageHandler>&& handler) { m_bidiHandler = WTFMove(handler); }
 #endif
 
 private:
@@ -117,7 +117,7 @@ private:
     void sendMessageToBackend(const String&);
     void dispatchMessage(const String&);
 #if ENABLE(WEBDRIVER_BIDI)
-    void dispatchEvent(RefPtr<JSON::Object>&&);
+    void dispatchBidiMessage(RefPtr<JSON::Object>&&);
 #endif
 
 #if USE(GLIB)
@@ -153,7 +153,7 @@ private:
     HashMap<long, Function<void (CommandResponse&&)>> m_commandRequests;
 
 #if ENABLE(WEBDRIVER_BIDI)
-    WeakPtr<BiDiEventHandler> m_eventHandler;
+    WeakPtr<BidiMessageHandler> m_bidiHandler;
 #endif
 
     String m_targetIp;

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -134,7 +134,6 @@ private:
     void takeElementScreenshot(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    // BiDi message handlers
     void bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
     void bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
     void bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&&, Function<void (WebSocketMessageHandler::Message&&)>&&);
@@ -171,7 +170,7 @@ private:
         BidiCommandHandler handler;
     };
     static const BidiCommand s_bidiCommands[];
-    static bool findBidiCommand(RefPtr<JSON::Value>&, BidiCommandHandler*, unsigned& id, RefPtr<JSON::Object>& parsedParams);
+    static bool findBidiCommand(const RefPtr<JSON::Object>&, BidiCommandHandler*, RefPtr<JSON::Object>& parsedParams);
 #endif // ENABLE(WEBDRIVER_BIDI)
 
     HTTPServer m_server;

--- a/Source/WebDriver/WebSocketServer.h
+++ b/Source/WebDriver/WebSocketServer.h
@@ -132,7 +132,8 @@ public:
     String getResourceName(const String& sessionId);
     String getWebSocketURL(const RefPtr<WebSocketListener>, const String& sessionId);
     String getSessionID(const String& resource);
-    void sendMessage(const String& session, const String& message);
+    void sendMessage(const String& sessionId, const String& message);
+    void sendErrorResponse(const String& sessionId, std::optional<unsigned> commandId, CommandResult::ErrorCode, const String& errorMessage, std::optional<String> stacktrace = std::nullopt);
 
     // Non-spec method
     void removeResourceForSession(const String& sessionId);
@@ -141,6 +142,8 @@ public:
 private:
     explicit WebSocketServer(WebSocketMessageHandler&);
 
+    void sendMessage(WebSocketMessageHandler::Connection, const String& message);
+    void sendErrorResponse(WebSocketMessageHandler::Connection, std::optional<unsigned> commandId, CommandResult::ErrorCode, const String& errorMessage, std::optional<String> stacktrace = std::nullopt);
     WebSocketMessageHandler& m_messageHandler;
     String m_listenerURL;
     RefPtr<WebSocketListener> m_listener;

--- a/Source/WebDriver/soup/WebSocketServerSoup.cpp
+++ b/Source/WebDriver/soup/WebSocketServerSoup.cpp
@@ -171,20 +171,17 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
 #endif
 }
 
-void WebSocketServer::sendMessage(const String& session, const String& message)
+void WebSocketServer::sendMessage(WebSocketMessageHandler::Connection connection, const String& message)
 {
 #if USE(SOUP2)
-    UNUSED_PARAM(session);
+    UNUSED_PARAM(connection);
     UNUSED_PARAM(message);
     RELEASE_LOG(WebDriverBiDi, "WebSockets support not implemented yet with libsoup2");
 #else
-    for (const auto& pair : m_connectionToSession) {
-        if (pair.value == session) {
-            GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.utf8().data(), message.utf8().length()));
-            soup_websocket_connection_send_message(pair.key.get(), SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
-            return;
-        }
-    }
+    ASSERT(connection);
+    RELEASE_LOG(WebDriverBiDi, "Sending message: %s", message.utf8().data());
+    GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.utf8().data(), message.utf8().length()));
+    soup_websocket_connection_send_message(connection.get(), SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -935,18 +935,6 @@
             ]
         },
         {
-            "name": "logEntryAdded",
-            "description": "Fired when a new log entry is added.",
-            "parameters": [
-                { "name": "level", "type": "string", "description": "The log entry level." },
-                { "name": "source", "type": "string", "description": "The source script information" },
-                { "name": "text", "type": "string", "description": "The log entry text message." },
-                { "name": "timestamp", "type": "number", "description": "The timestamp of the log entry." },
-                { "name": "type", "type": "string", "description": "The log entry type." },
-                { "name": "method", "type": "string", "optional": true, "description": "The log entry console method."}
-            ]
-        },
-        {
             "name": "bidiMessageSent",
             "description": "Relay a WebDriver Bidi message from the automation session to be processed by the client.",
             "condition": "ENABLE(WEBDRIVER_BIDI)",

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2504,6 +2504,7 @@ Ref<WebAutomationSession::Debuggable> WebAutomationSession::protectedDebuggable(
 }
 #endif
 
+#if ENABLE(WEBDRIVER_BIDI)
 static String logEntryLevelForMessage(const JSC::MessageType& messageType, const MessageLevel& messageLevel)
 {
     if (messageType == JSC::MessageType::Assert || messageLevel == JSC::MessageLevel::Error)
@@ -2536,9 +2537,11 @@ static String logEntryTypeForMessage(const JSC::MessageSource& messageSource)
         return "javascript"_s;
     return "console"_s;
 }
+#endif // ENABLE(WEBDRIVER_BIDI)
 
 void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource, const JSC::MessageLevel& messageLevel, const String& messageText, const JSC::MessageType& messageType, const WallTime& timestamp)
 {
+#if ENABLE(WEBDRIVER_BIDI)
     // FIXME Support getting source information
     // https://bugs.webkit.org/show_bug.cgi?id=282978
     String sourceString;
@@ -2550,9 +2553,13 @@ void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource
 
     // FIXME Get browsing context handle and source info
     // https://bugs.webkit.org/show_bug.cgi?id=282981
-    m_domainNotifier->logEntryAdded(level, sourceString, messageText, milliseconds, type, method);
-#if ENABLE(WEBDRIVER_BIDI)
     m_bidiProcessor->logDomainNotifier().entryAdded(level, sourceString, messageText, milliseconds, type, method);
+#else
+    UNUSED_PARAM(messageSource);
+    UNUSED_PARAM(messageLevel);
+    UNUSED_PARAM(messageText);
+    UNUSED_PARAM(messageType);
+    UNUSED_PARAM(timestamp);
 #endif
 }
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -21,7 +21,7 @@
                 "expected": {"wpe": {"status": ["SKIP"], "note": "Related to setWindowRect, but Wayland does not allow setting client position"}}
             },
             "test_change_window_size": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/279100"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}}
             }
         }
     },
@@ -2026,10 +2026,24 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288106"}}
     },
     "imported/w3c/webdriver/tests/bidi/browser/get_user_contexts/get_user_contexts.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288107"}}
+        "subtests": {
+            "test_default": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_create_remove_contexts": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288107"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browser/remove_user_context/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
+        "subtests": {
+            "test_params_user_context_invalid_value": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
+            },
+            "test_params_user_context_no_such_user_context": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browser/remove_user_context/user_context.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
@@ -2037,55 +2051,179 @@
 
 
     "imported/w3c/webdriver/tests/bidi/browsing_context/activate/activate.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/activate/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_params_context_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
+            },
+            "test_params_context_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
+            },
+            "test_params_context_iframe": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/frame_tentative.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/clip.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/format.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/origin.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
-    },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/close/close.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/close/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_params_context_invalid_value": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288326"}}
+            },
+            "test_child_context": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288326"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/close/prompt_unload.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288326"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/context_created/context_created.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_not_unsubscribed": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_new_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_evaluate_window_open_without_url": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_evaluate_window_open_with_url": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_existing_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_existing_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_event_emitted_before_create_returns[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_event_emitted_before_create_returns[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_navigate_creates_iframes": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_navigate_creates_nested_iframes": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_subscribe_to_one_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_new_user_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            },
+            "test_new_user_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/context_created/original_opener.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/281943"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_navigate[same_origin]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_navigate[cross_origin]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_new_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288336"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/context_destroyed/original_opener.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_window_open[None]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_window_open[]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_window_open[popup]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_window_open[noopener]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_window_open[noreferrer]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_different_origins[same_origin]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_different_origins[cross_origin]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            },
+            "test_with_closed_original_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288336"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/background.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+        "subtests": {
+            "test_params_reference_context_invalid_value": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_reference_context_non_top_level": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_type_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_type_invalid_value[foo]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_user_context_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_user_context_invalid_value[unknown]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_user_context_invalid_value_with_ref_context": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
+            "test_params_user_context_removed_context": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/reference_context.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
@@ -2097,166 +2235,547 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py": {
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context_not_emitted[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context_not_emitted[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_subscribe": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288337"}}
+            },
+            "test_timestamp": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288337"}}
+            },
+            "test_early_same_document_navigation": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288337"}}
+            },
+            "test_page_with_base_tag": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288337"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_regular_navigation[-?foo]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_regular_navigation[#foo-]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_subscribe": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_timestamp": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_navigation_id": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_url_with_base_tag": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_document_location[-#foo]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_document_location[#foo-#bar]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_document_location[#foo-#foo]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_browsing_context_navigate[-#foo]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_browsing_context_navigate[#foo-#bar]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            },
+            "test_browsing_context_navigate[#foo-#foo]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288338"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288339"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/frames.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+        "subtests": {
+            "test_params_max_depth_invalid_value[-1]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_params_max_depth_invalid_value[1.1]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_params_max_depth_invalid_value[9007199254740992]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_params_root_invalid_value": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/max_depth.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+        "subtests": {
+            "test_null": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_top_level_only": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_top_level_and_one_child": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/original_opener.py": {
+        "subtests": {
+            "test_window_open[None]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_window_open[]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_window_open[popup]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_window_open[noopener]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_window_open[noreferrer]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_different_origins[same_origin]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_different_origins[cross_origin]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            },
+            "test_with_closed_original_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/root.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/handle_user_prompt/handle_user_prompt.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288328"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/handle_user_prompt/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_params_context_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288328"}}
+            },
+            "test_params_context_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288328"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/history_updated/history_updated.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287936"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/load/load.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context_not_emitted[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context_not_emitted[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_subscribe": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288340"}}
+            },
+            "test_timestamp": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288340"}}
+            },
+            "test_early_same_document_navigation": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288340"}}
+            },
+            "test_page_with_base_tag": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288340"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288340"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/context.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/max_node_count.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/serialization_options.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/locate_nodes/start_nodes.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288329"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/about_blank.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/data_url.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/error.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_with_new_navigation": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_close_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_close_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288330"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/frame.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/hash.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/image.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_params_context_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_context_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_url_invalid_value[:invalid-http]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_url_invalid_value[:invalid-https]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_url_invalid_value[#invalid-http]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_url_invalid_value[#invalid-https]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_wait_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            },
+            "test_params_wait_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/navigate.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_payload": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigate/wait.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_expected_url[none]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_slow_image_blocks_load[none-False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_slow_page[none-False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_slow_script_blocks_domContentLoaded[none-False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288330"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigation_committed/navigation_committed.py": {
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_same_document": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[about:blank]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[about:blank?test]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_subscribe": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_timestamp": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_base_element": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_navigate_to_about_blank": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_window_open_with_url": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287934"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigation_started/navigation_started.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_same_document_navigation": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_new_context[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[about:blank]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_window_open_with_about_blank[about:blank?test]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_subscribe": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_timestamp": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_page_with_base_tag": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_navigate_history_pushstate": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_navigate_to_about_blank": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            },
+            "test_window_open_with_url": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287934"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288342"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py": {
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_with_csp_meta_tag": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287933"}}
+            },
+            "test_with_content_blocking_header_in_top_context[Content-Security-Policy, default-src 'self']": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287933"}}
+            },
+            "test_with_content_blocking_header_in_top_context[Cross-Origin-Embedder-Policy, require-corp]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287933"}}
+            },
+            "test_with_x_frame_options_header[SAMEORIGIN]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287933"}}
+            },
+            "test_with_x_frame_options_header[DENY]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287933"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287933"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/background.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/context.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/frame_tentative.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/margin.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/orientation.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/page.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/page_ranges.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/scale.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/print/shrink_to_fit.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288331"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/frame.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_params_context_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
+            },
+            "test_params_context_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
+            },
+            "test_params_wait_invalid_value[]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
+            },
+            "test_params_wait_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/reload.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/wait.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_expected_url[none]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_slow_image_blocks_load[none-False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_slow_page[none-False]": {
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/288332"}}
+            },
+            "test_slow_script_blocks_domContentLoaded[none-False]": {
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/288332"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/set_viewport/device_pixel_ratio.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288333"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/set_viewport/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288333"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/set_viewport/viewport.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288333"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/traverse_history/context.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/traverse_history/delta.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288343"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288343"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_opened/beforeunload.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288344"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_unsubscribe": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_prompt_type[alert]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_prompt_type[confirm]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_prompt_type[prompt]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_prompt_default_value[undefined]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_prompt_default_value[empty string]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_prompt_default_value[non empty string]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_subscribe_to_one_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_subscribe_to_one_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_two_prompts[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_two_prompts[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288344"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_opened/handler.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/281943"}}
+        "subtests": {
+            "test_accept[capabilities0]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_accept_and_notify[capabilities0]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_dismiss[capabilities0]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_dismiss_and_notify[capabilities0]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            },
+            "test_ignore[capabilities0]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288344"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288344"}}
     },
 
     "imported/w3c/webdriver/tests/bidi/external/permissions/set_permission/invalid.py": {
@@ -2370,6 +2889,11 @@
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/log/entry_added/console.py": {
+        "subtests": {
+            "test_method_timeEnd": {
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/log/entry_added/event_buffer.py": {
@@ -2691,10 +3215,26 @@
     },
 
     "imported/w3c/webdriver/tests/bidi/session/subscribe/contexts.py": {
+        "subtests": {
+            "test_subscribe_to_all_context_and_then_to_one_again": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/events.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784", "note": "Uses browsingContext module"}}
+        "subtests": {
+            "test_subscribe_to_module": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
+            },
+            "test_subscribe_to_one_event_and_then_to_module": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
+            },
+            "test_subscribe_to_module_and_then_to_one_event_again": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/291371"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/invalid.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286763"}},
@@ -2704,20 +3244,51 @@
             "test_params_events_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},
-            "test_params_events_invalid_type[value4]": {"expected": {"all": {"status": ["PASS"]}}}
+            "test_params_events_invalid_type[value4]": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_value_invalid_type[None]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_events_value_invalid_type[True]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_events_value_invalid_type[42]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_events_value_invalid_type[value3]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/286793"}}
+            },
+            "test_params_events_value_invalid_type[value4]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/286793"}}
+            }
         }
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/subscription_id.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287929"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/contexts.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
+        "subtests": {
+            "test_unsubscribe_from_one_context_after_navigation": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unsubscribe_from_one_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/events.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+        "subtests": {
+            "test_unsubscribe_from_module": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_subscribe_to_module_unsubscribe_from_one_event": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/invalid.py": {
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286763"}},
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}},
         "subtests": {
             "test_params_empty": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_invalid_type[None]": {"expected": {"all": {"status": ["PASS"]}}},
@@ -2740,6 +3311,11 @@
         }
     },
     "imported/w3c/webdriver/tests/bidi/session/unsubscribe/subscriptions.py": {
+        "subtests": {
+            "test_unsubscribe_partially_from_one_context": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/287930"}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/287930"}}
     },
 


### PR DESCRIPTION
#### 4b386b5e7393fbda26d42c08f9cc38f2a6fff81b
<pre>
[WebDriver][BiDi] Add support to relay commands with new processBidiMessage and bidiMessageSent in Source/WebDriver
<a href="https://bugs.webkit.org/show_bug.cgi?id=288194">https://bugs.webkit.org/show_bug.cgi?id=288194</a>

Reviewed by BJ Burg.

290582@main added two new features in Automation.json:

- processBidiMessage command
- bidiMessageSent event

This pair can be used to relay BiDi commands to the browser, which in
turn can send almost ready BiDi responses and events. In this scenario,
the service acts basically as a proxy, instead of worrying with
individual commands details.

Another benefit of this is that we can move more code inside WebKit itself,
allowing the ports not using `Source/WebDriver` directly to share more code,
and keeping the service code simpler.

This commit removes the previous `Automation.json` `logEntryAdded`
event, relying on the new `bidiMessageSent` event to wrap it. In a
follow-up commit, we&apos;ll move the post-processing code in
`Session::doLogEntryAdded` back inside `WebAutomationSession` so the
service can receive the ready event body.

This commit also makes WebDriverBidiProcessor translate &quot;inspector
protocol-like&quot; errors into the WebDriver-BiDi messages, so the driver
can just forward it ahead.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::Session): Rename EventHandler to BiDiHandler
(WebDriver::Session::dispatchBiDiMessage): Renamed from dispatch event
(WebDriver::Session::doLogEntryAdded): Better logging and no need to
check if event is enabled, as we do it in doBidiMessageSent.
(WebDriver::Session::enableGlobalEvent): No need to strip the &apos;.&apos;
between the module and event name, as they are not part of the
Automation.json protocol anymore.
(WebDriver::Session::disableGlobalEvent): Ditto.
(WebDriver::Session::relayBidiCommand): Forward the incoming bidi
message to the browser, replying the incoming message with the returned
payload.
(WebDriver::Session::doBidiMessageSent): Added. Unpack the received Bidi
message and process either the command reply or the incoming event.
(WebDriver::Session::dispatchEvent): Deleted.
(WebDriver::Session::toInternalEventName): Deleted.
* Source/WebDriver/Session.h: Rename EventHandler to BiDiMessageHandler
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::dispatchMessage): Ditto.
(WebDriver::SessionHost::dispatchBiDiMessage): Added.
(WebDriver::SessionHost::dispatchEvent): Deleted.
* Source/WebDriver/SessionHost.h: Rename EventHandler to
  BiDiMessageHandler
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::handleMessage): Fallback to
relayBidiCommand when we don&apos;t have a local method impl.
(WebDriver::WebDriverService::findBidiCommand): Simplify parameter
passing.
(WebDriver::WebDriverService::bidiSessionSubscribe): Logging.
* Source/WebDriver/WebDriverService.h:
* Source/WebKit/UIProcess/Automation/Automation.json: Remove uneeded
  logEntryAdded event.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp: Ditto.
(WebKit::WebAutomationSession::logEntryAdded):
* WebDriverTests/TestExpectations.json: Drive-by bug URL fix.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::Session): Rename EventHandler to BidiMessageHandler
(WebDriver::Session::dispatchBidiMessage): Renamed from dispatchEvent.
This function validates the message to be forwarded to the browser.
(WebDriver::Session::doLogEntryAdded): Move event enabled check
outside.
(WebDriver::Session::enableGlobalEvent): No need to strip the &apos;.&apos;
between the module and event name, as they&apos;re wrapped in
&apos;bidiMessageSent&apos; now.
(WebDriver::Session::disableGlobalEvent): Ditto.
(WebDriver::Session::relayBidiCommand): Forward the incoming bidi
message to the browser, with the callback just observing for errors
delivering the request.
(WebDriver::Session::dispatchEvent): Deleted.
(WebDriver::Session::toInternalEventName): Deleted.
* Source/WebDriver/Session.h: Rename EventHandler to BidiMessageHandler
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::dispatchMessage): Ditto.
(WebDriver::SessionHost::dispatchBidiMessage): Replaces dispatchEvent.
(WebDriver::SessionHost::dispatchEvent): Deleted.
* Source/WebDriver/SessionHost.h: Rename EventHandler to
  BidiMessageHandler.
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::handleMessage): Fallback to
relayBidiCommand when we don&apos;t have a local method impl.
(WebDriver::WebDriverService::findBidiCommand): Simplify parameter
passing.
* Source/WebDriver/WebDriverService.h:
* Source/WebDriver/WebSocketServer.cpp:
(WebDriver::WebSocketServer::sendMessage): Added helpers around getting
the connection for a given SessionId.
(WebDriver::WebSocketServer::sendErrorResponse): Ditto.
* Source/WebDriver/WebSocketServer.h:
* Source/WebDriver/soup/WebSocketServerSoup.cpp:
(WebDriver::WebSocketServer::sendMessage): No need to iterate the
available sessions.
* Source/WebKit/UIProcess/Automation/Automation.json: Removed deprecated
  logEntryAdded event, relying on bidiMessageSent instead.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::logEntryAdded): Ditto.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::toBiDiErrorCode): Added, to help translate our inspector-based
errors into BiDi errors.
(WebKit::WebDriverBidiProcessor::sendBidiMessage): Add &quot;type&quot; field in
bidi message and translate the error message to BiDi ErrorResponse
production.
* WebDriverTests/TestExpectations.json: Drive-by gardening of W3C BiDi
  tests.

Canonical link: <a href="https://commits.webkit.org/294391@main">https://commits.webkit.org/294391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3344770791e1258bd83576e28887963441af158e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76871 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108446 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85383 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33270 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->