### PR TITLE
[OOM] REGRESSION (Glow): StabilityTracer: com.apple.WebKit.Networking at com.apple.CFNetwork: -[NSHTTPCookieStorage _initWithCFHTTPCookieStorage:]

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -152,6 +152,7 @@ public:
     CredentialStorage& credentialStorage() { return m_credentialStorage; }
 
 #ifdef __OBJC__
+    WEBCORE_EXPORT RetainPtr<NSHTTPCookieStorage> nsCookieStorageIfExists() const;
     WEBCORE_EXPORT RetainPtr<NSHTTPCookieStorage> nsCookieStorage() const;
 #endif
 


### PR DESCRIPTION
#### 08e0a854450627dfe40d44caa687c921dd1457e9
<pre>
[OOM] REGRESSION (Glow): StabilityTracer: com.apple.WebKit.Networking at com.apple.CFNetwork: -[NSHTTPCookieStorage _initWithCFHTTPCookieStorage:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=290472">https://bugs.webkit.org/show_bug.cgi?id=290472</a>
<a href="https://rdar.apple.com/130167032">rdar://130167032</a>

Reviewed by NOBODY (OOPS!).

It is unclear what exactly is causing the crash. But what we can see is:

1. &quot;~NetworkConnectionToWebProcess&quot; destructor is called, which calls:
2. &quot;stopListeningForCookieChangeNotifications&quot; which calls:
3. &quot;nsCookieStorage()&quot; to get the cookie storage object so that it can
   update it&apos;s list of subscribed domains.

If a cookie storage object does not exist, &quot;nsCookieStorage()&quot; will make
one using &quot;_initWithCFHTTPCookieStorage&quot;. The crash follows after this point.

But if a cookie storage object doesn&apos;t exist, we shouldn&apos;t need to update
a non-existent list of subscribed domains. So we add a &quot;nsCookieStorageIfExists()&quot;
function to avoid this creation altogether.

This is a speculative fix.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::nsCookieStorageIfExists const):
(WebCore::NetworkStorageSession::nsCookieStorage const):
(WebCore::NetworkStorageSession::stopListeningForCookieChangeNotifications):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e0a854450627dfe40d44caa687c921dd1457e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73837 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12671 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87670 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocus (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104004 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82278 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17478 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->