### PR TITLE
Use RetainPtr in [_WKWebPushAction webPushActionWithDictionary]

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
@@ -87,12 +87,12 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
     if (!type || ![type isKindOfClass:[NSString class]])
         return nil;
 
-    _WKWebPushAction *result = [[_WKWebPushAction alloc] init];
-    result.version = version;
-    result.webClipIdentifier = uuid.get();
-    result.type = type;
+    RetainPtr result = adoptNS([[_WKWebPushAction alloc] init]);
+    result.get().version = version;
+    result.get().webClipIdentifier = uuid.get();
+    result.get().type = type;
 
-    return [result autorelease];
+    return result.autorelease();
 }
 
 + (_WKWebPushAction *)_webPushActionWithNotificationResponse:(UNNotificationResponse *)response


### PR DESCRIPTION
#### 5a0f12e530d1fc3a6d925856d88a903167235ba3
<pre>
Use RetainPtr in [_WKWebPushAction webPushActionWithDictionary]
<a href="https://bugs.webkit.org/show_bug.cgi?id=290375">https://bugs.webkit.org/show_bug.cgi?id=290375</a>

Reviewed by Geoffrey Garen.

Use adoptNS and RetainPtr instead of manually adding to autorelease pool.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(+[_WKWebPushAction webPushActionWithDictionary:]):

Canonical link: <a href="https://commits.webkit.org/292688@main">https://commits.webkit.org/292688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1956548967edc88d80b868280a54b0661ed763

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47189 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30894 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99672 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12476 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12234 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83476 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82104 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17210 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15600 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28854 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->