### PR TITLE
objectIsRelayoutBoundary doesn't account for baseline changes across the boundary.

### DIFF
--- a/LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+</head>
+<body>
+
+<div style="display: flex; align-items: baseline">
+  <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+    <div id="target" style="background: green; width: 100px; height: 50px;"></div>
+  </div>
+  <div style="background: blue; height: 70px; width: 100px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-flex.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-flex.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+
+<div style="display: flex; align-items: baseline">
+  <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+    <div id="target" style="background: green; width: 100px; height: 150px;"></div>
+  </div>
+  <div style="background: blue; height: 70px; width: 100px;"></div>
+</div>
+</body>
+<script>
+function doTest() {
+    document.getElementById("target").style.height = "50px";
+    document.documentElement.classList.remove("reftest-wait");
+}
+window.addEventListener('load', doTest, false);
+</script>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+</head>
+<body>
+
+<div style="display: inline-grid">
+  <div style="display: grid">
+    <div style="display: inline-flex">
+      <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+        <div id="target" style="background: green; width: 100px; height: 50px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div style="background: blue; height: 70px; width: 100px; display: inline-block;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-inline.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-inline.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+
+<div style="display: inline-grid">
+  <div style="display: grid">
+    <div style="display: inline-flex">
+      <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+        <div id="target" style="background: green; width: 100px; height: 150px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div style="background: blue; height: 70px; width: 100px; display: inline-block;"></div>
+</body>
+<script>
+function doTest() {
+    document.getElementById("target").style.height = "50px";
+    document.documentElement.classList.remove("reftest-wait");
+}
+window.addEventListener('load', doTest, false);
+</script>
+</html>


### PR DESCRIPTION
#### cb80e57398c2e145c8b94651e59f99cb40404cab
<pre>
objectIsRelayoutBoundary doesn&apos;t account for baseline changes across the boundary.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290359">https://bugs.webkit.org/show_bug.cgi?id=290359</a>
&lt;<a href="https://rdar.apple.com/147799932">rdar://147799932</a>&gt;

Reviewed by Alan Baradlay.

Being an independent formatting context isn&apos;t sufficient to be a layout
boundary, as placement within the formatting context can affect the baseline
positioning of things outside.

We need to prevent these being treated as boundaries if they are inside an
formatting context that uses baselines.

Caches the lookup of nearest ancestor baseline formatting context to prevent extra
ancestor walks during markContainingBlocksForLayout.

* LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-flex.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-inline.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::nearestBaselineContextAncestor):
(WebCore::objectIsRelayoutBoundary):
(WebCore::RenderObject::markContainingBlocksForLayout):

Canonical link: <a href="https://commits.webkit.org/292662@main">https://commits.webkit.org/292662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8e9ee47953c7f70161c97a407c7a33b3c555774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73662 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17297 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82712 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83459 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82093 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17198 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->