### PR TITLE
[Cocoa] Pass spatial audio experience preference to the GPU process

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7982,6 +7982,10 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     updateShouldContinueAfterNeedKey();
 #endif
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    player->setPrefersSpatialAudioExperience(document().settings().preferSpatialAudioExperience());
+#endif
+
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
 #endif

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
@@ -44,6 +44,7 @@ struct SpatialAudioExperienceOptions {
 };
 
 WEBCORE_EXPORT RetainPtr<CASpatialAudioExperience> createSpatialAudioExperienceWithOptions(const SpatialAudioExperienceOptions&);
+WEBCORE_EXPORT String spatialAudioExperienceDescription(CASpatialAudioExperience *);
 
 }
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1118,7 +1118,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
     }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
-    [m_avPlayer _setSTSLabel:nsStringNilIfNull(m_spatialTrackingLabel)];
+    updateSpatialTrackingLabel();
 #endif
 
     if (m_avPlayerItem)
@@ -4098,6 +4098,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
             .spatialTrackingLabel = m_spatialTrackingLabel,
 #endif
         });
+        INFO_LOG(LOGIDENTIFIER, "Setting spatialAudioExperience: ", spatialAudioExperienceDescription(experience.get()));
         [m_avPlayer setIntendedSpatialAudioExperience:experience.get()];
         return;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1823,6 +1823,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
             .spatialTrackingLabel = m_spatialTrackingLabel,
 #endif
         });
+        INFO_LOG(LOGIDENTIFIER, "Setting spatialAudioExperience: ", spatialAudioExperienceDescription(experience.get()));
         [m_synchronizer setIntendedSpatialAudioExperience:experience.get()];
         return;
     }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -106,6 +106,9 @@ RemoteMediaPlayerProxy::RemoteMediaPlayerProxy(RemoteMediaPlayerManagerProxy& ma
     RefPtr player = m_player;
     player->setResourceOwner(resourceOwner);
     player->setPresentationSize(m_configuration.presentationSize);
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    player->setPrefersSpatialAudioExperience(m_configuration.prefersSpatialAudioExperience);
+#endif
 }
 
 RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
@@ -65,6 +65,9 @@ struct RemoteMediaPlayerProxyConfiguration {
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked { false };
 #endif
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    bool prefersSpatialAudioExperience { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
@@ -50,5 +50,8 @@ struct WebKit::RemoteMediaPlayerProxyConfiguration {
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked;
 #endif
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    bool prefersSpatialAudioExperience;
+#endif
 };
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -189,6 +189,9 @@ Ref<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRemoteMediaPlay
 #if PLATFORM(IOS_FAMILY)
     proxyConfiguration.canShowWhileLocked = player->canShowWhileLocked();
 #endif
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    proxyConfiguration.prefersSpatialAudioExperience = player->prefersSpatialAudioExperience();
+#endif
 
     auto identifier = MediaPlayerIdentifier::generate();
     auto clientIdentifier = player->clientIdentifier();


### PR DESCRIPTION
#### b77f4aac5f8520116ec7750fa04778317ee44463
<pre>
[Cocoa] Pass spatial audio experience preference to the GPU process
<a href="https://rdar.apple.com/147084592">rdar://147084592</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290461">https://bugs.webkit.org/show_bug.cgi?id=290461</a>

Reviewed by Eric Carlson.

Add prefersSpatialAudioExperience to RemoteMediaPlayerProxyConfiguration and initialize
the MediaPlayer in the GPU process with that new value.

Drive-by fix: Replace one instance where we were setting a STSLabel regardless of that prefrence,
and add more logging in updateSpatialTrackingLabel() about the experince we create.

* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h:
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm:
(WebCore::spatialAudioExperienceDescription):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::RemoteMediaPlayerProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::createRemoteMediaPlayer):

Canonical link: <a href="https://commits.webkit.org/292759@main">https://commits.webkit.org/292759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcbba15d149141123bc2f4a2fb2721f100a9cdbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31034 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103985 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82872 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82265 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17459 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29073 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->