### PR TITLE
[view-transitions] active-view-transition-type should treat type identifiers as case-sensitive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<style>
+.test {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+
+#container {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+body { background: lightpink; }
+</style>
+
+<div id="container">
+  <div class="test"></div>
+  <div class="test"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<style>
+.test {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+
+#container {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+body { background: lightpink; }
+</style>
+
+<div id="container">
+  <div class="test"></div>
+  <div class="test"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>View transitions: active-view-transition-type should treat types as case-sensitive</title>
+
+<link rel="help" href="https://www.w3.org/TR/css-transitions-2/">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="view-transition-types-matches-case-sensitive-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+html:active-view-transition-type(foo) #positive1 { background: green; }
+html:active-view-transition-type(Foo) #positive1 { background: red; }
+html:active-view-transition-type(FoO) #positive1 { background: magenta; }
+html:active-view-transition-type(FOo) #positive1 { background: black; }
+
+html:active-view-transition-type(Bar) #positive2 { background: green; }
+html:active-view-transition-type(bar) #positive2 { background: red; }
+html:active-view-transition-type(bAr) #positive2 { background: magenta; }
+html:active-view-transition-type(baR) #positive2 { background: black; }
+
+#positive1 { view-transition-name: positive1; background: yellow; }
+#positive2 { view-transition-name: positive2; background: yellow; }
+
+.test {
+  width: 100px;
+  height: 100px;
+}
+
+#container {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+html::view-transition-group(*) {
+  animation-play-state: paused;
+}
+
+html::view-transition-new(*) {
+  animation: unset;
+  opacity: 0;
+}
+
+html::view-transition-old(*) {
+  animation: unset;
+  opacity: 1;
+}
+
+html::view-transition-group(root) {
+  display: none;
+}
+
+html::view-transition { background: lightpink; }
+</style>
+
+<div id="container">
+  <div class="test" id="positive1"></div>
+  <div class="test" id="positive2"></div>
+</div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+function runTest() {
+  let transition = document.startViewTransition({
+    types: ["foo", "Bar"]
+  });
+  transition.ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</html>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -322,7 +322,7 @@ static std::optional<FixedVector<AtomString>> consumeCommaSeparatedCustomIdentLi
     Vector<AtomString> customIdents { };
 
     do {
-        auto ident = CSSPropertyParserHelpers::consumeCustomIdentRaw(range, /* shouldLowercase */ true);
+        auto ident = CSSPropertyParserHelpers::consumeCustomIdentRaw(range);
         if (ident.isEmpty())
             return std::nullopt;
 


### PR DESCRIPTION
#### 19b9f08da5e44b20a54b97357060aa0d2473c975
<pre>
[view-transitions] active-view-transition-type should treat type identifiers as case-sensitive
<a href="https://rdar.apple.com/147867471">rdar://147867471</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290408">https://bugs.webkit.org/show_bug.cgi?id=290408</a>

Reviewed by Tim Nguyen.

Current code treats type identifiers in :active-view-transition-type() as
case insensitive and lowercases them, which is wrong. Fix the code to
preserve letter case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches-case-sensitive.html: Added.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::consumeCommaSeparatedCustomIdentList):

Canonical link: <a href="https://commits.webkit.org/292840@main">https://commits.webkit.org/292840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52652773d30356f593a41b372b3aa56672b6e663

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46791 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24011 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17605 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17514 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->