### PR TITLE
[Grid] Allow extrinsically sized grid to perform simplified layout when grid items are mutated.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations-expected.txt
@@ -1,0 +1,19 @@
+x x x x
+x x x
+xx
+xx
+x x x x x x x x x
+xx
+x x x
+xx xx
+x x x x
+
+PASS grid-extrinsically-sized-mutations
+PASS grid-extrinsically-sized-mutations 1
+PASS grid-extrinsically-sized-mutations 2
+PASS grid-extrinsically-sized-mutations 3
+PASS grid-extrinsically-sized-mutations 4
+PASS grid-extrinsically-sized-mutations 5
+PASS grid-extrinsically-sized-mutations 6
+PASS grid-extrinsically-sized-mutations 7
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#layout-algorithm">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Tests that an extrinsically sized grid responds to various changes to both the grid and its constraints.">
+<style>
+.container {
+  width: 50px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: 50px;
+  height: 50px;
+  outline: 1px solid blue;
+  font: 10px Ahem;
+}
+
+.alignStart {
+  align-items: start;
+}
+
+.fixedHeight {
+  height: 100px;
+}
+
+.percentHeight {
+  height: 100%;
+}
+
+.percentRow {
+  grid-template-rows: 100%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function mutateContent() {
+  document.getElementById("one").style.width = "10px";
+  document.getElementById("two").style.alignItems = "stretch";
+  document.getElementById("three").style.gridTemplateRows = "30px";
+  document.getElementById("four").style.height = "10px";
+  document.getElementById("five").innerHTML += " x x x x x x";
+  document.getElementById("six").style.height = "50px";
+  document.getElementById("seven").style.gridTemplateColumns = "20%";
+
+  document.getElementById("eight").innerHTML += "<div class='test' data-expected-height='40'>x x x x</div>";
+}
+</script>
+</head>
+<body>
+
+<!-- Inline constraint on the grid changes -->
+<div class="container" id="one">
+  <div class="grid alignStart">
+    <div class="test" data-expected-height="40">x x x x</div>
+  </div>
+</div>
+
+<!-- Alignment of grid items changes -->
+<div class="container">
+  <div id="two" class="grid alignStart">
+    <div class="test" data-expected-height="50">x x x</div>
+  </div>
+</div>
+
+<!-- grid-template-rows changes to different fixed size. -->
+<div id="three" class="grid">
+  <div class="test" data-expected-height="30">xx</div>
+</div>
+
+<!-- Grid block size changes with % based rows -->
+<div id="four" class="grid percentRow">
+  <div class="test" data-expected-height="10">xx</div>
+</div>
+
+<!-- Grid item content changes -->
+<div class="container">
+  <div class="grid alignStart">
+    <div id="five" class="test" data-expected-height="30">x x x</div>
+  </div>
+</div>
+
+<!-- Grid with % height and rows has fixed block constraint changed -->
+<div class="container fixedHeight" id="six">
+  <div class="grid percentRow percentHeight">
+    <div class="test" data-expected-height="50">xx</div>
+  </div>
+</div>
+
+<!-- grid-template-columns changes to different % value -->
+<div class="container">
+  <div id="seven" class="grid alignStart">
+    <div class="test" data-expected-height="30">x x x</div>
+  </div>
+</div>
+
+<!-- Grid has new item added -->
+<div class="container">
+  <div id="eight" class="grid alignStart" style="grid-template-columns: 50% 50%;">
+    <div>xx xx</div>
+  </div>
+</div>
+</body>
+<script>
+document.body.offsetHeight;
+mutateContent();
+document.body.offsetHeight;
+
+let tests = document.querySelectorAll(".test");
+tests.forEach((element) => {
+  test(function() {
+    let expectedHeight = element.getAttribute("data-expected-height");
+    assert_equals(element.offsetHeight, Number(expectedHeight), "height");
+  });
+});
+</script>
+</html>
+

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -145,6 +145,11 @@ public:
 
     bool shouldCheckExplicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
 
+    // Checks both the grid container and the grid since the grid container is sized
+    // according to the rules of the formatting context it lives in while the size of the
+    // grid is determined by the lines/grid areas which come from track sizing.
+    bool isExtrinsicallySized() const;
+
 private:
     friend class GridTrackSizingAlgorithm;
     friend class GridTrackSizingAlgorithmStrategy;
@@ -182,6 +187,7 @@ private:
     void placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidth);
     void populateExplicitGridAndOrderIterator();
     GridArea createEmptyGridAreaAtSpecifiedPositionsOutsideGrid(const RenderBox&, GridTrackSizingDirection, const GridSpan&) const;
+    bool isPlacedWithinExtrinsicallySizedExplicitTracks(const RenderBox&) const;
     void placeSpecifiedMajorAxisItemsOnGrid(const Vector<RenderBox*>&);
     void placeAutoMajorAxisItemsOnGrid(const Vector<RenderBox*>&);
     void placeItemUsingMasonryPositioning(Grid&, RenderBox*) const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -53,6 +53,7 @@
 #include "RenderCounter.h"
 #include "RenderElementInlines.h"
 #include "RenderFragmentedFlow.h"
+#include "RenderGrid.h"
 #include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderLayer.h"
@@ -676,6 +677,9 @@ RenderElement* RenderObject::markContainingBlocksForLayout(RenderElement* layout
             if (boundary == RelayoutBoundary::OverflowOnly)
                 simplifiedNormalFlowLayout = true;
         }
+
+        if (auto* renderGrid = dynamicDowncast<RenderGrid>(container.get()); renderGrid && renderGrid->isExtrinsicallySized())
+            simplifiedNormalFlowLayout = true;
 
         hasOutOfFlowPosition = ancestor->isOutOfFlowPositioned();
         ancestor = WTFMove(container);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1063,16 +1063,14 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
 void RenderTreeBuilder::attachToRenderGrid(RenderGrid& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
 {
     auto& newChild = *child;
-    blockBuilder().attach(parent, WTFMove(child), beforeChild);
-
-    // Positioned grid items do not take up space or otherwise participate in the layout of the grid,
-    // for that reason we don't need to mark the grid as dirty when they are added.
-    if (newChild.isOutOfFlowPositioned())
-        return;
-
     // The grid needs to be recomputed as it might contain auto-placed items that
-    // will change their position.
-    parent.setNeedsItemPlacement();
+    // will change their position. Positioned grid items do not take up space or
+    // otherwise participate in the layout of the grid, for that reason we don't
+    // need to mark the grid as dirty when they are added.
+    if (!newChild.isOutOfFlowPositioned())
+        parent.setNeedsItemPlacement();
+
+    blockBuilder().attach(parent, WTFMove(child), beforeChild);
 }
 
 void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& parent, const RenderObject& child)


### PR DESCRIPTION
#### 83bba6965f882753ecfbea7c0e45ad3b6ea3dd50
<pre>
[Grid] Allow extrinsically sized grid to perform simplified layout when grid items are mutated.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290573">https://bugs.webkit.org/show_bug.cgi?id=290573</a>
<a href="https://rdar.apple.com/148055966">rdar://148055966</a>

Reviewed by Alan Baradlay.

When a grid item experiences some types of mutations, such as content
mutations or non-grid specific style changes, it may be possible to
contain the damage within the formatting context established by the item
and not need to propagate this damage into the formatting context of the
grid itself or any ancestors. One such example of content where this is
a case is when a grid item experiences a content mutation but is inside
a grid that is extrinsically sized by perhaps having all fixed or
percentage-based rows and columns. In this case, the damage is local to
the grid item and will have no impact on the GFC and will not change any
of the constraints on the grid item.

This patch attempts to identify these types of damage and respond by
running simplified layout from the RenderView, or any other layout root,
through the grid. We can do this as we are invalidating the containing
block chain and seeing if we find an ancestor that meets this criterion.
If so, we will start marking needs simplified layout on the chain.

The mechanism that is used is a new function on RenderGrid, which
is not meant to be completely exhaustive but focuses on some
simple pieces of content and can be built upon in future patches.

While most of the conditions we are looking at currently are fairly
straightforward, I should probably mention and explain my rationale for
a few notable ones:

1.) We check to see if the grid has a logical width of auto but couple this
with that fact that the grid needs to be participating in block layout/a
BFC. In some formatting contexts, having a logical width of auto may end
up performing some sort of measurements on the box based on the content,
but in this case, it should not, so we can allow it. If we need to check
whether or not the grid is extrinsically sized when it lives inside
another type of formatting context, we may need to revisit this logic to
make it correct.

2.) Checking to see if the grid has an aspect ratio. This is to avoid
the automatic content-based minimum size that may be applied by the use
of the property.

3.) Making sure all of the items are placed within extrinsically sized
explicit (i.e. grid-template-rows/columns) tracks. The purpose here is
twofold. First, if any items need item placement, which could happen by
adding or removing grid items, we should just bail out since at that
point the GFC itself experienced damage and we cannot predict what will
happen. Second, in a previous layout, a grid item may have been placed in
a track that was implicitly created. If that is the case, we need to
figure out how that track was sized since intrinsic values could have
been used for grid-auto-rows/columns, but we bail now for simplicity.

In order to accomplish the above, we needed to shuffle around the logic
in RenderTreeBuilder::attachToRenderGrid so that we mark the grid as
needing item placement before we attach the new renderer to the grid.
This is because we can only determine if all items are placed within
Extrinsic tracks if we do not need to perform item placement. Otherwise,
we could add a renderer to the grid, start marking the containing block
chain, and incorrectly determine we can mark the grid as needing
simplified layout before we mark it as needing item placement.

I also added various tests in grid-extrinsically-sized-mutations.html
to help test that we were still performing layout properly. The tests
include changes to the grid items only along with mutations on the grid
and the constraints imposed upon it by its containing block.

* LayoutTests/imported/w3c/web-platform-tests/css
* LayoutTests/imported/w3c/web-platform-tests/css
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::isExtrinsicallySized const)
(WebCore::RenderGrid::isPlacedWithinExtrinsically
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::markContainingBlocksForLa
* Source/WebCore/rendering/updating/RenderTreeBui
(WebCore::RenderTreeBuilder::attachToRenderGrid):

Canonical link: <a href="https://commits.webkit.org/292994@main">https://commits.webkit.org/292994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be04a747fc549542a35c93ba278d4317c71a7864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6092 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47511 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24620 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17961 "Found 3 new test failures: fast/workers/use-machine-stack.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83373 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18213 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29750 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->