### PR TITLE
[JSC] Optimize searching untyped element from int32 array for `indexOf` and `includes`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-includes-untyped-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-includes-untyped-int32.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.includes(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = i;
+}
+
+for (let i = 0; i < 1e5; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? 512 : {};
+    shouldBe(test(array, searchElement), odd ? true : false);
+}

--- a/JSTests/microbenchmarks/array-prototype-indexOf-untyped-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-untyped-int32.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.indexOf(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = i;
+}
+
+for (let i = 0; i < 1e5; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? 512 : {};
+    shouldBe(test(array, searchElement), odd ? 512 : -1);
+}

--- a/JSTests/stress/array-prototype-includes-untyped-int32-double.js
+++ b/JSTests/stress/array-prototype-includes-untyped-int32-double.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.includes(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = i;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    shouldBe(test(array, odd ? 256.0 : {}), odd ? true : false);
+    shouldBe(test(array, 24.9), false);
+}

--- a/JSTests/stress/array-prototype-includes-untyped-int32-hole.js
+++ b/JSTests/stress/array-prototype-includes-untyped-int32-hole.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.includes(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    if (i !== 256)
+        array[i] = i;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? undefined : {};
+    shouldBe(test(array, searchElement), odd ? true : false);
+}

--- a/JSTests/stress/array-prototype-indexOf-untyped-int32-double.js
+++ b/JSTests/stress/array-prototype-indexOf-untyped-int32-double.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.indexOf(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = i;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    shouldBe(test(array, odd ? 256.0 : {}), odd ? 256 : -1);
+    shouldBe(test(array, 24.9), -1);
+}

--- a/JSTests/stress/array-prototype-indexOf-untyped-int32-hole.js
+++ b/JSTests/stress/array-prototype-indexOf-untyped-int32-hole.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.indexOf(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    if (i !== 256)
+        array[i] = i;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? undefined : {};
+    shouldBe(test(array, searchElement), -1);
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -382,12 +382,14 @@ JSC_DECLARE_JIT_OPERATION(operationHasOwnProperty, size_t, (JSGlobalObject*, JSO
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9845,6 +9845,11 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
                 callOperation(operationArrayIndexOfValueDouble, lengthGPR, storageGPR, searchElementRegs, indexGPR);
             break;
         case Array::Int32:
+            if (isArrayIncludes)
+                callOperation(operationArrayIncludesValueInt32, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
+            else
+                callOperation(operationArrayIndexOfValueInt32, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);
+            break;
         case Array::Contiguous:
             if (isArrayIncludes)
                 callOperation(operationArrayIncludesValueInt32OrContiguous, lengthGPR, LinkableConstant::globalObject(*this, node), storageGPR, searchElementRegs, indexGPR);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -7914,12 +7914,16 @@ IGNORE_CLANG_WARNINGS_END
             case Array::Contiguous:
                 // We have to keep base alive since that keeps content of storage alive.
                 ensureStillAliveHere(base);
-                FALLTHROUGH;
-            case Array::Int32:
                 if (isArrayIncludes)
                     setBoolean(vmCall(Int32, operationArrayIncludesValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 else
                     setInt32(vmCall(Int32, operationArrayIndexOfValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
+                return;
+            case Array::Int32:
+                if (isArrayIncludes)
+                    setBoolean(vmCall(Int32, operationArrayIncludesValueInt32, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
+                else
+                    setInt32(vmCall(Int32, operationArrayIndexOfValueInt32, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 return;
             default:
                 RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 3e9331148002ecc61cc0a11e2084e58689d5f5a2
<pre>
[JSC] Optimize searching untyped element from int32 array for `indexOf` and `includes`
<a href="https://bugs.webkit.org/show_bug.cgi?id=290388">https://bugs.webkit.org/show_bug.cgi?id=290388</a>

Reviewed by Yusuke Suzuki.

This patch adds a dedicated JIT operation for searching untyped
element from int32 array for `Array#indexOf` and `Array#includes`.

                                                TipOfTree                  Patched

array-prototype-indexOf-untyped-int32        36.1595+-0.6719     ^      6.9764+-0.0820        ^ definitely 5.1831x faster
array-prototype-includes-untyped-int32       39.2141+-0.4759     ^      8.3772+-0.0831        ^ definitely 4.6811x faster

* JSTests/microbenchmarks/array-prototype-includes-untyped-int32.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/array-prototype-indexOf-untyped-int32.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-includes-untyped-int32-hole.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-indexOf-untyped-int32-hole.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Canonical link: <a href="https://commits.webkit.org/292999@main">https://commits.webkit.org/292999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a87f35017c633504515bf0e312dc6e099bbffb8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31585 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13328 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47644 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90349 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104781 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96296 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24753 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82875 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27441 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24714 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119921 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24536 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33661 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->