### PR TITLE
Networking process crash in WebKit:  extractResolutionReport

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -888,18 +888,21 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
     if (!interfaces.get())
         return nil;
     nw_path_enumerate_interfaces(static_cast<nw_path_t>(pathValue.get()), ^bool(nw_interface_t interface) {
+        String name = String::fromUTF8(nw_interface_get_name(interface));
         [interfaces addObject:@{
             @"type" : description(nw_interface_get_type(interface)),
-            @"name" : @(nw_interface_get_name(interface) ?: "")
+            @"name" : static_cast<NSString *>(name) ?: @"",
         }];
         return true;
     });
 
     auto report = static_cast<nw_resolution_report_t>(reportValue.get());
+    String provider = String::fromUTF8(nw_resolution_report_get_provider_name(report));
+    String extraText = String::fromUTF8(nw_resolution_report_get_extended_dns_error_extra_text(report));
     return @{
-        @"provider" : @(nw_resolution_report_get_provider_name(report) ?: ""),
+        @"provider" : static_cast<NSString *>(provider) ?: @"",
         @"dnsFailureReason" : description(nw_resolution_report_get_dns_failure_reason(report)),
-        @"extendedDNSErrorExtraText" : @(nw_resolution_report_get_extended_dns_error_extra_text(report) ?: ""),
+        @"extendedDNSErrorExtraText" : static_cast<NSString *>(extraText) ?: @"",
         @"interfaces" : interfaces.get(),
     };
 }


### PR DESCRIPTION
#### 4a35c6d8f72ded2d5885b96302d26a205d36e6b1
<pre>
Networking process crash in WebKit:  extractResolutionReport
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=290401">https://bugs.webkit.org/show_bug.cgi?id=290401</a>&gt;
&lt;<a href="https://rdar.apple.com/146069022">rdar://146069022</a>&gt;

Reviewed by Alex Christensen.

The @() immediate operator calls +[NSString stringWithUTF8String:],
which may return `nil`.  Tighten up string operations by converting to
WTF::String first, then making sure the conversion to NSString results
in a non-nil value.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(extractResolutionReport):
- Convert from `const char*` to WTF::String, then to NSString, with a
  fall back to @&quot;&quot;.  This will prevent an unexpected `nil` value in the
  immediate NSDictionary, thus fixing the crash.

Canonical link: <a href="https://commits.webkit.org/292684@main">https://commits.webkit.org/292684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be73093168081fbc46fa1dc7e72216321316881d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87527 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54081 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12321 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17391 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82794 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83595 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82182 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26839 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17326 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15598 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28965 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23469 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->