### PR TITLE
getUserMedia may not use the correct camera/microphone if devices change while user is answering the permission prompt

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -117,6 +117,8 @@ public:
     void setCurrentMediaEnvironment(String&&);
 #endif
 
+    Expected<ValidDevices, MediaConstraintType> validateRequestConstraintsAfterEnumeration(const MediaStreamRequest&, const MediaDeviceHashSalts&);
+
 private:
     RealtimeMediaSourceCenter();
     friend class NeverDestroyed<RealtimeMediaSourceCenter>;
@@ -132,7 +134,6 @@ private:
 
     void getDisplayMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>&, MediaConstraintType&);
     void getUserMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>& audioDevices, Vector<DeviceInfo>& videoDevices, MediaConstraintType&);
-    void validateRequestConstraintsAfterEnumeration(ValidateHandler&&, const MediaStreamRequest&, MediaDeviceHashSalts&&);
     void enumerateDevices(bool shouldEnumerateCamera, bool shouldEnumerateDisplay, bool shouldEnumerateMicrophone, bool shouldEnumerateSpeakers, CompletionHandler<void()>&&);
 
     RunLoop::Timer m_debounceTimer;

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -499,7 +499,8 @@ static bool shouldBeDefaultDevice(const MockMediaDevice& device)
 
 void MockRealtimeMediaSourceCenter::addDevice(const MockMediaDevice& device)
 {
-    bool isDefault = shouldBeDefaultDevice(device);
+    bool isDefault = device.isDefault || shouldBeDefaultDevice(device);
+
     if (isDefault)
         devices().insert(0, device);
     else

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
@@ -36,7 +36,7 @@
 
 using namespace WebKit;
 
-void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties)
+void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties, bool isDefault)
 {
 #if ENABLE(MEDIA_STREAM)
     String typeString = WebKit::toImpl(type)->string();
@@ -72,7 +72,6 @@ void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStri
         }
     }
 
-    bool isDefault = false;
     toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), flags, isDefault, WTFMove(deviceProperties) });
 #endif
 }

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-WK_EXPORT void WKAddMockMediaDevice(WKContextRef, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties);
+WK_EXPORT void WKAddMockMediaDevice(WKContextRef, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties, bool isDefault);
 WK_EXPORT void WKClearMockMediaDevices(WKContextRef);
 WK_EXPORT void WKRemoveMockMediaDevice(WKContextRef, WKStringRef persistentId);
 WK_EXPORT void WKResetMockMediaDevices(WKContextRef);

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -64,8 +64,8 @@ public:
     bool requiresDisplayCapture() const { return m_request.type == WebCore::MediaStreamRequest::Type::DisplayMedia || m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio; }
     bool requiresDisplayCaptureWithAudio() const { return m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio; }
 
-    void setEligibleVideoDeviceUIDs(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleVideoDevices = WTFMove(devices); }
-    void setEligibleAudioDeviceUIDs(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleAudioDevices = WTFMove(devices); }
+    void setEligibleVideoDevices(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleVideoDevices = WTFMove(devices); }
+    void setEligibleAudioDevices(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleAudioDevices = WTFMove(devices); }
 
     Vector<String> videoDeviceUIDs() const;
     Vector<String> audioDeviceUIDs() const;

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
@@ -42,7 +42,7 @@ private:
     void invalidate() final;
 
 #if ENABLE(MEDIA_STREAM)
-    bool m_hasPendingGetDispayMediaPrompt { false };
+    bool m_hasPendingGetDisplayMediaPrompt { false };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -50,10 +50,10 @@ UserMediaPermissionRequestProxyMac::~UserMediaPermissionRequestProxyMac()
 void UserMediaPermissionRequestProxyMac::invalidate()
 {
 #if ENABLE(MEDIA_STREAM)
-    if (m_hasPendingGetDispayMediaPrompt) {
+    if (m_hasPendingGetDisplayMediaPrompt) {
         if (RefPtr page = protectedManager()->page())
             DisplayCaptureSessionManager::singleton().cancelGetDisplayMediaPrompt(*page);
-        m_hasPendingGetDispayMediaPrompt = false;
+        m_hasPendingGetDisplayMediaPrompt = false;
     }
 #endif
     UserMediaPermissionRequestProxy::invalidate();
@@ -69,17 +69,17 @@ void UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia(UserMediaDispl
     if (!page)
         return;
 
-    m_hasPendingGetDispayMediaPrompt = true;
+    m_hasPendingGetDisplayMediaPrompt = true;
     DisplayCaptureSessionManager::singleton().promptForGetDisplayMedia(promptType, *page, topLevelDocumentSecurityOrigin().data(), [protectedThis = Ref { *this }](std::optional<CaptureDevice> device) mutable {
 
-        protectedThis->m_hasPendingGetDispayMediaPrompt = false;
+        protectedThis->m_hasPendingGetDisplayMediaPrompt = false;
 
         if (!device) {
             protectedThis->deny(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied);
             return;
         }
 
-        protectedThis->setEligibleVideoDeviceUIDs({ device.value() });
+        protectedThis->setEligibleVideoDevices({ device.value() });
         protectedThis->allow(String(), device.value().persistentId());
     });
 #else

--- a/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
@@ -51,4 +51,11 @@
 
 @end
 
+@interface UserMediaCaptureUIDelegateWithDeviceChange : NSObject<WKNavigationDelegate, WKUIDelegate> {
+    bool _wasPrompted;
+}
+-(void)addDefaultCamera:(WKWebViewConfiguration*)configuration;
+-(void)addDefaultMicrophone:(WKWebViewConfiguration*)configuration;
+
+@end
 #endif // ENABLE(MEDIA_STREAM)

--- a/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm
@@ -29,6 +29,8 @@
 #if ENABLE(MEDIA_STREAM)
 #import "PlatformUtilities.h"
 #import "Utilities.h"
+#import <WebKit/WKMockMediaDevice.h>
+#import <WebKit/WKString.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
 
 @implementation UserMediaCaptureUIDelegate {
@@ -152,4 +154,31 @@
 
 @end
 
+@implementation UserMediaCaptureUIDelegateWithDeviceChange {
+}
+-(id)init {
+    self = [super init];
+    return self;
+}
+
+- (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {
+    WKResetMockMediaDevices((__bridge WKContextRef)webView.configuration.processPool);
+    decisionHandler(WKPermissionDecisionGrant);
+}
+
+-(void)addDefaultCamera:(WKWebViewConfiguration*)configuration {
+    auto persistentId = adoptWK(WKStringCreateWithUTF8CString("PERSISTENTCAMERAID1"));
+    auto label = adoptWK(WKStringCreateWithUTF8CString("NEWDEFAULTCAMERA"));
+    auto type = adoptWK(WKStringCreateWithUTF8CString("camera"));
+    WKAddMockMediaDevice((__bridge WKContextRef)configuration.processPool, persistentId.get(), label.get(), type.get(), nullptr, true);
+}
+
+-(void)addDefaultMicrophone:(WKWebViewConfiguration*)configuration {
+    auto persistentId = adoptWK(WKStringCreateWithUTF8CString("PERSISTENTMICROPHONEID1"));
+    auto label = adoptWK(WKStringCreateWithUTF8CString("NEWDEFAULTMICROPHONE"));
+    auto type = adoptWK(WKStringCreateWithUTF8CString("microphone"));
+    WKAddMockMediaDevice((__bridge WKContextRef)configuration.processPool, persistentId.get(), label.get(), type.get(), nullptr, true);
+}
+
+@end
 #endif // ENABLE(MEDIA_STREAM)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4383,7 +4383,8 @@ void TestController::removeAllCookies(CompletionHandler<void(WKTypeRef)>&& compl
 
 void TestController::addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type, WKDictionaryRef properties)
 {
-    WKAddMockMediaDevice(platformContext(), persistentID, label, type, properties);
+    bool isDefault = false;
+    WKAddMockMediaDevice(platformContext(), persistentID, label, type, properties, isDefault);
 }
 
 void TestController::clearMockMediaDevices()


### PR DESCRIPTION
#### dfeaa8b89023341c2ce42233192c6df34d2c7774
<pre>
getUserMedia may not use the correct camera/microphone if devices change while user is answering the permission prompt
<a href="https://rdar.apple.com/147762070">rdar://147762070</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290324">https://bugs.webkit.org/show_bug.cgi?id=290324</a>

Reviewed by Eric Carlson.

Redo constraints matching after the permission is granted.
This ensures that if the user plugs in a camera before granting the getUserMedia prompt, there is a chance to use the new camera.

Minor refactoring to rename setEligibleVideoDeviceUIDs and setEligibleAudioDeviceUIDs.

We write a test that adds a new device and removes the new device just before the permission is granted.
We update the code to allow a mock device to be set as the default.

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraints):
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::addDevice):
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp:
(WKAddMockMediaDevice):
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
(WebKit::UserMediaPermissionRequestProxy::setEligibleVideoDevices):
(WebKit::UserMediaPermissionRequestProxy::setEligibleAudioDevices):
(WebKit::UserMediaPermissionRequestProxy::setEligibleVideoDeviceUIDs): Deleted.
(WebKit::UserMediaPermissionRequestProxy::setEligibleAudioDeviceUIDs): Deleted.
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h:
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::invalidate):
(WebKit::UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit2, getUserMediaWithDeviceChangeWebPage)):
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm:
(-[UserMediaCaptureUIDelegateWithDeviceChange init]):
(-[UserMediaCaptureUIDelegateWithDeviceChange webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:]):
(-[UserMediaCaptureUIDelegateWithDeviceChange addDefaultCamera:]):
(-[UserMediaCaptureUIDelegateWithDeviceChange addDefaultMicrophone:]):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::addMockMediaDevice):

Canonical link: <a href="https://commits.webkit.org/292696@main">https://commits.webkit.org/292696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d8ec9f1783c4450a1afd10b18bf175b9c07721e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96832 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30995 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103928 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82831 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83653 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82220 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17385 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23521 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->