### PR TITLE
Safer CPP recommendations: use std::exchange for std::optional

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
@@ -197,9 +197,8 @@ void LibWebRTCRtpSenderBackend::setParameters(const RTCRtpSendParameters& parame
         return;
     }
 
-    auto rtcParameters = WTFMove(*m_currentParameters);
+    auto rtcParameters = *std::exchange(m_currentParameters, std::nullopt);
     updateRTCRtpSendParameters(parameters, rtcParameters);
-    m_currentParameters = std::nullopt;
 
     auto error = m_rtcSender->SetParameters(rtcParameters);
     if (!error.ok()) {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -55,8 +55,7 @@ public:
         if (!m_additionalDataVector.isEmpty() || !additionalData)
             return m_additionalDataVector;
 
-        BufferSource additionalDataBuffer = WTFMove(*additionalData);
-        additionalData = std::nullopt;
+        BufferSource additionalDataBuffer = *std::exchange(additionalData, std::nullopt);
         if (!additionalDataBuffer.length())
             return m_additionalDataVector;
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -44,8 +44,7 @@ public:
         if (!m_labelVector.isEmpty() || !label)
             return m_labelVector;
 
-        BufferSource labelBuffer = WTFMove(*label);
-        label = std::nullopt;
+        BufferSource labelBuffer = *std::exchange(label, std::nullopt);
         if (!labelBuffer.length())
             return m_labelVector;
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -529,9 +529,7 @@ void DocumentThreadableLoader::didFail(std::optional<ResourceLoaderIdentifier>, 
         clearResource();
 
         m_options.serviceWorkersMode = ServiceWorkersMode::None;
-        makeCrossOriginAccessRequestWithPreflight(WTFMove(m_bypassingPreflightForServiceWorkerRequest.value()));
-        ASSERT(m_bypassingPreflightForServiceWorkerRequest->isNull());
-        m_bypassingPreflightForServiceWorkerRequest = std::nullopt;
+        makeCrossOriginAccessRequestWithPreflight(*std::exchange(m_bypassingPreflightForServiceWorkerRequest, std::nullopt));
         return;
     }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -914,8 +914,7 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
 #if ENABLE(DAMAGE_TRACKING)
     if (m_pendingChanges.contains(Change::Damage)) {
         ASSERT(m_damage.has_value());
-        layer.setDamage(WTFMove(*m_damage));
-        m_damage = std::nullopt;
+        layer.setDamage(*std::exchange(m_damage, std::nullopt));
     }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8275,8 +8275,7 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, const Resou
 
         if (m_internals->pendingWebsitePolicies && frame.isMainFrame()) {
             m_allowsContentJavaScriptFromMostRecentNavigation = m_internals->pendingWebsitePolicies->allowsContentJavaScript;
-            WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_internals->pendingWebsitePolicies), documentLoader);
-            m_internals->pendingWebsitePolicies = std::nullopt;
+            WebsitePoliciesData::applyToDocumentLoader(*std::exchange(m_internals->pendingWebsitePolicies, std::nullopt), documentLoader);
         }
     }
 


### PR DESCRIPTION
#### e9ed5612a59b3e66993b06943cabb285bfc77721
<pre>
Safer CPP recommendations: use std::exchange for std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=290386">https://bugs.webkit.org/show_bug.cgi?id=290386</a>

Reviewed by Youenn Fablet and Adrian Perez de Castro.

This uses *std::exchange(foo, std::nullopt), rather than separately
moving the value out of the optional, and then restoring it to nullopt.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::LibWebRTCRtpSenderBackend::setParameters):
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::didFail):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::createDocumentLoader):

Canonical link: <a href="https://commits.webkit.org/292697@main">https://commits.webkit.org/292697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6368c7509f944a45d63c2673c276a772a17bf2d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73699 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87466 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54034 "Found 2 new API test failures: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies, /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5268 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83522 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82133 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17248 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23736 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28891 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->