### PR TITLE
REGRESSION(292391@main): [macOS Debug] inspector/animation/lifecycle-web-animation.html is flaky failure (flaky in EWS)

### DIFF
--- a/LayoutTests/inspector/animation/lifecycle-web-animation.html
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation.html
@@ -101,6 +101,7 @@ function test()
     animation-iteration-count: infinite;
     animation-duration: 1s;
     animation-direction: alternate;
+    animation-play-state: paused;
 }
 </style>
 </head>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2427,5 +2427,3 @@ imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-complex-001.s
 # webkit.org/b/289495 REGRESSION(291808@main): [ macOS ] 2x svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-*-context.svg are constant failures.
 svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-ltr-context.svg [ Failure ]
 svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg [ Failure ]
-
-# webkit.org/b/290417 [ Debug ] inspector/animation/lifecycle-web-animation.html [ Pass Failure ]


### PR DESCRIPTION
#### 8b943bbaac0d717a51aa13adc4626df477eb129c
<pre>
REGRESSION(292391@main): [macOS Debug] inspector/animation/lifecycle-web-animation.html is flaky failure (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290417">https://bugs.webkit.org/show_bug.cgi?id=290417</a>
&lt;<a href="https://rdar.apple.com/problem/147875563">rdar://problem/147875563</a>&gt;

Unreviewed.  Ensure that the animation starts paused so that the state remains consistent if getting the effect takes a little while.

* LayoutTests/inspector/animation/lifecycle-web-animation.html:

Canonical link: <a href="https://commits.webkit.org/292689@main">https://commits.webkit.org/292689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6efe8763436312a5487401a6278ed80690669c6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30978 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99814 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12585 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46659 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23879 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82814 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83629 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82203 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26865 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26980 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->