### PR TITLE
Guard testing endpoints with feature flag

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6058,6 +6058,8 @@ ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]
 
 # WebGPU settings need to be exposed through the test runner.
 ipc/restrictedendpoints/allow-access-webGPU.html [ Pass Failure ]
+ipc/restrictedendpoints/deny-access-testOnlyIPC.html [ Crash ]
+ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html [ Crash ]
 
 # Restarted GPUP seems to crash.
 webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false allowTestOnlyIPC=true ] -->
 <title>Test that calling a message which should be blocked behind AllowTestOnlyIPC kills the calling process if AllowTestOnlyIPC isn't set</title>
 <script src="../../resources/ipc.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false allowTestOnlyIPC=false] -->
 <title>Test that calling updateQuotaBasedOnSpaceUsageForTesting (which should be blocked behind AllowTestOnlyIPC) kills the calling process if AllowTestOnlyIPC isn't set</title>
 <script src="../../resources/ipc.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -59,7 +59,7 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     ReleaseWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier) AllowedWhenWaitingForSyncReply
 #endif
 #if ENABLE(MEDIA_SOURCE)
-    [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled] EnableMockMediaSource();
+    [EnabledBy=AllowTestOnlyIPC] EnableMockMediaSource();
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -54,7 +54,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
-    void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
+    [EnabledBy=AllowTestOnlyIPC] void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
     void GetBufferSubDataInline(uint32_t target, uint64_t offset, size_t dataSize) -> (std::span<const uint8_t> data) Synchronous
     void GetBufferSubDataSharedMemory(uint32_t target, uint64_t offset, size_t dataSize, WebCore::SharedMemory::Handle handle) -> (bool valid) Synchronous NotStreamEncodable
     void ReadPixelsInline(WebCore::IntRect rect, uint32_t format, uint32_t type, bool packReverseRowOrder) -> (std::optional<WebCore::IntSize> readArea, std::span<const uint8_t> data) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -30,7 +30,7 @@
 messages -> RemoteRenderingBackend Stream {
     CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteDisplayListRecorderIdentifier contextIdentifier)
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier identifier)
-    GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
+    [EnabledBy=AllowTestOnlyIPC] GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseNativeImage(WebCore::RenderingResourceIdentifier identifier)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -29,7 +29,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     ScheduleResourceLoad(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters, std::optional<WebKit::NetworkResourceLoadIdentifier> existingLoaderToResume)
     PerformSynchronousLoad(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters) -> (WebCore::ResourceError error, WebCore::ResourceResponse response, Vector<uint8_t> data) Synchronous
-    TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebKit::WebPageProxyIdentifier pageID) -> (bool handled) Synchronous
+    [EnabledBy=AllowTestOnlyIPC] TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebKit::WebPageProxyIdentifier pageID) -> (bool handled) Synchronous
     LoadPing(struct WebKit::NetworkResourceLoadParameters resourceLoadParameters)
     RemoveLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
     PageLoadCompleted(WebCore::PageIdentifier webPageID)
@@ -128,7 +128,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     PrioritizeResourceLoads(Vector<WebCore::ResourceLoaderIdentifier> loadIdentifiers)
 
 #if ENABLE(CONTENT_FILTERING)
-    InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
+    [EnabledBy=AllowTestOnlyIPC] InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
 
     UseRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, WebCore::ResourceResponse response)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -44,8 +44,8 @@ messages -> WebSWServerConnection {
     RegisterServiceWorkerClient(struct WebCore::ClientOrigin clientOrigin, struct WebCore::ServiceWorkerClientData data, std::optional<WebCore::ServiceWorkerRegistrationIdentifier> controllingServiceWorkerRegistrationIdentifier, String userAgent)
     UnregisterServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier identifier)
 
-    TerminateWorkerFromClient(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
-    WhenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
+    [EnabledBy=AllowTestOnlyIPC] TerminateWorkerFromClient(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
+    [EnabledBy=AllowTestOnlyIPC] WhenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
 
     SetThrottleState(bool isThrottleable)
     StoreRegistrationsOnDisk() -> ()

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -100,5 +100,5 @@
     CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> ()
     CacheStorageRepresentation() -> (String representation)
 
-    ResetQuotaUpdatedBasedOnUsageForTesting(struct WebCore::ClientOrigin origin)
+    [EnabledBy=AllowTestOnlyIPC] ResetQuotaUpdatedBasedOnUsageForTesting(struct WebCore::ClientOrigin origin)
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -491,13 +491,13 @@ messages -> WebPageProxy {
     RemovePlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
     ShowPlaybackTargetPicker(WebCore::PlaybackTargetClientContextIdentifier contextId, WebCore::FloatRect pickerLocation, bool hasVideo)
     PlaybackTargetPickerClientStateDidChange(WebCore::PlaybackTargetClientContextIdentifier contextId, OptionSet<WebCore::MediaProducerMediaState> mediaState)
-    SetMockMediaPlaybackTargetPickerEnabled(bool enabled)
-    SetMockMediaPlaybackTargetPickerState(String name, enum:uint8_t WebCore::MediaPlaybackTargetContextMockState pickerState)
-    MockMediaPlaybackTargetPickerDismissPopup()
+    [EnabledBy=AllowTestOnlyIPC] SetMockMediaPlaybackTargetPickerEnabled(bool enabled)
+    [EnabledBy=AllowTestOnlyIPC] SetMockMediaPlaybackTargetPickerState(String name, enum:uint8_t WebCore::MediaPlaybackTargetContextMockState pickerState)
+    [EnabledBy=AllowTestOnlyIPC] MockMediaPlaybackTargetPickerDismissPopup()
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    [EnabledBy=VideoPresentationManagerEnabled || VideoPresentationModeAPIEnabled] SetMockVideoPresentationModeEnabled(bool enabled)
+    [EnabledBy=AllowTestOnlyIPC] SetMockVideoPresentationModeEnabled(bool enabled)
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -577,7 +577,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    SetMockWebAuthenticationConfiguration(struct WebCore::MockWebAuthenticationConfiguration configuration);
+    [EnabledBy=AllowTestOnlyIPC] SetMockWebAuthenticationConfiguration(struct WebCore::MockWebAuthenticationConfiguration configuration);
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -145,6 +145,7 @@ static RetainPtr<WKWebViewConfiguration> createConfigurationWithNotificationsEna
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration preferences] _setNotificationsEnabled:YES];
     [[configuration preferences] _setNotificationEventEnabled:YES];
+    [configuration _setAllowTestOnlyIPC:YES];
     return configuration;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -214,6 +214,7 @@ TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)
     [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:YES];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
 
     // Test page requires window.internals.
 #if WK_HAVE_C_SPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -1141,6 +1141,7 @@ TEST(ServiceWorkers, SWProcessConnectionCreation)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
+    [configuration _setAllowTestOnlyIPC:YES];
 
     done = false;
 
@@ -1245,6 +1246,7 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
+    [configuration _setAllowTestOnlyIPC:YES];
     RetainPtr<WKProcessPool> originalProcessPool = configuration.get().processPool;
 
     done = false;
@@ -1285,6 +1287,7 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
     // Now that a sw is registered, let's create a new configuration and try loading a regular page, there should be no service worker process created.
     RetainPtr<WKWebViewConfiguration> newConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(newConfiguration.get());
+    [newConfiguration _setAllowTestOnlyIPC:YES];
     newConfiguration.get().websiteDataStore = [configuration websiteDataStore];
 
     [[newConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
@@ -1575,6 +1578,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
+    [configuration _setAllowTestOnlyIPC:YES];
 
     RetainPtr<DirectoryPageMessageHandler> directoryPageMessageHandler = adoptNS([[DirectoryPageMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:directoryPageMessageHandler.get() name:@"sw"];
@@ -1617,6 +1621,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
+    [configuration _setAllowTestOnlyIPC:YES];
     auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     NSString* tempDirectory = @"/var/tmp";
     [dataStoreConfiguration _setServiceWorkerRegistrationDirectory:[NSURL fileURLWithPath:tempDirectory]];
@@ -2121,6 +2126,7 @@ TEST(ServiceWorkers, SuspendAndTerminateWorker)
     done = false;
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
 
     if ([[configuration preferences] inactiveSchedulingPolicy] == WKInactiveSchedulingPolicyNone)
         return;
@@ -3052,6 +3058,7 @@ TEST(ServiceWorker, ExtensionServiceWorker)
     auto otherViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     otherViewConfiguration.get().processPool = webViewConfiguration.processPool;
     [otherViewConfiguration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"sw-ext"];
+    [otherViewConfiguration _setAllowTestOnlyIPC:YES];
     auto otherWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:otherViewConfiguration.get()]);
     [otherWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"sw-ext://ABC/other.html"]]];
     [otherWebView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/WKWebViewConfigurationExtras.mm
+++ b/Tools/TestWebKitAPI/WKWebViewConfigurationExtras.mm
@@ -28,6 +28,7 @@
 
 #import "PlatformUtilities.h"
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
 
@@ -49,6 +50,7 @@
 
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
+    [webViewConfiguration _setAllowTestOnlyIPC:YES];
 
     return webViewConfiguration.autorelease();
 }

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -913,6 +913,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration addToWindow:(BOOL)addToWindow
 {
+    [configuration _setAllowTestOnlyIPC:YES];
     self = [super initWithFrame:frame configuration:configuration];
     if (!self)
         return nil;

--- a/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
@@ -40,6 +40,7 @@ void PlatformWebView::initialize(WKPageConfigurationRef pageConfiguration)
 {
     NSRect rect = NSMakeRect(0, 0, 800, 600);
 
+    [(__bridge WKWebViewConfiguration *)pageConfiguration _setAllowTestOnlyIPC:true];
     m_view = [[WKWebView alloc] initWithFrame:rect configuration:(__bridge WKWebViewConfiguration *)pageConfiguration];
     [m_view _setWindowOcclusionDetectionEnabled:NO];
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -178,7 +178,7 @@ const TestFeatures& TestOptions::defaults()
         };
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
-            { "allowTestOnlyIPC", false },
+            { "allowTestOnlyIPC", true },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
             { "editable", false },

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -30,6 +30,7 @@
 #import "TestController.h"
 #import "WebKitTestRunnerDraggingInfo.h"
 #import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKFormInputSession.h>
 #import <wtf/Assertions.h>
@@ -108,6 +109,7 @@ IGNORE_WARNINGS_END
 
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration
 {
+    [configuration _setAllowTestOnlyIPC:YES];
     if (self = [super initWithFrame:frame configuration:configuration]) {
         NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### ec2aa4b0a85f8b3e5cbc8928f5902588815f8ab0
<pre>
Guard testing endpoints with feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=290469">https://bugs.webkit.org/show_bug.cgi?id=290469</a>
<a href="https://rdar.apple.com/147953176">rdar://147953176</a>

Reviewed by NOBODY (OOPS!).

Guard Testing endpoints behind relevant feature flag. Also enable this flag
by default during testing.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html:
* LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorkers, SWProcessConnectionCreation)):
((ServiceWorkers, ServiceWorkerProcessCreation)):
((ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)):
((ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)):
((ServiceWorkers, SuspendAndTerminateWorker)):
((ServiceWorker, ExtensionServiceWorker)):
* Tools/TestWebKitAPI/WKWebViewConfigurationExtras.mm:
(+[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:configureJSCForTesting:]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView initWithFrame:configuration:addToWindow:]):
* Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm:
(TestWebKitAPI::PlatformWebView::initialize):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView initWithFrame:configuration:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec2aa4b0a85f8b3e5cbc8928f5902588815f8ab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83108 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82522 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17799 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->