### PR TITLE
AX: Add AXTextMarker and AXTextMarkerRange DebugDescription APIs for client debugging.

### DIFF
--- a/LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt
+++ b/LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt
@@ -1,0 +1,21 @@
+This tests the AXTextMarker and AXTextMarkerRange DebugDescription APIs.
+
+text:
+text: 'some text', start: {role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown}, end: {role StaticText, anchor 0, affinity 1, offset 9, charStart 0, charOffset 9, origin Unknown}
+
+role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown
+
+role StaticText, anchor 0, affinity 1, offset 9, charStart 0, charOffset 9, origin Unknown
+
+link:
+text: 'Click on the hypertext.', start: {role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown}, end: {role StaticText, anchor 0, affinity 1, offset 23, charStart 0, charOffset 23, origin Unknown}
+
+role StaticText, anchor 0, affinity 1, offset 0, charStart 0, charOffset 0, origin Unknown
+
+role StaticText, anchor 0, affinity 1, offset 23, charStart 0, charOffset 23, origin Unknown
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/text-marker/text-marker-debug-description.html
+++ b/LayoutTests/accessibility/text-marker/text-marker-debug-description.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div id="content">
+<div id="text">some text</div>
+<a href="#" id="link">Click on the hypertext.</a>
+</div>
+
+<script>
+if (window.accessibilityController) {
+    let output = "This tests the AXTextMarker and AXTextMarkerRange DebugDescription APIs.\n\n";
+
+    let ids = ["text", "link"];
+    ids.forEach((id) => {
+        output += `${id}:\n`;
+        let axElement = accessibilityController.accessibleElementById(id);
+        let range = axElement.textMarkerRangeForElement(axElement);
+        output += `${axElement.textMarkerRangeDebugDescription(range)}\n\n`;
+
+        let start = axElement.startTextMarkerForTextMarkerRange(range);
+        let end = axElement.endTextMarkerForTextMarkerRange(range);
+        output += `${axElement.textMarkerDebugDescription(start)}\n\n`;
+        output += `${axElement.textMarkerDebugDescription(end)}\n\n`;
+    });
+
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2420,6 +2420,8 @@ accessibility/attachment-element.html [ Pass ]
 
 # Enable Text marker tests for iOS
 webkit.org/b/153292 accessibility/text-marker [ Pass ]
+# TextMarkerDebugDescription not implemented on iOS:
+accessibility/text-marker/text-marker-debug-description.html [ Skip ]
 
 # More flaky tests (Sept 18, 2015)
 

--- a/LayoutTests/platform/mac-sonoma/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma/TestExpectations
@@ -8,3 +8,5 @@ http/tests/paymentrequest/paymentrequest-merchantCategoryCode.https.html [ Skip 
 # linkedOnOrAfter(Sequoa) for Cross Origin Redirect Downloads.
 http/tests/download/anchor-download-redirect-cross-origin.html
 http/tests/download/anchor-download-redirect-cross-origin-top-level.html
+
+accessibility/text-marker/text-marker-debug-description.html [ Skip ]

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -225,16 +225,28 @@ String AXTextMarker::debugDescription() const
 {
     auto separator = ", "_s;
     RefPtr object = this->object();
-    return makeString(
-        "treeID "_s, treeID() ? treeID()->loggingString() : ""_s
-        , separator, "objectID "_s, objectID() ? objectID()->loggingString() : ""_s
-        , separator, "role "_s, object ? accessibilityRoleToString(object->roleValue()) : "no object"_str
+
+    String ids;
+#if PLATFORM(MAC)
+    // Since treeID and objectID change from run to run and this is used in a Mac LayoutTest, don't include them in the debugDescription when running tests.
+    if (!AXObjectCache::clientIsInTestMode()) {
+#endif
+        ids = makeString(
+            "treeID "_s, treeID() ? treeID()->loggingString() : "null"_s
+            , separator, "objectID "_s, objectID() ? objectID()->loggingString() : "null"_s
+            , separator);
+#if PLATFORM(MAC)
+    }
+#endif
+
+    return makeString(ids
+        , "role "_s, object ? accessibilityRoleToString(object->roleValue()) : "no object"_s
         , isIgnored() ? makeString(separator, "ignored"_s) : ""_s
         , separator, "anchor "_s, m_data.anchorType
         , separator, "affinity "_s, m_data.affinity
         , separator, "offset "_s, m_data.offset
-        , separator, "characterStart "_s, m_data.characterStart
-        , separator, "characterOffset "_s, m_data.characterOffset
+        , separator, "charStart "_s, m_data.characterStart
+        , separator, "charOffset "_s, m_data.characterOffset
         , separator, "origin "_s, originToString(m_data.origin)
     );
 }
@@ -448,7 +460,9 @@ std::optional<AXTextMarkerRange> AXTextMarkerRange::intersectionWith(const AXTex
 
 String AXTextMarkerRange::debugDescription() const
 {
-    return makeString("start: {"_s, m_start.debugDescription(), "}\nend:   {"_s, m_end.debugDescription(), '}');
+    return makeString("text: '"_s, toString(), "'"_s,
+        ", start: {"_s, m_start.debugDescription(), '}',
+        ", end: {"_s, m_end.debugDescription(), '}');
 }
 
 std::partial_ordering partialOrder(const AXTextMarker& marker1, const AXTextMarker& marker2)

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -247,10 +247,12 @@
 #define NSAccessibilityStartTextMarkerForBoundsAttribute @"AXStartTextMarkerForBounds"
 #define NSAccessibilityStringForTextMarkerRangeAttribute @"AXStringForTextMarkerRange"
 #define NSAccessibilityStyleTextMarkerRangeForTextMarkerAttribute @"AXStyleTextMarkerRangeForTextMarker"
+#define NSAccessibilityTextMarkerDebugDescriptionAttribute @"AXTextMarkerDebugDescription"
 #define NSAccessibilityTextMarkerForIndexAttribute @"AXTextMarkerForIndex"
 #define NSAccessibilityTextMarkerForPositionAttribute @"AXTextMarkerForPosition" // FIXME: should be AXTextMarkerForPoint.
 #define NSAccessibilityTextMarkerIsNullParameterizedAttribute @"AXTextMarkerIsNull"
 #define NSAccessibilityTextMarkerIsValidAttribute @"AXTextMarkerIsValid"
+#define NSAccessibilityTextMarkerRangeDebugDescriptionAttribute @"AXTextMarkerRangeDebugDescription"
 #define NSAccessibilityTextMarkerRangeForLineAttribute @"AXTextMarkerRangeForLine"
 #define NSAccessibilityTextMarkerRangeForTextMarkersAttribute @"AXTextMarkerRangeForTextMarkers"
 #define NSAccessibilityTextMarkerRangeForUIElementAttribute @"AXTextMarkerRangeForUIElement"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -323,8 +323,5 @@ void* WKAccessibilityRootObject(WKBundleFrameRef frameRef)
         return nullptr;
 
     auto* root = axObjectCache->rootObjectForFrame(*frame);
-    if (!root)
-        return nullptr;
-
-    return root->wrapper();
+    return root ? root->wrapper() : nullptr;
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
@@ -54,7 +54,7 @@ public:
 
     void makeWindowObject(JSContextRef);
     virtual JSClassRef wrapperClass();
-    
+
     // Enhanced accessibility.
     void enableEnhancedAccessibility(bool);
     bool enhancedAccessibilityEnabled();

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp
@@ -31,7 +31,7 @@
 #include "JSAccessibilityTextMarker.h"
 
 namespace WTR {
-    
+
 Ref<AccessibilityTextMarker> AccessibilityTextMarker::create(PlatformTextMarker marker)
 {
     return adoptRef(*new AccessibilityTextMarker(marker));

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h
@@ -47,13 +47,13 @@ public:
     static Ref<AccessibilityTextMarker> create(const AccessibilityTextMarker&);
 
     ~AccessibilityTextMarker();
-    
+
     PlatformTextMarker platformTextMarker() const;
     virtual JSClassRef wrapperClass();
 
     static JSObjectRef makeJSAccessibilityTextMarker(JSContextRef, const AccessibilityTextMarker&);
     bool isEqual(AccessibilityTextMarker*);
-    
+
 private:
     AccessibilityTextMarker(PlatformTextMarker);
     AccessibilityTextMarker(const AccessibilityTextMarker&);

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
@@ -31,7 +31,7 @@
 #include "JSAccessibilityTextMarkerRange.h"
 
 namespace WTR {
-    
+
 Ref<AccessibilityTextMarkerRange> AccessibilityTextMarkerRange::create(PlatformTextMarkerRange markerRange)
 {
     return adoptRef(*new AccessibilityTextMarkerRange(markerRange));

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
@@ -38,24 +38,24 @@ typedef void* PlatformTextMarkerRange;
 #endif
 
 namespace WTR {
-    
+
 class AccessibilityTextMarkerRange : public JSWrappable {
 public:
     static Ref<AccessibilityTextMarkerRange> create(PlatformTextMarkerRange);
     static Ref<AccessibilityTextMarkerRange> create(const AccessibilityTextMarkerRange&);
-    
+
     ~AccessibilityTextMarkerRange();
-    
+
     PlatformTextMarkerRange platformTextMarkerRange() const;
     virtual JSClassRef wrapperClass();
-    
+
     static JSObjectRef makeJSAccessibilityTextMarkerRange(JSContextRef, const AccessibilityTextMarkerRange&);
     bool isEqual(AccessibilityTextMarkerRange*);
-    
+
 private:
     AccessibilityTextMarkerRange(PlatformTextMarkerRange);
     AccessibilityTextMarkerRange(const AccessibilityTextMarkerRange&);
-    
+
 #if PLATFORM(COCOA)
     RetainPtr<id> m_textMarkerRange;
 #else
@@ -80,7 +80,7 @@ inline PlatformTextMarkerRange AccessibilityTextMarkerRange::platformTextMarkerR
     return m_textMarkerRange;
 }
 #endif
-    
+
 #ifdef __OBJC__
 inline std::optional<RefPtr<AccessibilityTextMarkerRange>> makeVectorElement(const RefPtr<AccessibilityTextMarkerRange>*, id range) { return { { AccessibilityTextMarkerRange::create(range) } }; }
 #endif

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -125,6 +125,8 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForR
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::selectedTextMarkerRange() { return nullptr; }
 void AccessibilityUIElement::resetSelectedTextMarkerRange() { }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textInputMarkedTextMarkerRange() const { return nullptr; }
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(AccessibilityTextMarker*) { return nullptr; }
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*) { return nullptr; }
 void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
 void AccessibilityUIElement::setValue(JSStringRef) { }
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef, JSValueRef, JSStringRef, JSStringRef) { return nullptr; }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -382,6 +382,8 @@ public:
     RefPtr<AccessibilityTextMarker> nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*);
     RefPtr<AccessibilityTextMarker> previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*);
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*);
+    JSRetainPtr<JSStringRef> textMarkerDebugDescription(AccessibilityTextMarker*);
+    JSRetainPtr<JSStringRef> textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*);
 
     // Returns an ordered list of supported actions for an element.
     JSRetainPtr<JSStringRef> supportedActions() const;

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -292,6 +292,8 @@ interface AccessibilityUIElement {
     AccessibilityTextMarker previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     AccessibilityTextMarker nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     AccessibilityTextMarkerRange textMarkerRangeMatchesTextNearMarkers(DOMString text, AccessibilityTextMarker startMarker, AccessibilityTextMarker endMarker);
+    DOMString textMarkerDebugDescription(AccessibilityTextMarker marker);
+    DOMString textMarkerRangeDebugDescription(AccessibilityTextMarkerRange range);
 
     // Returns an ordered list of supported actions for an element.
     readonly attribute DOMString supportedActions;

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityTextMarkerRangeCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityTextMarkerRangeCocoa.mm
@@ -34,4 +34,3 @@ bool AccessibilityTextMarkerRange::isEqual(AccessibilityTextMarkerRange* other)
 }
 
 } // namespace WTR
-

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2818,6 +2818,32 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextSentenceEndTextMarke
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(AccessibilityTextMarker* marker)
+{
+    if (!marker)
+        return nullptr;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    RetainPtr description = attributeValueForParameter(@"AXTextMarkerDebugDescription", marker->platformTextMarker());
+    return [description createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(AccessibilityTextMarkerRange* range)
+{
+    if (!range)
+        return nullptr;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    RetainPtr description = attributeValueForParameter(@"AXTextMarkerRangeDebugDescription", range->platformTextMarkerRange());
+    return [description createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 static NSString *_convertMathMultiscriptPairsToString(NSArray *pairs)
 {
     __block NSMutableString *result = [NSMutableString string];


### PR DESCRIPTION
#### 5deaf7c534b2895e6c3445fcfeb05fda6426c394
<pre>
AX: Add AXTextMarker and AXTextMarkerRange DebugDescription APIs for client debugging.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290383">https://bugs.webkit.org/show_bug.cgi?id=290383</a>
&lt;<a href="https://rdar.apple.com/problem/147836473">rdar://problem/147836473</a>&gt;

Reviewed by Tyler Wilcock.

For accessibility clients, AXTextMarkers and AXTextMarkerRanges are opaque pointers and there is no way of gaining any visibility into their values. This change adds the ability for a client to get a debug description of the TextMarkers to aid in debugging.

* LayoutTests/accessibility/text-marker/text-marker-debug-description-expected.txt: Added.
* LayoutTests/accessibility/text-marker/text-marker-debug-description.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-sonoma/TestExpectations:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::debugDescription const):
(WebCore::AXTextMarkerRange::debugDescription const):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper showNodeTreeForTextMarker:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
(-[WebAccessibilityObjectWrapper debugDescriptionForTextMarker:]): Deleted.
(-[WebAccessibilityObjectWrapper debugDescriptionForTextMarkerRange:]): Deleted.
(formatForDebugger): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKAccessibilityRootObject):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::textMarkerDebugDescription):
(WTR::AccessibilityUIElement::textMarkerRangeDebugDescription):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityTextMarkerRangeCocoa.mm:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::textMarkerDebugDescription):
(WTR::AccessibilityUIElement::textMarkerRangeDebugDescription):

Canonical link: <a href="https://commits.webkit.org/292698@main">https://commits.webkit.org/292698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0bf81001d06a8dc42eb3733339fa011425d17fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17404 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82806 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83607 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82195 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17339 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28978 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->