### PR TITLE
New test(271791@main): [ macOS wk2 ] http/wpt/opener/parent-access-child-via-windowproxy.html is a flaky failure.

### DIFF
--- a/LayoutTests/http/wpt/opener/parent-access-child-via-windowproxy.html
+++ b/LayoutTests/http/wpt/opener/parent-access-child-via-windowproxy.html
@@ -15,8 +15,18 @@ promise_test(async function(t) {
 
   var w = window.open("/common/redirect.py?location=" + encodeURIComponent(url.href));
 
-  await new Promise(resolve => setTimeout(resolve, 100));
-  assert_false(w.closed);
+  // A janky way to ensure that we're accessing a property on a cross-origin
+  // WindowProxy without having the opened page communicate with us.
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    try {
+      w.location;
+    } catch (e) {
+      if (e instanceof SecurityError) {
+        break;
+      }
+    }
+  }
 
   let domains = await new Promise(resolve => {
     window.testRunner.getAndClearReportedWindowProxyAccessDomains(resolve);

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1718,6 +1718,7 @@ webkit.org/b/265599 [ Sonoma+ Debug x86_64 ] imported/w3c/web-platform-tests/htm
 http/wpt/opener/child-access-parent-via-windowproxy.html [ Pass ]
 http/wpt/opener/cross-site-child-access-parent-iframe-via-windowproxy.html [ Pass ]
 http/wpt/opener/iframe-access-top-via-windowproxy.html [ Pass ]
+http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass ]
 http/wpt/opener/same-site-child-access-parent-iframe-via-windowproxy.html [ Pass ]
 
 webkit.org/b/265957 [ Release ] fullscreen/full-screen-layer-dump.html [ Pass Failure ]
@@ -2075,5 +2076,3 @@ imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-s
 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-scrolled-remove-sibling-002.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/290346 [ arm64 ] gamepad/gamepad-event-handlers.html [ Pass Timeout ]
-
-webkit.org/b/290398 http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass Failure ]


### PR DESCRIPTION
#### 24339930a54925fd87420efd4cc770458596abfa
<pre>
New test(271791@main): [ macOS wk2 ] http/wpt/opener/parent-access-child-via-windowproxy.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290398">https://bugs.webkit.org/show_bug.cgi?id=290398</a>
<a href="https://rdar.apple.com/147853995">rdar://147853995</a>

Reviewed by Brady Eidson and Per Arne Vollan.

This test was using a 100 ms timeout to try and wait until an opened window had navigated
cross-origin before accessing a property on the cross-origin WindowProxy object. The timeout seems
to be flaky on the bots.

Change the test to keep trying to access the property until the origin of the opened window changes.

* LayoutTests/http/wpt/opener/parent-access-child-via-windowproxy.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/292769@main">https://commits.webkit.org/292769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc4b5c9ec05bffa58f2d55b67ac85cfeffacfed6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73844 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104023 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23994 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17517 "Found 2 new test failures: imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.htm imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82892 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82286 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23956 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->