### PR TITLE
[CoordinatedGraphics] Use Damage to track the dirty region of GraphicsLayer

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -108,6 +108,8 @@ public:
     virtual float pageScaleFactor() const { return 1; }
     virtual float zoomedOutPageScaleFactor() const { return 0; }
 
+    virtual FloatSize enclosingFrameViewVisibleSize() const { return { }; }
+
     virtual std::optional<float> customContentsScale(const GraphicsLayer*) const { return { }; }
 
     virtual float contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const { return 1; }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -152,10 +152,7 @@ public:
     void setContentsColor(const Color&);
     void setContentsTileSize(const FloatSize&);
     void setContentsTilePhase(const FloatSize&);
-    void setDirtyRegion(Vector<IntRect, 1>&&);
-#if ENABLE(DAMAGE_TRACKING)
-    void setDamage(Damage&&);
-#endif
+    void setDirtyRegion(Damage&&);
 
     void setFilters(const FilterOperations&);
     void setMask(CoordinatedPlatformLayer*);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include "Damage.h"
 #include "GraphicsLayer.h"
 #include "GraphicsLayerTransform.h"
 #include "TextureMapperAnimation.h"
@@ -171,10 +172,6 @@ private:
     IntRect transformedRect(const FloatRect&) const;
     IntRect transformedRectIncludingFuture(const FloatRect&) const;
     void updateGeometry(float pageScaleFactor, const FloatPoint&);
-#if ENABLE(DAMAGE_TRACKING)
-    void updateDamage(const FloatSize&);
-#endif
-    void updateDirtyRegion(const FloatSize&);
     void updateBackdropFilters();
     void updateBackdropFiltersRect();
     void updateAnimations();
@@ -201,10 +198,7 @@ private:
     bool m_hasDescendantsWithPendingTilesCreation { false };
     bool m_hasDescendantsWithRunningTransformAnimations { false };
     FloatSize m_pixelAlignmentOffset;
-    struct {
-        bool fullRepaint { false };
-        Vector<FloatRect> rects;
-    } m_dirtyRegion;
+    std::optional<Damage> m_dirtyRegion;
     FloatRect m_visibleRect;
     struct {
         GraphicsLayerTransform current;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4089,6 +4089,11 @@ float RenderLayerBacking::zoomedOutPageScaleFactor() const
     return compositor().zoomedOutPageScaleFactor();
 }
 
+FloatSize RenderLayerBacking::enclosingFrameViewVisibleSize() const
+{
+    return compositor().enclosingFrameViewVisibleSize();
+}
+
 float RenderLayerBacking::deviceScaleFactor() const
 {
     return compositor().deviceScaleFactor();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -242,6 +242,8 @@ public:
     float pageScaleFactor() const override;
     float zoomedOutPageScaleFactor() const override;
 
+    FloatSize enclosingFrameViewVisibleSize() const override;
+
     void didChangePlatformLayerForLayer(const GraphicsLayer*) override;
     bool getCurrentTransform(const GraphicsLayer*, TransformationMatrix&) const override;
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4503,6 +4503,17 @@ float RenderLayerCompositor::zoomedOutPageScaleFactor() const
     return page().zoomedOutPageScaleFactor();
 }
 
+FloatSize RenderLayerCompositor::enclosingFrameViewVisibleSize() const
+{
+    const Ref frameView = m_renderView.frameView();
+#if PLATFORM(IOS_FAMILY)
+    return frameView->exposedContentRect().size();
+#endif
+    if (m_scrolledContentsLayer)
+        return frameView->sizeForVisibleContent(scrollbarInclusionForVisibleRect());
+    return frameView->visibleContentRect().size();
+}
+
 float RenderLayerCompositor::contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -345,6 +345,7 @@ public:
     float contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const override;
     float pageScaleFactor() const override;
     float zoomedOutPageScaleFactor() const override;
+    FloatSize enclosingFrameViewVisibleSize() const override;
     void didChangePlatformLayerForLayer(const GraphicsLayer*) override { }
 
     void layerTiledBackingUsageChanged(const GraphicsLayer*, bool /*usingTiledBacking*/);

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -43,8 +43,8 @@ TEST(Damage, Mode)
 {
     // Rectangles is the default mode.
     Damage rectsDamage(IntSize { 1024, 768 });
-    rectsDamage.add(IntRect { 100, 100, 200, 200 });
-    rectsDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_TRUE(rectsDamage.add(IntRect { 100, 100, 200, 200 }));
+    EXPECT_TRUE(rectsDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(rectsDamage.isEmpty());
     EXPECT_EQ(rectsDamage.rects().size(), 2);
     EXPECT_EQ(rectsDamage.bounds().x(), 100);
@@ -54,8 +54,8 @@ TEST(Damage, Mode)
 
     // BoundingBox always unite damage in bounds.
     Damage bboxDamage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
-    bboxDamage.add(IntRect { 100, 100, 200, 200 });
-    bboxDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_TRUE(bboxDamage.add(IntRect { 100, 100, 200, 200 }));
+    EXPECT_TRUE(bboxDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(bboxDamage.isEmpty());
     EXPECT_EQ(bboxDamage.rects().size(), 1);
     EXPECT_EQ(bboxDamage.rects()[0], bboxDamage.bounds());
@@ -66,8 +66,8 @@ TEST(Damage, Mode)
 
     // Full ignores any adds and always reports the whole area.
     Damage fullDamage(IntSize { 1024, 768 }, Damage::Mode::Full);
-    fullDamage.add(IntRect { 100, 100, 200, 200 });
-    fullDamage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_FALSE(fullDamage.add(IntRect { 100, 100, 200, 200 }));
+    EXPECT_FALSE(fullDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(fullDamage.isEmpty());
     EXPECT_EQ(fullDamage.rects().size(), 1);
     EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
@@ -101,8 +101,8 @@ TEST(Damage, Mode)
 TEST(Damage, Move)
 {
     Damage damage(IntSize { 2048, 1024 });
-    damage.add(IntRect { 100, 100, 200, 200 });
-    damage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(damage.isEmpty());
     EXPECT_EQ(damage.rects().size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
@@ -125,15 +125,10 @@ TEST(Damage, Move)
     EXPECT_EQ(damage.bounds().height(), 400);
 }
 
-TEST(Damage, Resize)
-{
-
-}
-
 TEST(Damage, AddRect)
 {
     Damage damage(IntSize { 2048, 1024 });
-    damage.add(IntRect { 100, 100, 200, 200 });
+    EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // When there's only one rect, that should be the bounds.
@@ -144,15 +139,15 @@ TEST(Damage, AddRect)
 
     // When there's only one rect, adding a rect already contained
     // by the bounding box does nothing.
-    damage.add(IntRect { 150, 150, 100, 100 });
+    EXPECT_FALSE(damage.add(IntRect { 150, 150, 100, 100 }));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // Adding an empty rect does nothing.
-    damage.add(IntRect { });
+    EXPECT_FALSE(damage.add(IntRect { }));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // Adding a new rect not contained by previous one adds it to the list.
-    damage.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_EQ(damage.rects().size(), 2);
 
     // Now the bounding box contains the two rectangles.
@@ -162,7 +157,7 @@ TEST(Damage, AddRect)
     EXPECT_EQ(damage.bounds().height(), 400);
 
     // Adding a rect containing the bounds makes it the only rect.
-    damage.add(IntRect { 50, 50, 500, 500 });
+    EXPECT_TRUE(damage.add(IntRect { 50, 50, 500, 500 }));
     EXPECT_EQ(damage.rects().size(), 1);
     EXPECT_EQ(damage.bounds().x(), 50);
     EXPECT_EQ(damage.bounds().y(), 50);
@@ -170,7 +165,7 @@ TEST(Damage, AddRect)
     EXPECT_EQ(damage.bounds().height(), 500);
 
     // Adding FloatRect takes the enclosingIntRect
-    damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 });
+    EXPECT_TRUE(damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 }));
     EXPECT_EQ(damage.rects().size(), 2);
     EXPECT_EQ(damage.rects().last().x(), 1024);
     EXPECT_EQ(damage.rects().last().y(), 1024);
@@ -178,25 +173,25 @@ TEST(Damage, AddRect)
     EXPECT_EQ(damage.rects().last().height(), 26);
 
     // Adding an empty FloatRect does nothing.
-    damage.add(FloatRect { 1024.50, 1024.25, 0, 0 });
+    EXPECT_FALSE(damage.add(FloatRect { 1024.50, 1024.25, 0, 0 }));
     EXPECT_EQ(damage.rects().size(), 2);
 }
 
 TEST(Damage, AddDamage)
 {
     Damage damage(IntSize { 2048, 1024 });
-    damage.add(IntRect { 100, 100, 200, 200 });
+    EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // Adding empty Damage does nothing.
     Damage other(IntSize { 2048, 1024 });
-    damage.add(other);
+    EXPECT_FALSE(damage.add(other));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // Adding a valid Damage adds its rectangles.
-    other.add(IntRect { 300, 300, 200, 200 });
+    EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_EQ(other.rects().size(), 1);
-    damage.add(other);
+    EXPECT_TRUE(damage.add(other));
     EXPECT_EQ(damage.rects().size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
@@ -208,15 +203,15 @@ TEST(Damage, Unite)
 {
     // Add several rects to the first tile.
     Damage damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 200, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 200, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 0, 200, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 200, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 200, 200, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 200, 200, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 128, 128, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 128, 128, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
@@ -226,15 +221,15 @@ TEST(Damage, Unite)
 
     // Add several rects to the second tile.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 300, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 500, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 300, 200, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 500, 200, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 384, 128, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_FALSE(damage.rects()[1].isEmpty());
@@ -244,15 +239,15 @@ TEST(Damage, Unite)
 
     // Add several rects to the third tile.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 200, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 200, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 0, 500, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 500, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 200, 500, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 200, 500, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 128, 384, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 128, 384, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
@@ -262,15 +257,15 @@ TEST(Damage, Unite)
 
     // Add several rects to the fourth tile.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 300, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 500, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 500, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 300, 500, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 500, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 500, 500, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 500, 500, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 384, 384, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
@@ -280,13 +275,13 @@ TEST(Damage, Unite)
 
     // Add one rect per tile.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 300, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 0, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 300, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_EQ(damage.rects()[0].x(), 0);
@@ -311,21 +306,21 @@ TEST(Damage, Unite)
 
     // Add rects with points off the grid area.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { -2, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { -2, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 50, -2, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 50, -2, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 2);
-    damage.add(IntRect { 550, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 550, 0, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 3);
-    damage.add(IntRect { 300, -2, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, -2, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { -2, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { -2, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 50, 550, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 50, 550, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 300, 550, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 550, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 550, 300, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 550, 300, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_EQ(damage.rects()[0].x(), -2);
@@ -350,45 +345,41 @@ TEST(Damage, Unite)
 
     // Add several rects and check that unite works for single tile grid.
     damage = Damage(IntSize { 128, 128 });
-    damage.add(IntRect { 10, 10, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 60, 60, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 60, 60, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 70, 0, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 70, 10, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 120, 60, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 120, 60, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 0, 70, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 10, 70, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 60, 70, 4, 4 });
-    EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 70, 70, 4, 4 });
-    EXPECT_EQ(damage.rects().size(), 1);
-    damage.add(IntRect { 120, 120, 4, 4 });
+    EXPECT_TRUE(damage.add(IntRect { 120, 120, 4, 4 }));
     EXPECT_EQ(damage.rects().size(), 1);
 
     // Grid size should be ceiled.
     damage = Damage(IntSize { 512, 333 });
-    damage.add(IntRect { 0, 0, 1, 1 });
-    damage.add(IntRect { 1, 1, 1, 1 });
-    damage.add(IntRect { 2, 2, 1, 1 });
-    damage.add(IntRect { 3, 3, 1, 1 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 2, 2, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 3, 3, 1, 1 }));
     EXPECT_EQ(damage.rects().size(), 4);
 
     // Grid size should be ceiled with high precision.
     damage = Damage(IntSize { 257, 50 });
-    damage.add(IntRect { 0, 0, 1, 1 });
-    damage.add(IntRect { 1, 1, 1, 1 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
     EXPECT_EQ(damage.rects().size(), 2);
 
     // Unification should work correctly when grid does not start and { 0, 0 }.
     damage = Damage(IntRect { 256, 256, 512, 512 });
-    damage.add(IntRect { 300, 300, 1, 1 });
-    damage.add(IntRect { 600, 300, 1, 1 });
-    damage.add(IntRect { 300, 600, 1, 1 });
-    damage.add(IntRect { 600, 600, 1, 1 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 300, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 600, 300, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 300, 600, 1, 1 }));
+    EXPECT_TRUE(damage.add(IntRect { 600, 600, 1, 1 }));
     EXPECT_EQ(damage.rects().size(), 4);
-    damage.add(IntRect { 301, 301, 1, 1 });
+    EXPECT_TRUE(damage.add(IntRect { 301, 301, 1, 1 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_EQ(damage.rects()[0], IntRect(300, 300, 2, 2));
     EXPECT_EQ(damage.rects()[1], IntRect(600, 300, 1, 1));
@@ -400,61 +391,61 @@ TEST(Damage, RectsForPainting)
 {
     // The function should return the original rect when theres only a single one.
     Damage damage(IntSize { 512, 512 });
-    damage.add(IntRect { 250, 250, 12, 12 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
     ASSERT_EQ(damage.rectsForPainting().size(), 1);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 12, 12));
 
     // The function should remove overlaps.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 0, 100, 100 });
-    damage.add(IntRect { 50, 50, 100, 100 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 100, 100 }));
+    EXPECT_TRUE(damage.add(IntRect { 50, 50, 100, 100 }));
     ASSERT_EQ(damage.rectsForPainting().size(), 1);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 150, 150));
 
     // The function should remove empty rects.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 0, 10, 10 });
-    damage.add(IntRect { 10, 10, 10, 10 });
-    damage.add(IntRect { 20, 20, 10, 10 });
-    damage.add(IntRect { 30, 30, 10, 10 });
-    damage.add(IntRect { 40, 40, 10, 10 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 20, 20, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 30, 30, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 40, 40, 10, 10 }));
     EXPECT_EQ(damage.rects().size(), 4);
     ASSERT_EQ(damage.rectsForPainting().size(), 1);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 50, 50));
 
     // The function should clip the rects.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { -2, -2, 10, 10 });
-    damage.add(IntRect { 504, 504, 10, 10 });
+    EXPECT_TRUE(damage.add(IntRect { -2, -2, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 504, 504, 10, 10 }));
     ASSERT_EQ(damage.rectsForPainting().size(), 2);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 8, 8));
     EXPECT_EQ(damage.rectsForPainting()[1], IntRect(504, 504, 8, 8));
 
     // The function should preserve the layout of cells when unification is enabled.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 0, 0, 10, 10 });
-    damage.add(IntRect { 10, 10, 10, 10 });
-    damage.add(IntRect { 0, 256, 10, 10 });
-    damage.add(IntRect { 256, 0, 10, 10 });
-    damage.add(IntRect { 256, 256, 10, 10 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 0, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_EQ(damage.rects(), damage.rectsForPainting());
 
     // The function should preserve the layout of cells when unification is enabled
     // and the grid does not start at { 0, 0 }.
     damage = Damage(IntRect { 256, 256, 512, 512 });
-    damage.add(IntRect { 256, 256, 10, 10 });
-    damage.add(IntRect { 256+10, 256+10, 10, 10 });
-    damage.add(IntRect { 256, 256+256, 10, 10 });
-    damage.add(IntRect { 256+256, 256, 10, 10 });
-    damage.add(IntRect { 256+256, 256+256, 10, 10 });
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 10, 256 + 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256 + 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256 + 256, 10, 10 }));
     EXPECT_EQ(damage.rects().size(), 4);
     EXPECT_EQ(damage.rects(), damage.rectsForPainting());
 
     // The function should split a rect spanning multiple cells.
     damage = Damage(IntSize { 512, 512 });
-    damage.add(IntRect { 250, 250, 12, 12 });
-    damage.add(IntRect { 249, 249, 1, 1 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    EXPECT_TRUE(damage.add(IntRect { 249, 249, 1, 1 }));
     ASSERT_EQ(damage.rectsForPainting().size(), 4);
     EXPECT_EQ(damage.rectsForPainting()[0], IntRect(249, 249, 7, 7));
     EXPECT_EQ(damage.rectsForPainting()[1], IntRect(256, 250, 6, 6));
@@ -463,10 +454,10 @@ TEST(Damage, RectsForPainting)
 
     // The function should just return original rects when mode != Mode::Rectangles.
     damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::BoundingBox);
-    damage.add(IntRect { 1278, 678, 9, 341 });
-    damage.add(IntRect { 1285, 678, 5, 341 });
-    damage.add(IntRect { 1279, 678, 9, 341 });
-    damage.add(IntRect { 1286, 678, 5, 341 });
+    EXPECT_TRUE(damage.add(IntRect { 1278, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1285, 678, 5, 341 }));
+    EXPECT_FALSE(damage.add(IntRect { 1279, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1286, 678, 5, 341 }));
     EXPECT_EQ(damage.rects(), damage.rectsForPainting());
     damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::Full);
     EXPECT_EQ(damage.rects(), damage.rectsForPainting());


### PR DESCRIPTION
#### c5f315a9682101aa5a3c1bb2f66dab405dacc7a4
<pre>
[CoordinatedGraphics] Use Damage to track the dirty region of GraphicsLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=290385">https://bugs.webkit.org/show_bug.cgi?id=290385</a>

Reviewed by Nikolas Zimmermann.

We can use the Damage class to track the dirty rects in GraphicsLayer
which should improve the performance. This patch adds a viewSize()
method to GraphicsLayerClient since it&apos;s needed to create the Damage
from GraphicsLayer.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::mode const):
(WebCore::Damage::add):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::viewSize const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setDirtyRegion):
(WebCore::CoordinatedPlatformLayer::setDamage): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setNeedsDisplay):
(WebCore::GraphicsLayerCoordinated::setNeedsDisplayInRect):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
(WebCore::GraphicsLayerCoordinated::updateDamage): Deleted.
(WebCore::GraphicsLayerCoordinated::updateDirtyRegion): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::viewSize const):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::viewSize const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, Mode)):
(TestWebKitAPI::TEST(Damage, Move)):
(TestWebKitAPI::TEST(Damage, AddRect)):
(TestWebKitAPI::TEST(Damage, AddDamage)):
(TestWebKitAPI::TEST(Damage, Unite)):
(TestWebKitAPI::TEST(Damage, Resize)): Deleted.

Canonical link: <a href="https://commits.webkit.org/292747@main">https://commits.webkit.org/292747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0bfb1d58a43f972ef4edbe1e806a18a7ecce739

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73904 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31118 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12768 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46873 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104120 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24092 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83849 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82349 "Found 1 new API test failure: /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27035 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17591 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29205 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->