### PR TITLE
GPUP: RemoteDisplayListRecorder sends redundant transform operations

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -74,7 +74,7 @@ void Recorder::commitRecording()
 void Recorder::appendStateChangeItem(const GraphicsContextState& state)
 {
     ASSERT(state.changes());
-    
+
     if (state.containsOnlyInlineChanges()) {
         if (state.changes().contains(GraphicsContextState::Change::FillBrush))
             recordSetInlineFillColor(*fillColor().tryGetAsPackedInline());
@@ -107,17 +107,23 @@ void Recorder::appendStateChangeItem(const GraphicsContextState& state)
 
 void Recorder::appendStateChangeItemIfNecessary()
 {
+    auto& currentState = this->currentState();
+    if (currentState.ctmChangeDeferred) {
+        recordDeferredSetCTM(currentState.ctm);
+        currentState.ctmChangeDeferred = false;
+    }
+
     // FIXME: This is currently invoked in an ad-hoc manner when recording drawing items. We should consider either
     // splitting GraphicsContext state changes into individual display list items, or refactoring the code such that
     // this method is automatically invoked when recording a drawing item.
-    auto& state = currentState().state;
+    auto& state = currentState.state;
     if (!state.changes())
         return;
 
     LOG_WITH_STREAM(DisplayLists, stream << "pre-drawing, saving state " << state);
     appendStateChangeItem(state);
     state.didApplyChanges();
-    currentState().lastDrawingState = state;
+    currentState.lastDrawingState = state;
 }
 
 SetInlineStroke Recorder::buildSetInlineStroke(const GraphicsContextState& state)
@@ -313,38 +319,58 @@ bool Recorder::updateStateForTranslate(float x, float y)
 {
     if (!x && !y)
         return false;
-    currentState().translate(x, y);
-    return true;
+    auto& currentState = this->currentState();
+    currentState.ctm.translate(x, y);
+    return !currentState.ctmChangeDeferred;
 }
 
 bool Recorder::updateStateForRotate(float angleInRadians)
 {
     if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, piFloat * 2.f)))
         return false;
-    currentState().rotate(angleInRadians);
-    return true;
+    double angleInDegrees = rad2deg(static_cast<double>(angleInRadians));
+    auto& currentState = this->currentState();
+    currentState.ctm.rotate(angleInDegrees);
+    return !currentState.ctmChangeDeferred;
 }
 
 bool Recorder::updateStateForScale(const FloatSize& size)
 {
     if (areEssentiallyEqual(size, FloatSize { 1.f, 1.f }))
         return false;
-    currentState().scale(size);
-    return true;
+    auto& currentState = this->currentState();
+    currentState.ctm.scale(size);
+    return !currentState.ctmChangeDeferred;
 }
 
 bool Recorder::updateStateForConcatCTM(const AffineTransform& transform)
 {
     if (transform.isIdentity())
         return false;
-
-    currentState().concatCTM(transform);
+    auto& currentState = this->currentState();
+    currentState.ctm *= transform;
     return true;
 }
 
-void Recorder::updateStateForSetCTM(const AffineTransform& transform)
+bool Recorder::updateStateForSetCTM(const AffineTransform& transform)
 {
-    currentState().setCTM(transform);
+    auto& currentState = this->currentState();
+    if (transform == currentState.ctm)
+        return false;
+    currentState.ctm = transform;
+    return true;
+}
+
+void Recorder::updateStateForDeferredSetCTM(const AffineTransform& transform)
+{
+    if (updateStateForSetCTM(transform))
+        currentState().ctmChangeDeferred = true;
+}
+
+void Recorder::updateStateForDeferredConcatCTM(const AffineTransform& transform)
+{
+    if (updateStateForConcatCTM(transform))
+        currentState().ctmChangeDeferred = true;
 }
 
 AffineTransform Recorder::getCTM(GraphicsContext::IncludeDeviceScale) const
@@ -502,7 +528,7 @@ void Recorder::updateStateForApplyDeviceScaleFactor(float deviceScaleFactor)
 {
     // We modify the state directly here instead of calling GraphicsContext::scale()
     // because the recorded item will scale() when replayed.
-    currentState().scale({ deviceScaleFactor, deviceScaleFactor });
+    currentState().ctm.scale({ deviceScaleFactor, deviceScaleFactor });
 
     // FIXME: this changes the baseCTM, which will invalidate all of our cached extents.
     // Assert that it's only called early on?
@@ -523,35 +549,6 @@ Recorder::ContextState& Recorder::currentState()
 const AffineTransform& Recorder::ctm() const
 {
     return currentState().ctm;
-}
-
-void Recorder::ContextState::translate(float x, float y)
-{
-    ctm.translate(x, y);
-}
-
-void Recorder::ContextState::rotate(float angleInRadians)
-{
-    double angleInDegrees = rad2deg(static_cast<double>(angleInRadians));
-    ctm.rotate(angleInDegrees);
-    
-    AffineTransform rotation;
-    rotation.rotate(angleInDegrees);
-}
-
-void Recorder::ContextState::scale(const FloatSize& size)
-{
-    ctm.scale(size);
-}
-
-void Recorder::ContextState::setCTM(const AffineTransform& matrix)
-{
-    ctm = matrix;
-}
-
-void Recorder::ContextState::concatCTM(const AffineTransform& matrix)
-{
-    ctm *= matrix;
 }
 
 } // namespace DisplayList

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -71,6 +71,7 @@ public:
 protected:
     WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode);
 
+    virtual void recordDeferredSetCTM(const AffineTransform&) = 0;
     virtual void recordSetInlineFillColor(PackedColor::RGBA) = 0;
     virtual void recordSetInlineStroke(SetInlineStroke&&) = 0;
     virtual void recordSetState(const GraphicsContextState&) = 0;
@@ -116,6 +117,7 @@ protected:
         AffineTransform ctm;
         FloatRect clipBounds;
         std::optional<GraphicsContextState> lastDrawingState { std::nullopt };
+        bool ctmChangeDeferred = false;
 
         ContextState cloneForTransparencyLayer() const
         {
@@ -125,12 +127,6 @@ protected:
                 lastDrawingStateClone = lastDrawingState->clone(GraphicsContextState::Purpose::TransparencyLayer);
             return ContextState { WTFMove(stateClone), ctm, clipBounds, WTFMove(lastDrawingStateClone) };
         }
-
-        void translate(float x, float y);
-        void rotate(float angleInRadians);
-        void scale(const FloatSize&);
-        void concatCTM(const AffineTransform&);
-        void setCTM(const AffineTransform&);
     };
 
     const Vector<ContextState, 4>& stateStack() const { return m_stateStack; }
@@ -145,7 +141,9 @@ protected:
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForRotate(float angleInRadians);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForScale(const FloatSize&);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForConcatCTM(const AffineTransform&);
-    WEBCORE_EXPORT void updateStateForSetCTM(const AffineTransform&);
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForSetCTM(const AffineTransform&);
+    WEBCORE_EXPORT void updateStateForDeferredConcatCTM(const AffineTransform&);
+    WEBCORE_EXPORT void updateStateForDeferredSetCTM(const AffineTransform&);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(float opacity);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(CompositeOperator, BlendMode);
     WEBCORE_EXPORT void updateStateForEndTransparencyLayer();

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -93,7 +93,8 @@ void RecorderImpl::scale(const FloatSize& scale)
 
 void RecorderImpl::setCTM(const AffineTransform& transform)
 {
-    updateStateForSetCTM(transform);
+    if (!updateStateForSetCTM(transform))
+        return;
     append(SetCTM(transform));
 }
 
@@ -102,6 +103,12 @@ void RecorderImpl::concatCTM(const AffineTransform& transform)
     if (!updateStateForConcatCTM(transform))
         return;
     append(ConcatenateCTM(transform));
+}
+
+void RecorderImpl::recordDeferredSetCTM(const AffineTransform&)
+{
+    // Deferring feature not used, since some display lists must remain agnostic to the initial transform of the recording context.
+    ASSERT_NOT_REACHED();
 }
 
 void RecorderImpl::recordSetInlineFillColor(PackedColor::RGBA inlineColor)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -100,6 +100,7 @@ public:
     void setURLForRect(const URL&, const FloatRect&) final;
 
 private:
+    void recordDeferredSetCTM(const AffineTransform&) final;
     void recordSetInlineFillColor(PackedColor::RGBA) final;
     void recordSetInlineStroke(SetInlineStroke&&) final;
     void recordSetState(const GraphicsContextState&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -123,11 +123,6 @@ void RemoteDisplayListRecorder::setCTM(const AffineTransform& ctm)
     context().setCTM(ctm);
 }
 
-void RemoteDisplayListRecorder::concatCTM(const AffineTransform& ctm)
-{
-    context().concatCTM(ctm);
-}
-
 void RemoteDisplayListRecorder::setInlineFillColor(PackedColor::RGBA color)
 {
     context().setFillColor(asSRGBA(color));

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -70,7 +70,6 @@ public:
     void rotate(float angle);
     void scale(const WebCore::FloatSize& scale);
     void setCTM(const WebCore::AffineTransform&);
-    void concatCTM(const WebCore::AffineTransform&);
     void setInlineFillColor(WebCore::PackedColor::RGBA);
     void setInlineStroke(std::optional<WebCore::PackedColor::RGBA>, std::optional<float> thickness);
     void setState(WebCore::DisplayList::SetState&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -34,7 +34,6 @@ messages -> RemoteDisplayListRecorder Stream {
     Rotate(float angle) StreamBatched
     Scale(WebCore::FloatSize scale) StreamBatched
     SetCTM(WebCore::AffineTransform ctm) StreamBatched
-    ConcatCTM(WebCore::AffineTransform ctm) StreamBatched
     SetInlineFillColor(struct WebCore::PackedColor::RGBA fillColor) StreamBatched;
     SetInlineStroke(std::optional<WebCore::PackedColor::RGBA> strokeColor, std::optional<float> strokeThickness) StreamBatched;
     SetState(WebCore::DisplayList::SetState item) StreamBatched

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -147,15 +147,17 @@ void RemoteDisplayListRecorderProxy::scale(const FloatSize& scale)
 
 void RemoteDisplayListRecorderProxy::setCTM(const AffineTransform& transform)
 {
-    updateStateForSetCTM(transform);
-    send(Messages::RemoteDisplayListRecorder::SetCTM(transform));
+    updateStateForDeferredSetCTM(transform);
 }
 
 void RemoteDisplayListRecorderProxy::concatCTM(const AffineTransform& transform)
 {
-    if (!updateStateForConcatCTM(transform))
-        return;
-    send(Messages::RemoteDisplayListRecorder::ConcatCTM(transform));
+    updateStateForDeferredConcatCTM(transform);
+}
+
+void RemoteDisplayListRecorderProxy::recordDeferredSetCTM(const AffineTransform& transform)
+{
+    send(Messages::RemoteDisplayListRecorder::SetCTM(transform));
 }
 
 void RemoteDisplayListRecorderProxy::recordSetInlineFillColor(PackedColor::RGBA color)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -120,6 +120,7 @@ private:
     void setURLForRect(const URL&, const WebCore::FloatRect&) final;
 
 private:
+    void recordDeferredSetCTM(const WebCore::AffineTransform&) final;
     void recordSetInlineFillColor(WebCore::PackedColor::RGBA) final;
     void recordSetInlineStroke(WebCore::DisplayList::SetInlineStroke&&) final;
     void recordSetState(const WebCore::GraphicsContextState&) final;


### PR DESCRIPTION
#### 1590ec5f2fb475b479198442192bbab48c35894d
<pre>
GPUP: RemoteDisplayListRecorder sends redundant transform operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=290379">https://bugs.webkit.org/show_bug.cgi?id=290379</a>
<a href="https://rdar.apple.com/147825579">rdar://147825579</a>

Reviewed by NOBODY (OOPS!).

Merge subsequent SetCTM and ConcatCTM commands to single SetCTM command.
For simple content, RenderLayer::paintLayerByApplyingTransform will
induce such sequences.

Reduces the amount of time spent serializing these commands.

Does not implement the feature for normal DisplayList recording, since
display lists may be intended to be independent of initial transform.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::appendStateChangeItem):
(WebCore::DisplayList::Recorder::appendStateChangeItemIfNecessary):
(WebCore::DisplayList::Recorder::updateStateForTranslate):
(WebCore::DisplayList::Recorder::updateStateForRotate):
(WebCore::DisplayList::Recorder::updateStateForScale):
(WebCore::DisplayList::Recorder::updateStateForConcatCTM):
(WebCore::DisplayList::Recorder::updateStateForSetCTM):
(WebCore::DisplayList::Recorder::updateStateForDeferredSetCTM):
(WebCore::DisplayList::Recorder::updateStateForDeferredConcatCTM):
(WebCore::DisplayList::Recorder::updateStateForApplyDeviceScaleFactor):
(WebCore::DisplayList::Recorder::ContextState::translate): Deleted.
(WebCore::DisplayList::Recorder::ContextState::rotate): Deleted.
(WebCore::DisplayList::Recorder::ContextState::scale): Deleted.
(WebCore::DisplayList::Recorder::ContextState::setCTM): Deleted.
(WebCore::DisplayList::Recorder::ContextState::concatCTM): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::ContextState::cloneForTransparencyLayer const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::setCTM):
(WebCore::DisplayList::RecorderImpl::recordDeferredSetCTM):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::concatCTM): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::setCTM):
(WebKit::RemoteDisplayListRecorderProxy::concatCTM):
(WebKit::RemoteDisplayListRecorderProxy::recordDeferredSetCTM):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1590ec5f2fb475b479198442192bbab48c35894d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16588 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24751 "Failed to checkout and rebase branch from PR 42989") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73681 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99681 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12484 "Found 1 new test failure: imported/mozilla/svg/non-scaling-stroke-03.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5239 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46526 "Failed to checkout and rebase branch from PR 42989") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82344 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5327 "Found 2 new test failures: imported/mozilla/svg/non-scaling-stroke-03.svg imported/w3c/web-platform-tests/svg/painting/reftests/marker-units-userspaceonuse-non-scaling-stroke.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23746 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17317 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82729 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83492 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82112 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26764 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4298 "Found 2 new test failures: imported/mozilla/svg/non-scaling-stroke-03.svg imported/w3c/web-platform-tests/svg/painting/reftests/marker-units-userspaceonuse-non-scaling-stroke.svg (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17219 "Failed to checkout and rebase branch from PR 42989") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23708 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28863 "Failed to checkout and rebase branch from PR 42989") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->