### PR TITLE
Form controls inside a declarative shadow DOM erroneously get associated with form element in an outer tree

### DIFF
--- a/LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer-expected.txt
+++ b/LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer-expected.txt
@@ -1,0 +1,14 @@
+This tests having a declarative shadow DOM inside a form element. form control elements inside the declarative shadow DOM should not be associated with the form in the document tree.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS !!document.forms[0]['email'] is false
+PASS !!document.forms[0]['nickname'] is false
+PASS !!document.forms[0]['name'] is true
+PASS !!document.querySelector('some-element').shadowRoot.querySelector('form')['nickname'] is true
+PASS document.querySelector('some-element').shadowRoot.innerHTML is "<input name=\"email\"><form><input name=\"nickname\"></form>"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer.html
+++ b/LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<form>
+<some-element><template shadowrootmode="open"><input name="email"><form><input name="nickname"></form></template></some-element>
+<input name="name">
+</form>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('This tests having a declarative shadow DOM inside a form element. form control elements inside the declarative shadow DOM should not be associated with the form in the document tree.');
+shouldBeFalse(`!!document.forms[0]['email']`);
+shouldBeFalse(`!!document.forms[0]['nickname']`);
+shouldBeTrue(`!!document.forms[0]['name']`);
+shouldBeTrue(`!!document.querySelector('some-element').shadowRoot.querySelector('form')['nickname']`);
+shouldBeEqualToString(`document.querySelector('some-element').shadowRoot.innerHTML`, '<input name="email"><form><input name="nickname"></form>');
+document.querySelector('form').remove();
+</script>

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -823,7 +823,7 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#create-an-element-for-the-token
     Ref treeScope = treeScopeForCurrentNode();
     Ref ownerDocument = treeScope->documentScope();
-    bool insideTemplateElement = !ownerDocument->frame();
+    bool insideTemplateElement = m_openElements.containsTemplateElement();
     RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
     if (UNLIKELY(!element)) {
         RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? registryForCurrentNode(currentNode(), treeScope) : m_registry;

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -31,6 +31,7 @@
 #include "HTMLOptGroupElement.h"
 #include "HTMLOptionElement.h"
 #include "HTMLTableElement.h"
+#include "HTMLTemplateElement.h"
 #include "MathMLNames.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -518,6 +519,9 @@ void HTMLElementStack::pushCommon(HTMLStackItem&& item)
 {
     ASSERT(m_rootNode);
 
+    if (UNLIKELY(is<HTMLTemplateElement>(item.node())))
+        ++m_templateElementCount;
+
     ++m_stackDepth;
     m_top = makeUnique<ElementRecord>(WTFMove(item), WTFMove(m_top));
 }
@@ -530,6 +534,11 @@ void HTMLElementStack::popCommon()
 
     Ref oldTop = top();
     m_top = m_top->releaseNext();
+
+    if (UNLIKELY(is<HTMLTemplateElement>(oldTop))) {
+        ASSERT(m_templateElementCount);
+        --m_templateElementCount;
+    }
 
     oldTop->finishParsingChildren();
 
@@ -545,6 +554,12 @@ void HTMLElementStack::removeNonTopCommon(Element& element)
         if (&record->next()->element() == &element) {
             record->setNext(record->next()->releaseNext());
             --m_stackDepth;
+
+            if (UNLIKELY(is<HTMLTemplateElement>(element))) {
+                ASSERT(m_templateElementCount);
+                --m_templateElementCount;
+            }
+
             // FIXME: Is it OK to call finishParsingChildren()
             // when the children aren't actually finished?
             element.finishParsingChildren();

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -92,6 +92,8 @@ public:
     ElementRecord* furthestBlockForFormattingElement(Element&) const;
     ElementRecord* topmost(ElementName) const;
 
+    bool containsTemplateElement() const { return m_templateElementCount; }
+
     void insertAbove(HTMLStackItem&&, ElementRecord&);
 
     void push(HTMLStackItem&&);
@@ -161,6 +163,7 @@ private:
     CheckedPtr<Element> m_headElement;
     CheckedPtr<Element> m_bodyElement;
     unsigned m_stackDepth { 0 };
+    unsigned m_templateElementCount { 0 };
 };
     
 } // namespace WebCore


### PR DESCRIPTION
#### e657338dfd4124f6bb30ce69535ca8f8813ff566
<pre>
Form controls inside a declarative shadow DOM erroneously get associated with form element in an outer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=290396">https://bugs.webkit.org/show_bug.cgi?id=290396</a>

Reviewed by Anne van Kesteren.

The bug was caused by HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface not using nullptr
for the form element pointer [1] when constructing an element inside a declarative shadow DOM. Fixed the bug
by introducing a new counter which keeps track of the number of template elements in HTMLElementStack,
and checking this counter in HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface to check if
there is any template element in the stack of open elements [2] when creating an element for a token [3].

[1] <a href="https://html.spec.whatwg.org/multipage/parsing.html#form-element-pointer">https://html.spec.whatwg.org/multipage/parsing.html#form-element-pointer</a>
[2] <a href="https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements">https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements</a>
[3] <a href="https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token">https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token</a>

* LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer-expected.txt: Added.
* LayoutTests/fast/shadow-dom/declarative-shadow-dom-with-parser-form-element-pointer.html: Added.
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::HTMLElementStack::pushCommon):
(WebCore::HTMLElementStack::popCommon):
(WebCore::HTMLElementStack::removeNonTopCommon):
* Source/WebCore/html/parser/HTMLElementStack.h:
(WebCore::HTMLElementStack::containsTemplateElement const):

Canonical link: <a href="https://commits.webkit.org/292703@main">https://commits.webkit.org/292703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1656c854da524af8fb770035462526f1db0a9181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82456 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5472 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103924 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83646 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82215 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17380 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15609 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29013 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->