### PR TITLE
[GTK][WPE] Avoid inflating canvas 2d's dirty rects

### DIFF
--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
@@ -34,7 +34,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[4, 4, 7, 7]]);
+              assertRectsEq(damage.rects, [[5, 5, 5, 5]]);
           },
           () => {
               ctx.fillStyle = "green";
@@ -42,7 +42,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[9, 9, 7, 7]]);
+              assertRectsEq(damage.rects, [[10, 10, 5, 5]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
@@ -21,9 +21,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              // We take a 1px margin into account as we cannot avoid it. It was added in:
-              // https://github.com/WebKit/WebKit/commit/0e8b2662b634fbd074709ee8ac30b3499c10e081
-              assertRectsEq(damage.rects, [[4, 4, 12, 12]]);
+              assertRectsEq(damage.rects, [[5, 5, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
@@ -27,7 +27,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[26, 26, 12, 12]]);
+              assertRectsEq(damage.rects, [[27, 27, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
@@ -39,7 +39,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[0, 0, 11, 11], [19, 19, 12, 12]]);
+              assertRectsEq(damage.rects, [[0, 0, 10, 10], [20, 20, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
@@ -26,7 +26,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[9, 9, 32, 32]]);
+              assertRectsEq(damage.rects, [[10, 10, 30, 30]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
@@ -30,7 +30,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[9, 9, 7, 7]]);
+              assertRectsEq(damage.rects, [[10, 10, 5, 5]]);
           },
       ], 0);
     </script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2386,15 +2386,15 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     else
 #endif
     {
-        // Inflate dirty rect to cover antialiasing on image buffers.
-        if (context->shouldAntialias())
-            dirtyRect.inflate(1);
 #if USE(COORDINATED_GRAPHICS)
         // In COORDINATED_GRAPHICS graphics layer is tiled and tiling logic handles dirty rects
         // internally and thus no unification of rects is needed here because that causes
         // unnecessary invalidation of tiles which are actually not dirty
         m_dirtyRect = dirtyRect;
 #else
+        // Inflate dirty rect to cover antialiasing on image buffers.
+        if (context->shouldAntialias())
+            dirtyRect.inflate(1);
         m_dirtyRect.unite(dirtyRect);
 #endif
         canvasBase().didDraw(m_dirtyRect, shouldApplyPostProcessing);


### PR DESCRIPTION
#### 1fdfbaad4d65958767f0d0c95fdf7d5573295ff8
<pre>
[GTK][WPE] Avoid inflating canvas 2d&apos;s dirty rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=290529">https://bugs.webkit.org/show_bug.cgi?id=290529</a>

Reviewed by NOBODY (OOPS!).

On GTK and WPE ports, inflating the canvas 2D dirty rects to account
for antialiasing is not necessary and therefore can be avoided thus
improving the canvas 2D performance.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fdfbaad4d65958767f0d0c95fdf7d5573295ff8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94312 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62577 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110916 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74910 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34351 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29080 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/multicol/vlr-rtl-rtl-in-multicols.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102783 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102595 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47805 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->