### PR TITLE
[WebGPU] Assert command buffers complete successfully or with known errors

### DIFF
--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -289,8 +289,28 @@ void Queue::commitMTLCommandBuffer(id<MTLCommandBuffer> commandBuffer)
                 NSError* underlyingError = error.userInfo[NSUnderlyingErrorKey];
                 if (underlyingError.code == 0x10a)
                     loseTheDevice = false;
-                else
+                else {
                     WTFLogAlways("Encountered fatal command buffer error %@, underlying error %@", error, underlyingError);
+                    bool fatal = false;
+                    switch (underlyingError.code) {
+                    case 2: // kIOGPUCommandBufferCallbackErrorTimeout = 2,
+                    case 3: // kIOGPUCommandBufferCallbackErrorHang = 3,
+                    case 4: // kIOGPUCommandBufferCallbackErrorSubmissionsIgnored = 4,
+                    case 8: // kIOGPUCommandBufferCallbackErrorOutOfMemory = 8,
+                    case 9: // kIOGPUCommandBufferCallbackErrorInvalidResource = 9,
+                    case 10: // kIOGPUCommandBufferCallbackErrorInvalidInput = 10,
+                    case 11: // kIOGPUCommandBufferCallbackErrorPageFault = 11,
+                    case 12: // kIOGPUCommandBufferCallbackErrorExceededHardwareLimit = 12,
+                    case 13: // kIOGPUCommandBufferCallbackErrorOutOfMemoryForParameterBuffer = 13,
+                    case 16: // kIOGPUCommandBufferCallbackErrorProtectionViolation = 16,
+                    case 17: // kIOGPUCommandBufferCallbackErrorStackOverflow = 17,
+                        fatal = true;
+                        break;
+                    default:
+                        break;
+                    }
+                    RELEASE_ASSERT(!fatal);
+                }
             }
         }
 


### PR DESCRIPTION
#### 8fed05a6d280f20551c787e5e4a9ddcce8988bda
<pre>
[WebGPU] Assert command buffers complete successfully or with known errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=290473">https://bugs.webkit.org/show_bug.cgi?id=290473</a>
<a href="https://rdar.apple.com/145582227">rdar://145582227</a>

Reviewed by Cameron McCormack.

Some malicous workloads can cause GPU hangs as proving
a shader executes in a finite period of time is not only
NP-complete but would require memory synchronization impacting
performance greatly.

Release assert this never occurs, as it would only occur with
malicous or invalid workloads (e.g., programmer error). When
this does occur, not only are Metal resources WebGPU created in
a potentially inconsistent state, so any validation could be defeated,
but so are other Metal resources created from WebKit.

No test as we can not test a GPU hang without impacting other tests.

Note the constants are not public, but are trivially discoverable
via logging the NSError* on the MTLComandBuffer.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::commitMTLCommandBuffer):

Canonical link: <a href="https://commits.webkit.org/292741@main">https://commits.webkit.org/292741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e23bd64d599a14467025274b52f75a94c09ebada

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12435 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82887 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17484 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->