### PR TITLE
AX: Remove unnecessary AXProperty::BlockquoteLevel

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -947,6 +947,16 @@ String AXCoreObject::ariaLandmarkRoleDescription() const
     }
 }
 
+unsigned AXCoreObject::blockquoteLevel() const
+{
+    unsigned level = 0;
+    for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
+        if (ancestor->roleValue() == AccessibilityRole::Blockquote)
+            ++level;
+    }
+    return level;
+}
+
 bool AXCoreObject::supportsPressAction() const
 {
     if (roleValue() == AccessibilityRole::Presentational)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1008,7 +1008,7 @@ public:
 
     virtual bool isIgnored() const = 0;
 
-    virtual unsigned blockquoteLevel() const = 0;
+    unsigned blockquoteLevel() const;
     virtual unsigned headingLevel() const = 0;
     virtual AccessibilityButtonState checkboxOrRadioValue() const = 0;
     virtual String valueDescription() const = 0;
@@ -1532,7 +1532,6 @@ inline Vector<AXID> axIDs(const AXCoreObject::AccessibilityChildrenVector& objec
 
 #if PLATFORM(MAC)
 void attributedStringSetExpandedText(NSMutableAttributedString *, const AXCoreObject&, const NSRange&);
-void attributedStringSetBlockquoteLevel(NSMutableAttributedString *, const AXCoreObject&, const NSRange&);
 void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *, const AXCoreObject&);
 void attributedStringSetElement(NSMutableAttributedString *, NSString *attribute, const AXCoreObject&, const NSRange&);
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -659,9 +659,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::BackgroundColor:
         stream << "BackgroundColor";
         break;
-    case AXProperty::BlockquoteLevel:
-        stream << "BlockquoteLevel";
-        break;
     case AXProperty::BrailleLabel:
         stream << "BrailleLabel";
         break;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -507,17 +507,6 @@ AXTextMarkerRange AccessibilityObject::textInputMarkedTextMarkerRange() const
     return { editor.compositionRange() };
 }
 
-unsigned AccessibilityObject::blockquoteLevel() const
-{
-    unsigned level = 0;
-    for (Node* elementNode = node(); elementNode; elementNode = elementNode->parentNode()) {
-        if (elementNode->hasTagName(blockquoteTag))
-            ++level;
-    }
-    
-    return level;
-}
-
 AccessibilityObject* AccessibilityObject::displayContentsParent() const
 {
     auto* parentNode = node() ? node()->parentNode() : nullptr;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -261,7 +261,6 @@ public:
     bool isShowingValidationMessage() const;
     String validationMessage() const;
 
-    unsigned blockquoteLevel() const final;
     unsigned headingLevel() const override { return 0; }
     AccessibilityButtonState checkboxOrRadioValue() const override;
     String valueDescription() const override { return String(); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -161,13 +161,18 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::IsBusy, object.isBusy());
     setProperty(AXProperty::IsEnabled, object.isEnabled());
     setProperty(AXProperty::IsExpanded, object.isExpanded());
+
+    // FIXME: These three properties, plus AXProperty::IsRadioInput below, are basically
+    // all just variations of HTMLInputElement::m_inputType. It would be better to cache
+    // just that rather than have four separate properties.
     setProperty(AXProperty::IsFileUploadButton, object.isFileUploadButton());
+    setProperty(AXProperty::IsInputImage, object.isInputImage());
+    setProperty(AXProperty::IsSecureField, object.isSecureField());
+
     setProperty(AXProperty::IsIndeterminate, object.isIndeterminate());
     setProperty(AXProperty::IsInlineText, object.isInlineText());
-    setProperty(AXProperty::IsInputImage, object.isInputImage());
     setProperty(AXProperty::IsMultiSelectable, object.isMultiSelectable());
     setProperty(AXProperty::IsRequired, object.isRequired());
-    setProperty(AXProperty::IsSecureField, object.isSecureField());
     setProperty(AXProperty::IsSelected, object.isSelected());
     setProperty(AXProperty::InsideLink, object.insideLink());
     setProperty(AXProperty::IsValueAutofillAvailable, object.isValueAutofillAvailable());
@@ -177,7 +182,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::CanSetFocusAttribute, object.canSetFocusAttribute());
     setProperty(AXProperty::CanSetValueAttribute, object.canSetValueAttribute());
     setProperty(AXProperty::CanSetSelectedAttribute, object.canSetSelectedAttribute());
-    setProperty(AXProperty::BlockquoteLevel, object.blockquoteLevel());
     setProperty(AXProperty::HeadingLevel, object.headingLevel());
     setProperty(AXProperty::ValueDescription, object.valueDescription().isolatedCopy());
     setProperty(AXProperty::ValueForRange, object.valueForRange());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -252,7 +252,6 @@ private:
     String datetimeAttributeValue() const final { return stringAttributeValue(AXProperty::DatetimeAttributeValue); }
     bool canSetValueAttribute() const final { return boolAttributeValue(AXProperty::CanSetValueAttribute); }
     bool canSetSelectedAttribute() const final { return boolAttributeValue(AXProperty::CanSetSelectedAttribute); }
-    unsigned blockquoteLevel() const final { return unsignedAttributeValue(AXProperty::BlockquoteLevel); }
     unsigned headingLevel() const final { return unsignedAttributeValue(AXProperty::HeadingLevel); }
     AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXProperty::ButtonState); }
     String valueDescription() const final { return stringAttributeValue(AXProperty::ValueDescription); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -97,7 +97,6 @@ enum class AXProperty : uint16_t {
     AncestorFlags,
     AutoCompleteValue,
     BackgroundColor,
-    BlockquoteLevel,
     BrailleLabel,
     BrailleRoleDescription,
     ButtonState,


### PR DESCRIPTION
#### 9157140e2fcccbded53306d8fde80a0077ce8b51
<pre>
AX: Remove unnecessary AXProperty::BlockquoteLevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=290353">https://bugs.webkit.org/show_bug.cgi?id=290353</a>
<a href="https://rdar.apple.com/147791741">rdar://147791741</a>

Reviewed by Chris Fleizach.

We can compute this on-demand off the main-thread rather than eagerly caching it for every single object. This saves
memory, and eliminates one ancestry traversal per-object created. It also makes it impossible for us to ever return
stale data, which theoretically could&apos;ve happened with the property (e.g. an element is re-parented, resulting in
a different blockquote level).

This commit also adds a FIXME around how we cache several different properties that are basically just wrappers over
HTMLInputType::m_inputType. It would be better just to have that as a property, and implement these properties / functions
on top of that.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::blockquoteLevel const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::blockquoteLevel const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
(WebCore::attributedStringSetBlockquoteLevel): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/292666@main">https://commits.webkit.org/292666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b32f6a8b1e900e69da0cf8639134c35542a14637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30866 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83432 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82074 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28822 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->