### PR TITLE
Ensure updating referenceTarget updates the accessibility tree appropriately.

### DIFF
--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt
@@ -1,0 +1,36 @@
+This tests the basic interaction between referenceTarget and aria-activedescendant.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+aria-activedescendant targeting a custom element with shadowrootreferencetarget.
+PASS: combobox1.selectedChildrenCount === 1
+PASS: combobox1.selectedChildAtIndex(0).title === 'AXTitle: Option 2'
+
+ShadowRoot.referenceTarget property works on an imperatively defined custom element.
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option C'
+
+Modifying a ShadowRoot's referenceTarget also updates the accessibility object.
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option A'
+
+Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.
+PASS: combobox2.selectedChildrenCount === 0
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option B'
+
+aria-activedescendant works when the linkage is created across two sibling shadow trees.
+PASS: realInput.selectedChildrenCount === 1
+PASS: realInput.selectedChildAtIndex(0).title === 'AXTitle: Option C'
+
+Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.
+PASS: realInput.selectedChildrenCount === 1
+PASS: realInput.selectedChildAtIndex(0).title === 'AXTitle: Option B'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
@@ -1,0 +1,137 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <script src="../../../../resources/accessibility-helper.js"></script>
+  <script src="../../../../resources/js-test.js"></script>
+</head>
+
+<body>
+<div class="container">
+    <input id="combobox1" role="combobox" aria-controls="x-listbox1" aria-activedescendant="x-listbox1">
+    <x-listbox1 id="x-listbox1" role="listbox">
+        <template shadowrootmode="closed" shadowrootreferencetarget="option-2">
+            <div role="option" id="option-1">Option 1</div>
+            <div role="option" id="option-2">Option 2</div>
+            <div role="option" id="option-3">Option 3</div>
+        </template>
+    </x-listbox1>
+</div>
+
+
+<script>
+customElements.define(
+    "x-listbox2",
+    class XListbox2 extends HTMLElement {
+        constructor() {
+            super();
+            this.shadowRoot_ = this.attachShadow({ mode: "closed" });
+            this.shadowRoot_.innerHTML = `
+            <div id="real-listbox" role="listbox">
+                <div id="option-a" role="option">Option A</div>
+                <div id="option-b" role="option">Option B</div>
+                <div id="option-c" role="option">Option C</div>
+            </div>
+            `;
+            this.shadowRoot_.referenceTarget = "option-c";
+        }
+
+        setReferenceTarget(target) {
+            this.shadowRoot_.referenceTarget = target;
+        }
+
+        referenceTargetElement() {
+            return this.shadowRoot_.getElementById(this.shadowRoot_.referenceTarget);
+        }
+    }
+);
+</script>
+
+<div class="container">
+    <input id="combobox2" role="combobox" aria-controls="x-listbox2" aria-activedescendant="x-listbox2">
+    <x-listbox2 id="x-listbox2" role="listbox"></x-listbox2>
+</div>
+
+<script>
+customElements.define(
+    "x-input",
+    class FancyInput extends HTMLElement {
+        static observedAttributes = ["fancylistbox"];
+
+        constructor() {
+            super();
+            this.shadowRoot_ = this.attachShadow({
+                mode: "closed",
+            });
+            this.shadowRoot_.innerHTML = `<input id="real-input">`;
+            this.realInput_ = this.shadowRoot_.getElementById("real-input");
+        }
+
+        attributeChangedCallback(attr, oldValue, newValue) {
+            if (attr === "fancylistbox") {
+                const fancyListbox = newValue ? document.getElementById(newValue) : null;
+                this.realInput_.ariaActiveDescendantElement = fancyListbox;
+            }
+        }
+    }
+);
+</script>
+
+<div class="container">
+    <x-listbox2 id="fancy-listbox" role="listbox"></x-listbox2>
+    <x-input role="combobox" fancylistbox="fancy-listbox"></x-input>
+</div>
+
+<script>
+description("This tests the basic interaction between referenceTarget and aria-activedescendant.");
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    let output = "aria-activedescendant targeting a custom element with shadowrootreferencetarget.\n"
+    var combobox1 = accessibilityController.accessibleElementById("combobox1");
+    output += expect("combobox1.selectedChildrenCount", "1");
+    output += expect("combobox1.selectedChildAtIndex(0).title", "'AXTitle: Option 2'");
+    output += "\n";
+
+    output += "ShadowRoot.referenceTarget property works on an imperatively defined custom element.\n";
+    var combobox2 = accessibilityController.accessibleElementById("combobox2");
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object.\n";
+    const listboxElement = document.getElementById("x-listbox2");
+    listboxElement.setReferenceTarget("option-a");
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option A'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.\n";
+    let referenceTargetElement = listboxElement.referenceTargetElement();
+    referenceTargetElement.id = "option-d";
+    output += expect("combobox2.selectedChildrenCount", "0");
+    referenceTargetElement.nextElementSibling.id = "option-a";
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+    output += "\n";
+
+    output += "aria-activedescendant works when the linkage is created across two sibling shadow trees.\n";
+    var realInput = accessibilityController.accessibleElementById("real-input");
+    output += expect("realInput.selectedChildrenCount", "1");
+    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.\n";
+    const fancyListboxElement = document.getElementById("fancy-listbox");
+    fancyListboxElement.setReferenceTarget("option-b");
+    output += expect("realInput.selectedChildrenCount", "1");
+    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -788,6 +788,7 @@ accessibility/display-contents/tree-and-treeitems.html [ Skip ]
 webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
 
 accessibility/combobox/mac [ Skip ]
+accessibility/shadow-dom/reference-target/mac [ Skip ]
 
 accessibility/textarea-line-for-index.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2709,6 +2709,11 @@ void AXObjectCache::deferAttributeChangeIfNeeded(Element& element, const Qualifi
         relationsNeedUpdate(true);
 }
 
+void AXObjectCache::handleReferenceTargetChanged()
+{
+    relationsNeedUpdate(true);
+}
+
 bool AXObjectCache::shouldProcessAttributeChange(Element* element, const QualifiedName& attrName)
 {
     if (!element)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -387,6 +387,7 @@ public:
     void checkedStateChanged(Element&);
     void autofillTypeChanged(HTMLInputElement&);
     void handleRoleChanged(AccessibilityObject&, AccessibilityRole previousRole);
+    void handleReferenceTargetChanged();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void columnIndexChanged(AccessibilityObject&);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "ShadowRoot.h"
 
+#include "AXObjectCache.h"
 #include "CSSStyleSheet.h"
 #include "ChildListMutationScope.h"
 #include "CustomElementRegistry.h"
@@ -472,7 +473,13 @@ void ShadowRoot::setReferenceTarget(const AtomString& referenceTarget)
     if (!document().settings().shadowRootReferenceTargetEnabled())
         return;
 
+    if (m_referenceTarget == referenceTarget)
+        return;
+
     m_referenceTarget = referenceTarget;
+
+    if (CheckedPtr cache = document().existingAXObjectCache())
+        cache->handleReferenceTargetChanged();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 40e4a4391283399f73e147f0f1d9c9654460f92b
<pre>
Ensure updating referenceTarget updates the accessibility tree appropriately.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290440">https://bugs.webkit.org/show_bug.cgi?id=290440</a>

Reviewed by Tyler Wilcock and Ryosuke Niwa.

This introduces a method on AXObjectCache to mark relations dirty when a referenceTarget value is changed.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleReferenceTargetChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setReferenceTarget):

Canonical link: <a href="https://commits.webkit.org/292817@main">https://commits.webkit.org/292817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb92a92ec0a2a909d955e21383d354c4d20b165d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73898 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46866 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82943 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4572 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17580 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->