### PR TITLE
IndexedDB in Worker commits when thread is terminated

### DIFF
--- a/LayoutTests/storage/indexeddb/resources/transaction-abort-on-worker-terminate.js
+++ b/LayoutTests/storage/indexeddb/resources/transaction-abort-on-worker-terminate.js
@@ -1,0 +1,81 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+const objectStoreName = 'object-store';
+const databaseName = 'transaction-abort-on-worker-terminate';
+const recordKey = 'record-key';
+
+async function openDatabase()
+{
+    const openRequest = indexedDB.open(databaseName);
+    openRequest.onupgradeneeded = (event) => {
+        database = event.target.result;
+        database.createObjectStore(objectStoreName);
+    }
+    return new Promise((resolve, reject) => {
+        openRequest.onsuccess = (event) => { resolve(event.target.result); };
+        openRequest.onerror = reject;
+    });
+}
+
+async function getRecord(transaction, key)
+{
+    const objectStore = transaction.objectStore(objectStoreName);
+    const request = objectStore.get(key);
+    return new Promise((resolve, reject) => {
+        request.onsuccess = resolve;
+        request.onerror = reject;
+    });
+}
+
+async function writeRecord(transaction, key, value)
+{
+    const objectStore = transaction.objectStore(objectStoreName);
+    const request = objectStore.put(value, key);
+    return new Promise((resolve, reject) => {
+        request.onsuccess = resolve;
+        request.onerror = reject;
+    });
+}
+
+async function deleteRecord(transaction, key)
+{
+    const objectStore = transaction.objectStore(objectStoreName);
+    const request = objectStore.delete(key);
+    return new Promise((resolve, reject) => {
+        request.onsuccess = resolve;
+        request.onerror = reject;
+    });
+}
+
+async function executeTransaction(database, callback)
+{
+    let transaction = database.transaction(objectStoreName, 'readwrite');
+    await writeRecord(transaction, recordKey, "record-value");
+    self.postMessage('continue'); 
+    await callback(transaction);
+    await deleteRecord(transaction, recordKey);
+}
+
+function sleep(duration) 
+{
+    const start = Date.now();
+    while (Date.now() - start < duration) {
+        Math.sqrt(Math.random());
+    }
+}
+
+async function test()
+{
+    const database = await openDatabase();
+    await executeTransaction(database, async (transaction) => {
+        sleep(1000);
+        // New request is scheduled, so transaction should not be committed automatically.
+        const record = await getRecord(transaction, recordKey);
+    });
+}
+
+test();
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate-expected.txt
+++ b/LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate-expected.txt
@@ -1,0 +1,8 @@
+Starting worker: resources/transaction-abort-on-worker-terminate.js
+PASS event.data is "continue"
+PASS String(transaction) is "[object IDBTransaction]"
+PASS event.target.result is
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate.html
+++ b/LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script>
+const objectStoreName = 'object-store';
+const databaseName = 'transaction-abort-on-worker-terminate';
+const recordKey = 'record-key';
+
+var transaction = null;
+
+function checkRecord()
+{
+    const openRequest = indexedDB.open(databaseName);
+    openRequest.onsuccess = (event) => {
+        const database = event.target.result;
+        transaction = database.transaction(objectStoreName);
+        shouldBeEqualToString("String(transaction)", "[object IDBTransaction]");
+        const request = transaction.objectStore(objectStoreName).get(recordKey);
+        request.onsuccess = (event) => {
+            // The record should not exist if transaction aborts correctly.
+            shouldBe("event.target.result", "");
+            finishJSTest();
+        };
+        request.onerror = unexpectedErrorCallback;
+    }
+    openRequest.onerror = unexpectedErrorCallback;
+}
+
+worker = startWorker('resources/transaction-abort-on-worker-terminate.js');
+worker.onmessage = function(event) {
+    shouldBeEqualToString("event.data", "continue");
+    worker.terminate();
+    checkRecord();
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### b9d8178a06354839d750efb4911eefda2991e26b
<pre>
IndexedDB in Worker commits when thread is terminated
<a href="https://bugs.webkit.org/show_bug.cgi?id=288682">https://bugs.webkit.org/show_bug.cgi?id=288682</a>
<a href="https://rdar.apple.com/146354005">rdar://146354005</a>

Reviewed by Brady Eidson.

According to spec, IDBTransaction should be committed automatically when there is no more pending request on the
transaction, and a request is finished when its result is dispatched via event handler. Normally, if the event handler
resolves a Promise and client starts new request when the Promise is resolved, the new request can keep transaction
from automatic commit. In the case of Worker termination, WebKit might stop script execution early, so that the new
request might not get created as expected. See the new test for an example: the Worker script is stopped at sleep(),
before new IDBRequest is created by getRecord(). Because the new request is not created, WebKit would think there
is no more request after event dispatch, and continue to commit transaction automatically. This is not the expected
behavior, given that client actually wants to schedule more request for the transaction. For consistency, it&apos;s better
abort transaction instead of committing it.

To fix this, this patch disables automatic commit of transaction if Worker is terminating and script execution has
stopped. In this case, the transaction will be aborted in IDBTransaction::stop() (when ActiveDOMObjects are stopped).

Test: storage/indexeddb/transaction-abort-on-worker-terminate.html

* LayoutTests/storage/indexeddb/resources/transaction-abort-on-worker-terminate.js: Added.
(async openDatabase):
(async getRecord):
(async writeRecord):
(async deleteRecord):
(async executeTransaction):
(sleep):
(async test):
* LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate-expected.txt: Added.
* LayoutTests/storage/indexeddb/transaction-abort-on-worker-terminate.html: Added.
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::autoCommit):

Canonical link: <a href="https://commits.webkit.org/292795@main">https://commits.webkit.org/292795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fd4a1625476acbbcb4632ece258ecea93a22433

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73826 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31039 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103989 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23960 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17535 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82266 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29077 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->