### PR TITLE
WIP aspectRatioDouble change

### DIFF
--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -79,7 +79,7 @@ public:
     bool isExpressibleAsIntSize() const;
 
     constexpr float aspectRatio() const { return m_width / m_height; }
-    constexpr double aspectRatioDouble() const { return m_width / static_cast<double>(m_height); }
+    constexpr double aspectRatioDouble() const { return m_width / m_height; }
 
     void expand(float width, float height)
     {


### PR DESCRIPTION
#### 3b668cc60d5b2e4e80f12a3c2b411c60135d9937
<pre>
WIP aspectRatioDouble change
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b668cc60d5b2e4e80f12a3c2b411c60135d9937

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24690 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73652 "2 flakes 75 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99644 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12448 "Found 5 new test failures: css1/formatting_model/floating_elements.html fast/forms/ios/focus-input-via-button.html fast/replaced/width100percent-image.html platform/ipad/media/modern-media-controls/media-documents/media-document-video-ios-sizing.html svg/as-image/svg-intrinsic-size-rectangular-vertical.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12207 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5181 "Found 3 new test failures: css1/formatting_model/floating_elements.html fast/replaced/width100percent-image.html media/modern-media-controls/media-documents/media-document-video-mac-sizing.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82308 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5271 "Found 4 new test failures: css1/formatting_model/floating_elements.html fast/replaced/width100percent-image.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html media/modern-media-controls/media-documents/media-document-video-mac-sizing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103737 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23708 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17280 "Found 4 new test failures: css1/formatting_model/floating_elements.html fast/replaced/width100percent-image.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html media/modern-media-controls/media-documents/media-document-video-mac-sizing.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82698 "Found 9 new test failures: css1/formatting_model/floating_elements.html fast/replaced/width100percent-image.html imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-positioned-spans.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-container-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-element-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/old-root-vertical-writing-mode.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html svg/as-image/svg-intrinsic-size-rectangular-vertical.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83434 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82078 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26731 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4252 "Found 6 new test failures: css1/formatting_model/floating_elements.html fast/replaced/width100percent-image.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-positioned-spans.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html media/modern-media-controls/media-documents/media-document-video-mac-sizing.html svg/as-image/svg-intrinsic-size-rectangular-vertical.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28826 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->