### PR TITLE
Some Smart Pointer adoption in LocalFrameView.

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -962,7 +962,7 @@ GraphicsLayer* LocalFrameView::graphicsLayerForPlatformWidget(PlatformWidget pla
 
 GraphicsLayer* LocalFrameView::graphicsLayerForPageScale()
 {
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return nullptr;
 
@@ -995,7 +995,7 @@ GraphicsLayer* LocalFrameView::graphicsLayerForScrolledContents()
 #if HAVE(RUBBER_BANDING)
 GraphicsLayer* LocalFrameView::graphicsLayerForTransientZoomShadow()
 {
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return nullptr;
 
@@ -2778,7 +2778,7 @@ void LocalFrameView::scrollRectToVisibleInTopLevelView(const LayoutRect& absolut
     if (options.revealMode == SelectionRevealMode::RevealUpToMainFrame && m_frame->isMainFrame())
         return;
 
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
@@ -2969,7 +2969,7 @@ void LocalFrameView::updateScriptedAnimationsAndTimersThrottlingState(const IntR
     bool shouldThrottle = visibleRect.isEmpty() && !m_lastUsedSizeForLayout.isEmpty() && m_frame->ownerRenderer();
     document->setTimerThrottlingEnabled(shouldThrottle);
 
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page || !page->canUpdateThrottlingReason(ThrottlingReason::OutsideViewport))
         return;
     
@@ -3263,7 +3263,7 @@ void LocalFrameView::addedOrRemovedScrollbar()
 
 OptionSet<TiledBacking::Scrollability> LocalFrameView::computeScrollability() const
 {
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
 
     // Use smaller square tiles if the Window is not active to facilitate app napping.
     if (!page || !page->isWindowActive())
@@ -4011,7 +4011,7 @@ void LocalFrameView::scheduleResizeEventIfNeeded()
     if (!renderView || renderView->printing())
         return;
 
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (page && page->chrome().client().isSVGImageChromeClient())
         return;
 
@@ -4103,7 +4103,7 @@ void LocalFrameView::autoSizeIfEnabled()
         break;
     }
 
-    if (auto* page = m_frame->page(); page && m_frame->isMainFrame())
+    if (RefPtr page = m_frame->page(); page && m_frame->isMainFrame())
         page->chrome().client().intrinsicContentsSizeChanged(m_autoSizeContentSize);
 
     m_didRunAutosize = true;
@@ -5128,7 +5128,7 @@ void LocalFrameView::updateHasReachedSignificantRenderedTextThreshold()
     if (m_hasReachedSignificantRenderedTextThreshold)
         return;
 
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page || !page->requestedLayoutMilestones().contains(LayoutMilestone::DidRenderSignificantAmountOfText))
         return;
 
@@ -5765,7 +5765,7 @@ void LocalFrameView::setScrollVelocity(const VelocityData& velocityData)
 void LocalFrameView::setScrollingPerformanceTestingEnabled(bool scrollingPerformanceTestingEnabled)
 {
     if (scrollingPerformanceTestingEnabled) {
-        auto* page = m_frame->page();
+        RefPtr page = m_frame->page();
         if (page && page->performanceLoggingClient())
             page->performanceLoggingClient()->logScrollingEvent(PerformanceLoggingClient::ScrollingEvent::LoggingEnabled, MonotonicTime::now(), 0);
     }
@@ -5776,7 +5776,7 @@ void LocalFrameView::setScrollingPerformanceTestingEnabled(bool scrollingPerform
 
 void LocalFrameView::createScrollbarsController()
 {
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page) {
         ScrollView::createScrollbarsController();
         return;
@@ -5787,7 +5787,7 @@ void LocalFrameView::createScrollbarsController()
 
 void LocalFrameView::didAddScrollbar(Scrollbar* scrollbar, ScrollbarOrientation orientation)
 {
-    auto* page = m_frame->page();
+    RefPtr page = m_frame->page();
 
     ScrollableArea::didAddScrollbar(scrollbar, orientation);
 


### PR DESCRIPTION
#### a719899296aa4d6595b713ad5f2c1fa7e6126146
<pre>
Some Smart Pointer adoption in LocalFrameView.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290477">https://bugs.webkit.org/show_bug.cgi?id=290477</a>
<a href="https://rdar.apple.com/147960720">rdar://147960720</a>

Reviewed by Aditya Keerthi.

Additional smart pointer adoption.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::graphicsLayerForPageScale):
(WebCore::LocalFrameView::graphicsLayerForTransientZoomShadow):
(WebCore::LocalFrameView::textFragmentIndicatorTimerFired):
(WebCore::LocalFrameView::scrollRectToVisibleInTopLevelView):
(WebCore::LocalFrameView::updateScriptedAnimationsAndTimersThrottlingState):
(WebCore::LocalFrameView::computeScrollability const):
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
(WebCore::LocalFrameView::autoSizeIfEnabled):
(WebCore::LocalFrameView::updateHasReachedSignificantRenderedTextThreshold):
(WebCore::LocalFrameView::setScrollingPerformanceTestingEnabled):
(WebCore::LocalFrameView::createScrollbarsController):
(WebCore::LocalFrameView::didAddScrollbar):

Canonical link: <a href="https://commits.webkit.org/292779@main">https://commits.webkit.org/292779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb115d3357318c728cb5fade659bad30758793eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31161 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12813 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46922 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104170 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24141 "Hash bb115d33 for PR 43061 does not build (failure)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82388 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20730 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29257 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23929 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->