### PR TITLE
Convert "local & session storage restoration" SPI into API

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3184,11 +3184,11 @@ void NetworkProcess::setPersistedDomains(PAL::SessionID sessionID, HashSet<Regis
         session->setPersistedDomains(WTFMove(domains));
 }
 
-void NetworkProcess::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void NetworkProcess::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     CheckedPtr session = networkSession(sessionID);
     if (!session) {
-        completionHandler({ });
+        completionHandler(std::nullopt);
         return;
     }
 
@@ -3206,11 +3206,11 @@ void NetworkProcess::restoreLocalStorage(PAL::SessionID sessionID, HashMap<WebCo
     session->protectedStorageManager()->restoreLocalStorage(WTFMove(localStorageMap), WTFMove(completionHandler));
 }
 
-void NetworkProcess::fetchSessionStorage(PAL::SessionID sessionID, WebPageProxyIdentifier pageID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void NetworkProcess::fetchSessionStorage(PAL::SessionID sessionID, WebPageProxyIdentifier pageID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     CheckedPtr session = networkSession(sessionID);
     if (!session) {
-        completionHandler({ });
+        completionHandler(std::nullopt);
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -461,10 +461,10 @@ public:
 
     bool enableModernDownloadProgress() const { return m_enableModernDownloadProgress; }
 
-    void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(PAL::SessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
-    void fetchSessionStorage(PAL::SessionID, WebPageProxyIdentifier, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchSessionStorage(PAL::SessionID, WebPageProxyIdentifier, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreSessionStorage(PAL::SessionID, WebPageProxyIdentifier, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlockingForPage(std::optional<WebPageProxyIdentifier>) const;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -266,10 +266,10 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     GetAppBadgeForTesting(PAL::SessionID sessionID) -> (std::optional<uint64_t> badge)
 
-    FetchLocalStorage(PAL::SessionID sessionID) -> (HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap)
+    FetchLocalStorage(PAL::SessionID sessionID) -> (std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>> localStorageMap)
     RestoreLocalStorage(PAL::SessionID sessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap) -> (bool succeeded)
 
-    FetchSessionStorage(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID) -> (HashMap<WebCore::ClientOrigin, HashMap<String, String>> sessionStorageMap)
+    FetchSessionStorage(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID) -> (std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>> sessionStorageMap)
     RestoreSessionStorage(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID, HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap) -> (bool succeeded)
 
     SetShouldRelaxThirdPartyCookieBlockingForPage(WebKit::WebPageProxyIdentifier pageID)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -831,7 +831,7 @@ void NetworkStorageManager::cloneSessionStorageNamespace(StorageNamespaceIdentif
     }
 }
 
-void NetworkStorageManager::fetchSessionStorageForWebPage(WebPageProxyIdentifier pageIdentifier, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void NetworkStorageManager::fetchSessionStorageForWebPage(WebPageProxyIdentifier pageIdentifier, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     ASSERT(!m_closed);
@@ -1378,7 +1378,7 @@ void NetworkStorageManager::syncLocalStorage(CompletionHandler<void()>&& complet
     });
 }
 
-void NetworkStorageManager::fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void NetworkStorageManager::fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     ASSERT(!m_closed);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -113,7 +113,7 @@ public:
     void resetStoragePersistedState(CompletionHandler<void()>&&);
     void clearStorageForWebPage(WebPageProxyIdentifier);
     void cloneSessionStorageForWebPage(WebPageProxyIdentifier, WebPageProxyIdentifier);
-    void fetchSessionStorageForWebPage(WebPageProxyIdentifier, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchSessionStorageForWebPage(WebPageProxyIdentifier, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreSessionStorageForWebPage(WebPageProxyIdentifier, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
     void didIncreaseQuota(WebCore::ClientOrigin&&, QuotaIncreaseRequestIdentifier, std::optional<uint64_t> newQuota);
     enum class ShouldComputeSize : bool { No, Yes };
@@ -128,7 +128,7 @@ public:
     void resume();
     void handleLowMemoryWarning();
     void syncLocalStorage(CompletionHandler<void()>&&);
-    void fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
     void registerTemporaryBlobFilePaths(IPC::Connection&, const Vector<String>&);
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -670,6 +670,26 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
  */
 @property (nonatomic, readonly, getter=isWritingToolsActive) BOOL writingToolsActive WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(WK_XROS_TBA));
 
+/* @enum WKWebViewDataType
+   @abstract The type of WKWebView data.
+   @constant WKWebViewDataTypeSessionStorage Session Storage data.
+*/
+typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
+    WKWebViewDataTypeSessionStorage = 1 << 0
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Called when the client wants to fetch WKWebView data.
+   @param dataTypes The option set of WKWebView data types whose data the client wants to fetch.
+   @param completionHandler The completion handler that should be invoked with the retrieved data and possibly an error. The retrieved data will be a serialized blob. If an error occurred, the retrieved data will be nil. An error may occur if the data cannot be retrieved for some reason (such as a crash).
+*/
+- (void)fetchDataOfTypes:(WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Called when the client wants to restore WKWebView data.
+   @param data The serialized blob containing the data that the client wants to restore.
+   @param completionHandler The completion handler that may be invoked with an error if the data is in an invalid format or if the data cannot be restored for some other reason (such as a crash).
+ */
+- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -89,6 +89,18 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
  */
 @property (nonatomic, readonly, nullable) NSUUID *identifier WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
+/* @abstract Called when the client wants to fetch WKWebsiteDataStore data.
+   @param dataTypes The set of WKWebsiteDataStore data types whose data the client wants to fetch.
+   @param completionHandler The completion handler that should be invoked with the retrieved data and possibly an error. The retrieved data will be a serialized blob. If an error occurred, the retrieved data will be nil. An error may occur if a requested data type is not supported or if the data cannot be retrieved for some other reason (such as a crash).
+ */
+- (void)fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Called when the client wants to restore WKWebsiteDataStore data.
+   @param data The serialized blob containing the data that the client wants to restore.
+   @param completionHandler The completion handler that may be invoked with an error if the data is in an invalid format or if the data cannot be restored for some other reason (such as a crash).
+ */
+- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 /*! @abstract Get a persistent data store.
  @param identifier An identifier that is used to uniquely identify the data store.
  @discussion If a data store with this identifier does not exist yet, it will be created. Throws exception if identifier

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2018,7 +2018,7 @@ void NetworkProcessProxy::setEmulatedConditions(PAL::SessionID sessionID, std::o
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-void NetworkProcessProxy::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void NetworkProcessProxy::fetchLocalStorage(PAL::SessionID sessionID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::NetworkProcess::FetchLocalStorage(sessionID), WTFMove(completionHandler));
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -341,7 +341,7 @@ public:
 
     void notifyMediaStreamingActivity(bool);
 
-    void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(PAL::SessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16261,12 +16261,12 @@ FloatPoint WebPageProxy::mainFrameScrollPosition() const
 
 #endif // PLATFORM(COCOA) && ENABLE(ASYNC_SCROLLING)
 
-void WebPageProxy::fetchSessionStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void WebPageProxy::fetchSessionStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
         networkProcess->sendWithAsyncReply(Messages::NetworkProcess::FetchSessionStorage(sessionID(), identifier()), WTFMove(completionHandler));
     else
-        completionHandler({ });
+        completionHandler(HashMap<WebCore::ClientOrigin, HashMap<String, String>> { });
 }
 
 void WebPageProxy::restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& sessionStorage, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2698,7 +2698,7 @@ public:
     WebCore::FloatPoint mainFrameScrollPosition() const;
 #endif
 
-    void fetchSessionStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchSessionStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2879,12 +2879,12 @@ void WebsiteDataStore::setRestrictedOpenerTypeForDomainForTesting(const WebCore:
     m_restrictedOpenerTypesForTesting.set(domain, type);
 }
 
-void WebsiteDataStore::fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&& completionHandler)
+void WebsiteDataStore::fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&& completionHandler)
 {
     if (RefPtr networkProcess = networkProcessIfExists())
         networkProcess->fetchLocalStorage(m_sessionID, WTFMove(completionHandler));
     else
-        completionHandler({ });
+        protectedNetworkProcess()->fetchLocalStorage(m_sessionID, WTFMove(completionHandler));
 }
 
 void WebsiteDataStore::restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& localStorage, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -503,7 +503,7 @@ public:
 
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 
-    void fetchLocalStorage(CompletionHandler<void(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&)>&&);
+    void fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm
@@ -35,7 +35,6 @@
 #import <WebKit/WKScriptMessageHandler.h>
 #import <WebKit/WKWebsiteDataRecord.h>
 #import <WebKit/WKWebsiteDataStore.h>
-#import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <wtf/RetainPtr.h>
 
 static void testRestoreLocalStorage(RetainPtr<WKWebsiteDataStore> websiteDataStore)
@@ -71,8 +70,9 @@ static void testRestoreLocalStorage(RetainPtr<WKWebsiteDataStore> websiteDataSto
     // Fetch the local storage data.
     RetainPtr set = [NSSet setWithObject:WKWebsiteDataTypeLocalStorage];
     __block RetainPtr<NSData> localStorageData;
-    [[[webView configuration] websiteDataStore] _fetchDataOfTypes:set.get() completionHandler:^(NSData *data) {
+    [[[webView configuration] websiteDataStore] fetchDataOfTypes:set.get() completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
+        EXPECT_NULL(error);
         localStorageData = data;
         done = true;
     }];
@@ -93,8 +93,8 @@ static void testRestoreLocalStorage(RetainPtr<WKWebsiteDataStore> websiteDataSto
     [newWebView setNavigationDelegate:navigationDelegate.get()];
 
     // Restore the local storage data.
-    [[[newWebView configuration] websiteDataStore] _restoreData:localStorageData.get() completionHandler:^(BOOL succeeded) {
-        EXPECT_TRUE(succeeded);
+    [[[newWebView configuration] websiteDataStore] restoreData:localStorageData.get() completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -208,8 +208,9 @@ static void testRestoreLocalStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataStore
     // Fetch the local storage data.
     RetainPtr set = [NSSet setWithObject:WKWebsiteDataTypeLocalStorage];
     __block RetainPtr<NSData> localStorageData;
-    [[[webView configuration] websiteDataStore] _fetchDataOfTypes:set.get() completionHandler:^(NSData *data) {
+    [[[webView configuration] websiteDataStore] fetchDataOfTypes:set.get() completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
+        EXPECT_NULL(error);
         localStorageData = data;
         done = true;
     }];
@@ -230,8 +231,8 @@ static void testRestoreLocalStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataStore
     [newWebView setNavigationDelegate:navigationDelegate.get()];
 
     // Restore the local storage data.
-    [[[newWebView configuration] websiteDataStore] _restoreData:localStorageData.get() completionHandler:^(BOOL succeeded) {
-        EXPECT_TRUE(succeeded);
+    [[[newWebView configuration] websiteDataStore] restoreData:localStorageData.get() completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
@@ -33,7 +33,7 @@
 #import "TestWKWebView.h"
 #import "Utilities.h"
 #import <WebKit/WKScriptMessageHandler.h>
-#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebView.h>
 #import <WebKit/WKWebsiteDataStore.h>
 #import <wtf/RetainPtr.h>
 
@@ -69,8 +69,9 @@ static void testRestoreSessionStorage(RetainPtr<WKWebsiteDataStore> websiteDataS
 
     // Fetch the session storage data.
     __block RetainPtr<NSData> sessionStorageData;
-    [webView _fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data) {
+    [webView fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
+        EXPECT_NULL(error);
         sessionStorageData = data;
         done = true;
     }];
@@ -91,8 +92,8 @@ static void testRestoreSessionStorage(RetainPtr<WKWebsiteDataStore> websiteDataS
     [newWebView setNavigationDelegate:navigationDelegate.get()];
 
     // Restore the session storage data.
-    [newWebView _restoreData:sessionStorageData.get() completionHandler:^(BOOL succeeded) {
-        EXPECT_TRUE(succeeded);
+    [newWebView restoreData:sessionStorageData.get() completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -205,8 +206,9 @@ static void testRestoreSessionStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataSto
 
     // Fetch the session storage data.
     __block RetainPtr<NSData> sessionStorageData;
-    [webView _fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data) {
+    [webView fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
+        EXPECT_NULL(error);
         sessionStorageData = data;
         done = true;
     }];
@@ -227,8 +229,8 @@ static void testRestoreSessionStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataSto
     [newWebView setNavigationDelegate:navigationDelegate.get()];
 
     // Restore the local storage data.
-    [newWebView _restoreData:sessionStorageData.get() completionHandler:^(BOOL succeeded) {
-        EXPECT_TRUE(succeeded);
+    [newWebView restoreData:sessionStorageData.get() completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);


### PR DESCRIPTION
#### 7d45f9b66472677f35f7cc48e486c392720196f0
<pre>
Convert &quot;local &amp; session storage restoration&quot; SPI into API
<a href="https://bugs.webkit.org/show_bug.cgi?id=290418">https://bugs.webkit.org/show_bug.cgi?id=290418</a>
<a href="https://rdar.apple.com/141842219">rdar://141842219</a>

Reviewed by Sihui Liu.

Based on API review, the following changes are being made as
the SPI is promoted to API:

1. &quot;fetchDataOfTypes&quot; will return both an NSData and NSError.

   The data will be nullptr if there is an error and the error
   will be nullptr if there not.

2. The completion handler of &quot;fetchDataOfTypes&quot; will be called with
   an std::optional&lt;HashMap&gt; instead of just a HashMap.

   This is to differentiate between the cases of there being no data
   to return (the optional will contain an empty HashMap) versus an error
   occurring during retrieval (in which case the optional will have no
   value). For example, if the Network Process crashes during the retrieval,
   the completion handler will be called with the default value of an
   optional (std::nullopt) which will indicate to &quot;fetchDataOfTypes&quot; that
   it should return an error.

2. &quot;restoreData&quot; will return an error instead of a boolean.

   For example, if &quot;restoreData&quot; is called with data that doesn&apos;t follow
   the intended format, or the Network Process crashes during restoration,
   an error will be thrown.

The existing SPI will remain for now until users adopt the API. To reduce
code duplication, the existing SPI has been converted to use the API.
The API tests that previously tested the SPI have been converted to test the API.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::fetchLocalStorage):
(WebKit::NetworkProcess::fetchSessionStorage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::fetchSessionStorageForWebPage):
(WebKit::NetworkStorageManager::fetchLocalStorage):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView fetchDataOfTypes:completionHandler:]):
(-[WKWebView restoreData:completionHandler:]):
(-[WKWebView _fetchDataOfTypes:completionHandler:]):
(-[WKWebView _restoreData:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore fetchDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore restoreData:completionHandler:]):
(-[WKWebsiteDataStore _fetchDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore _restoreData:completionHandler:]):
(filterSupportedTypes): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::fetchLocalStorage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::fetchSessionStorage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchLocalStorage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreLocalStorage.mm:
(testRestoreLocalStorage):
(testRestoreLocalStorageThirdPartyIFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm:
(testRestoreSessionStorage):
(testRestoreSessionStorageThirdPartyIFrame):

Canonical link: <a href="https://commits.webkit.org/293571@main">https://commits.webkit.org/293571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/724482828264d0c366f5e3d0bf670c5c902fd7f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75563 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32669 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49252 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19251 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84526 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84038 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20134 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16152 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31536 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->