### PR TITLE
[BBQ] Inline (most) Wasm GC object allocations

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -445,6 +445,10 @@ public:
     public:
         Label() = default;
 
+        Label(AbstractMacroAssemblerType& masm)
+            : Label(&masm)
+        { }
+
         Label(AbstractMacroAssemblerType* masm)
             : m_label(masm->m_assembler.label())
         {
@@ -687,6 +691,7 @@ public:
             return result;
         }
 
+        void link(AbstractMacroAssemblerType& masm) const { link(&masm); }
         void link(AbstractMacroAssemblerType* masm) const
         {
             masm->invalidateAllTempRegisters();
@@ -709,8 +714,7 @@ public:
 #endif
         }
 
-        void link(AbstractMacroAssemblerType& masm) const { link(&masm); }
-        
+        void linkTo(Label label, AbstractMacroAssemblerType& masm) const { linkTo(label, &masm); }
         void linkTo(Label label, AbstractMacroAssemblerType* masm) const
         {
 #if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
@@ -802,6 +806,7 @@ public:
                 append(jump);
         }
 
+        void link(AbstractMacroAssemblerType& masm) const { link(&masm); }
         void link(AbstractMacroAssemblerType* masm) const
         {
             size_t size = m_jumps.size();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2210,82 +2210,69 @@ public:
         store64(dataTempRegister, address);
     }
 
-    void transfer32(Address src, Address dest)
+    // FIXME: This could be a shared implementation with a size template but there's no equivalently templated load/store functions to use.
+    template<typename SrcType, typename DestType>
+    void transfer8(SrcType src, DestType dest)
     {
-        if (src == dest)
-            return;
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
+        load8(src, getCachedDataTempRegisterIDAndInvalidate());
+        store8(getCachedDataTempRegisterIDAndInvalidate(), dest);
+    }
+
+    template<typename SrcType, typename DestType>
+    void transfer16(SrcType src, DestType dest)
+    {
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
+        load16(src, getCachedDataTempRegisterIDAndInvalidate());
+        store16(getCachedDataTempRegisterIDAndInvalidate(), dest);
+    }
+
+    template<typename SrcType, typename DestType>
+    void transfer32(SrcType src, DestType dest)
+    {
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
         load32(src, getCachedDataTempRegisterIDAndInvalidate());
         store32(getCachedDataTempRegisterIDAndInvalidate(), dest);
     }
 
-    void transfer64(Address src, Address dest)
+    template<typename SrcType, typename DestType>
+    void transfer64(SrcType src, DestType dest)
     {
-        if (src == dest)
-            return;
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
         load64(src, getCachedDataTempRegisterIDAndInvalidate());
         store64(getCachedDataTempRegisterIDAndInvalidate(), dest);
     }
 
-    void transferFloat(Address src, Address dest)
-    {
-        transfer32(src, dest);
-    }
+    void transferPtr(auto src, auto dest) { transfer64(src, dest); }
+    void transferFloat(auto src, auto dest) { transfer32(src, dest); }
+    void transferDouble(auto src, auto dest) { transfer64(src, dest); }
 
-    void transferDouble(Address src, Address dest)
+    template<typename SrcType, typename DestType>
+    void transferVector(SrcType src, DestType dest)
     {
-        transfer64(src, dest);
-    }
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
 
-    void transferVector(Address src, Address dest)
-    {
-        if (src == dest)
-            return;
         loadVector(src, fpTempRegister);
         storeVector(fpTempRegister, dest);
-    }
-
-    void transferPtr(Address src, Address dest)
-    {
-        transfer64(src, dest);
-    }
-
-    void transfer32(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        load32(src, getCachedDataTempRegisterIDAndInvalidate());
-        store32(getCachedDataTempRegisterIDAndInvalidate(), dest);
-    }
-
-    void transfer64(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        load64(src, getCachedDataTempRegisterIDAndInvalidate());
-        store64(getCachedDataTempRegisterIDAndInvalidate(), dest);
-    }
-
-    void transferFloat(BaseIndex src, BaseIndex dest)
-    {
-        transfer32(src, dest);
-    }
-
-    void transferDouble(BaseIndex src, BaseIndex dest)
-    {
-        transfer64(src, dest);
-    }
-
-    void transferVector(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        loadVector(src, fpTempRegister);
-        storeVector(fpTempRegister, dest);
-    }
-
-    void transferPtr(BaseIndex src, BaseIndex dest)
-    {
-        transfer64(src, dest);
     }
 
     DataLabel32 store64WithAddressOffsetPatch(RegisterID src, Address address)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -5935,82 +5935,69 @@ public:
         storePair64(src1, src2, dest.base, TrustedImm32(dest.offset));
     }
 
-    void transfer32(Address src, Address dest)
+    // FIXME: This could be a shared implementation with a size template but there's no equivalently templated load/store functions to use.
+    template<typename SrcType, typename DestType>
+    void transfer8(SrcType src, DestType dest)
     {
-        if (src == dest)
-            return;
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
+        load8(src, scratchRegister());
+        store8(scratchRegister(), dest);
+    }
+
+    template<typename SrcType, typename DestType>
+    void transfer16(SrcType src, DestType dest)
+    {
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
+        load16(src, scratchRegister());
+        store16(scratchRegister(), dest);
+    }
+
+    template<typename SrcType, typename DestType>
+    void transfer32(SrcType src, DestType dest)
+    {
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
         load32(src, scratchRegister());
         store32(scratchRegister(), dest);
     }
 
-    void transfer64(Address src, Address dest)
+    template<typename SrcType, typename DestType>
+    void transfer64(SrcType src, DestType dest)
     {
-        if (src == dest)
-            return;
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
+
         load64(src, scratchRegister());
         store64(scratchRegister(), dest);
     }
 
-    void transferFloat(Address src, Address dest)
-    {
-        transfer32(src, dest);
-    }
+    void transferPtr(auto src, auto dest) { transfer64(src, dest); }
+    void transferFloat(auto src, auto dest) { transfer32(src, dest); }
+    void transferDouble(auto src, auto dest) { transfer64(src, dest); }
 
-    void transferDouble(Address src, Address dest)
+    template<typename SrcType, typename DestType>
+    void transferVector(SrcType src, DestType dest)
     {
-        transfer64(src, dest);
-    }
+        if constexpr (std::equality_comparable_with<SrcType, DestType>) {
+            if (src == dest)
+                return;
+        }
 
-    void transferVector(Address src, Address dest)
-    {
-        if (src == dest)
-            return;
         loadVector(src, fpTempRegister);
         storeVector(fpTempRegister, dest);
-    }
-
-    void transferPtr(Address src, Address dest)
-    {
-        transfer64(src, dest);
-    }
-
-    void transfer32(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        load32(src, scratchRegister());
-        store32(scratchRegister(), dest);
-    }
-
-    void transfer64(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        load64(src, scratchRegister());
-        store64(scratchRegister(), dest);
-    }
-
-    void transferFloat(BaseIndex src, BaseIndex dest)
-    {
-        transfer32(src, dest);
-    }
-
-    void transferDouble(BaseIndex src, BaseIndex dest)
-    {
-        transfer64(src, dest);
-    }
-
-    void transferVector(BaseIndex src, BaseIndex dest)
-    {
-        if (src == dest)
-            return;
-        loadVector(src, fpTempRegister);
-        storeVector(fpTempRegister, dest);
-    }
-
-    void transferPtr(BaseIndex src, BaseIndex dest)
-    {
-        transfer64(src, dest);
     }
 
     DataLabel32 store64WithAddressOffsetPatch(RegisterID src, Address address)

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -200,5 +200,14 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
     return allocation->cell();
 }
 
+void CompleteSubspace::prepareAllAllocators()
+{
+    for (unsigned i = MarkedSpace::numSizeClasses - 1; i--;) {
+        if (!m_allocatorForSizeStep[i])
+            allocatorForSlow(MarkedSpace::s_sizeClassForSizeStep[i]);
+        ASSERT(m_allocatorForSizeStep[i]);
+    }
+}
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/CompleteSubspace.h
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.h
@@ -47,7 +47,9 @@ public:
     
     static constexpr ptrdiff_t offsetOfAllocatorForSizeStep() { return OBJECT_OFFSETOF(CompleteSubspace, m_allocatorForSizeStep); }
     
-    Allocator* allocatorForSizeStep() { return &m_allocatorForSizeStep[0]; }
+    std::span<Allocator, MarkedSpace::numSizeClasses> allocatorsForSizeSteps() { return m_allocatorForSizeStep; }
+
+    void prepareAllAllocators();
 
 private:
     JS_EXPORT_PRIVATE Allocator allocatorForSlow(size_t);

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -198,9 +198,7 @@ class Heap;
 
 // FIXME: This is a bit confusingly named since the objects in here are exclusive to the subspace but they can vary in size thus can't be in an IsoSubspace.
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_NON_ISO_SUBSPACE(v) \
-    v(webAssemblyArraySpace, webAssemblyArrayHeapCellType, JSWebAssemblyArray, CompleteSubspace) \
-    v(webAssemblyInstanceSpace, webAssemblyInstanceHeapCellType, JSWebAssemblyInstance, PreciseSubspace) \
-    v(webAssemblyStructSpace, webAssemblyStructHeapCellType, JSWebAssemblyStruct, CompleteSubspace)
+    v(webAssemblyInstanceSpace, webAssemblyInstanceHeapCellType, JSWebAssemblyInstance, PreciseSubspace)
 
 #else
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v)
@@ -1085,7 +1083,7 @@ public:
     
     // Whenever possible, use subspaceFor<CellType>(vm) to get one of these subspaces.
     CompleteSubspace cellSpace;
-    CompleteSubspace variableSizedCellSpace; // FIXME: This space is problematic because we have things in here like DirectArguments and ScopedArguments; those should be split into JSValueOOB cells and JSValueStrict auxiliaries. https://bugs.webkit.org/show_bug.cgi?id=182858
+    CompleteSubspace variableSizedCellSpace;
     CompleteSubspace destructibleObjectSpace;
 
 #define DECLARE_ISO_SUBSPACE(name, heapCellType, type) \

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -130,9 +130,25 @@ public:
         else
             store64(src.gpr(), dst);
     }
+
+    void store64FromReg(Reg src, BaseIndex dst)
+    {
+        if (src.isFPR())
+            storeDouble(src.fpr(), dst);
+        else
+            store64(src.gpr(), dst);
+    }
 #endif
     
     void store32FromReg(Reg src, Address dst)
+    {
+        if (src.isFPR())
+            storeFloat(src.fpr(), dst);
+        else
+            store32(src.gpr(), dst);
+    }
+
+    void store32FromReg(Reg src, BaseIndex dst)
     {
         if (src.isFPR())
             storeFloat(src.fpr(), dst);
@@ -2019,6 +2035,7 @@ public:
     
     // allocationSize can be aliased with any of the other input GPRs. If it's not aliased then it
     // won't be clobbered.
+    void emitAllocateVariableSized(GPRReg resultGPR, const JITAllocator& allocator, Address subspaceAllocatorsBase, GPRReg allocationSize, GPRReg scratchGPR1, GPRReg scratchGPR2, JumpList& slowPath, SlowAllocationResult = SlowAllocationResult::ClearToNull);
     void emitAllocateVariableSized(GPRReg resultGPR, CompleteSubspace&, GPRReg allocationSize, GPRReg scratchGPR1, GPRReg scratchGPR2, JumpList& slowPath, SlowAllocationResult = SlowAllocationResult::ClearToNull);
     
     template<typename ClassType, typename StructureType>

--- a/Source/JavaScriptCore/jit/JITAllocator.h
+++ b/Source/JavaScriptCore/jit/JITAllocator.h
@@ -31,27 +31,24 @@ namespace JSC {
 
 class JITAllocator {
 public:
-    enum Kind {
+    enum class Kind {
         Constant,
-        Variable
+        Variable,
+        VariableNonNull,
     };
+    using enum Kind;
     
-    JITAllocator() { }
+    JITAllocator() = default;
     
     static JITAllocator constant(Allocator allocator)
     {
-        JITAllocator result;
-        result.m_kind = Constant;
+        JITAllocator result(Constant);
         result.m_allocator = allocator;
         return result;
     }
     
-    static JITAllocator variable()
-    {
-        JITAllocator result;
-        result.m_kind = Variable;
-        return result;
-    }
+    static JITAllocator variable() { return JITAllocator(Variable); }
+    static JITAllocator variableNonNull() { return JITAllocator(VariableNonNull); }
     
     friend bool operator==(const JITAllocator&, const JITAllocator&) = default;
     
@@ -62,7 +59,7 @@ public:
     
     Kind kind() const { return m_kind; }
     bool isConstant() const { return m_kind == Constant; }
-    bool isVariable() const { return m_kind == Variable; }
+    bool isVariable() const { return m_kind != Constant; }
     
     Allocator allocator() const
     {
@@ -71,6 +68,10 @@ public:
     }
     
 private:
+    JITAllocator(Kind kind)
+        : m_kind(kind)
+    { }
+
     Kind m_kind { Constant };
     Allocator m_allocator;
 };

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -125,7 +125,7 @@ ALWAYS_INLINE Structure* JSObject::visitButterflyImpl(Visitor& visitor)
 
     auto visitElements = [&] (IndexingType indexingMode) {
         switch (indexingMode) {
-        // We don't need to visit the elements for CopyOnWrite butterflies since they we marked the JSImmutableButterfly acting as out butterfly.
+        // We don't need to visit the elements for CopyOnWrite butterflies since they we marked the JSImmutableButterfly acting as our butterfly.
         case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES:
             visitor.appendValuesHidden(butterfly->contiguous().data(), butterfly->publicLength());
             break;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -536,6 +536,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxNumWasmFastMemories, hasCapacityToUseLargeGigacage() ? 8 : 3, Normal, nullptr) \
     v(Bool, verboseBBQJITAllocation, false, Normal, "Logs extra information about register allocation during BBQ JIT"_s) \
     v(Bool, verboseBBQJITInstructions, false, Normal, "Logs instruction information during BBQ JIT"_s) \
+    v(Bool, disableBBQConsts, false, Normal, "Wasm <type>.const instructions in BBQ JIT won't lower to a const BBQ::Value"_s) \
     v(Bool, useWasmLLInt, true, Normal, nullptr) \
     v(Bool, useBBQJIT, true, Normal, "allows the BBQ JIT to be used if true"_s) \
     v(Bool, useOMGJIT, !isARM_THUMB2(), Normal, "allows the OMG JIT to be used if true"_s) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
@@ -389,11 +389,11 @@ void BBQJIT::emitCCall(Func function, const Vector<Value, N>& arguments, Value& 
 
     RegisterBinding currentBinding;
     if (resultLocation.isGPR())
-        currentBinding = m_gprBindings[resultLocation.asGPR()];
+        currentBinding = gprBindings()[resultLocation.asGPR()];
     else if (resultLocation.isFPR())
-        currentBinding = m_fprBindings[resultLocation.asFPR()];
+        currentBinding = fprBindings()[resultLocation.asFPR()];
     else if (resultLocation.isGPR2())
-        currentBinding = m_gprBindings[resultLocation.asGPRhi()];
+        currentBinding = gprBindings()[resultLocation.asGPRhi()];
     RELEASE_ASSERT(!currentBinding.isScratch());
 
     bind(result, resultLocation);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -580,9 +580,9 @@ void BBQJIT::emitCCall(Func function, const Vector<Value, N>& arguments, Value& 
 
     RegisterBinding currentBinding;
     if (resultLocation.isGPR())
-        currentBinding = m_gprBindings[resultLocation.asGPR()];
+        currentBinding = gprBindings()[resultLocation.asGPR()];
     else if (resultLocation.isFPR())
-        currentBinding = m_fprBindings[resultLocation.asFPR()];
+        currentBinding = fprBindings()[resultLocation.asFPR()];
     RELEASE_ASSERT(!currentBinding.isScratch());
 
     bind(result, resultLocation);

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "HeapVerifier.h"
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyStruct.h"
 #include <wtf/CheckedArithmetic.h>
@@ -76,6 +77,12 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
             ASSERT(expectedType.isNullable());
             return;
         }
+
+        if (isExternref(expectedType)) {
+            if (value.isCell())
+                HeapVerifier::validateCell(value.asCell());
+        }
+
 
         if (!isExternref(expectedType) && !isI31ref(expectedType))
             ASSERT(value.isCell());

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -430,6 +430,24 @@ inline bool isDefaultableType(StorageType type)
     return true;
 }
 
+inline size_t sizeOfType(TypeKind kind)
+{
+    switch (kind) {
+    case Wasm::TypeKind::I32:
+    case Wasm::TypeKind::F32:
+        return sizeof(uint32_t);
+    case Wasm::TypeKind::I64:
+    case Wasm::TypeKind::F64:
+    case Wasm::TypeKind::Ref:
+    case Wasm::TypeKind::RefNull:
+        return sizeof(uint64_t);
+    case Wasm::TypeKind::V128:
+        return sizeof(v128_t);
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
 inline JSValue internalizeExternref(JSValue value)
 {
     if (value.isDouble() && JSC::canBeStrictInt32(value.asDouble())) {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -2222,7 +2222,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addRefI31(value, result));
 
             m_expressionStack.constructAndAppend(Type { TypeKind::Ref, static_cast<TypeIndex>(TypeKind::I31ref) }, result);
-            return { };
+            break;
         }
         case ExtGCOpType::I31GetS: {
             TypedExpression ref;
@@ -2233,7 +2233,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addI31GetS(ref, result));
 
             m_expressionStack.constructAndAppend(Types::I32, result);
-            return { };
+            break;
         }
         case ExtGCOpType::I31GetU: {
             TypedExpression ref;
@@ -2244,7 +2244,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addI31GetU(ref, result));
 
             m_expressionStack.constructAndAppend(Types::I32, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayNew: {
             uint32_t typeIndex;
@@ -2270,7 +2270,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             m_expressionStack.constructAndAppend(arrayRefType, result);
 
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayNewDefault: {
             uint32_t typeIndex;
@@ -2287,7 +2287,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewDefault(typeIndex, size, result));
 
             m_expressionStack.constructAndAppend(arrayRefType, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayNewFixed: {
             // Get the array type and element type
@@ -2332,7 +2332,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewFixed(typeIndex, args, result));
             m_expressionStack.constructAndAppend(arrayRefType, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayNewData: {
             uint32_t typeIndex;
@@ -2362,7 +2362,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewData(typeIndex, dataIndex, size, offset, result));
             m_expressionStack.constructAndAppend(arrayRefType, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayNewElem: {
             uint32_t typeIndex;
@@ -2404,7 +2404,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addArrayNewElem(typeIndex, elemSegmentIndex, size, offset, result));
             m_expressionStack.constructAndAppend(arrayRefType, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayGet:
         case ExtGCOpType::ArrayGetS:
@@ -2443,7 +2443,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addArrayGet(op, typeIndex, arrayref, index, result));
 
             m_expressionStack.constructAndAppend(resultType, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArraySet: {
             uint32_t typeIndex;
@@ -2472,7 +2472,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             WASM_TRY_ADD_TO_CONTEXT(addArraySet(typeIndex, arrayref, index, value));
 
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayLen: {
             TypedExpression arrayref;
@@ -2483,7 +2483,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addArrayLen(arrayref, result));
 
             m_expressionStack.constructAndAppend(Types::I32, result);
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayFill: {
             uint32_t typeIndex;
@@ -2511,7 +2511,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             }
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayFill(typeIndex, arrayref, offset, value, size));
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayCopy: {
             uint32_t dstTypeIndex;
@@ -2539,7 +2539,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.copy size to type ", size.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayCopy(dstTypeIndex, dst, dstOffset, srcTypeIndex, src, srcOffset, size));
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayInitElem: {
             uint32_t dstTypeIndex;
@@ -2570,7 +2570,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_elem size to type ", size.type(), " expected ", TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayInitElem(dstTypeIndex, dst, dstOffset, elemSegmentIndex, srcOffset, size));
-            return { };
+            break;
         }
         case ExtGCOpType::ArrayInitData: {
             uint32_t dstTypeIndex;
@@ -2595,7 +2595,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_data size to type "_s, size.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayInitData(dstTypeIndex, dst, dstOffset, dataSegmentIndex, srcOffset, size));
-            return { };
+            break;
         }
         case ExtGCOpType::StructNew: {
             uint32_t typeIndex;
@@ -2632,7 +2632,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addStructNew(typeIndex, args, result));
             m_expressionStack.constructAndAppend(Type { TypeKind::Ref, typeDefinition->index() }, result);
-            return { };
+            break;
         }
         case ExtGCOpType::StructNewDefault: {
             uint32_t typeIndex;
@@ -2647,7 +2647,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addStructNewDefault(typeIndex, result));
             m_expressionStack.constructAndAppend(Type { TypeKind::Ref, typeDefinition->index() }, result);
-            return { };
+            break;
         }
         case ExtGCOpType::StructGet:
         case ExtGCOpType::StructGetS:
@@ -2674,7 +2674,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addStructGet(op, structGetInput.structReference, structType, structGetInput.indices.fieldIndex, result));
 
             m_expressionStack.constructAndAppend(structGetInput.field.type.unpacked(), result);
-            return { };
+            break;
         }
         case ExtGCOpType::StructSet: {
             TypedExpression value;
@@ -2695,7 +2695,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const auto& structType = *m_info.typeSignatures[structSetInput.indices.structTypeIndex]->expand().template as<StructType>();
             WASM_TRY_ADD_TO_CONTEXT(addStructSet(structSetInput.structReference, structType, structSetInput.indices.fieldIndex, value));
-            return { };
+            break;
         }
         case ExtGCOpType::RefTest:
         case ExtGCOpType::RefTestNull:
@@ -2754,7 +2754,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
                 m_expressionStack.constructAndAppend(Types::I32, result);
             }
 
-            return { };
+            break;
         }
         case ExtGCOpType::BrOnCast:
         case ExtGCOpType::BrOnCastFail: {
@@ -2811,7 +2811,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             WASM_TRY_ADD_TO_CONTEXT(addBranchCast(data, ref, m_expressionStack, hasNull2, heapType2, op == ExtGCOpType::BrOnCastFail));
 
-            return { };
+            break;
         }
         case ExtGCOpType::AnyConvertExtern: {
             TypedExpression reference;
@@ -2821,7 +2821,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addAnyConvertExtern(reference, result));
             m_expressionStack.constructAndAppend(anyrefType(reference.type().isNullable()), result);
-            return { };
+            break;
         }
         case ExtGCOpType::ExternConvertAny: {
             TypedExpression reference;
@@ -2831,12 +2831,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addExternConvertAny(reference, result));
             m_expressionStack.constructAndAppend(externrefType(reference.type().isNullable()), result);
-            return { };
+            break;
         }
         default:
             WASM_PARSER_FAIL_IF(true, "invalid extended GC op "_s, m_currentExtOp);
             break;
         }
+
         return { };
     }
 

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -911,6 +911,7 @@ auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& s
         WASM_PARSER_FAIL_IF(structInstancePayloadSize.hasOverflowed(), "struct layout is too big"_s);
     }
 
+    m_info->m_hasGCObjectTypes = true;
     structType = TypeInformation::typeDefinitionForStruct(fields);
     return { };
 }
@@ -924,6 +925,7 @@ auto SectionParser::parseArrayType(uint32_t position, RefPtr<TypeDefinition>& ar
     WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get array's mutability"_s);
     WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid array mutability: 0x"_s, hex(mutability, 2, Lowercase));
 
+    m_info->m_hasGCObjectTypes = true;
     arrayType = TypeInformation::typeDefinitionForArray(FieldType { elementType, static_cast<Mutability>(mutability) });
     return { };
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -47,12 +47,13 @@ public:
     template<typename CellType, SubspaceAccess mode>
     static CompleteSubspace* subspaceFor(VM& vm)
     {
-        return vm.heap.webAssemblyStructSpace<mode>();
+        return &vm.heap.variableSizedCellSpace;
     }
 
     DECLARE_INFO;
 
     static inline WebAssemblyGCStructure* createStructure(VM&, JSGlobalObject*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
+    static JSWebAssemblyStruct* tryCreate(VM&, WebAssemblyGCStructure*);
     static JSWebAssemblyStruct* create(VM&, WebAssemblyGCStructure*);
 
     DECLARE_VISIT_CHILDREN;
@@ -68,6 +69,8 @@ public:
     const uint8_t* fieldPointer(uint32_t fieldIndex) const { return const_cast<JSWebAssemblyStruct*>(this)->fieldPointer(fieldIndex); }
 
     using TrailingArrayType::offsetOfData;
+    using TrailingArrayType::offsetOfSize;
+    using TrailingArrayType::allocationSize;
 
 protected:
     JSWebAssemblyStruct(VM&, WebAssemblyGCStructure*);

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1898,6 +1898,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq-no-consts", "--useWasmLLInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
         if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
           run("wasm-no-wasm-jit", "--useWasmJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -1930,6 +1931,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq-no-consts", "--useWasmLLInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         # FIXME: this is a hacky way to check if we use SIMD rdar://138436830
         if $runJITlessWasm and not $testSpecificRequiredOptions.include? "--useWasmSIMD=1"
           run("wasm-no-wasm-jit", "--useWasmJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -2043,9 +2045,11 @@ def runWebAssemblySpecTestBase(mode, specHarnessPath, postfix, *optionalTestSpec
     runWithOutputHandler("default-wasm" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, *(FTL_OPTIONS + optionalTestSpecificOptions))
     if $mode != "quick"
         runWithOutputHandler("wasm-no-cjit" + (postfix || ''), noisyOutputHandler, specHarnessJsPath,  *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
+        # FIXME: We should probably only run these two for GC spec tests.
         runWithOutputHandler("wasm-eager-jettison" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWithOutputHandler("wasm-collect-continuously" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
         runWithOutputHandler("wasm-bbq" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        runWithOutputHandler("wasm-bbq-no-consts" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", "--disableBBQConsts=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isOMGPlatform
             runWithOutputHandler("wasm-omg" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=true", "--useBBQJIT=true", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end


### PR DESCRIPTION
#### 0f34249dbaea992d1a2dd5aee7770350d81daddb
<pre>
[BBQ] Inline (most) Wasm GC object allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=290400">https://bugs.webkit.org/show_bug.cgi?id=290400</a>
<a href="https://rdar.apple.com/147855601">rdar://147855601</a>

Reviewed by Yusuke Suzuki.

This patch adds support for inlining Wasm GC allocations in BBQ. To make this work/effecient a number of changes were made:

1) BBQ supports a mutator fence rather than doing a write barrier on any new allocations.
2) BBQ now supports slow paths which automatically spill and fill register state rather than force a flush in the basic block. This is distinct from late paths which are just out of line snippets of code but are assumed to preserve register state.
3) BBQ has better support for just getting some value to some other location via emitStore/emitMove taking an Address/BaseIndex destination.
4) BBQ also has a way to force a value into a register.
5) Added more MacroAssembler transfer sizes for 8 and 16 byte values.
6) CompleteSubspaces can prepare all the local allocators needed for every size class
7) AssemblyHelpers/JITAllocator can now handle a variable but non-null allocator (hence 6)
8) ModuleInformation knows if any types in the types section are GC types so we only allocate extra space for structures/completeSubspace allocators when there are GC types.

Also, added a disableBBQConsts option that prevents BBQ from passing around const Values for values on the wasm stack. This greatly increases our test coverage for BBQ for e.g. spec tests where most values are passed as consts.

* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::Label::Label):
(JSC::AbstractMacroAssembler::Jump::link const):
(JSC::AbstractMacroAssembler::Jump::linkTo const):
(JSC::AbstractMacroAssembler::JumpList::link const):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::transfer8):
(JSC::MacroAssemblerARM64::transfer16):
(JSC::MacroAssemblerARM64::transfer32):
(JSC::MacroAssemblerARM64::transfer64):
(JSC::MacroAssemblerARM64::transferPtr):
(JSC::MacroAssemblerARM64::transferFloat):
(JSC::MacroAssemblerARM64::transferDouble):
(JSC::MacroAssemblerARM64::transferVector):
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::prepareAllAllocators):
* Source/JavaScriptCore/heap/CompleteSubspace.h:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitAllocateWithNonNullAllocator):
(JSC::AssemblyHelpers::emitAllocate):
(JSC::AssemblyHelpers::emitAllocateVariableSized):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::store64FromReg):
(JSC::AssemblyHelpers::store32FromReg):
* Source/JavaScriptCore/jit/JITAllocator.h:
(JSC::JITAllocator::constant):
(JSC::JITAllocator::variable):
(JSC::JITAllocator::variableNonNull):
(JSC::JITAllocator::isVariable const):
(JSC::JITAllocator::JITAllocator):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::visitButterflyImpl):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitMutatorFence):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLatePath):
(JSC::Wasm::BBQJITImpl::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::flushRegistersForException):
(JSC::Wasm::BBQJITImpl::BBQJIT::flushRegisters):
(JSC::Wasm::BBQJITImpl::BBQJIT::slowPathSpillBindings):
(JSC::Wasm::BBQJITImpl::BBQJIT::slowPathRestoreBindings):
(JSC::Wasm::BBQJITImpl::BBQJIT::saveValuesAcrossCallAndPassArguments):
(JSC::Wasm::BBQJITImpl::BBQJIT::returnValuesFromCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRTTSlowPathJump):
(JSC::Wasm::BBQJITImpl::BBQJIT::materializeToRegister):
(JSC::Wasm::BBQJITImpl::BBQJIT::bind):
(JSC::Wasm::BBQJITImpl::BBQJIT::unbind):
(JSC::Wasm::BBQJITImpl::BBQJIT::unbindAllRegisters):
(JSC::Wasm::BBQJITImpl::BBQJIT::nextGPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::nextFPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::evictGPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::evictFPR):
(JSC::Wasm::BBQJITImpl::BBQJIT::clobber):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::Location::asReg const):
(JSC::Wasm::BBQJITImpl::BBQJIT::gprBindings):
(JSC::Wasm::BBQJITImpl::BBQJIT::fprBindings):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::bindGPRToScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::bindFPRToScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::unbindGPRFromScratch):
(JSC::Wasm::BBQJITImpl::BBQJIT::ScratchScope::unbindFPRFromScratch):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCCall):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayStoreElementUnchecked):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArraySetUnchecked):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStoreConst):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitMoveMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitMove):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCCall):
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::validateWasmValue):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::sizeOfType):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::fillArray):
(JSC::Wasm::arrayNew):
(JSC::Wasm::copyElementsInReverse):
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::arrayNewElem):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseArrayType):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::tryCreateUninitializedRestricted):
(JSC::JSWebAssemblyArray::tryCreate):
(JSC::JSWebAssemblyArray::visitChildrenImpl):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::allocationSize):
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::tryCreateUninitializedRestricted):
(JSC::JSWebAssemblyStruct::create):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/292808@main">https://commits.webkit.org/292808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3862430b76fb21b8a5a4428dfa28dc32236899

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97162 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74024 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100165 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12897 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87871 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54371 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47059 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89835 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104265 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95783 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83060 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20744 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17741 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29352 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119410 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24024 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33531 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Found 4 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default, microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js.no-llint, wasm.yaml/wasm/stress/spilled-constant-block-argument.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/spilled-constant-block-result.js.wasm-bbq-no-consts; Compiled JSC; Found 2 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default, microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js.no-llint; Running analyze-jsc-tests-results") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->