### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Caret sometimes appears in the wrong place after inserting newline

### DIFF
--- a/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea-expected.txt
+++ b/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea-expected.txt
@@ -1,0 +1,17 @@
+
+Verifies that the selection caret rect updates properly when inserting newlines in a textarea with vertical overflow.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS caretRects[0].height is caretRects[1].height
+PASS caretRects[0].height is caretRects[2].height
+PASS caretRects[0].height is caretRects[3].height
+PASS caretRects[0].height is caretRects[4].height
+PASS caretRects[0].height is caretRects[5].height
+PASS caretRects[4].top is caretRects[5].top
+PASS caretRects[5].width is > 1
+PASS caretRects[5].height is > 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html
+++ b/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    margin: 0;
+}
+
+textarea {
+    width: 250px;
+    height: 80px;
+    font-size: 18px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+caretRects = [];
+
+addEventListener("load", async () => {
+    description("Verifies that the selection caret rect updates properly when inserting newlines in a textarea with vertical overflow.");
+
+    const textarea = document.querySelector("textarea");
+    await UIHelper.activateElementAndWaitForInputSession(textarea);
+
+    for (const stringToType of ["\n", "One\n", "Two\n", "Three\n", "Four\n", "Five\n"]) {
+        await UIHelper.typeCharacters(stringToType);
+        await UIHelper.ensurePresentationUpdate();
+        caretRects.push(await UIHelper.getUICaretViewRect());
+    }
+
+    shouldBe("caretRects[0].height", "caretRects[1].height");
+    shouldBe("caretRects[0].height", "caretRects[2].height");
+    shouldBe("caretRects[0].height", "caretRects[3].height");
+    shouldBe("caretRects[0].height", "caretRects[4].height");
+    shouldBe("caretRects[0].height", "caretRects[5].height");
+    shouldBe("caretRects[4].top", "caretRects[5].top");
+    shouldBeGreaterThan("caretRects[5].width", "1");
+    shouldBeGreaterThan("caretRects[5].height", "1");
+
+    textarea.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <textarea>Zero</textarea>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -232,6 +232,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView;
 #endif
 
+- (BOOL)_isInStableState:(UIScrollView *)scrollView;
+
 - (UIEdgeInsets)currentlyVisibleContentInsetsWithScale:(CGFloat)scaleFactor obscuredInsets:(UIEdgeInsets)obscuredInsets;
 
 @end

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2738,6 +2738,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     [self _scheduleVisibleContentRectUpdate];
 }
 
+- (BOOL)_isInStableState:(UIScrollView *)scrollView
+{
+    return [self _viewStabilityState:scrollView].isEmpty();
+}
+
 - (OptionSet<WebKit::ViewStabilityFlag>)_viewStabilityState:(UIScrollView *)scrollView
 {
     OptionSet<WebKit::ViewStabilityFlag> stabilityFlags;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -587,6 +587,9 @@ struct ImageAnalysisContextMenuActionData {
     std::optional<BOOL> _cachedRequiresLegacyTextInputTraits;
     NSInteger _dropAnimationCount;
 
+    BOOL _waitingForEditorStateAfterScrollingSelectionContainer;
+    std::optional<WebCore::IntPoint> _lastSelectionChildScrollViewContentOffset;
+
     BOOL _hasSetUpInteractions;
     std::optional<BOOL> _cachedHasCustomTintColor;
     NSUInteger _ignoreSelectionCommandFadeCount;


### PR DESCRIPTION
#### 1f4f2000ed16188b1eecbfdd36bf58e623142390
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Caret sometimes appears in the wrong place after inserting newline
<a href="https://bugs.webkit.org/show_bug.cgi?id=290393">https://bugs.webkit.org/show_bug.cgi?id=290393</a>
<a href="https://rdar.apple.com/147362685">rdar://147362685</a>

Reviewed by Aditya Keerthi.

With SelectionHonorsOverflowScrolling enabled, inserting (or deleting) newlines inside a `textarea`
sometimes causes the caret to appear in the wrong place, if the editing command triggered
programmatic scrolling in the `textarea`&apos;s content. This is due to 2 main causes:

1.  `-_reconcileEnclosingScrollViewContentOffset:` yields incorrect `EditorState` geometry in the
    case where scrolling is triggered by the web process itself (and the scroll position is being
    synced to the UI process through the same layer tree commit that contains this `EditorState`).
    From manually testing the scenario in 286537@main (i.e. composing an email in Outlook and Gmail)
    this logic is only needed in the case where the user begins scrolling a scroll view that
    contains the selection UI, such that the child scroller is in unstable state (and therefore, the
    UI-side `-contentOffset` holds the source of truth, regarding the scroll offset of the scroller
    containing the selection). To mitigate this, limit the codepath to trigger only when the scroll
    view is in unstable state.

2.  Add a mechanism to call into `-[UITextSelectionDisplayInteraction setNeedsSelectionUpdate]`
    (via `WKTextInteractionWrapper`) in the case where a subscroller containing the selection has
    been scrolled and the geometry of the `EditorState` in root view coordinates is still the same
    as it was during the previous update. Even ignoring (1), when inserting or removing a newline at
    the end of a `textarea`, it&apos;s possible for the caret rect to *immediately* become stale, if the
    caret view is installed before the `-contentOffset` of the subscroller changes after inserting
    or deleting at the end of the `textarea`. In this case, a subsequent `EditorState` update will
    not update the selection at all since the caret rect in root view coordinates is identical, even
    if the caret rect in the coordinate space of the view containing the selection changes.

    We can mitigate this by calling into `-setNeedsSelectionUpdate` in this case, which tells UIKit
    to remap root view coordinates into selection container coordinates and reposition managed
    selection views accordingly. Note that without this part, inserting and removing newlines
    *sometimes* still causes the caret to be positioned incorrectly (either one line too high or one
    line too low) when typing near the last line of a vertically scrollable `textarea`.

See below for more details.

* LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea-expected.txt: Added.
* LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _isInStableState:]):

Expose a method to check whether a given `UIScrollView` is in stable state, using heuristics which
currently only apply to the main scroller (`WKScrollView`).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _scrollingNodeScrollingDidEnd:]):

Keep track of whether we&apos;ve just ended scrolling inside a scroll view that contains the current
selection, but haven&apos;t received an editor state update yet that honors this new scroll position.
This flag (`_waitingForEditorStateAfterScrollingSelectionContainer`) allows us to bail from updating
the selection with stale geometry in `-_updateSelectionViewsInChildScrollViewIfNeeded`, in the case
where momentum scrolling ends in a subscrollable region containing the selection (undoing this
results in a 1-frame flicker of the selection when scrolling the compose window on Gmail).

(-[WKContentView _reconcileEnclosingScrollViewContentOffset:]):

See (1) above.

(-[WKContentView _updateChangedSelection:]):
(-[WKContentView _updateSelectionViewsInChildScrollViewIfNeeded]):

See (2) above.

Canonical link: <a href="https://commits.webkit.org/292677@main">https://commits.webkit.org/292677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a5e70c42d0dce6f8b5a0100cbf8a05df1fd36c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73731 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30948 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83571 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82166 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26822 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28933 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->