### PR TITLE
WebKit::platformDisbursementRequest(): Unnecessary array copy when setting PKDisbursementRequest.requiredRecipientContactFields

### DIFF
--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -44,36 +44,33 @@
 namespace WebKit {
 using namespace WebCore;
 
+static PKContactField platformContactField(ApplePayContactField contactField)
+{
+    using enum ApplePayContactField;
+    switch (contactField) {
+    case Email:
+        return PKContactFieldEmailAddress;
+    case Name:
+        return PKContactFieldName;
+    case PhoneticName:
+        return PKContactFieldPhoneticName;
+    case Phone:
+        return PKContactFieldPhoneNumber;
+    case PostalAddress:
+        return PKContactFieldPostalAddress;
+    }
+    ASSERT_NOT_REACHED();
+    return nil;
+}
+
 RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const ApplePaySessionPaymentRequest& request, const URL& originatingURL, const std::optional<Vector<ApplePayContactField>>& requiredRecipientContactFields)
 {
     // This merchantID is not actually used for web payments, passing an empty string here is fine
     auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstance() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode() regionCode:request.countryCode() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);
 
     // FIXME: we should consolidate the types for various contact fields in the system(WebCore::ApplePayContactField, WebCore::ApplePaySessionPaymentRequest::ContactFields etc.)
-    if (requiredRecipientContactFields) {
-        NSMutableArray<NSString *> *result = [NSMutableArray array];
-        for (auto& contactField : requiredRecipientContactFields.value()) {
-            switch (contactField) {
-            case ApplePayContactField::Email:
-                [result addObject:PKContactFieldEmailAddress];
-                break;
-            case ApplePayContactField::Name:
-                [result addObject:PKContactFieldName];
-                break;
-            case ApplePayContactField::PhoneticName:
-                [result addObject:PKContactFieldPhoneticName];
-                break;
-            case ApplePayContactField::Phone:
-                [result addObject:PKContactFieldPhoneNumber];
-                break;
-            case ApplePayContactField::PostalAddress:
-                [result addObject:PKContactFieldPostalAddress];
-                break;
-            }
-        }
-
-        [disbursementRequest setRequiredRecipientContactFields:[result copy]];
-    }
+    if (requiredRecipientContactFields)
+        [disbursementRequest setRequiredRecipientContactFields:createNSArray(WTFMove(*requiredRecipientContactFields), platformContactField).get()];
 
     auto disbursementPaymentRequest = adoptNS([PAL::allocPKDisbursementPaymentRequestInstance() initWithDisbursementRequest:disbursementRequest.get()]);
     [disbursementPaymentRequest setOriginatingURL:originatingURL];


### PR DESCRIPTION
#### 058a0eb0108a459d183657840521b235b8eed485
<pre>
WebKit::platformDisbursementRequest(): Unnecessary array copy when setting PKDisbursementRequest.requiredRecipientContactFields
<a href="https://bugs.webkit.org/show_bug.cgi?id=290376">https://bugs.webkit.org/show_bug.cgi?id=290376</a>
<a href="https://rdar.apple.com/147820070">rdar://147820070</a>

Reviewed by Ryosuke Niwa.

requiredRecipientContactFields is a strong property, and as such its
setter retains on its own. We need not copy the input.

* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
(WebKit::platformContactField):
(WebKit::platformDisbursementRequest):

Canonical link: <a href="https://commits.webkit.org/292643@main">https://commits.webkit.org/292643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a71fc2cefa3baf6f104c03f4f6d895d210b70448

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47191 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73676 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12235 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23739 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17309 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 16 flakes 1 failures; Uploaded test results") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82726 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83481 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82109 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28856 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->