### PR TITLE
Slack on a large iPad or using an external display is extremely large.

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -723,6 +723,15 @@ bool Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const
     return false;
 }
 
+// slack.com rdar://138614711
+bool Quirks::shouldIgnoreViewportArgumentsToAvoidEnlargedView() const
+{
+#if ENABLE(META_VIEWPORT)
+    return needsQuirks() && m_quirksData.shouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk;
+#endif
+    return false;
+}
+
 // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199933
 bool Quirks::shouldOpenAsAboutBlank(const String& stringToOpen) const
 {
@@ -1959,6 +1968,18 @@ static void handleSkypeQuirks(QuirksData& quirksData, const URL& quirksURL, cons
     quirksData.needsIPadSkypeOverflowScrollQuirk = true;
 }
 
+static void handleSlackQuirks(QuirksData& quirksData, const URL&, const String& quirksDomainString, const URL&)
+{
+    if (quirksDomainString != "slack.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksData);
+#if ENABLE(META_VIEWPORT)
+    // slack.com: rdar://138614711
+    quirksData.shouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk = true;
+#endif
+}
+
 static void handleWalmartQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "walmart.com"_s)
@@ -2763,6 +2784,9 @@ void Quirks::determineRelevantQuirks()
         { "reddit"_s, & handleRedditQuirks },
 #endif
         { "sfusd"_s, &handleSFUSDQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "slack"_s, &handleSlackQuirks },
+#endif
         { "sharepoint"_s, &handleSharePointQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "skype"_s, &handleSkypeQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -94,6 +94,7 @@ public:
     WEBCORE_EXPORT bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() const;
     WEBCORE_EXPORT bool shouldIgnoreAriaForFastPathContentObservationCheck() const;
     WEBCORE_EXPORT bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const;
+    WEBCORE_EXPORT bool shouldIgnoreViewportArgumentsToAvoidEnlargedView() const;
     WEBCORE_EXPORT bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() const;
     WEBCORE_EXPORT static bool shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin);
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -143,6 +143,7 @@ struct WEBCORE_EXPORT QuirksData {
 
 #if ENABLE(META_VIEWPORT)
     bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk { false };
+    bool shouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk { false };
 #endif
 
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -57,6 +57,15 @@ static inline void adjustViewportArgumentsToAvoidExcessiveZooming(ViewportArgume
     arguments.width = zoomedWidthFromArguments / arguments.zoom;
 }
 
+static inline void ignoreViewportArgumentsToAvoidEnlargedView(ViewportArguments& arguments, FloatSize viewLayoutSize)
+{
+    if (!viewportArgumentValueIsValid(arguments.width))
+        return;
+
+    if (arguments.width < viewLayoutSize.width())
+        arguments.width = 0;
+}
+
 constexpr double defaultDesktopViewportWidth = 980;
 constexpr double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling = 820;
 
@@ -207,6 +216,9 @@ bool ViewportConfiguration::setViewportArguments(const ViewportArguments& viewpo
 
     if (m_canIgnoreViewportArgumentsToAvoidExcessiveZoom)
         adjustViewportArgumentsToAvoidExcessiveZooming(m_viewportArguments);
+
+    if (m_canIgnoreViewportArgumentsToAvoidEnlargedView)
+        ignoreViewportArgumentsToAvoidEnlargedView(m_viewportArguments, m_viewLayoutSize);
 
     updateDefaultConfiguration();
     updateMinimumLayoutSize();
@@ -765,7 +777,8 @@ String ViewportConfiguration::description() const
     ts.dumpProperty("known to lay out wider than viewport"_s, m_isKnownToLayOutWiderThanViewport ? "true"_s : "false"_s);
     ts.dumpProperty("prefers horizontal scrolling"_s, m_prefersHorizontalScrollingBelowDesktopViewportWidths ? "true"_s : "false"_s);
     ts.dumpProperty("can ignore viewport width and zoom"_s, m_canIgnoreViewportArgumentsToAvoidExcessiveZoom ? "true"_s : "false"_s);
-    
+    ts.dumpProperty("can ignore viewport width"_s, m_canIgnoreViewportArgumentsToAvoidEnlargedView ? "true"_s : "false"_s);
+
     ts.endGroup();
 
     return ts.release();

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -131,6 +131,7 @@ public:
 
     void setPrefersHorizontalScrollingBelowDesktopViewportWidths(bool value) { m_prefersHorizontalScrollingBelowDesktopViewportWidths = value; }
     void setCanIgnoreViewportArgumentsToAvoidExcessiveZoom(bool value) { m_canIgnoreViewportArgumentsToAvoidExcessiveZoom = value; }
+    void setCanIgnoreViewportArgumentsToAvoidEnlargedView(bool value) { m_canIgnoreViewportArgumentsToAvoidEnlargedView = value; }
 
     WEBCORE_EXPORT IntSize layoutSize() const;
     WEBCORE_EXPORT int layoutWidth() const;
@@ -218,6 +219,7 @@ private:
     bool m_isKnownToLayOutWiderThanViewport { false };
     bool m_prefersHorizontalScrollingBelowDesktopViewportWidths { false };
     bool m_canIgnoreViewportArgumentsToAvoidExcessiveZoom { false };
+    bool m_canIgnoreViewportArgumentsToAvoidEnlargedView { false };
     bool m_minimumEffectiveDeviceWidthWasSetByClient { false };
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7814,6 +7814,12 @@ static void setCanIgnoreViewportArgumentsToAvoidExcessiveZoomIfNeeded(ViewportCo
     if (auto* document = frame ? frame->document() : nullptr; document && document->quirks().shouldIgnoreViewportArgumentsToAvoidExcessiveZoom())
         configuration.setCanIgnoreViewportArgumentsToAvoidExcessiveZoom(shouldIgnoreMetaViewport);
 }
+
+static void setCanIgnoreViewportArgumentsToAvoidEnlargedViewIfNeeded(ViewportConfiguration& configuration, LocalFrame* frame)
+{
+    if (auto* document = frame ? frame->document() : nullptr; document && document->quirks().shouldIgnoreViewportArgumentsToAvoidEnlargedView())
+        configuration.setCanIgnoreViewportArgumentsToAvoidEnlargedView(true);
+}
 #endif
 
 void WebPage::didCommitLoad(WebFrame* frame)
@@ -7912,6 +7918,8 @@ void WebPage::didCommitLoad(WebFrame* frame)
     bool viewportChanged = false;
 
     setCanIgnoreViewportArgumentsToAvoidExcessiveZoomIfNeeded(m_viewportConfiguration, coreFrame.get(), shouldIgnoreMetaViewport());
+    setCanIgnoreViewportArgumentsToAvoidEnlargedViewIfNeeded(m_viewportConfiguration, coreFrame.get());
+
     m_viewportConfiguration.setPrefersHorizontalScrollingBelowDesktopViewportWidths(shouldEnableViewportBehaviorsForResizableWindows());
 
     LOG_WITH_STREAM(VisibleRects, stream << "WebPage " << m_identifier.toUInt64() << " didCommitLoad setting content size to " << coreFrame->view()->contentsSize());
@@ -8214,6 +8222,7 @@ void WebPage::updateWebsitePolicies(WebsitePoliciesData&& websitePolicies)
 
 #if ENABLE(META_VIEWPORT)
     setCanIgnoreViewportArgumentsToAvoidExcessiveZoomIfNeeded(m_viewportConfiguration, localMainFrame.get(), shouldIgnoreMetaViewport());
+    setCanIgnoreViewportArgumentsToAvoidEnlargedViewIfNeeded(m_viewportConfiguration, localMainFrame.get());
 #endif
 }
 


### PR DESCRIPTION
#### 8dbe225f029575e5d95866aa7bd1302507de12ee
<pre>
Slack on a large iPad or using an external display is extremely large.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290492">https://bugs.webkit.org/show_bug.cgi?id=290492</a>
<a href="https://rdar.apple.com/138614711">rdar://138614711</a>

Reviewed by Tim Horton.

Slack has a set viewport that doesn&apos;t take the screen size of the
device into account. This means that it doesn&apos;t look great on anything
but a smaller iPad. Quirk slack to ignore this set viewport width, but
narrowly, so that if they change their code it will behave as expected.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldIgnoreViewportArgumentsToAvoidEnlargedView const):
(WebCore::handleSlackQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ignoreViewportArgumentsToAvoidElargedView):
(WebCore::ViewportConfiguration::setViewportArguments):
(WebCore::ViewportConfiguration::description const):
* Source/WebCore/page/ViewportConfiguration.h:
(WebCore::ViewportConfiguration::setCanIgnoreViewportArgumentsToAvoidEnlargedView):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::setCanIgnoreViewportArgumentsToAvoidEnlargedViewIfNeeded):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::updateWebsitePolicies):

Canonical link: <a href="https://commits.webkit.org/292836@main">https://commits.webkit.org/292836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb5f62967fa7b0959898161725d46276a8a935df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74026 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31230 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5759 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47102 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104280 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83072 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20769 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29367 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->