### PR TITLE
qualifiesForContentfulPaint uses wrong coordinate space for frames.

### DIFF
--- a/LayoutTests/performance-api/paint-timing/paint-timing-frames.html
+++ b/LayoutTests/performance-api/paint-timing/paint-timing-frames.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <div class="spacer"></div>
-    <iframe width="100" height="100" id="nonSandboxed" src="./resources/fcp-subframe.html"></iframe>
+    <iframe width="100" height="100" id="nonSandboxed" src="./resources/fcp-subframe.html" style="position:relative; left: 200px;"></iframe>
 <div class="spacer"></div>
 <iframe id="sandboxed" src="./resources/fcp-subframe.html" sandbox="allow-scripts"></iframe>
 <div class="spacer"></div>

--- a/Source/WebCore/rendering/ContentfulPaintChecker.cpp
+++ b/Source/WebCore/rendering/ContentfulPaintChecker.cpp
@@ -40,7 +40,9 @@ bool ContentfulPaintChecker::qualifiesForContentfulPaint(LocalFrameView& frameVi
     frameView.setPaintsEntireContents(true);
 
     NullGraphicsContext checkerContext(NullGraphicsContext::PaintInvalidationReasons::DetectingContentfulPaint);
-    frameView.paint(checkerContext, frameView.renderView()->documentRect());
+    IntRect documentRect = frameView.renderView()->documentRect();
+    documentRect.moveBy(frameView.locationOfContents());
+    frameView.paint(checkerContext, documentRect);
 
     frameView.setPaintsEntireContents(oldEntireContents);
     frameView.setPaintBehavior(oldPaintBehavior);


### PR DESCRIPTION
#### 28a3439a52bc2dc70a76f89d3d4be33180cdf200
<pre>
qualifiesForContentfulPaint uses wrong coordinate space for frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290365">https://bugs.webkit.org/show_bug.cgi?id=290365</a>
&lt;<a href="https://rdar.apple.com/147804424">rdar://147804424</a>&gt;

Reviewed by Simon Fraser.

This can result in the paint dirty rect not intersecting with the document, if
the &lt;iframe&gt; is positioned.

* LayoutTests/performance-api/paint-timing/paint-timing-frames.html:
* Source/WebCore/rendering/ContentfulPaintChecker.cpp:
(WebCore::ContentfulPaintChecker::qualifiesForContentfulPaint):

Canonical link: <a href="https://commits.webkit.org/292679@main">https://commits.webkit.org/292679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89e8bfeb03c8160d1514e6643fff22511acce067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73663 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99661 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12465 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5207 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82713 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83460 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82094 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->