### PR TITLE
Make NetworkResourceLoadParameters.webPageProxyID non-Markable

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -48,8 +48,9 @@ namespace WebKit {
 
 class Download;
 class NetworkLoad;
-class NetworkLoadParameters;
 class NetworkSession;
+
+struct NetworkLoadParameters;
 
 class PendingDownload : public RefCountedAndCanMakeWeakPtr<PendingDownload>, public NetworkLoadClient, public IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(PendingDownload);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -516,7 +516,7 @@ NetworkSession* NetworkConnectionToWebProcess::networkSession()
 
 Vector<RefPtr<WebCore::BlobDataFileReference>> NetworkConnectionToWebProcess::resolveBlobReferences(const NetworkResourceLoadParameters& loadParameters)
 {
-    CONNECTION_RELEASE_LOG(Loading, "resolveBlobReferences: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
+    CONNECTION_RELEASE_LOG(Loading, "resolveBlobReferences: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto* session = networkSession();
     if (!session)
@@ -550,7 +550,7 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);
 
-    CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
+    CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
     if (auto* session = networkSession()) {
         if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
@@ -587,8 +587,8 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     if (loadParameters.shouldRecordFrameLoadForStorageAccess && loadParameters.mainResourceNavigationDataForAnyFrame) {
         if (auto* session = networkSession()) {
-            if (auto* resourceLoadStatistics = session->resourceLoadStatistics(); resourceLoadStatistics && loadParameters.webPageProxyID && loadParameters.webFrameID)
-                resourceLoadStatistics->recordFrameLoadForStorageAccess(*loadParameters.webPageProxyID, *loadParameters.webFrameID, RegistrableDomain { loadParameters.request.url() });
+            if (auto* resourceLoadStatistics = session->resourceLoadStatistics(); resourceLoadStatistics)
+                resourceLoadStatistics->recordFrameLoadForStorageAccess(loadParameters.webPageProxyID, loadParameters.webFrameID, RegistrableDomain { loadParameters.request.url() });
         }
     }
 
@@ -600,7 +600,7 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 void NetworkConnectionToWebProcess::performSynchronousLoad(NetworkResourceLoadParameters&& loadParameters, CompletionHandler<void(const ResourceError&, const ResourceResponse, Vector<uint8_t>&&)>&& reply)
 {
     MESSAGE_CHECK(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
-    CONNECTION_RELEASE_LOG(Loading, "performSynchronousLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
+    CONNECTION_RELEASE_LOG(Loading, "performSynchronousLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto identifier = loadParameters.identifier;
     RELEASE_ASSERT(identifier);
@@ -621,7 +621,7 @@ void NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingFo
 
 void NetworkConnectionToWebProcess::loadPing(NetworkResourceLoadParameters&& loadParameters)
 {
-    CONNECTION_RELEASE_LOG(Loading, "loadPing: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
+    CONNECTION_RELEASE_LOG(Loading, "loadPing: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto completionHandler = [connection = m_connection, identifier = *loadParameters.identifier] (const ResourceError& error, const ResourceResponse& response) {
         connection->send(Messages::NetworkProcessConnection::DidFinishPingLoad(identifier, error, response), 0);
@@ -684,7 +684,7 @@ void NetworkConnectionToWebProcess::sendH2Ping(NetworkResourceLoadParameters&& p
         return completionHandler(makeUnexpected(internalError(parameters.request.url())));
 
     URL url = parameters.request.url();
-    auto* task = new PreconnectTask(*networkSession, WTFMove(parameters), [] (const ResourceError&, const WebCore::NetworkLoadMetrics&) { });
+    auto* task = new PreconnectTask(*networkSession, parameters.networkLoadParameters(), [] (const ResourceError&, const WebCore::NetworkLoadMetrics&) { });
     task->setH2PingCallback(url, WTFMove(completionHandler));
     task->start();
 #else
@@ -695,7 +695,7 @@ void NetworkConnectionToWebProcess::sendH2Ping(NetworkResourceLoadParameters&& p
 
 void NetworkConnectionToWebProcess::preconnectTo(std::optional<WebCore::ResourceLoaderIdentifier> preconnectionIdentifier, NetworkResourceLoadParameters&& loadParameters)
 {
-    CONNECTION_RELEASE_LOG(Loading, "preconnectTo: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
+    CONNECTION_RELEASE_LOG(Loading, "preconnectTo: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     ASSERT(!loadParameters.request.httpBody());
 
@@ -714,7 +714,7 @@ void NetworkConnectionToWebProcess::preconnectTo(std::optional<WebCore::Resource
 #if ENABLE(SERVER_PRECONNECT)
     auto* session = networkSession();
     if (session && session->allowsServerPreconnect()) {
-        (new PreconnectTask(*session, WTFMove(loadParameters), [completionHandler = WTFMove(completionHandler)] (const ResourceError& error, const WebCore::NetworkLoadMetrics&) {
+        (new PreconnectTask(*session, loadParameters.networkLoadParameters(), [completionHandler = WTFMove(completionHandler)] (const ResourceError& error, const WebCore::NetworkLoadMetrics&) {
             completionHandler(error);
         }))->start();
         return;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -108,7 +108,6 @@ class NetworkOriginAccessPatterns;
 class NetworkSchemeRegistry;
 class NetworkProcess;
 class NetworkResourceLoader;
-class NetworkResourceLoadParameters;
 class NetworkSession;
 class NetworkSocketChannel;
 class NetworkTransportSession;
@@ -120,6 +119,7 @@ class WebSharedWorkerServerToContextConnection;
 
 struct CoreIPCAuditToken;
 struct NetworkProcessConnectionParameters;
+struct NetworkResourceLoadParameters;
 struct WebTransportSessionIdentifierType;
 
 using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -27,16 +27,16 @@
 ]
 messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
-    ScheduleResourceLoad(WebKit::NetworkResourceLoadParameters resourceLoadParameters, std::optional<WebKit::NetworkResourceLoadIdentifier> existingLoaderToResume)
-    PerformSynchronousLoad(WebKit::NetworkResourceLoadParameters resourceLoadParameters) -> (WebCore::ResourceError error, WebCore::ResourceResponse response, Vector<uint8_t> data) Synchronous
+    ScheduleResourceLoad(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters, std::optional<WebKit::NetworkResourceLoadIdentifier> existingLoaderToResume)
+    PerformSynchronousLoad(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters) -> (WebCore::ResourceError error, WebCore::ResourceResponse response, Vector<uint8_t> data) Synchronous
     TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebKit::WebPageProxyIdentifier pageID) -> (bool handled) Synchronous
-    LoadPing(WebKit::NetworkResourceLoadParameters resourceLoadParameters)
+    LoadPing(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters)
     RemoveLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
     PageLoadCompleted(WebCore::PageIdentifier webPageID)
     BrowsingContextRemoved(WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, WebCore::FrameIdentifier webFrameID)
     PrefetchDNS(String hostname)
-    SendH2Ping(WebKit::NetworkResourceLoadParameters parameters) -> (Expected<Seconds, WebCore::ResourceError> result)
-    PreconnectTo(std::optional<WebCore::ResourceLoaderIdentifier> preconnectionIdentifier, WebKit::NetworkResourceLoadParameters loadParameters);
+    SendH2Ping(struct WebKit::NetworkResourceLoadParameters parameters) -> (Expected<Seconds, WebCore::ResourceError> result)
+    PreconnectTo(std::optional<WebCore::ResourceLoaderIdentifier> preconnectionIdentifier, struct WebKit::NetworkResourceLoadParameters loadParameters);
     IsResourceLoadFinished(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier) -> (bool isFinished)
 
     StartDownload(WebKit::DownloadID downloadID, WebCore::ResourceRequest request, std::optional<WebCore::SecurityOriginData> topOrigin, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, String suggestedName, enum:bool WebCore::FromDownloadAttribute fromDownloadAttribute, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID)

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -50,12 +50,14 @@ class SharedBuffer;
 
 namespace WebKit {
 
-class NetworkLoadParameters;
 class NetworkSession;
 class PendingDownload;
+
 enum class AuthenticationChallengeDisposition : uint8_t;
 enum class NegotiatedLegacyTLS : bool;
 enum class PrivateRelayed : bool;
+
+struct NetworkLoadParameters;
 
 using RedirectCompletionHandler = CompletionHandler<void(WebCore::ResourceRequest&&)>;
 using ChallengeCompletionHandler = CompletionHandler<void(AuthenticationChallengeDisposition, const WebCore::Credential&)>;

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -41,34 +41,7 @@ namespace WebKit {
 
 enum class PreconnectOnly : bool { No, Yes };
 
-class NetworkLoadParameters {
-public:
-    NetworkLoadParameters() = default;
-    NetworkLoadParameters(Markable<WebPageProxyIdentifier> webPageProxyID, Markable<WebCore::PageIdentifier> webPageID, Markable<WebCore::FrameIdentifier> webFrameID, RefPtr<WebCore::SecurityOrigin>&& topOrigin, RefPtr<WebCore::SecurityOrigin>&& sourceOrigin, WTF::ProcessID parentPID, WebCore::ResourceRequest&& request, WebCore::ContentSniffingPolicy contentSniffingPolicy, WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, WebCore::ClientCredentialPolicy clientCredentialPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool needsCertificateInfo, bool isMainFrameNavigation, std::optional<NavigationActionData>&& mainResourceNavigationDataForAnyFrame, PreconnectOnly shouldPreconnectOnly, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections, uint64_t requiredCookiesVersion)
-        : webPageProxyID(webPageProxyID)
-        , webPageID(webPageID)
-        , webFrameID(webFrameID)
-        , topOrigin(WTFMove(topOrigin))
-        , sourceOrigin(WTFMove(sourceOrigin))
-        , parentPID(parentPID)
-        , request(WTFMove(request))
-        , contentSniffingPolicy(contentSniffingPolicy)
-        , contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
-        , storedCredentialsPolicy(storedCredentialsPolicy)
-        , clientCredentialPolicy(clientCredentialPolicy)
-        , shouldClearReferrerOnHTTPSToHTTPRedirect(shouldClearReferrerOnHTTPSToHTTPRedirect)
-        , needsCertificateInfo(needsCertificateInfo)
-        , isMainFrameNavigation(isMainFrameNavigation)
-        , mainResourceNavigationDataForAnyFrame(mainResourceNavigationDataForAnyFrame)
-        , shouldPreconnectOnly(shouldPreconnectOnly)
-        , isNavigatingToAppBoundDomain(isNavigatingToAppBoundDomain)
-        , hadMainFrameMainResourcePrivateRelayed(hadMainFrameMainResourcePrivateRelayed)
-        , allowPrivacyProxy(allowPrivacyProxy)
-        , advancedPrivacyProtections(advancedPrivacyProtections)
-        , requiredCookiesVersion(requiredCookiesVersion)
-    {
-    }
-    
+struct NetworkLoadParameters {
     Markable<WebPageProxyIdentifier> webPageProxyID;
     Markable<WebCore::PageIdentifier> webPageID;
     Markable<WebCore::FrameIdentifier> webFrameID;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -31,7 +31,27 @@ namespace WebKit {
 using namespace WebCore;
 
 NetworkResourceLoadParameters::NetworkResourceLoadParameters(
-    NetworkLoadParameters&& networkLoadParameters
+    WebPageProxyIdentifier webPageProxyID
+    , WebCore::PageIdentifier webPageID
+    , WebCore::FrameIdentifier webFrameID
+    , RefPtr<WebCore::SecurityOrigin>&& topOrigin
+    , RefPtr<WebCore::SecurityOrigin>&& sourceOrigin
+    , WTF::ProcessID parentPID
+    , WebCore::ResourceRequest&& request
+    , WebCore::ContentSniffingPolicy contentSniffingPolicy
+    , WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy
+    , WebCore::StoredCredentialsPolicy storedCredentialsPolicy
+    , WebCore::ClientCredentialPolicy clientCredentialPolicy
+    , bool shouldClearReferrerOnHTTPSToHTTPRedirect
+    , bool needsCertificateInfo
+    , bool isMainFrameNavigation
+    , std::optional<NavigationActionData>&& mainResourceNavigationDataForAnyFrame
+    , PreconnectOnly shouldPreconnectOnly
+    , std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain
+    , bool hadMainFrameMainResourcePrivateRelayed
+    , bool allowPrivacyProxy
+    , OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections
+    , uint64_t requiredCookiesVersion
     , std::optional<WebCore::ResourceLoaderIdentifier> identifier
     , RefPtr<WebCore::FormData>&& httpBody
     , std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensionIfHttpBody
@@ -75,50 +95,71 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
 #endif
     , bool linkPreconnectEarlyHintsEnabled
     , bool shouldRecordFrameLoadForStorageAccess
-    ) : NetworkLoadParameters(WTFMove(networkLoadParameters))
-        , identifier(identifier)
-        , maximumBufferingTime(maximumBufferingTime)
-        , options(WTFMove(options))
-        , cspResponseHeaders(WTFMove(cspResponseHeaders))
-        , parentFrameURL(WTFMove(parentFrameURL))
-        , frameURL(WTFMove(frameURL))
-        , parentCrossOriginEmbedderPolicy(parentCrossOriginEmbedderPolicy)
-        , crossOriginEmbedderPolicy(crossOriginEmbedderPolicy)
-        , originalRequestHeaders(WTFMove(originalRequestHeaders))
-        , shouldRestrictHTTPResponseAccess(shouldRestrictHTTPResponseAccess)
-        , preflightPolicy(preflightPolicy)
-        , shouldEnableCrossOriginResourcePolicy(shouldEnableCrossOriginResourcePolicy)
-        , frameAncestorOrigins(WTFMove(frameAncestorOrigins))
-        , pageHasResourceLoadClient(pageHasResourceLoadClient)
-        , parentFrameID(parentFrameID)
-        , crossOriginAccessControlCheckEnabled(crossOriginAccessControlCheckEnabled)
-        , documentURL(WTFMove(documentURL))
-        , isCrossOriginOpenerPolicyEnabled(isCrossOriginOpenerPolicyEnabled)
-        , isClearSiteDataHeaderEnabled(isClearSiteDataHeaderEnabled)
-        , isClearSiteDataExecutionContextEnabled(isClearSiteDataExecutionContextEnabled)
-        , isDisplayingInitialEmptyDocument(isDisplayingInitialEmptyDocument)
-        , effectiveSandboxFlags(effectiveSandboxFlags)
-        , openerURL(WTFMove(openerURL))
-        , sourceCrossOriginOpenerPolicy(WTFMove(sourceCrossOriginOpenerPolicy))
-        , navigationID(navigationID)
-        , navigationRequester(WTFMove(navigationRequester))
-        , serviceWorkersMode(serviceWorkersMode)
-        , serviceWorkerRegistrationIdentifier(serviceWorkerRegistrationIdentifier)
-        , httpHeadersToKeep(httpHeadersToKeep)
-        , navigationPreloadIdentifier(navigationPreloadIdentifier)
-        , workerIdentifier(workerIdentifier)
+) : webPageProxyID(webPageProxyID)
+    , webPageID(webPageID)
+    , webFrameID(webFrameID)
+    , topOrigin(WTFMove(topOrigin))
+    , sourceOrigin(WTFMove(sourceOrigin))
+    , parentPID(parentPID)
+    , request(WTFMove(request))
+    , contentSniffingPolicy(contentSniffingPolicy)
+    , contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
+    , storedCredentialsPolicy(storedCredentialsPolicy)
+    , clientCredentialPolicy(clientCredentialPolicy)
+    , shouldClearReferrerOnHTTPSToHTTPRedirect(shouldClearReferrerOnHTTPSToHTTPRedirect)
+    , needsCertificateInfo(needsCertificateInfo)
+    , isMainFrameNavigation(isMainFrameNavigation)
+    , mainResourceNavigationDataForAnyFrame(mainResourceNavigationDataForAnyFrame)
+    , shouldPreconnectOnly(shouldPreconnectOnly)
+    , isNavigatingToAppBoundDomain(isNavigatingToAppBoundDomain)
+    , hadMainFrameMainResourcePrivateRelayed(hadMainFrameMainResourcePrivateRelayed)
+    , allowPrivacyProxy(allowPrivacyProxy)
+    , advancedPrivacyProtections(advancedPrivacyProtections)
+    , requiredCookiesVersion(requiredCookiesVersion)
+    , identifier(identifier)
+    , maximumBufferingTime(maximumBufferingTime)
+    , options(WTFMove(options))
+    , cspResponseHeaders(WTFMove(cspResponseHeaders))
+    , parentFrameURL(WTFMove(parentFrameURL))
+    , frameURL(WTFMove(frameURL))
+    , parentCrossOriginEmbedderPolicy(parentCrossOriginEmbedderPolicy)
+    , crossOriginEmbedderPolicy(crossOriginEmbedderPolicy)
+    , originalRequestHeaders(WTFMove(originalRequestHeaders))
+    , shouldRestrictHTTPResponseAccess(shouldRestrictHTTPResponseAccess)
+    , preflightPolicy(preflightPolicy)
+    , shouldEnableCrossOriginResourcePolicy(shouldEnableCrossOriginResourcePolicy)
+    , frameAncestorOrigins(WTFMove(frameAncestorOrigins))
+    , pageHasResourceLoadClient(pageHasResourceLoadClient)
+    , parentFrameID(parentFrameID)
+    , crossOriginAccessControlCheckEnabled(crossOriginAccessControlCheckEnabled)
+    , documentURL(WTFMove(documentURL))
+    , isCrossOriginOpenerPolicyEnabled(isCrossOriginOpenerPolicyEnabled)
+    , isClearSiteDataHeaderEnabled(isClearSiteDataHeaderEnabled)
+    , isClearSiteDataExecutionContextEnabled(isClearSiteDataExecutionContextEnabled)
+    , isDisplayingInitialEmptyDocument(isDisplayingInitialEmptyDocument)
+    , effectiveSandboxFlags(effectiveSandboxFlags)
+    , openerURL(WTFMove(openerURL))
+    , sourceCrossOriginOpenerPolicy(WTFMove(sourceCrossOriginOpenerPolicy))
+    , navigationID(navigationID)
+    , navigationRequester(WTFMove(navigationRequester))
+    , serviceWorkersMode(serviceWorkersMode)
+    , serviceWorkerRegistrationIdentifier(serviceWorkerRegistrationIdentifier)
+    , httpHeadersToKeep(httpHeadersToKeep)
+    , navigationPreloadIdentifier(navigationPreloadIdentifier)
+    , workerIdentifier(workerIdentifier)
 #if ENABLE(CONTENT_EXTENSIONS)
-        , mainDocumentURL(WTFMove(mainDocumentURL))
-        , userContentControllerIdentifier(userContentControllerIdentifier)
+    , mainDocumentURL(WTFMove(mainDocumentURL))
+    , userContentControllerIdentifier(userContentControllerIdentifier)
 #endif
 #if ENABLE(WK_WEB_EXTENSIONS)
-        , pageHasLoadedWebExtensions(pageHasLoadedWebExtensions)
+    , pageHasLoadedWebExtensions(pageHasLoadedWebExtensions)
 #endif
-        , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
-        , shouldRecordFrameLoadForStorageAccess(shouldRecordFrameLoadForStorageAccess)
+    , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
+    , shouldRecordFrameLoadForStorageAccess(shouldRecordFrameLoadForStorageAccess)
 {
     if (httpBody) {
-        request.setHTTPBody(WTFMove(httpBody));
+        // FIXME: Use EncodeRequestBody instead of this.
+        this->request.setHTTPBody(WTFMove(httpBody));
 
         if (!sandboxExtensionIfHttpBody)
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("NetworkResourceLoadParameters which specify a httpBody should have sandboxExtensionIfHttpBody");
@@ -127,8 +168,8 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
                 requestBodySandboxExtensions.append(WTFMove(extension));
         }
     }
-    
-    if (request.url().protocolIsFile()) {
+
+    if (this->request.url().protocolIsFile()) {
         if (!sandboxExtensionIflocalFile)
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("NetworkResourceLoadParameters which specify a URL of a local file should have sandboxExtensionIflocalFile");
         resourceSandboxExtension = SandboxExtension::create(WTFMove(*sandboxExtensionIflocalFile));
@@ -178,5 +219,37 @@ std::optional<SandboxExtension::Handle> NetworkResourceLoadParameters::sandboxEx
 
     return requestSandboxExtension;
 }
-    
+
+NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() const
+{
+    return {
+        webPageProxyID,
+        webPageID,
+        webFrameID,
+        topOrigin,
+        sourceOrigin,
+        parentPID,
+#if HAVE(AUDIT_TOKEN)
+        networkProcessAuditToken,
+#endif
+        request,
+        contentSniffingPolicy,
+        contentEncodingSniffingPolicy,
+        storedCredentialsPolicy,
+        clientCredentialPolicy,
+        shouldClearReferrerOnHTTPSToHTTPRedirect,
+        needsCertificateInfo,
+        isMainFrameNavigation,
+        mainResourceNavigationDataForAnyFrame,
+        blobFileReferences,
+        shouldPreconnectOnly,
+        networkActivityTracker,
+        isNavigatingToAppBoundDomain,
+        hadMainFrameMainResourcePrivateRelayed,
+        allowPrivacyProxy,
+        advancedPrivacyProtections,
+        requiredCookiesVersion
+    };
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -49,11 +49,34 @@ class Encoder;
 
 namespace WebKit {
 
-class NetworkResourceLoadParameters : public NetworkLoadParameters {
-public:
-    NetworkResourceLoadParameters() = default;
+struct NetworkResourceLoadParameters {
+    NetworkResourceLoadParameters(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, WebCore::FrameIdentifier webFrameID)
+        : webPageProxyID(webPageProxyID)
+        , webPageID(webPageID)
+        , webFrameID(webFrameID) { }
+
     NetworkResourceLoadParameters(
-        NetworkLoadParameters&&
+        WebPageProxyIdentifier
+        , WebCore::PageIdentifier
+        , WebCore::FrameIdentifier
+        , RefPtr<WebCore::SecurityOrigin>&&
+        , RefPtr<WebCore::SecurityOrigin>&&
+        , WTF::ProcessID
+        , WebCore::ResourceRequest&&
+        , WebCore::ContentSniffingPolicy
+        , WebCore::ContentEncodingSniffingPolicy
+        , WebCore::StoredCredentialsPolicy
+        , WebCore::ClientCredentialPolicy
+        , bool shouldClearReferrerOnHTTPSToHTTPRedirect
+        , bool needsCertificateInfo
+        , bool isMainFrameNavigation
+        , std::optional<NavigationActionData>&&
+        , PreconnectOnly
+        , std::optional<NavigatingToAppBoundDomain>
+        , bool hadMainFrameMainResourcePrivateRelayed
+        , bool allowPrivacyProxy
+        , OptionSet<WebCore::AdvancedPrivacyProtections>
+        , uint64_t requiredCookiesVersion
         , std::optional<WebCore::ResourceLoaderIdentifier>
         , RefPtr<WebCore::FormData>&& httpBody
         , std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensionIfHttpBody
@@ -103,6 +126,36 @@ public:
     std::optional<SandboxExtension::Handle> sandboxExtensionIflocalFile() const;
 
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const;
+    NetworkLoadParameters networkLoadParameters() const;
+
+    WebPageProxyIdentifier webPageProxyID;
+    WebCore::PageIdentifier webPageID;
+    WebCore::FrameIdentifier webFrameID;
+    RefPtr<WebCore::SecurityOrigin> topOrigin;
+    RefPtr<WebCore::SecurityOrigin> sourceOrigin;
+    WTF::ProcessID parentPID { 0 };
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> networkProcessAuditToken;
+#endif
+    WebCore::ResourceRequest request;
+    WebCore::ContentSniffingPolicy contentSniffingPolicy { WebCore::ContentSniffingPolicy::SniffContent };
+    WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy { WebCore::ContentEncodingSniffingPolicy::Default };
+    WebCore::StoredCredentialsPolicy storedCredentialsPolicy { WebCore::StoredCredentialsPolicy::DoNotUse };
+    WebCore::ClientCredentialPolicy clientCredentialPolicy { WebCore::ClientCredentialPolicy::CannotAskClientForCredentials };
+    bool shouldClearReferrerOnHTTPSToHTTPRedirect { true };
+    bool needsCertificateInfo { false };
+    bool isMainFrameNavigation { false };
+    std::optional<NavigationActionData> mainResourceNavigationDataForAnyFrame;
+    Vector<RefPtr<WebCore::BlobDataFileReference>> blobFileReferences;
+    PreconnectOnly shouldPreconnectOnly { PreconnectOnly::No };
+    std::optional<NetworkActivityTracker> networkActivityTracker;
+    std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain { NavigatingToAppBoundDomain::No };
+    bool hadMainFrameMainResourcePrivateRelayed { false };
+    bool allowPrivacyProxy { true };
+    OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
+
+    RefPtr<WebCore::SecurityOrigin> protectedSourceOrigin() const { return sourceOrigin; }
+    uint64_t requiredCookiesVersion { 0 };
 
     Markable<WebCore::ResourceLoaderIdentifier> identifier;
     Vector<RefPtr<SandboxExtension>> requestBodySandboxExtensions; // Created automatically for the sender.

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -25,10 +25,10 @@ headers: "NetworkResourceLoadParameters.h"
 enum class WebKit::PreconnectOnly : bool;
 enum class WebKit::NavigatingToAppBoundDomain : bool;
 
-class WebKit::NetworkLoadParameters {
-    Markable<WebKit::WebPageProxyIdentifier> webPageProxyID;
-    Markable<WebCore::PageIdentifier> webPageID;
-    Markable<WebCore::FrameIdentifier> webFrameID;
+struct WebKit::NetworkResourceLoadParameters {
+    WebKit::WebPageProxyIdentifier webPageProxyID;
+    WebCore::PageIdentifier webPageID;
+    WebCore::FrameIdentifier webFrameID;
     RefPtr<WebCore::SecurityOrigin> topOrigin;
     RefPtr<WebCore::SecurityOrigin> sourceOrigin;
     WTF::ProcessID parentPID;
@@ -54,11 +54,9 @@ class WebKit::NetworkLoadParameters {
     bool allowPrivacyProxy;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;
-}
 
-class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
     Markable<WebCore::ResourceLoaderIdentifier> identifier;
-    
+
     RefPtr<WebCore::FormData> request.httpBody();
     std::optional<Vector<WebKit::SandboxExtensionHandle>> sandboxExtensionsIfHttpBody();
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -148,10 +148,6 @@ NetworkResourceLoader::NetworkResourceLoader(NetworkResourceLoadParameters&& par
     if (auto* session = connection.protectedNetworkProcess()->networkSession(sessionID()))
         m_cache = session->cache();
 
-    // FIXME: This is necessary because of the existence of EmptyFrameLoaderClient in WebCore.
-    //        Once bug 116233 is resolved, this ASSERT can just be "m_webPageID && m_webFrameID"
-    ASSERT((m_parameters.webPageID && m_parameters.webFrameID) || m_parameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
-
     if (synchronousReply || m_parameters.shouldRestrictHTTPResponseAccess || m_parameters.options.keepAlive) {
         NetworkLoadChecker::LoadType requestLoadType = isMainFrameLoad() ? NetworkLoadChecker::LoadType::MainFrame : NetworkLoadChecker::LoadType::Other;
         m_networkLoadChecker = NetworkLoadChecker::create(Ref { connection.networkProcess() }.get(), this,  connection.protectedSchemeRegistry().ptr(), FetchOptions { m_parameters.options },
@@ -405,7 +401,7 @@ void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoa
             m_bufferedDataForCache.empty();
     }
 
-    NetworkLoadParameters parameters = m_parameters;
+    NetworkLoadParameters parameters = m_parameters.networkLoadParameters();
     parameters.networkActivityTracker = m_networkActivityTracker;
     if (parameters.storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use && m_networkLoadChecker)
         parameters.storedCredentialsPolicy = m_networkLoadChecker->storedCredentialsPolicy();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -122,9 +122,9 @@ public:
     Ref<NetworkConnectionToWebProcess> protectedConnectionToWebProcess() const;
     PAL::SessionID sessionID() const { return m_connection->sessionID(); }
     WebCore::ResourceLoaderIdentifier coreIdentifier() const { return *m_parameters.identifier; }
-    WebCore::FrameIdentifier frameID() const { return *m_parameters.webFrameID; }
-    WebCore::PageIdentifier pageID() const { return *m_parameters.webPageID; }
-    WebPageProxyIdentifier webPageProxyID() const { return *m_parameters.webPageProxyID; }
+    WebCore::FrameIdentifier frameID() const { return m_parameters.webFrameID; }
+    WebCore::PageIdentifier pageID() const { return m_parameters.webPageID; }
+    WebPageProxyIdentifier webPageProxyID() const { return m_parameters.webPageProxyID; }
     const NetworkResourceLoadParameters& parameters() const { return m_parameters; }
     NetworkResourceLoadIdentifier identifier() const { return m_resourceLoadID; }
     const URL& firstResponseURL() const { return m_firstResponseURL; }

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -125,7 +125,7 @@ void PingLoad::loadRequest(NetworkProcess& networkProcess, ResourceRequest&& req
 {
     PING_RELEASE_LOG("startNetworkLoad");
     if (auto* networkSession = networkProcess.networkSession(m_sessionID)) {
-        auto loadParameters = m_parameters;
+        auto loadParameters = m_parameters.networkLoadParameters();
         loadParameters.request = WTFMove(request);
         Ref task = NetworkDataTask::create(*networkSession, *this, WTFMove(loadParameters));
         m_task = task.copyRef();

--- a/Source/WebKit/NetworkProcess/PreconnectTask.h
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.h
@@ -35,9 +35,10 @@
 namespace WebKit {
 
 class NetworkLoad;
-class NetworkLoadParameters;
 class NetworkProcess;
 class NetworkSession;
+
+struct NetworkLoadParameters;
 
 class PreconnectTask final : public NetworkLoadClient {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClient.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClient.h
@@ -39,7 +39,7 @@ class ResourceResponse;
 
 namespace WebKit {
 
-class NetworkLoadParameters;
+struct NetworkLoadParameters;
 
 namespace PCM {
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -112,7 +112,7 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
     bool shouldDoNavigationPreload = session && isNavigationRequest(loader.parameters().options.destination) && m_currentRequest.httpMethod() == "GET"_s;
 
     if (shouldDoNavigationPreload && (!isWorkerReady || registration.navigationPreloadState().enabled)) {
-        NetworkLoadParameters parameters = loader.parameters();
+        NetworkLoadParameters parameters = loader.parameters().networkLoadParameters();
         parameters.request = m_currentRequest;
         m_preloader = makeUnique<ServiceWorkerNavigationPreloader>(*session, WTFMove(parameters), registration.navigationPreloadState(), loader.shouldCaptureExtraNetworkLoadMetrics());
         session->addNavigationPreloaderTask(*this);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -67,9 +67,10 @@ namespace WebKit {
 
 class NetworkConnectionToWebProcess;
 class NetworkProcess;
-class NetworkResourceLoadParameters;
 class NetworkResourceLoader;
 class ServiceWorkerFetchTask;
+
+struct NetworkResourceLoadParameters;
 struct SharedPreferencesForWebProcess;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -87,11 +87,11 @@
 #define WEBLOADERSTRATEGY_RELEASE_LOG_ERROR_BASIC(fmt, ...) RELEASE_LOG_ERROR(Network, "%p - WebLoaderStrategy::" fmt, this, ##__VA_ARGS__)
 
 #define WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_TEMPLATE "%p - [resourceLoader=%p, frameLoader=%p, frame=%p, webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::"
-#define WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_PARAMETERS this, &resourceLoader, resourceLoader.frameLoader(), resourceLoader.frame(), trackingParameters.pageID ? trackingParameters.pageID->toUInt64() : 0, trackingParameters.frameID ? trackingParameters.frameID->object().toUInt64() : 0, trackingParameters.resourceID ? trackingParameters.resourceID->toUInt64() : 0
-#define WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_STANDARD_PARAMETERS this, nullptr, &frameLoader, &frameLoader.frame(), trackingParameters.pageID ? trackingParameters.pageID->toUInt64() : 0, trackingParameters.frameID ? trackingParameters.frameID->object().toUInt64() : 0, trackingParameters.resourceID ? trackingParameters.resourceID->toUInt64() : 0
+#define WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_PARAMETERS this, &resourceLoader, resourceLoader.frameLoader(), resourceLoader.frame(), pageIDForLog(trackingParameters), frameIDForLog(trackingParameters), resourceIDForLog(trackingParameters)
+#define WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_STANDARD_PARAMETERS this, nullptr, &frameLoader, &frameLoader.frame(), pageIDForLog(trackingParameters), frameIDForLog(trackingParameters), resourceIDForLog(trackingParameters)
 
 #define WEBLOADERSTRATEGY_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_TEMPLATE fmt, WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_PARAMETERS, ##__VA_ARGS__)
-#define WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, trackingParameters.pageID ? trackingParameters.pageID->toUInt64() : 0, trackingParameters.frameID ? trackingParameters.frameID->object().toUInt64() : 0, trackingParameters.resourceID ? trackingParameters.resourceID->toUInt64() : 0, ##__VA_ARGS__)
+#define WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, pageIDForLog(trackingParameters), frameIDForLog(trackingParameters), resourceIDForLog(trackingParameters), ##__VA_ARGS__)
 #define WEBLOADERSTRATEGY_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(Network, WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_TEMPLATE fmt, WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_PARAMETERS, ##__VA_ARGS__)
 
 #define WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, WEBLOADERSTRATEGY_RELEASE_LOG_STANDARD_TEMPLATE fmt, WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_STANDARD_PARAMETERS, ##__VA_ARGS__)
@@ -101,6 +101,21 @@ namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebLoaderStrategy);
+
+[[maybe_unused]] static uint64_t pageIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+{
+    return parameters ? parameters->pageID.toUInt64() : 0;
+}
+
+[[maybe_unused]] static uint64_t frameIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+{
+    return parameters ? parameters->pageID.toUInt64() : 0;
+}
+
+[[maybe_unused]] static uint64_t resourceIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+{
+    return parameters ? parameters->pageID.toUInt64() : 0;
+}
 
 WebLoaderStrategy::WebLoaderStrategy(WebProcess& webProcess)
     : m_webProcess(webProcess)
@@ -195,19 +210,26 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
 {
     auto identifier = *resourceLoader.identifier();
 
-    auto* frameLoader = resourceLoader.frameLoader();
-    ASSERT(frameLoader);
+    RefPtr frameLoader = resourceLoader.frameLoader();
+    if (!frameLoader) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
     auto& frameLoaderClient = frameLoader->client();
+    auto pageID = frameLoader->frame().pageID();
 
-    WebResourceLoader::TrackingParameters trackingParameters {
-        .pageID = frameLoader->frame().pageID(),
-        .frameID = frameLoader->frameID(),
-        .resourceID = identifier
-    };
+    std::optional<WebPageProxyIdentifier> webPageProxyID;
     if (auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoaderClient))
-        trackingParameters.webPageProxyID = webFrameLoaderClient->webPageProxyID();
+        webPageProxyID = webFrameLoaderClient->webPageProxyID();
     else if (auto* workerFrameLoaderClient = dynamicDowncast<RemoteWorkerFrameLoaderClient>(frameLoaderClient))
-        trackingParameters.webPageProxyID = workerFrameLoaderClient->webPageProxyID();
+        webPageProxyID = workerFrameLoaderClient->webPageProxyID();
+
+    auto trackingParameters = webPageProxyID && pageID ? std::optional(WebResourceLoader::TrackingParameters {
+        *webPageProxyID,
+        *pageID,
+        frameLoader->frameID(),
+        identifier
+    }) : std::nullopt;
 
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
     // If the DocumentLoader schedules this as an archive resource load,
@@ -255,20 +277,25 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
     if (tryLoadingUsingURLSchemeHandler(resourceLoader, trackingParameters))
         return;
 
+    if (!trackingParameters) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
     if (InspectorInstrumentationWebKit::shouldInterceptRequest(resourceLoader)) {
         InspectorInstrumentationWebKit::interceptRequest(resourceLoader, [this, protectedThis = Ref { *this }, protectedResourceLoader = Ref { resourceLoader }, trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, resource](const ResourceRequest& request) {
             auto& resourceLoader = protectedResourceLoader.get();
             WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: intercepted URL will be scheduled with the NetworkProcess");
-            scheduleLoadFromNetworkProcess(resourceLoader, request, trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
+            scheduleLoadFromNetworkProcess(resourceLoader, request, *trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
         });
         return;
     }
 
     WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WEBLOADERSTRATEGY_SCHEDULELOAD);
-    scheduleLoadFromNetworkProcess(resourceLoader, resourceLoader.request(), trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
+    scheduleLoadFromNetworkProcess(resourceLoader, resourceLoader.request(), *trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
 }
 
-bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resourceLoader, const WebResourceLoader::TrackingParameters& trackingParameters)
+bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resourceLoader, const std::optional<WebResourceLoader::TrackingParameters>& trackingParameters)
 {
     RefPtr<WebPage> webPage;
     RefPtr<WebFrame> webFrame;
@@ -307,7 +334,7 @@ bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resource
 }
 
 #if ENABLE(PDFJS)
-bool WebLoaderStrategy::tryLoadingUsingPDFJSHandler(ResourceLoader& resourceLoader, const WebResourceLoader::TrackingParameters& trackingParameters)
+bool WebLoaderStrategy::tryLoadingUsingPDFJSHandler(ResourceLoader& resourceLoader, const std::optional<WebResourceLoader::TrackingParameters>& trackingParameters)
 {
     if (!resourceLoader.request().url().protocolIs("webkit-pdfjs-viewer"_s))
         return false;
@@ -411,11 +438,12 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
 
     LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be scheduled with the NetworkProcess with priority %d, storedCredentialsPolicy %i", resourceLoader.url().string().latin1().data(), static_cast<int>(resourceLoader.request().priority()), (int)storedCredentialsPolicy);
 
-    NetworkResourceLoadParameters loadParameters;
+    NetworkResourceLoadParameters loadParameters {
+        trackingParameters.webPageProxyID,
+        trackingParameters.pageID,
+        trackingParameters.frameID
+    };
     loadParameters.identifier = identifier;
-    loadParameters.webPageProxyID = trackingParameters.webPageProxyID;
-    loadParameters.webPageID = trackingParameters.pageID;
-    loadParameters.webFrameID = trackingParameters.frameID;
     loadParameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
@@ -425,7 +453,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.contentEncodingSniffingPolicy = contentEncodingSniffingPolicy;
     loadParameters.storedCredentialsPolicy = storedCredentialsPolicy;
     // If there is no WebFrame then this resource cannot be authenticated with the client.
-    loadParameters.clientCredentialPolicy = (loadParameters.webFrameID && loadParameters.webPageID && resourceLoader.isAllowedToAskUserForCredentials()) ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
+    loadParameters.clientCredentialPolicy = resourceLoader.isAllowedToAskUserForCredentials() ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
     loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect;
     loadParameters.needsCertificateInfo = resourceLoader.shouldIncludeCertificateInfo();
     loadParameters.maximumBufferingTime = maximumBufferingTime;
@@ -551,8 +579,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
 
     if (RefPtr frameLoader = resourceLoader.frameLoader())
         loadParameters.requiredCookiesVersion = frameLoader->requiredCookiesVersion();
-
-    ASSERT((loadParameters.webPageID && loadParameters.webFrameID) || loadParameters.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials);
 
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     if (loadParameters.isMainFrameNavigation)
@@ -728,21 +754,35 @@ std::optional<WebLoaderStrategy::SyncLoadResult> WebLoaderStrategy::tryLoadingSy
 
 void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, const ResourceRequest& request, ClientCredentialPolicy clientCredentialPolicy,  const FetchOptions& options, const HTTPHeaderMap& originalRequestHeaders, ResourceError& error, ResourceResponse& response, Vector<uint8_t>& data)
 {
-    auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoader.client());
-    auto* webFrame = webFrameLoaderClient ? &webFrameLoaderClient->webFrame() : nullptr;
-    auto* webPage = webFrame ? webFrame->page() : nullptr;
-    auto* page = webPage ? webPage->corePage() : nullptr;
+    RefPtr webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoader.client());
+    RefPtr webFrame = webFrameLoaderClient ? &webFrameLoaderClient->webFrame() : nullptr;
+    if (!webFrame) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    RefPtr webPage = webFrame ? webFrame->page() : nullptr;
+    if (!webPage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    RefPtr page = webPage ? webPage->corePage() : nullptr;
+    if (!page) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
-    auto webPageProxyID = webPage ? std::optional { webPage->webPageProxyIdentifier() } : std::nullopt;
-    auto pageID = webPage ? std::optional { webPage->identifier() } : std::nullopt;
-    auto frameID = webFrame ? std::optional { webFrame->frameID() } : std::nullopt;
+    auto webPageProxyID = webPage->webPageProxyIdentifier();
+    auto pageID = webPage->identifier();
+    auto frameID = webFrame->frameID();
 
-    WebResourceLoader::TrackingParameters trackingParameters;
-    trackingParameters.pageID = pageID;
-    trackingParameters.frameID = frameID;
-    trackingParameters.resourceID = resourceLoadIdentifier;
+    [[maybe_unused]] WebResourceLoader::TrackingParameters trackingParameters {
+        webPageProxyID,
+        pageID,
+        frameID,
+        resourceLoadIdentifier
+    };
 
-    auto* document = frameLoader.frame().document();
+    RefPtr document = frameLoader.frame().document();
     if (!document) {
         WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: no document");
         error = internalError(request.url());
@@ -766,11 +806,12 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
         return;
     }
 
-    NetworkResourceLoadParameters loadParameters;
+    NetworkResourceLoadParameters loadParameters {
+        webPageProxyID,
+        pageID,
+        frameID
+    };
     loadParameters.identifier = resourceLoadIdentifier;
-    loadParameters.webPageProxyID = webPageProxyID;
-    loadParameters.webPageID = pageID;
-    loadParameters.webFrameID = frameID;
     loadParameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
@@ -847,11 +888,12 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
         return;
     }
 
-    NetworkResourceLoadParameters loadParameters;
+    NetworkResourceLoadParameters loadParameters {
+        webPage->webPageProxyIdentifier(),
+        webPage->identifier(),
+        webFrame->frameID()
+    };
     loadParameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
-    loadParameters.webPageProxyID = webPage->webPageProxyIdentifier();
-    loadParameters.webPageID = webPage->identifier();
-    loadParameters.webFrameID = webFrame->frameID();
     loadParameters.request = request;
     loadParameters.sourceOrigin = &document->securityOrigin();
     loadParameters.topOrigin = &document->topOrigin();
@@ -924,7 +966,11 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
             request.setIsAppInitiated(loader->lastNavigationWasAppInitiated());
     }
 
-    NetworkResourceLoadParameters parameters;
+    NetworkResourceLoadParameters parameters {
+        webPage.webPageProxyIdentifier(),
+        webPage.identifier(),
+        webFrame.frameID()
+    };
     parameters.request = WTFMove(request);
     if (parameters.request.httpUserAgent().isEmpty()) {
         // FIXME: we add user-agent to the preconnect request because otherwise the preconnect
@@ -934,9 +980,6 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
             parameters.request.setHTTPUserAgent(webPageUserAgent);
     }
     parameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
-    parameters.webPageProxyID = webPage.webPageProxyIdentifier();
-    parameters.webPageID = webPage.identifier();
-    parameters.webFrameID = webFrame.frameID();
     parameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     parameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -106,9 +106,9 @@ private:
     void scheduleInternallyFailedLoad(WebCore::ResourceLoader&);
     void internallyFailedLoadTimerFired();
     void startLocalLoad(WebCore::ResourceLoader&);
-    bool tryLoadingUsingURLSchemeHandler(WebCore::ResourceLoader&, const WebResourceLoader::TrackingParameters&);
+    bool tryLoadingUsingURLSchemeHandler(WebCore::ResourceLoader&, const std::optional<WebResourceLoader::TrackingParameters>&);
 #if ENABLE(PDFJS)
-    bool tryLoadingUsingPDFJSHandler(WebCore::ResourceLoader&, const WebResourceLoader::TrackingParameters&);
+    bool tryLoadingUsingPDFJSHandler(WebCore::ResourceLoader&, const std::optional<WebResourceLoader::TrackingParameters>&);
 #endif
 
     WebCore::ResourceError cancelledError(const WebCore::ResourceRequest&) const final;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -63,17 +63,17 @@
 #endif
 
 
-#define WEBRESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, m_trackingParameters.pageID ? m_trackingParameters.pageID->toUInt64() : 0, m_trackingParameters.frameID ? m_trackingParameters.frameID->object().toUInt64() : 0, m_trackingParameters.resourceID ? m_trackingParameters.resourceID->toUInt64() : 0, ##__VA_ARGS__)
+#define WEBRESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, m_trackingParameters ? m_trackingParameters->pageID.toUInt64() : 0, m_trackingParameters ? m_trackingParameters->frameID.object().toUInt64() : 0, m_trackingParameters ? m_trackingParameters->resourceID.toUInt64() : 0, ##__VA_ARGS__)
 
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebResourceLoader> WebResourceLoader::create(Ref<ResourceLoader>&& coreLoader, const TrackingParameters& trackingParameters)
+Ref<WebResourceLoader> WebResourceLoader::create(Ref<ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters)
 {
     return adoptRef(*new WebResourceLoader(WTFMove(coreLoader), trackingParameters));
 }
 
-WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, const TrackingParameters& trackingParameters)
+WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, const std::optional<TrackingParameters>& trackingParameters)
     : m_coreLoader(WTFMove(coreLoader))
     , m_trackingParameters(trackingParameters)
     , m_loadStart(MonotonicTime::now())

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -60,13 +60,13 @@ enum class PrivateRelayed : bool;
 class WebResourceLoader : public RefCounted<WebResourceLoader>, public IPC::MessageSender {
 public:
     struct TrackingParameters {
-        Markable<WebPageProxyIdentifier> webPageProxyID { };
-        Markable<WebCore::PageIdentifier> pageID;
-        Markable<WebCore::FrameIdentifier> frameID;
-        Markable<WebCore::ResourceLoaderIdentifier> resourceID;
+        WebPageProxyIdentifier webPageProxyID;
+        WebCore::PageIdentifier pageID;
+        WebCore::FrameIdentifier frameID;
+        WebCore::ResourceLoaderIdentifier resourceID;
     };
 
-    static Ref<WebResourceLoader> create(Ref<WebCore::ResourceLoader>&&, const TrackingParameters&);
+    static Ref<WebResourceLoader> create(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&);
 
     ~WebResourceLoader();
 
@@ -79,7 +79,7 @@ public:
     void detachFromCoreLoader();
 
 private:
-    WebResourceLoader(Ref<WebCore::ResourceLoader>&&, const TrackingParameters&);
+    WebResourceLoader(Ref<WebCore::ResourceLoader>&&, const std::optional<TrackingParameters>&);
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const override;
@@ -111,7 +111,7 @@ private:
     void updateBytesTransferredOverNetwork(uint64_t bytesTransferredOverNetwork);
 
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
-    const TrackingParameters m_trackingParameters;
+    const std::optional<TrackingParameters> m_trackingParameters;
     WebResourceInterceptController m_interceptController;
     size_t m_numBytesReceived { 0 };
     size_t m_bytesTransferredOverNetwork { 0 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1890,12 +1890,13 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
     if (!webPage)
         return completionHandler(makeUnexpected(internalError(url)));
 
-    NetworkResourceLoadParameters parameters;
+    NetworkResourceLoadParameters parameters {
+        webPage->webPageProxyIdentifier(),
+        webPage->identifier(),
+        m_frame->frameID()
+    };
     parameters.request = ResourceRequest(url);
     parameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
-    parameters.webPageProxyID = webPage->webPageProxyIdentifier();
-    parameters.webPageID = webPage->identifier();
-    parameters.webFrameID = m_frame->frameID();
     parameters.parentPID = legacyPresentingApplicationPID();
 #if HAVE(AUDIT_TOKEN)
     parameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();


### PR DESCRIPTION
#### b2cfc9f22cb71fcb5ad7c6f55e13b1c6f2278c0c
<pre>
Make NetworkResourceLoadParameters.webPageProxyID non-Markable
<a href="https://bugs.webkit.org/show_bug.cgi?id=290419">https://bugs.webkit.org/show_bug.cgi?id=290419</a>
<a href="https://rdar.apple.com/145704696">rdar://145704696</a>

Reviewed by Chris Dumez.

NetworkResourceLoadParameters is sent across IPC, NetworkLoadParameters is not.
To accomplish this most elegantly, I removed the inheritance relationship and added
an accessor to get NetworkLoadParameters from NetworkResourceLoadParameters.

This changes a rare crash in the NetworkResourceLoader constructor to an early return
in WebLoaderStrategy::loadResourceSynchronously.  It also makes it so we can&apos;t compile
code that would make an edge case where we could get a null webPageProxyID.

I considered moving the now non-nullable identifiers to NetworkResourceLoadParameters,
but there are too many places in NetworkSession that use the identifiers, so that
solution seemed too messy.  I also considered passing a separate struct to the
NetworkDataTask constructor containing optional identifiers, but that was also
messier than this.

* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::resolveBlobReferences):
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
(WebKit::NetworkConnectionToWebProcess::performSynchronousLoad):
(WebKit::NetworkConnectionToWebProcess::loadPing):
(WebKit::NetworkConnectionToWebProcess::sendH2Ping):
(WebKit::NetworkConnectionToWebProcess::preconnectTo):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
(WebKit::NetworkLoadParameters::NetworkLoadParameters): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
(WebKit::NetworkResourceLoadParameters::networkLoadParameters const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
(WebKit::NetworkResourceLoadParameters::protectedSourceOrigin const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::PingLoad::loadRequest):
* Source/WebKit/NetworkProcess/PreconnectTask.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClient.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoad):
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
(WebKit::WebLoaderStrategy::startPingLoad):
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::create):
(WebKit::WebResourceLoader::WebResourceLoader):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):

Canonical link: <a href="https://commits.webkit.org/292707@main">https://commits.webkit.org/292707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e8dd0a121812b42376c3b293c48e5a6f567b0f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96825 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73780 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30988 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54114 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12357 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103921 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83642 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82214 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26877 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17377 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->