### PR TITLE
Remove NotSerialized members of NetworkResourceLoadParameters

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -48,9 +48,6 @@ struct NetworkLoadParameters {
     RefPtr<WebCore::SecurityOrigin> topOrigin;
     RefPtr<WebCore::SecurityOrigin> sourceOrigin;
     WTF::ProcessID parentPID { 0 };
-#if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> networkProcessAuditToken;
-#endif
     WebCore::ResourceRequest request;
     WebCore::ContentSniffingPolicy contentSniffingPolicy { WebCore::ContentSniffingPolicy::SniffContent };
     WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy { WebCore::ContentEncodingSniffingPolicy::Default };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -26,153 +26,37 @@
 #include "config.h"
 #include "NetworkResourceLoadParameters.h"
 
+#include "NetworkProcessConnection.h"
+#include "WebProcess.h"
+#include <wtf/RuntimeApplicationChecks.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-NetworkResourceLoadParameters::NetworkResourceLoadParameters(
-    WebPageProxyIdentifier webPageProxyID
-    , WebCore::PageIdentifier webPageID
-    , WebCore::FrameIdentifier webFrameID
-    , RefPtr<WebCore::SecurityOrigin>&& topOrigin
-    , RefPtr<WebCore::SecurityOrigin>&& sourceOrigin
-    , WTF::ProcessID parentPID
-    , WebCore::ResourceRequest&& request
-    , WebCore::ContentSniffingPolicy contentSniffingPolicy
-    , WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy
-    , WebCore::StoredCredentialsPolicy storedCredentialsPolicy
-    , WebCore::ClientCredentialPolicy clientCredentialPolicy
-    , bool shouldClearReferrerOnHTTPSToHTTPRedirect
-    , bool needsCertificateInfo
-    , bool isMainFrameNavigation
-    , std::optional<NavigationActionData>&& mainResourceNavigationDataForAnyFrame
-    , PreconnectOnly shouldPreconnectOnly
-    , std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain
-    , bool hadMainFrameMainResourcePrivateRelayed
-    , bool allowPrivacyProxy
-    , OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections
-    , uint64_t requiredCookiesVersion
-    , std::optional<WebCore::ResourceLoaderIdentifier> identifier
-    , RefPtr<WebCore::FormData>&& httpBody
-    , std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensionIfHttpBody
-    , std::optional<SandboxExtension::Handle>&& sandboxExtensionIflocalFile
-    , Seconds maximumBufferingTime
-    , WebCore::FetchOptions&& options
-    , std::optional<WebCore::ContentSecurityPolicyResponseHeaders>&& cspResponseHeaders
-    , URL&& parentFrameURL
-    , URL&& frameURL
-    , WebCore::CrossOriginEmbedderPolicy parentCrossOriginEmbedderPolicy
-    , WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy
-    , WebCore::HTTPHeaderMap&& originalRequestHeaders
-    , bool shouldRestrictHTTPResponseAccess
-    , WebCore::PreflightPolicy preflightPolicy
-    , bool shouldEnableCrossOriginResourcePolicy
-    , Vector<Ref<WebCore::SecurityOrigin>>&& frameAncestorOrigins
-    , bool pageHasResourceLoadClient
-    , std::optional<WebCore::FrameIdentifier> parentFrameID
-    , bool crossOriginAccessControlCheckEnabled
-    , URL&& documentURL
-    , bool isCrossOriginOpenerPolicyEnabled
-    , bool isClearSiteDataHeaderEnabled
-    , bool isClearSiteDataExecutionContextEnabled
-    , bool isDisplayingInitialEmptyDocument
-    , WebCore::SandboxFlags effectiveSandboxFlags
-    , URL&& openerURL
-    , WebCore::CrossOriginOpenerPolicy&& sourceCrossOriginOpenerPolicy
-    , std::optional<WebCore::NavigationIdentifier> navigationID
-    , std::optional<WebCore::NavigationRequester>&& navigationRequester
-    , WebCore::ServiceWorkersMode serviceWorkersMode
-    , std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier
-    , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep
-    , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
-    , WebCore::FetchingWorkerIdentifier workerIdentifier
-#if ENABLE(CONTENT_EXTENSIONS)
-    , URL&& mainDocumentURL
-    , std::optional<UserContentControllerIdentifier> userContentControllerIdentifier
-#endif
-#if ENABLE(WK_WEB_EXTENSIONS)
-    , bool pageHasLoadedWebExtensions
-#endif
-    , bool linkPreconnectEarlyHintsEnabled
-    , bool shouldRecordFrameLoadForStorageAccess
-) : webPageProxyID(webPageProxyID)
-    , webPageID(webPageID)
-    , webFrameID(webFrameID)
-    , topOrigin(WTFMove(topOrigin))
-    , sourceOrigin(WTFMove(sourceOrigin))
-    , parentPID(parentPID)
-    , request(WTFMove(request))
-    , contentSniffingPolicy(contentSniffingPolicy)
-    , contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
-    , storedCredentialsPolicy(storedCredentialsPolicy)
-    , clientCredentialPolicy(clientCredentialPolicy)
-    , shouldClearReferrerOnHTTPSToHTTPRedirect(shouldClearReferrerOnHTTPSToHTTPRedirect)
-    , needsCertificateInfo(needsCertificateInfo)
-    , isMainFrameNavigation(isMainFrameNavigation)
-    , mainResourceNavigationDataForAnyFrame(mainResourceNavigationDataForAnyFrame)
-    , shouldPreconnectOnly(shouldPreconnectOnly)
-    , isNavigatingToAppBoundDomain(isNavigatingToAppBoundDomain)
-    , hadMainFrameMainResourcePrivateRelayed(hadMainFrameMainResourcePrivateRelayed)
-    , allowPrivacyProxy(allowPrivacyProxy)
-    , advancedPrivacyProtections(advancedPrivacyProtections)
-    , requiredCookiesVersion(requiredCookiesVersion)
-    , identifier(identifier)
-    , maximumBufferingTime(maximumBufferingTime)
-    , options(WTFMove(options))
-    , cspResponseHeaders(WTFMove(cspResponseHeaders))
-    , parentFrameURL(WTFMove(parentFrameURL))
-    , frameURL(WTFMove(frameURL))
-    , parentCrossOriginEmbedderPolicy(parentCrossOriginEmbedderPolicy)
-    , crossOriginEmbedderPolicy(crossOriginEmbedderPolicy)
-    , originalRequestHeaders(WTFMove(originalRequestHeaders))
-    , shouldRestrictHTTPResponseAccess(shouldRestrictHTTPResponseAccess)
-    , preflightPolicy(preflightPolicy)
-    , shouldEnableCrossOriginResourcePolicy(shouldEnableCrossOriginResourcePolicy)
-    , frameAncestorOrigins(WTFMove(frameAncestorOrigins))
-    , pageHasResourceLoadClient(pageHasResourceLoadClient)
-    , parentFrameID(parentFrameID)
-    , crossOriginAccessControlCheckEnabled(crossOriginAccessControlCheckEnabled)
-    , documentURL(WTFMove(documentURL))
-    , isCrossOriginOpenerPolicyEnabled(isCrossOriginOpenerPolicyEnabled)
-    , isClearSiteDataHeaderEnabled(isClearSiteDataHeaderEnabled)
-    , isClearSiteDataExecutionContextEnabled(isClearSiteDataExecutionContextEnabled)
-    , isDisplayingInitialEmptyDocument(isDisplayingInitialEmptyDocument)
-    , effectiveSandboxFlags(effectiveSandboxFlags)
-    , openerURL(WTFMove(openerURL))
-    , sourceCrossOriginOpenerPolicy(WTFMove(sourceCrossOriginOpenerPolicy))
-    , navigationID(navigationID)
-    , navigationRequester(WTFMove(navigationRequester))
-    , serviceWorkersMode(serviceWorkersMode)
-    , serviceWorkerRegistrationIdentifier(serviceWorkerRegistrationIdentifier)
-    , httpHeadersToKeep(httpHeadersToKeep)
-    , navigationPreloadIdentifier(navigationPreloadIdentifier)
-    , workerIdentifier(workerIdentifier)
-#if ENABLE(CONTENT_EXTENSIONS)
-    , mainDocumentURL(WTFMove(mainDocumentURL))
-    , userContentControllerIdentifier(userContentControllerIdentifier)
-#endif
-#if ENABLE(WK_WEB_EXTENSIONS)
-    , pageHasLoadedWebExtensions(pageHasLoadedWebExtensions)
-#endif
-    , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
-    , shouldRecordFrameLoadForStorageAccess(shouldRecordFrameLoadForStorageAccess)
+void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 {
-    if (httpBody) {
-        // FIXME: Use EncodeRequestBody instead of this.
-        this->request.setHTTPBody(WTFMove(httpBody));
-
-        if (!sandboxExtensionIfHttpBody)
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("NetworkResourceLoadParameters which specify a httpBody should have sandboxExtensionIfHttpBody");
-        for (auto& handle : WTFMove(*sandboxExtensionIfHttpBody)) {
-            if (auto extension = SandboxExtension::create(WTFMove(handle)))
-                requestBodySandboxExtensions.append(WTFMove(extension));
+    if (request.httpBody()) {
+        for (const FormDataElement& element : request.httpBody()->elements()) {
+            auto* fileData = std::get_if<FormDataElement::EncodedFileData>(&element.data);
+            if (!fileData)
+                continue;
+            const String& path = fileData->filename;
+            if (auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly))
+                requestBodySandboxExtensions.append(WTFMove(*handle));
         }
     }
 
-    if (this->request.url().protocolIsFile()) {
-        if (!sandboxExtensionIflocalFile)
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("NetworkResourceLoadParameters which specify a URL of a local file should have sandboxExtensionIflocalFile");
-        resourceSandboxExtension = SandboxExtension::create(WTFMove(*sandboxExtensionIflocalFile));
+    if (request.url().protocolIsFile()) {
+#if HAVE(AUDIT_TOKEN)
+        if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {
+            if (auto handle = SandboxExtension::createHandleForReadByAuditToken(request.url().fileSystemPath(), *networkProcessAuditToken))
+                resourceSandboxExtension = WTFMove(*handle);
+        } else
+#endif
+        {
+            if (auto handle = SandboxExtension::createHandle(request.url().fileSystemPath(), SandboxExtension::Type::ReadOnly))
+                resourceSandboxExtension = WTFMove(*handle);
+        }
     }
 }
 
@@ -181,43 +65,6 @@ RefPtr<SecurityOrigin> NetworkResourceLoadParameters::parentOrigin() const
     if (frameAncestorOrigins.isEmpty())
         return nullptr;
     return frameAncestorOrigins.first().ptr();
-}
-
-std::optional<Vector<SandboxExtension::Handle>> NetworkResourceLoadParameters::sandboxExtensionsIfHttpBody() const
-{
-    if (!request.httpBody())
-        return std::nullopt;
-    
-    Vector<SandboxExtension::Handle> requestBodySandboxExtensions;
-    for (const FormDataElement& element : request.httpBody()->elements()) {
-        if (auto* fileData = std::get_if<FormDataElement::EncodedFileData>(&element.data)) {
-            const String& path = fileData->filename;
-            if (auto handle = SandboxExtension::createHandle(path, SandboxExtension::Type::ReadOnly))
-                requestBodySandboxExtensions.append(WTFMove(*handle));
-        }
-    }
-    return requestBodySandboxExtensions;
-    
-}
-
-std::optional<SandboxExtension::Handle> NetworkResourceLoadParameters::sandboxExtensionIflocalFile() const
-{
-    if (!request.url().protocolIsFile())
-        return std::nullopt;
-    
-    SandboxExtension::Handle requestSandboxExtension;
-#if HAVE(AUDIT_TOKEN)
-    if (networkProcessAuditToken) {
-        if (auto handle = SandboxExtension::createHandleForReadByAuditToken(request.url().fileSystemPath(), *networkProcessAuditToken))
-            requestSandboxExtension = WTFMove(*handle);
-    } else
-#endif
-    {
-        if (auto handle = SandboxExtension::createHandle(request.url().fileSystemPath(), SandboxExtension::Type::ReadOnly))
-            requestSandboxExtension = WTFMove(*handle);
-    }
-
-    return requestSandboxExtension;
 }
 
 NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() const
@@ -229,9 +76,6 @@ NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() con
         topOrigin,
         sourceOrigin,
         parentPID,
-#if HAVE(AUDIT_TOKEN)
-        networkProcessAuditToken,
-#endif
         request,
         contentSniffingPolicy,
         contentEncodingSniffingPolicy,
@@ -241,9 +85,9 @@ NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() con
         needsCertificateInfo,
         isMainFrameNavigation,
         mainResourceNavigationDataForAnyFrame,
-        blobFileReferences,
+        { }, // blobFileReferences
         shouldPreconnectOnly,
-        networkActivityTracker,
+        std::nullopt, // networkActivityTracker
         isNavigatingToAppBoundDomain,
         hadMainFrameMainResourcePrivateRelayed,
         allowPrivacyProxy,

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -25,17 +25,15 @@ headers: "NetworkResourceLoadParameters.h"
 enum class WebKit::PreconnectOnly : bool;
 enum class WebKit::NavigatingToAppBoundDomain : bool;
 
-struct WebKit::NetworkResourceLoadParameters {
+[RValue] struct WebKit::NetworkResourceLoadParameters {
     WebKit::WebPageProxyIdentifier webPageProxyID;
     WebCore::PageIdentifier webPageID;
     WebCore::FrameIdentifier webFrameID;
+    [EncodeRequestBody] WebCore::ResourceRequest request;
+
     RefPtr<WebCore::SecurityOrigin> topOrigin;
     RefPtr<WebCore::SecurityOrigin> sourceOrigin;
     WTF::ProcessID parentPID;
-#if HAVE(AUDIT_TOKEN)
-    [NotSerialized] std::optional<audit_token_t> networkProcessAuditToken;
-#endif
-    WebCore::ResourceRequest request;
     
     WebCore::ContentSniffingPolicy contentSniffingPolicy;
     WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy;
@@ -46,9 +44,7 @@ struct WebKit::NetworkResourceLoadParameters {
     bool needsCertificateInfo;
     bool isMainFrameNavigation;
     std::optional<WebKit::NavigationActionData> mainResourceNavigationDataForAnyFrame;
-    [NotSerialized] Vector<RefPtr<WebCore::BlobDataFileReference>> blobFileReferences;
     WebKit::PreconnectOnly shouldPreconnectOnly;
-    [NotSerialized] std::optional<WebKit::NetworkActivityTracker> networkActivityTracker;
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     bool hadMainFrameMainResourcePrivateRelayed;
     bool allowPrivacyProxy;
@@ -57,10 +53,8 @@ struct WebKit::NetworkResourceLoadParameters {
 
     Markable<WebCore::ResourceLoaderIdentifier> identifier;
 
-    RefPtr<WebCore::FormData> request.httpBody();
-    std::optional<Vector<WebKit::SandboxExtensionHandle>> sandboxExtensionsIfHttpBody();
-
-    std::optional<WebKit::SandboxExtensionHandle> sandboxExtensionIflocalFile();
+    Vector<WebKit::SandboxExtensionHandle> requestBodySandboxExtensions;
+    std::optional<WebKit::SandboxExtensionHandle> resourceSandboxExtension;
 
     Seconds maximumBufferingTime;
     

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -295,6 +295,7 @@ private:
 #endif
 
     NetworkResourceLoadParameters m_parameters;
+    Vector<Ref<SandboxExtension>> m_extensionsToRevoke;
 
     Ref<NetworkConnectionToWebProcess> m_connection;
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -160,6 +160,7 @@ def types_that_must_be_moved():
         'WebKit::GPUProcessCreationParameters',
         'WebKit::ModelProcessCreationParameters',
         'WebKit::NetworkProcessCreationParameters',
+        'WebKit::NetworkResourceLoadParameters',
         'WebKit::WebsiteDataStoreParameters',
         'WebKit::GPUProcessSessionParameters',
         'WebKit::GoToBackForwardItemParameters',

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1893,20 +1893,19 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
     NetworkResourceLoadParameters parameters {
         webPage->webPageProxyIdentifier(),
         webPage->identifier(),
-        m_frame->frameID()
+        m_frame->frameID(),
+        ResourceRequest(url)
     };
-    parameters.request = ResourceRequest(url);
+    parameters.createSandboxExtensionHandlesIfNecessary();
+
     parameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
     parameters.parentPID = legacyPresentingApplicationPID();
-#if HAVE(AUDIT_TOKEN)
-    parameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
-#endif
     parameters.shouldPreconnectOnly = PreconnectOnly::Yes;
     parameters.options.destination = FetchOptions::Destination::EmptyString;
 #if ENABLE(APP_BOUND_DOMAINS)
     parameters.isNavigatingToAppBoundDomain = m_frame->isTopFrameNavigatingToAppBoundDomain();
 #endif
-    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SendH2Ping(parameters), WTFMove(completionHandler));
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::SendH2Ping(WTFMove(parameters)), WTFMove(completionHandler));
 }
 
 void WebLocalFrameLoaderClient::didRestoreScrollPosition()


### PR DESCRIPTION
#### 735ee34dd6bad62e5d2caf89d5f627de5644b1dd
<pre>
Remove NotSerialized members of NetworkResourceLoadParameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=290456">https://bugs.webkit.org/show_bug.cgi?id=290456</a>
<a href="https://rdar.apple.com/147940212">rdar://147940212</a>

Reviewed by Chris Dumez.

networkProcessAuditToken is only used in the web process, so replace it with
accessing it in NetworkResourceLoadParameters::sandboxExtensionIflocalFile.

blobFileReferences and networkActivityTracker are never set.  They only existed
for NetworkLoadParameters, which has some places where the NetworkLoadParameters
member is set from elsewhere.

I replaced some of the automatic sandbox extension generation with
NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary
called after the request is set to greatly simplify NetworkResourceLoadParameters.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::sandboxExtensionIflocalFile const):
(WebKit::NetworkResourceLoadParameters::networkLoadParameters const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
(WebKit::WebLoaderStrategy::startPingLoad):
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):

Canonical link: <a href="https://commits.webkit.org/292731@main">https://commits.webkit.org/292731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e69c7eb8fbfc56204cc2d1ca5db421be59efafb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73847 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31058 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12694 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54183 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/96416 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12452 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46776 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104025 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95549 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82290 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26964 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17499 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15639 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23958 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/23741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->