### PR TITLE
A RELEASE_ASSERT() may fire because RenderLayer does nor clear its SVG clipPath data

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1160,8 +1160,8 @@ private:
     bool setupFontSubpixelQuantization(GraphicsContext&, bool& didQuantizeFonts);
 
     std::pair<Path, WindRule> computeClipPath(const LayoutSize& offsetFromRoot, const LayoutRect& rootRelativeBoundsForNonBoxes) const;
-
     void setupClipPath(GraphicsContext&, GraphicsContextStateSaver&, RegionContextStateSaver&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>&, const LayoutSize& offsetFromRoot);
+    void clearLayerClipPath();
 
     void ensureLayerFilters();
     void clearLayerFilters();

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -584,6 +584,15 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResour
     return nullptr;
 }
 
+LegacyRenderSVGResourceClipper* RenderLayerModelObject::legacySVGClipperResourceFromStyle() const
+{
+    RefPtr referenceClipPathOperation = dynamicDowncast<ReferencePathOperation>(style().clipPath());
+    if (!referenceClipPathOperation)
+        return nullptr;
+
+    return ReferencedSVGResources::referencedClipperRenderer(treeScopeForSVGReferences(), *referenceClipPathOperation);
+}
+
 bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) const
 {
     auto* clipPathOperation = style().clipPath();

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 class BlendingKeyframes;
+class LegacyRenderSVGResourceClipper;
 class RenderLayer;
 class RenderSVGResourceClipper;
 class RenderSVGResourceFilter;
@@ -106,6 +107,8 @@ public:
     RenderSVGResourceMarker* svgMarkerStartResourceFromStyle() const;
     RenderSVGResourceMarker* svgMarkerMidResourceFromStyle() const;
     RenderSVGResourceMarker* svgMarkerEndResourceFromStyle() const;
+
+    LegacyRenderSVGResourceClipper* legacySVGClipperResourceFromStyle() const;
 
     bool pointInSVGClippingArea(const FloatPoint&) const;
 

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -66,7 +66,7 @@ void RenderSVGGradientStop::styleDidChange(StyleDifference diff, const RenderSty
         return;
     }
 
-    downcast<LegacyRenderSVGResourceContainer>(*renderer).removeAllClientsFromCache();
+    downcast<LegacyRenderSVGResourceContainer>(*renderer).removeAllClientsFromCacheAndMarkForInvalidation();
 }
 
 void RenderSVGGradientStop::layout()

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -234,7 +234,7 @@ static inline void invalidateResourcesOfChildren(RenderElement& renderer)
 {
     ASSERT(!renderer.needsLayout());
     if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer))
-        resources->removeClientFromCache(renderer, false);
+        resources->removeClientFromCacheAndMarkForInvalidation(renderer, false);
 
     for (auto& child : childrenOfType<RenderElement>(renderer))
         invalidateResourcesOfChildren(child);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -277,7 +277,7 @@ void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
     // The image resource defaults to nullImage until the resource arrives.
     // This empty image may be cached by SVG resources which must be invalidated.
     if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this))
-        resources->removeClientFromCache(*this);
+        resources->removeClientFromCacheAndMarkForInvalidation(*this);
 
     // Eventually notify parent resources, that we've changed.
     LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(*this, false);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -123,10 +123,10 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
     return uriResource;
 }
 
-void LegacyRenderSVGResource::removeAllClientsFromCache(bool markForInvalidation)
+void LegacyRenderSVGResource::removeAllClientsFromCacheAndMarkForInvalidation(bool markForInvalidation)
 {
     SingleThreadWeakHashSet<RenderObject> visitedRenderers;
-    removeAllClientsFromCacheIfNeeded(markForInvalidation, &visitedRenderers);
+    removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(markForInvalidation, &visitedRenderers);
 }
 
 LegacyRenderSVGResource* LegacyRenderSVGResource::fillPaintingResource(RenderElement& renderer, const RenderStyle& style, Color& fallbackColor)
@@ -151,13 +151,13 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
 {
     if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
         if (LegacyRenderSVGResourceFilter* filter = resources->filter())
-            filter->removeClientFromCache(renderer);
+            filter->removeClientFromCacheAndMarkForInvalidation(renderer);
 
         if (LegacyRenderSVGResourceMasker* masker = resources->masker())
-            masker->removeClientFromCache(renderer);
+            masker->removeClientFromCacheAndMarkForInvalidation(renderer);
 
         if (LegacyRenderSVGResourceClipper* clipper = resources->clipper())
-            clipper->removeClientFromCache(renderer);
+            clipper->removeClientFromCacheAndMarkForInvalidation(renderer);
     }
 
     auto svgElement = dynamicDowncast<SVGElement>(renderer.protectedElement());
@@ -238,7 +238,7 @@ void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded
         if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGResourceContainer>(*current)) {
             // This will process the rest of the ancestors.
             bool markForInvalidation = true;
-            container->removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
+            container->removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(markForInvalidation, visitedRenderers);
             break;
         }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
@@ -61,9 +61,11 @@ public:
     LegacyRenderSVGResource() = default;
     virtual ~LegacyRenderSVGResource() = default;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true);
-    virtual void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) = 0;
-    virtual void removeClientFromCache(RenderElement&, bool markForInvalidation = true) = 0;
+    void removeAllClientsFromCacheAndMarkForInvalidation(bool markForInvalidation = true);
+    virtual void removeAllClientsFromCache() = 0;
+    virtual void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) = 0;
+    virtual void removeClientFromCache(RenderElement&) = 0;
+    virtual void removeClientFromCacheAndMarkForInvalidation(RenderElement&, bool markForInvalidation = true) = 0;
 
     enum class ApplyResult : uint8_t {
         ResourceApplied = 1 << 0,

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -59,19 +59,15 @@ LegacyRenderSVGResourceClipper::LegacyRenderSVGResourceClipper(SVGClipPathElemen
 
 LegacyRenderSVGResourceClipper::~LegacyRenderSVGResourceClipper() = default;
 
-void LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceClipper::removeAllClientsFromCache()
 {
     m_clipBoundaries.fill(FloatRect { });
     m_clipperMap.clear();
-
-    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
-void LegacyRenderSVGResourceClipper::removeClientFromCache(RenderElement& client, bool markForInvalidation)
+void LegacyRenderSVGResourceClipper::removeClientFromCache(RenderElement& client)
 {
     m_clipperMap.remove(client);
-
-    markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
 }
 
 auto LegacyRenderSVGResourceClipper::applyResource(RenderElement& renderer, const RenderStyle&, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -66,8 +66,8 @@ public:
     inline SVGClipPathElement& clipPathElement() const;
     inline Ref<SVGClipPathElement> protectedClipPathElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCache() override;
+    void removeClientFromCache(RenderElement&) override;
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -40,6 +40,9 @@ public:
     static float computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
 
+    void removeClientFromCacheAndMarkForInvalidation(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
+
     void idChanged();
     void markAllClientsForRepaint();
     void addClientRenderLayer(RenderLayer&);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -54,16 +54,14 @@ bool LegacyRenderSVGResourceFilter::isIdentity() const
     return SVGFilter::isIdentity(protectedFilterElement());
 }
 
-void LegacyRenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceFilter::removeAllClientsFromCache()
 {
-    LOG(Filters, "LegacyRenderSVGResourceFilter %p removeAllClientsFromCacheIfNeeded", this);
+    LOG(Filters, "LegacyRenderSVGResourceFilter %p removeAllClientsFromCache", this);
 
     m_rendererFilterDataMap.clear();
-
-    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
-void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& client, bool markForInvalidation)
+void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& client)
 {
     LOG(Filters, "LegacyRenderSVGResourceFilter %p removing client %p", this, &client);
     
@@ -75,8 +73,6 @@ void LegacyRenderSVGResourceFilter::removeClientFromCache(RenderElement& client,
         else
             m_rendererFilterDataMap.remove(findResult);
     }
-
-    markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
 }
 
 auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const RenderStyle&, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>
@@ -202,7 +198,7 @@ void LegacyRenderSVGResourceFilter::postApplyResource(RenderElement& renderer, G
 
     case FilterData::PaintingSource:
         if (!filterData.savedContext) {
-            removeClientFromCache(renderer);
+            removeClientFromCacheAndMarkForInvalidation(renderer);
             return;
         }
 
@@ -248,7 +244,7 @@ void LegacyRenderSVGResourceFilter::markFilterForRebuild()
 {
     LOG(Filters, "LegacyRenderSVGResourceFilter %p markFilterForRebuild", this);
 
-    removeAllClientsFromCache();
+    removeAllClientsFromCacheAndMarkForInvalidation();
 }
 
 FloatRect LegacyRenderSVGResourceFilter::drawingRegion(RenderObject& object) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -64,8 +64,8 @@ public:
     inline Ref<SVGFilterElement> protectedFilterElement() const;
     bool isIdentity() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCache() override;
+    void removeClientFromCache(RenderElement&) override;
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -43,17 +43,21 @@ LegacyRenderSVGResourceGradient::LegacyRenderSVGResourceGradient(Type type, SVGG
 
 LegacyRenderSVGResourceGradient::~LegacyRenderSVGResourceGradient() = default;
 
-void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceGradient::removeAllClientsFromCache()
 {
     m_gradientMap.clear();
     m_shouldCollectGradientAttributes = true;
+}
+
+void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+{
+    removeAllClientsFromCache();
     markAllClientsForInvalidationIfNeeded(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
-void LegacyRenderSVGResourceGradient::removeClientFromCache(RenderElement& client, bool markForInvalidation)
+void LegacyRenderSVGResourceGradient::removeClientFromCache(RenderElement& client)
 {
     m_gradientMap.remove(&client);
-    markClientForInvalidation(client, markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
 }
 
 GradientData::Inputs LegacyRenderSVGResourceGradient::computeInputs(RenderElement& renderer, OptionSet<RenderSVGResourceMode> resourceMode)
@@ -73,7 +77,7 @@ GradientData* LegacyRenderSVGResourceGradient::gradientDataForRenderer(RenderEle
 {
     // Be sure to synchronize all SVG properties on the gradientElement _before_ processing any further.
     // Otherwhise the call to collectGradientAttributes() in createTileImage(), may cause the SVG DOM property
-    // synchronization to kick in, which causes removeAllClientsFromCache() to be called, which in turn deletes our
+    // synchronization to kick in, which causes removeAllClientsFromCacheAndMarkForInvalidation() to be called, which in turn deletes our
     // GradientData object! Leaving out the line below will cause svg/dynamic-updates/SVG*GradientElement-svgdom* to crash.
     if (m_shouldCollectGradientAttributes) {
         gradientElement().synchronizeAllAttributes();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -74,8 +74,9 @@ public:
 
     SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(LegacyRenderSVGResourceContainer::element()); }
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) final;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) final;
+    void removeAllClientsFromCache() final;
+    void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeClientFromCache(RenderElement&) final;
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) final;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -54,16 +54,6 @@ void LegacyRenderSVGResourceMarker::layout()
     LegacyRenderSVGContainer::layout();
 }
 
-void LegacyRenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
-{
-    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
-}
-
-void LegacyRenderSVGResourceMarker::removeClientFromCache(RenderElement& client, bool markForInvalidation)
-{
-    markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
-}
-
 void LegacyRenderSVGResourceMarker::applyViewportClip(PaintInfo& paintInfo)
 {
     if (SVGRenderSupport::isOverflowHidden(*this))

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -36,8 +36,8 @@ public:
 
     inline SVGMarkerElement& markerElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCache() override { }
+    void removeClientFromCache(RenderElement&) override { }
 
     void draw(PaintInfo&, const AffineTransform&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -42,19 +42,15 @@ LegacyRenderSVGResourceMasker::LegacyRenderSVGResourceMasker(SVGMaskElement& ele
 
 LegacyRenderSVGResourceMasker::~LegacyRenderSVGResourceMasker() = default;
 
-void LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceMasker::removeAllClientsFromCache()
 {
     m_maskContentBoundaries.fill(FloatRect { });
     m_masker.clear();
-
-    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
-void LegacyRenderSVGResourceMasker::removeClientFromCache(RenderElement& client, bool markForInvalidation)
+void LegacyRenderSVGResourceMasker::removeClientFromCache(RenderElement& client)
 {
     m_masker.remove(client);
-
-    markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
 }
 
 auto LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const RenderStyle&, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -47,8 +47,8 @@ public:
     inline SVGMaskElement& maskElement() const;
     inline Ref<SVGMaskElement> protectedMaskElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCache() override;
+    void removeClientFromCache(RenderElement&) override;
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& objectBoundingBox);
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -55,17 +55,21 @@ Ref<SVGPatternElement> LegacyRenderSVGResourcePattern::protectedPatternElement()
     return patternElement();
 }
 
-void LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourcePattern::removeAllClientsFromCache()
 {
     m_patternMap.clear();
     m_shouldCollectPatternAttributes = true;
+}
+
+void LegacyRenderSVGResourcePattern::removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
+{
+    removeAllClientsFromCache();
     markAllClientsForInvalidationIfNeeded(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
-void LegacyRenderSVGResourcePattern::removeClientFromCache(RenderElement& client, bool markForInvalidation)
+void LegacyRenderSVGResourcePattern::removeClientFromCache(RenderElement& client)
 {
     m_patternMap.remove(client);
-    markClientForInvalidation(client, markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
 }
 
 void LegacyRenderSVGResourcePattern::collectPatternAttributes(PatternAttributes& attributes) const
@@ -140,7 +144,7 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
 
     // Various calls above may trigger invalidations in some fringe cases (ImageBuffer allocation
     // failures in the SVG image cache for example). To avoid having our PatternData deleted by
-    // removeAllClientsFromCache(), we only make it visible in the cache at the very end.
+    // removeAllClientsFromCacheAndMarkForInvalidation(), we only make it visible in the cache at the very end.
     return m_patternMap.set(renderer, WTFMove(patternData)).iterator->value.get();
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -49,8 +49,9 @@ public:
     SVGPatternElement& patternElement() const;
     Ref<SVGPatternElement> protectedPatternElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
+    void removeAllClientsFromCache() override;
+    void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeClientFromCache(RenderElement&) override;
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
@@ -34,8 +34,10 @@ public:
     LegacyRenderSVGResourceSolidColor();
     virtual ~LegacyRenderSVGResourceSolidColor();
 
-    void removeAllClientsFromCacheIfNeeded(bool, SingleThreadWeakHashSet<RenderObject>*) override { }
-    void removeClientFromCache(RenderElement&, bool = true) override { }
+    void removeAllClientsFromCache() override { }
+    void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool, SingleThreadWeakHashSet<RenderObject>*) override { }
+    void removeClientFromCache(RenderElement&) override { }
+    void removeClientFromCacheAndMarkForInvalidation(RenderElement&, bool = true) override { }
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -191,7 +191,7 @@ void LegacyRenderSVGRoot::layout()
     if (!m_resourcesNeedingToInvalidateClients.isEmptyIgnoringNullReferences()) {
         // Invalidate resource clients, which may mark some nodes for layout.
         for (auto& resource :  m_resourcesNeedingToInvalidateClients) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             SVGResourcesCache::clientStyleChanged(resource, StyleDifference::Layout, nullptr, resource.style());
         }
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -369,7 +369,7 @@ bool SVGResources::markerReverseStart() const
         && m_markerData->markerStart->markerElement().orientType() == SVGMarkerOrientAutoStartReverse;
 }
 
-void SVGResources::removeClientFromCache(RenderElement& renderer, bool markForInvalidation) const
+void SVGResources::removeClientFromCacheAndMarkForInvalidation(RenderElement& renderer, bool markForInvalidation) const
 {
     if (isEmpty())
         return;
@@ -378,33 +378,33 @@ void SVGResources::removeClientFromCache(RenderElement& renderer, bool markForIn
         ASSERT(!m_clipperFilterMaskerData);
         ASSERT(!m_markerData);
         ASSERT(!m_fillStrokeData);
-        m_linkedResource->removeClientFromCache(renderer, markForInvalidation);
+        m_linkedResource->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         return;
     }
 
     if (m_clipperFilterMaskerData) {
         if (auto* clipper = m_clipperFilterMaskerData->clipper.get())
-            clipper->removeClientFromCache(renderer, markForInvalidation);
+            clipper->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         if (auto* filter = m_clipperFilterMaskerData->filter.get())
-            filter->removeClientFromCache(renderer, markForInvalidation);
+            filter->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         if (auto* masker = m_clipperFilterMaskerData->masker.get())
-            masker->removeClientFromCache(renderer, markForInvalidation);
+            masker->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
     }
 
     if (m_markerData) {
         if (auto* markerStart = m_markerData->markerStart.get())
-            markerStart->removeClientFromCache(renderer, markForInvalidation);
+            markerStart->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         if (auto* markerMid = m_markerData->markerMid.get())
-            markerMid->removeClientFromCache(renderer, markForInvalidation);
+            markerMid->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         if (auto* markerEnd = m_markerData->markerEnd.get())
-            markerEnd->removeClientFromCache(renderer, markForInvalidation);
+            markerEnd->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
     }
 
     if (m_fillStrokeData) {
         if (auto* fill = m_fillStrokeData->fill.get())
-            fill->removeClientFromCache(renderer, markForInvalidation);
+            fill->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
         if (auto* stroke = m_fillStrokeData->stroke.get())
-            stroke->removeClientFromCache(renderer, markForInvalidation);
+            stroke->removeClientFromCacheAndMarkForInvalidation(renderer, markForInvalidation);
     }
 }
 
@@ -417,7 +417,7 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         ASSERT(!m_clipperFilterMaskerData);
         ASSERT(!m_markerData);
         ASSERT(!m_fillStrokeData);
-        m_linkedResource->removeAllClientsFromCache();
+        m_linkedResource->removeAllClientsFromCacheAndMarkForInvalidation();
         m_linkedResource = nullptr;
         return true;
     }
@@ -428,7 +428,7 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break;
         if (m_clipperFilterMaskerData->masker == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_clipperFilterMaskerData->masker = nullptr;
             foundResources = true;
         }
@@ -437,17 +437,17 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         if (!m_markerData)
             break;
         if (m_markerData->markerStart == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_markerData->markerStart = nullptr;
             foundResources = true;
         }
         if (m_markerData->markerMid == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_markerData->markerMid = nullptr;
             foundResources = true;
         }
         if (m_markerData->markerEnd == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_markerData->markerEnd = nullptr;
             foundResources = true;
         }
@@ -458,12 +458,12 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         if (!m_fillStrokeData)
             break;
         if (m_fillStrokeData->fill == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_fillStrokeData->fill = nullptr;
             foundResources = true;
         }
         if (m_fillStrokeData->stroke == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_fillStrokeData->stroke = nullptr;
             foundResources = true;
         }
@@ -472,7 +472,7 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break;
         if (m_clipperFilterMaskerData->filter == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_clipperFilterMaskerData->filter = nullptr;
             foundResources = true;
         }
@@ -481,7 +481,7 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break;
         if (m_clipperFilterMaskerData->clipper == &resource) {
-            resource.removeAllClientsFromCache();
+            resource.removeAllClientsFromCacheAndMarkForInvalidation();
             m_clipperFilterMaskerData->clipper = nullptr;
             foundResources = true;
         }

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.h
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.h
@@ -71,7 +71,7 @@ public:
     void buildSetOfResources(SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>&);
 
     // Methods operating on all cached resources
-    void removeClientFromCache(RenderElement&, bool markForInvalidation = true) const;
+    void removeClientFromCacheAndMarkForInvalidation(RenderElement&, bool markForInvalidation = true) const;
     // Returns true if the resource-to-be-destroyed is one of our resources.
     bool resourceDestroyed(LegacyRenderSVGResourceContainer&);
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -128,7 +128,7 @@ void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)
     // Invalidate the resources if either the RenderElement itself changed,
     // or we have filter resources, which could depend on the layout of children.
     if ((renderer.selfNeedsLayout() || resources->filter()) && hasResourcesRequiringRemovalOnClientLayoutChange(*resources))
-        resources->removeClientFromCache(renderer, false);
+        resources->removeClientFromCacheAndMarkForInvalidation(renderer, false);
 }
 
 static inline bool rendererCanHaveResources(RenderObject& renderer)
@@ -251,7 +251,7 @@ void SVGResourcesCache::clientDestroyed(RenderElement& renderer)
         return;
 
     if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
-        resources->removeClientFromCache(renderer);
+        resources->removeClientFromCacheAndMarkForInvalidation(renderer);
         resourcesCacheFromRenderer(renderer).removeResourcesFromRenderer(renderer);
     }
 }


### PR DESCRIPTION
#### 500c16dfca9aef5d2fb07e80839e3e1fb00167e2
<pre>
A RELEASE_ASSERT() may fire because RenderLayer does nor clear its SVG clipPath data
<a href="https://bugs.webkit.org/show_bug.cgi?id=290363">https://bugs.webkit.org/show_bug.cgi?id=290363</a>
<a href="https://rdar.apple.com/147410341">rdar://147410341</a>

Reviewed by Simon Fraser.

LegacyRenderSVGResourceClipper::applyClippingToContext() is called from
RenderLayer::setupClipPath(). This function adds a new entry for the
RenderLayer::renderer() in its m_clipperMap for caching the clipping data.

This HashMap entry never gets deleted. RenderLayer::~RenderLayer() needs to
clear its clipPath data to remove the entry that it added.

The caching and the invalidation methods of all the SVG resources need to be
renamed to allow removeClientFromCache() without having to invalidate it.

LegacyRenderSVGResource needs to define four abstract methods:

1. removeClientFromCache(): Removes the renderer from the cache.
2. removeClientFromCacheAndMarkForInvalidation(): Remove the renderer and mark
   it for invalidation.
3. removeAllClientsFromCache(): Clears the cache.
4. removeAllClientsFromCacheAndMarkForInvalidationIfNeeded: Clears the cache and
   mark all the renderers for invalidation.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::~RenderLayer):
(WebCore::RenderLayer::setupClipPath):
(WebCore::RenderLayer::clearLayerClipPath):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::legacySVGClipperResourceFromStyle const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::styleDidChange):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::invalidateResourcesOfChildren):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::LegacyRenderSVGResource::removeAllClientsFromCacheAndMarkForInvalidation):
(WebCore::removeFromCacheAndInvalidateDependencies):
(WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResource::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceClipper::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::idChanged):
(WebCore::LegacyRenderSVGResourceContainer::removeClientFromCacheAndMarkForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::removeAllClientsFromCacheAndMarkForInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResourceContainer::removeClient):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceFilter::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceFilter::postApplyResource):
(WebCore::LegacyRenderSVGResourceFilter::markFilterForRebuild):
(WebCore::LegacyRenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceGradient::removeAllClientsFromCacheAndMarkForInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResourceGradient::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceGradient::gradientDataForRenderer):
(WebCore::LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp:
(WebCore::LegacyRenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded): Deleted.
(WebCore::LegacyRenderSVGResourceMarker::removeClientFromCache): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceMasker::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourcePattern::removeAllClientsFromCacheAndMarkForInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResourcePattern::removeClientFromCache):
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
(WebCore::LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::layout):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::removeClientFromCacheAndMarkForInvalidation const):
(WebCore::SVGResources::resourceDestroyed):
(WebCore::SVGResources::removeClientFromCache const): Deleted.
* Source/WebCore/rendering/svg/legacy/SVGResources.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientLayoutChanged):
(WebCore::SVGResourcesCache::clientDestroyed):

Canonical link: <a href="https://commits.webkit.org/292667@main">https://commits.webkit.org/292667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b832f4df15335258bf5767925b51c74328f1415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73713 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83541 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82147 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20623 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->