### PR TITLE
[JSC] Improve `TypeError` message for string methods

### DIFF
--- a/JSTests/ChakraCore/test/Function/apply3.baseline-jsc
+++ b/JSTests/ChakraCore/test/Function/apply3.baseline-jsc
@@ -64,17 +64,17 @@ Called with this: object[true], args: []
 Called with this: object[string], args: []
 
 --- f.apply(v), v is missing/null/undefined/123/true/'string', f: string.charCodeAt ---
-Exception: TypeError : Type error
-Exception: TypeError : Type error
-Exception: TypeError : Type error
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
 49
 116
 115
 
 --- f.apply(v), v is missing/null/undefined/123/true/'string', f: string.charAt ---
-Exception: TypeError : Type error
-Exception: TypeError : Type error
-Exception: TypeError : Type error
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
 1
 t
 s
@@ -88,17 +88,17 @@ Called with this: object[true], args: []
 Called with this: object[string], args: []
 
 --- f.call(v), v is missing/null/undefined/123/true/'string', f: string.charCodeAt ---
-Exception: TypeError : Type error
-Exception: TypeError : Type error
-Exception: TypeError : Type error
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charCodeAt requires that |this| not be null or undefined
 49
 116
 115
 
 --- f.call(v), v is missing/null/undefined/123/true/'string', f: string.charAt ---
-Exception: TypeError : Type error
-Exception: TypeError : Type error
-Exception: TypeError : Type error
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
+Exception: TypeError : String.prototype.charAt requires that |this| not be null or undefined
 1
 t
 s

--- a/JSTests/ChakraCore/test/Strings/charAt.baseline-jsc
+++ b/JSTests/ChakraCore/test/Strings/charAt.baseline-jsc
@@ -15,9 +15,9 @@ o
 r
 l
 d
-Got a exception. Type error
+Got a exception. String.prototype.charAt requires that |this| not be null or undefined
 >> FirstChar : undefined
-Got a exception. Type error
+Got a exception. String.prototype.charAt requires that |this| not be null or undefined
 >> FirstChar : 0
 0
 << FirstChar.

--- a/JSTests/ChakraCore/test/Strings/charCodeAt.baseline-jsc
+++ b/JSTests/ChakraCore/test/Strings/charCodeAt.baseline-jsc
@@ -15,9 +15,9 @@ AllChars : HelloWorld. Length : 10
 114
 108
 100
-Got a exception. Type error
+Got a exception. String.prototype.charCodeAt requires that |this| not be null or undefined
 >> FirstChar : undefined
-Got a exception. Type error
+Got a exception. String.prototype.charCodeAt requires that |this| not be null or undefined
 >> FirstChar : 0
 48
 << FirstChar.

--- a/JSTests/ChakraCore/test/es6/codePointAt.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/codePointAt.baseline-jsc
@@ -1,6 +1,6 @@
-TypeError: Type error
-TypeError: Type error
-TypeError: Type error
+TypeError: String.prototype.codePointAt requires that |this| not be null or undefined
+TypeError: String.prototype.codePointAt requires that |this| not be null or undefined
+TypeError: String.prototype.codePointAt requires that |this| not be null or undefined
 TypeError: function is not a constructor (evaluating 'new String.prototype.codePointAt()')
 TypeError: function is not a constructor (evaluating 'new String.fromCodePoint()')
 RangeError: Arguments contain a value that is out of range of code points

--- a/JSTests/ChakraCore/test/es6/normalize.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/normalize.baseline-jsc
@@ -1,7 +1,7 @@
 RangeError: argument does not match any normalization form
-TypeError: Type error
-TypeError: Type error
-TypeError: Type error
+TypeError: String.prototype.normalize requires that |this| not be null or undefined
+TypeError: String.prototype.normalize requires that |this| not be null or undefined
+TypeError: String.prototype.normalize requires that |this| not be null or undefined
 TypeError: function is not a constructor (evaluating 'new String.prototype.normalize()')
 Passed! Empty string noramlized to empty string.
 Passed! NFD normalization test.

--- a/JSTests/modules/string-prototype-module-scope.js
+++ b/JSTests/modules/string-prototype-module-scope.js
@@ -10,6 +10,6 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 function refer() { charAt; }

--- a/JSTests/stress/regress-192626.js
+++ b/JSTests/stress/regress-192626.js
@@ -19,5 +19,5 @@ try {
     exception = e;
 }
 
-if (exception != "TypeError: Type error")
+if (exception != "TypeError: String.prototype.toString requires that |this| be a string")
     throw "FAIL";

--- a/JSTests/stress/string-prototype-methods-type-error-message.js
+++ b/JSTests/stress/string-prototype-methods-type-error-message.js
@@ -1,0 +1,53 @@
+function shouldThrow(run, errorType, message) {
+    let actual;
+    var hadError = false;
+
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+shouldThrow(() => {
+    String.prototype.toString.call(null);
+}, TypeError, "String.prototype.toString requires that |this| be a string");
+
+shouldThrow(() => {
+    String.prototype[Symbol.iterator].call(null);
+}, TypeError, "String.prototype[Symbol.iterator] requires that |this| not be null or undefined");
+
+const prototypeFunctionNames = [
+    "charAt",
+    "charCodeAt",
+    "codePointAt",
+    "indexOf",
+    "lastIndexOf",
+    "slice",
+    "substr",
+    "substring",
+    "toLowerCase",
+    "toUpperCase",
+    "toLocaleLowerCase",
+    "toLocaleUpperCase",
+    "startsWith",
+    "endsWith",
+    "includes",
+    "normalize",
+    "isWellFormed",
+    "toWellFormed",
+    "at"
+];
+for (const prototypeFunctionName of prototypeFunctionNames) {
+    shouldThrow(() => {
+        String.prototype[prototypeFunctionName].call(null);
+    }, TypeError, `String.prototype.${prototypeFunctionName} requires that |this| not be null or undefined`);
+}

--- a/JSTests/stress/string-prototype-scopes-global-lexical-environment-strict.js
+++ b/JSTests/stress/string-prototype-scopes-global-lexical-environment-strict.js
@@ -12,4 +12,4 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);

--- a/JSTests/stress/string-prototype-scopes-global-lexical-environment.js
+++ b/JSTests/stress/string-prototype-scopes-global-lexical-environment.js
@@ -10,4 +10,4 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);

--- a/JSTests/stress/string-prototype-scopes-strict.js
+++ b/JSTests/stress/string-prototype-scopes-strict.js
@@ -14,7 +14,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 var error = null;
 try {
@@ -23,7 +23,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 var error = null;
 try {
@@ -33,7 +33,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 (function () {
     var error = null;
@@ -46,6 +46,6 @@ shouldBe(String(error), `TypeError: Type error`);
     }
 
     function refer() { charAt; } // Refer the charAt variable.
-    shouldBe(String(error), `TypeError: Type error`);
+    shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
     return ok;
 }());

--- a/JSTests/stress/string-prototype-scopes.js
+++ b/JSTests/stress/string-prototype-scopes.js
@@ -12,7 +12,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 var error = null;
 try {
@@ -21,7 +21,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 var error = null;
 try {
@@ -31,7 +31,7 @@ try {
 } catch (e) {
     error = e;
 }
-shouldBe(String(error), `TypeError: Type error`);
+shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
 
 (function () {
     var error = null;
@@ -44,7 +44,7 @@ shouldBe(String(error), `TypeError: Type error`);
     }
 
     function refer() { charAt; } // Refer the charAt variable.
-    shouldBe(String(error), `TypeError: Type error`);
+    shouldBe(String(error), `TypeError: String.prototype.charAt requires that |this| not be null or undefined`);
     return ok;
 }());
 

--- a/JSTests/stress/string-to-string-error.js
+++ b/JSTests/stress/string-to-string-error.js
@@ -28,13 +28,13 @@ noInline(test);
 var object = {};
 var symbol = Symbol("Cocoa");
 for (var i = 0; i < 3e3; ++i) {
-    shouldThrow(() => test(object), `TypeError: Type error`);
-    shouldThrow(() => test(false), `TypeError: Type error`);
-    shouldThrow(() => test(true), `TypeError: Type error`);
-    shouldThrow(() => test(42), `TypeError: Type error`);
-    shouldThrow(() => test(null), `TypeError: Type error`);
-    shouldThrow(() => test(undefined), `TypeError: Type error`);
-    shouldThrow(() => test(symbol), `TypeError: Type error`);
+    shouldThrow(() => test(object), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(false), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(true), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(42), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(null), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(undefined), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(symbol), `TypeError: String.prototype.toString requires that |this| be a string`);
 }
 
 var string = "Hello";

--- a/JSTests/stress/string-value-of-error.js
+++ b/JSTests/stress/string-value-of-error.js
@@ -28,13 +28,13 @@ noInline(test);
 var object = {};
 var symbol = Symbol("Cocoa");
 for (var i = 0; i < 3e3; ++i) {
-    shouldThrow(() => test(object), `TypeError: Type error`);
-    shouldThrow(() => test(false), `TypeError: Type error`);
-    shouldThrow(() => test(true), `TypeError: Type error`);
-    shouldThrow(() => test(42), `TypeError: Type error`);
-    shouldThrow(() => test(null), `TypeError: Type error`);
-    shouldThrow(() => test(undefined), `TypeError: Type error`);
-    shouldThrow(() => test(symbol), `TypeError: Type error`);
+    shouldThrow(() => test(object), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(false), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(true), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(42), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(null), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(undefined), `TypeError: String.prototype.toString requires that |this| be a string`);
+    shouldThrow(() => test(symbol), `TypeError: String.prototype.toString requires that |this| be a string`);
 }
 
 var string = "Hello";

--- a/LayoutTests/js/string-code-point-at-expected.txt
+++ b/LayoutTests/js/string-code-point-at-expected.txt
@@ -25,8 +25,8 @@ PASS "ウェブキット".codePointAt(3) is 12461
 PASS "ウェブキット".codePointAt(4) is 12483
 PASS "ウェブキット".codePointAt(5) is 12488
 PASS "ウェブキット".codePointAt(6) is undefined
-PASS "".codePointAt.call(null, 0) threw exception TypeError: Type error.
-PASS "".codePointAt.call(undefined, 0) threw exception TypeError: Type error.
+PASS "".codePointAt.call(null, 0) threw exception TypeError: String.prototype.codePointAt requires that |this| not be null or undefined.
+PASS "".codePointAt.call(undefined, 0) threw exception TypeError: String.prototype.codePointAt requires that |this| not be null or undefined.
 PASS "".codePointAt.call(0, 0) is 48
 PASS "".codePointAt.call(Math.PI, 0) is 51
 PASS "".codePointAt.call(Math.PI, 1) is 46
@@ -40,8 +40,8 @@ PASS "".codePointAt.call(objectThrowingOnToString, 0) threw exception Hehe.
 PASS "".codePointAt.call(objectCountingToString, 0) is 49
 PASS objectCountingToString.counter is 1
 PASS "abcde".codePointAt(objectWithCustomValueOf) is 98
-PASS "".codePointAt.call(null, objectRecordsValueOf) threw exception TypeError: Type error.
-PASS "".codePointAt.call(undefined, objectRecordsValueOf) threw exception TypeError: Type error.
+PASS "".codePointAt.call(null, objectRecordsValueOf) threw exception TypeError: String.prototype.codePointAt requires that |this| not be null or undefined.
+PASS "".codePointAt.call(undefined, objectRecordsValueOf) threw exception TypeError: String.prototype.codePointAt requires that |this| not be null or undefined.
 PASS "".codePointAt.call(Symbol("WebKit"), objectRecordsValueOf) threw exception TypeError: Cannot convert a symbol to a string.
 PASS "".codePointAt.call(objectThrowingOnToString, objectRecordsValueOf) threw exception Hehe.
 PASS objectRecordsValueOf.valueOfEvaluated is false

--- a/LayoutTests/js/string-includes-expected.txt
+++ b/LayoutTests/js/string-includes-expected.txt
@@ -124,9 +124,9 @@ PASS 'abc'.endsWith('bc', 3) is true
 PASS 'abc'.endsWith('', 3) is true
 PASS 'abc'.endsWith('', 4) is true
 PASS 'abc'.endsWith('', Infinity) is true
-PASS (function() { var f = String.prototype.startsWith; (function() { f('a'); })(); })() threw exception TypeError: Type error.
-PASS (function() { var f = String.prototype.endsWith; (function() { f('a'); })(); })() threw exception TypeError: Type error.
-PASS (function() { var f = String.prototype.includes; (function() { f('a'); })(); })() threw exception TypeError: Type error.
+PASS (function() { var f = String.prototype.startsWith; (function() { f('a'); })(); })() threw exception TypeError: String.prototype.startsWith requires that |this| not be null or undefined.
+PASS (function() { var f = String.prototype.endsWith; (function() { f('a'); })(); })() threw exception TypeError: String.prototype.endsWith requires that |this| not be null or undefined.
+PASS (function() { var f = String.prototype.includes; (function() { f('a'); })(); })() threw exception TypeError: String.prototype.includes requires that |this| not be null or undefined.
 PASS 'foo bar'.startsWith(/w+/) threw exception TypeError: Argument to String.prototype.startsWith cannot be a RegExp.
 PASS 'foo bar'.endsWith(/w+/) threw exception TypeError: Argument to String.prototype.endsWith cannot be a RegExp.
 PASS 'foo bar'.includes(/w+/) threw exception TypeError: Argument to String.prototype.includes cannot be a RegExp.

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -384,7 +384,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToString, (JSGlobalObject* globalObject,
 
     auto* stringObject = jsDynamicCast<StringObject*>(thisValue);
     if (!stringObject)
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.toString requires that |this| be a string"_s);
 
     Integrity::auditStructureID(stringObject->structureID());
     return JSValue::encode(stringObject->internalValue());
@@ -397,7 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCharAt, (JSGlobalObject* globalObject, C
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.charAt requires that |this| not be null or undefined"_s);
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     auto view = thisString->view(globalObject);
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCharCodeAt, (JSGlobalObject* globalObjec
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.charCodeAt requires that |this| not be null or undefined"_s);
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     auto view = thisString->view(globalObject);
@@ -460,7 +460,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCodePointAt, (JSGlobalObject* globalObje
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.codePointAt requires that |this| not be null or undefined"_s);
 
     String string = thisValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -490,7 +490,7 @@ static EncodedJSValue stringIndexOfImpl(JSGlobalObject* globalObject, CallFrame*
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.indexOf requires that |this| not be null or undefined"_s);
 
     JSValue a0 = callFrame->argument(0);
     JSValue a1 = callFrame->argument(1);
@@ -550,7 +550,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncLastIndexOf, (JSGlobalObject* globalObje
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.lastIndexOf requires that |this| not be null or undefined"_s);
 
     JSValue a0 = callFrame->argument(0);
     JSValue a1 = callFrame->argument(1);
@@ -595,7 +595,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSlice, (JSGlobalObject* globalObject, Ca
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.slice requires that |this| not be null or undefined"_s);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
@@ -860,7 +860,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstr, (JSGlobalObject* globalObject, C
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.substr requires that |this| not be null or undefined"_s);
     unsigned len;
     JSString* jsString = nullptr;
     String uString;
@@ -904,7 +904,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstring, (JSGlobalObject* globalObject
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.substring requires that |this| not be null or undefined"_s);
 
     JSString* jsString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -952,7 +952,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLowerCase, (JSGlobalObject* globalObje
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.toLowerCase requires that |this| not be null or undefined"_s);
 
     JSString* sVal = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -988,7 +988,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToUpperCase, (JSGlobalObject* globalObje
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.toUpperCase requires that |this| not be null or undefined"_s);
 
     JSString* sVal = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1066,8 +1066,12 @@ static EncodedJSValue toLocaleCase(JSGlobalObject* globalObject, CallFrame* call
 
     // 1. Let O be RequireObjectCoercible(this value).
     JSValue thisValue = callFrame->thisValue();
-    if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+    if (UNLIKELY(!checkObjectCoercible(thisValue))) {
+        if constexpr (mode == CaseConversionMode::Upper)
+            return throwVMTypeError(globalObject, scope, "String.prototype.toLocaleUpperCase requires that |this| not be null or undefined"_s);
+        else
+            return throwVMTypeError(globalObject, scope, "String.prototype.toLocaleLowerCase requires that |this| not be null or undefined"_s);
+    }
 
     // 2. Let S be ToString(O).
     JSString* sVal = thisValue.toString(globalObject);
@@ -1225,7 +1229,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.startsWith requires that |this| not be null or undefined"_s);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1259,7 +1263,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.endsWith requires that |this| not be null or undefined"_s);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1310,7 +1314,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.includes requires that |this| not be null or undefined"_s);
 
     String stringToSearchIn = thisValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1356,7 +1360,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIterator, (JSGlobalObject* globalObject,
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype[Symbol.iterator] requires that |this| not be null or undefined"_s);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     return JSValue::encode(JSStringIterator::create(vm, globalObject->stringIteratorStructure(), string));
@@ -1435,7 +1439,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncNormalize, (JSGlobalObject* globalObject
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.normalize requires that |this| not be null or undefined"_s);
     JSString* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1493,7 +1497,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIsWellFormed, (JSGlobalObject* globalObj
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.isWellFormed requires that |this| not be null or undefined"_s);
 
     // Latin-1 characters do not have surrogates.
     if (thisValue.isString() && asString(thisValue)->is8Bit())
@@ -1514,7 +1518,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToWellFormed, (JSGlobalObject* globalObj
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.toWellFormed requires that |this| not be null or undefined");
 
     // Latin-1 characters do not have surrogates.
     if (thisValue.isString() && asString(thisValue)->is8Bit())
@@ -1585,7 +1589,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncAt, (JSGlobalObject* globalObject, CallF
 
     JSValue thisValue = callFrame->thisValue();
     if (UNLIKELY(!checkObjectCoercible(thisValue)))
-        return throwVMTypeError(globalObject, scope);
+        return throwVMTypeError(globalObject, scope, "String.prototype.at requires that |this| not be null or undefined");
     auto* thisString = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 


### PR DESCRIPTION
#### 11eba2301506c1c13ad4e95056a3e30801dd90d0
<pre>
[JSC] Improve `TypeError` message for string methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=290454">https://bugs.webkit.org/show_bug.cgi?id=290454</a>

Reviewed by NOBODY (OOPS!).

Currently, functions defined in StringPrototype.js throw
a TypeError with a detailed error message after failing
the coercible check. However, functions defined in
StringPrototype.cpp throw a TypeError without an error message.

This patch changes the functions defined in StringPrototype.cpp
so that they throw a TypeError with a detailed error message for
consistency.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringIndexOfImpl):
(JSC::toLocaleCase):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11eba2301506c1c13ad4e95056a3e30801dd90d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47386 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24925 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73809 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31016 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99868 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12636 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12396 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5446 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46713 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89538 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82489 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5527 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103962 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95486 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23933 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17465 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82858 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83699 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82249 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26915 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4459 "Found 3 new test failures: js/dom/string-prototype-properties.html js/dom/string-prototype-scopes-in-workers.html js/dom/string-prototype-scopes.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29050 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119113 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23554 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33484 "Found 16 new JSC stress test failures: stress/string-to-string-error.js.bytecode-cache, stress/string-to-string-error.js.default, stress/string-to-string-error.js.dfg-eager, stress/string-to-string-error.js.dfg-eager-no-cjit-validate, stress/string-to-string-error.js.eager-jettison-no-cjit, stress/string-to-string-error.js.mini-mode, stress/string-to-string-error.js.no-cjit-collect-continuously, stress/string-to-string-error.js.no-llint, stress/string-value-of-error.js.bytecode-cache, stress/string-value-of-error.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->