### PR TITLE
[Safer CPP] Address UncountedLocalVars warnings in WebPluginInfoProvider.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -44,7 +44,6 @@ WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
-WebProcess/Plugins/WebPluginInfoProvider.cpp
 WebProcess/Storage/WebSWClientConnection.cpp
 WebProcess/Storage/WebServiceWorkerProvider.cpp
 WebProcess/UserContent/WebUserContentController.cpp

--- a/Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp
+++ b/Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp
@@ -27,6 +27,7 @@
 #include "WebPluginInfoProvider.h"
 
 #include <WebCore/Page.h>
+#include <wtf/NeverDestroyed.h>
 
 #if ENABLE(PDF_PLUGIN)
 #include "PDFPluginBase.h"
@@ -36,8 +37,8 @@ namespace WebKit {
 
 WebPluginInfoProvider& WebPluginInfoProvider::singleton()
 {
-    static auto& pluginInfoProvider = adoptRef(*new WebPluginInfoProvider).leakRef();
-    return pluginInfoProvider;
+    static MainThreadNeverDestroyed<Ref<WebPluginInfoProvider>> pluginInfoProvider = adoptRef(*new WebPluginInfoProvider);
+    return pluginInfoProvider.get();
 }
 
 void WebPluginInfoProvider::refreshPlugins()


### PR DESCRIPTION
#### 6de2c97febf065e4e8a7dd7f24ee042523ed27fe
<pre>
[Safer CPP] Address UncountedLocalVars warnings in WebPluginInfoProvider.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290470">https://bugs.webkit.org/show_bug.cgi?id=290470</a>
<a href="https://rdar.apple.com/147953280">rdar://147953280</a>

Reviewed by Alex Christensen and Chris Dumez.

Namely, we want to store the provider in a Ref&lt;&gt;.

```
/Volumes/Data/worker/macOS-Safer-CPP-Checks-EWS/build/Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp:39:18: warning: Static local variable &apos;pluginInfoProvider&apos; is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]
   39 |     static auto&amp; pluginInfoProvider = adoptRef(*new WebPluginInfoProvider).leakRef();
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp:
(WebKit::WebPluginInfoProvider::singleton):

Canonical link: <a href="https://commits.webkit.org/292746@main">https://commits.webkit.org/292746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ce20e8ba317fba089ae19a9bfebeda130478f2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73831 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54165 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12424 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17495 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82880 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82273 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17473 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15649 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->