### PR TITLE
[JSC] Add option to disallow loop unrolling for non-innermost loops

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -419,6 +419,9 @@ public:
 
     bool shouldUnrollLoop(LoopData& data)
     {
+        if (Options::disallowLoopUnrollingForNonInnermost() && !data.loop->isInnerMostLoop())
+            return false;
+
         uint32_t totalNodeCount = 0;
         uint32_t maxLoopUnrollingBodyNodeSize = data.isOperandConstant() ? Options::maxLoopUnrollingBodyNodeSize() : Options::maxPartialLoopUnrollingBodyNodeSize();
         for (uint32_t i = 0; i < data.loopSize(); ++i) {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -580,7 +580,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
     v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
-    v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, disallowLoopUnrollingForNonInnermost, false, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingCount, 2, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingIterationCount, 4, Normal, nullptr) \

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -41,13 +41,15 @@ public:
         : m_graph(nullptr)
         , m_header(nullptr)
         , m_outerLoopIndex(UINT_MAX)
+        , m_innerLoopIndex(UINT_MAX)
     {
     }
-    
+
     NaturalLoop(Graph& graph, typename Graph::Node header, unsigned index)
         : m_graph(&graph)
         , m_header(header)
         , m_outerLoopIndex(UINT_MAX)
+        , m_innerLoopIndex(UINT_MAX)
         , m_index(index)
     {
     }
@@ -78,6 +80,7 @@ public:
     unsigned index() const { return m_index; }
     
     bool isOuterMostLoop() const { return m_outerLoopIndex == UINT_MAX; }
+    bool isInnerMostLoop() const { return m_innerLoopIndex == UINT_MAX; }
     
     void dump(PrintStream& out) const
     {
@@ -106,6 +109,7 @@ private:
     typename Graph::Node m_header;
     Vector<typename Graph::Node, 4> m_body;
     unsigned m_outerLoopIndex;
+    unsigned m_innerLoopIndex;
     unsigned m_index;
 };
 
@@ -235,6 +239,8 @@ public:
             RELEASE_ASSERT(m_innerMostLoopIndices[loop.header()][0] == i);
         
             loop.m_outerLoopIndex = m_innerMostLoopIndices[loop.header()][1];
+            if (loop.m_outerLoopIndex != UINT_MAX)
+                m_loops[loop.m_outerLoopIndex].m_innerLoopIndex = loop.index();
         }
     
         if (selfCheck) {


### PR DESCRIPTION
#### 347de29970599c886ec99b6a825eaf5bfacc92ac
<pre>
[JSC] Add option to disallow loop unrolling for non-innermost loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=290427">https://bugs.webkit.org/show_bug.cgi?id=290427</a>
<a href="https://rdar.apple.com/147881147">rdar://147881147</a>

Reviewed by Yusuke Suzuki.

This patch introduces a new option, `disallowLoopUnrollingForNonInnermostLoops`,
to control whether the DFG should unroll loops that contain inner loops.

By default, loop unrolling is disallowed for loops that are not innermost,
to avoid complexity and potential inefficiency when dealing with nested loops.
This behavior can now be toggled via `Options::disallowLoopUnrollingForNonInnermostLoops`.

NaturalLoops infrastructure is updated to track both outer and inner loop relationships.
A loop is considered &quot;innermost&quot; if no other loop is nested inside it.

* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::shouldUnrollLoop):
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoop::NaturalLoop):
(WTF::NaturalLoop::isInnerMostLoop const):
(WTF::NaturalLoops::NaturalLoops):

Canonical link: <a href="https://commits.webkit.org/292744@main">https://commits.webkit.org/292744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8178e8f61d7e8bab57d29a05cab01edd07dfd6a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97006 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/16620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102082 "Failed to checkout and rebase branch from PR 43020") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/16916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/25069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/102082 "Failed to checkout and rebase branch from PR 43020") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100009 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/16916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/102082 "Failed to checkout and rebase branch from PR 43020") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/16916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/46854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/89679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/16916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95627 "Failed to checkout and rebase branch from PR 43020") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/25069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/104104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/6824 "Hash 8178e8f6 for PR 43020 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15648 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/119254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/23863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/119254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/25437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->