### PR TITLE
Fix memory leaks in _WKApplicationManifestIcon and _WKApplicationManifestShortcut

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -115,7 +115,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 - (instancetype)initWithCoreIcon:(const WebCore::ApplicationManifest::Icon *)icon
 {
-    if (!(self = [[_WKApplicationManifestIcon alloc] init]))
+    if (!(self = [super init]))
         return nil;
 
     if (icon) {
@@ -208,7 +208,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 - (instancetype)initWithCoreShortcut:(const WebCore::ApplicationManifest::Shortcut *)shortcut
 {
-    if (!(self = [[_WKApplicationManifestShortcut alloc] init]))
+    if (!(self = [super init]))
         return nil;
 
     if (shortcut) {


### PR DESCRIPTION
#### e409135bcd51030b7b04873b1990e58f7cbcfc43
<pre>
Fix memory leaks in _WKApplicationManifestIcon and _WKApplicationManifestShortcut
<a href="https://bugs.webkit.org/show_bug.cgi?id=290367">https://bugs.webkit.org/show_bug.cgi?id=290367</a>

Reviewed by David Kilzer and Aditya Keerthi.

Simply call [super init] instead of alloc&apos;ing another object.

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifestIcon initWithCoreIcon:]):
(-[_WKApplicationManifestShortcut initWithCoreShortcut:]):

Canonical link: <a href="https://commits.webkit.org/292636@main">https://commits.webkit.org/292636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a7d29d5926d29e809db4197950cc58237d8b9fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24705 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73660 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30878 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99658 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12463 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12222 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103751 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23723 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83455 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82089 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4268 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15564 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23685 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/28840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->