### PR TITLE
Remove unused custom fullscreen behavior booleans in DRT and WKTR

### DIFF
--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -1683,17 +1683,6 @@ static JSValueRef setTextDirectionCallback(JSContextRef context, JSObjectRef fun
 
 }
 
-static JSValueRef setHasCustomFullScreenBehaviorCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
-{
-    if (argumentCount == 1) {
-        bool hasCustomBehavior = JSValueToBoolean(context, arguments[0]);
-        TestRunner* controller = static_cast<TestRunner*>(JSObjectGetPrivate(thisObject));
-        controller->setHasCustomFullScreenBehavior(hasCustomBehavior);
-    }
-
-    return JSValueMakeUndefined(context);
-}
-
 static JSValueRef setStorageDatabaseIdleIntervalCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     if (argumentCount != 1)
@@ -2098,7 +2087,6 @@ const JSStaticFunction* TestRunner::staticFunctions()
         { "focusWebView", focusWebViewCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setBackingScaleFactor", setBackingScaleFactorCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "preciseTime", preciseTimeCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
-        { "setHasCustomFullScreenBehavior", setHasCustomFullScreenBehaviorCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setStorageDatabaseIdleInterval", setStorageDatabaseIdleIntervalCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "closeIdleLocalStorageDatabases", closeIdleLocalStorageDatabasesCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "grantWebNotificationPermission", grantWebNotificationPermissionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -360,10 +360,6 @@ public:
     const std::string& titleTextDirection() const { return m_titleTextDirection; }
     void setTitleTextDirection(const std::string& direction) { m_titleTextDirection = direction; }
 
-    // Custom full screen behavior.
-    void setHasCustomFullScreenBehavior(bool value) { m_customFullScreenBehavior = value; }
-    bool hasCustomFullScreenBehavior() const { return m_customFullScreenBehavior; }
-
     void setStorageDatabaseIdleInterval(double);
     void closeIdleLocalStorageDatabases();
 
@@ -463,7 +459,6 @@ private:
     bool m_shouldStayOnPageAfterHandlingBeforeUnload { false };
     // FIXME 81697: This variable most likely will be removed once we have migrated the tests from fast/notifications to http/tests/notifications.
     bool m_areLegacyWebNotificationPermissionRequestsIgnored { false };
-    bool m_customFullScreenBehavior { false };
     bool m_hasPendingWebNotificationClick { false };
     bool m_dumpJSConsoleLogInStdErr { false };
     bool m_didCancelClientRedirect { false };

--- a/Tools/DumpRenderTree/mac/UIDelegate.mm
+++ b/Tools/DumpRenderTree/mac/UIDelegate.mm
@@ -304,8 +304,7 @@ static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
 
 - (void)webView:(WebView *)webView enterFullScreenForElement:(DOMElement*)element listener:(NSObject<WebKitFullScreenListener>*)listener
 {
-    if (!gTestRunner->hasCustomFullScreenBehavior())
-        [self performSelector:@selector(enterFullScreenWithListener:) withObject:listener afterDelay:0];
+    [self performSelector:@selector(enterFullScreenWithListener:) withObject:listener afterDelay:0];
 }
 
 - (void)exitFullScreenWithListener:(NSObject<WebKitFullScreenListener>*)listener
@@ -316,8 +315,7 @@ static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
 
 - (void)webView:(WebView *)webView exitFullScreenForElement:(DOMElement*)element listener:(NSObject<WebKitFullScreenListener>*)listener
 {
-    if (!gTestRunner->hasCustomFullScreenBehavior())
-        [self performSelector:@selector(exitFullScreenWithListener:) withObject:listener afterDelay:0];
+    [self performSelector:@selector(exitFullScreenWithListener:) withObject:listener afterDelay:0];
 }
 
 - (void)webView:(WebView *)sender closeFullScreenWithListener:(NSObject<WebKitFullScreenListener>*)listener

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -632,7 +632,6 @@ private:
     bool m_shouldStopProvisionalFrameLoads { false };
 
     bool m_globalFlag { false };
-    bool m_customFullScreenBehavior { false };
 
     bool m_shouldDecideNavigationPolicyAfterDelay { false };
     bool m_shouldDecideResponsePolicyAfterDelay { false };


### PR DESCRIPTION
#### 0d312554220c8b9bb02a521739353b9d79d8aea6
<pre>
Remove unused custom fullscreen behavior booleans in DRT and WKTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=290356">https://bugs.webkit.org/show_bug.cgi?id=290356</a>
<a href="https://rdar.apple.com/147794548">rdar://147794548</a>

Reviewed by Tim Nguyen.

This was replaced by TestRunner::waitBeforeFinishingFullscreenExit and TestRunner::finishFullscreenExit.

* Tools/DumpRenderTree/TestRunner.cpp:
(TestRunner::staticFunctions):
(setHasCustomFullScreenBehaviorCallback): Deleted.
* Tools/DumpRenderTree/TestRunner.h:
(TestRunner::setHasCustomFullScreenBehavior): Deleted.
(TestRunner::hasCustomFullScreenBehavior const): Deleted.
* Tools/DumpRenderTree/mac/UIDelegate.mm:
(-[UIDelegate webView:enterFullScreenForElement:listener:]):
(-[UIDelegate webView:exitFullScreenForElement:listener:]):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/292657@main">https://commits.webkit.org/292657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6dc3eba8ba31e971c51800a3703722039528c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30867 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53980 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83433 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82072 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17181 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15577 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->