### PR TITLE
setValidity of ElementInternals can't handle missing optional anchor parameter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
 
 
 PASS willValidate

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
-CONSOLE MESSAGE: An invalid form control with name='' is not focusable.
 
 
 FAIL willValidate assert_false: false in DATALIST expected false got true

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -101,7 +101,8 @@ void FormAssociatedCustomElement::setFormValue(CustomElementFormValue&& submissi
 HTMLElement* FormAssociatedCustomElement::validationAnchorElement()
 {
     ASSERT(m_element->isDefinedCustomElement());
-    return m_validationAnchor.get();
+    auto anchor = m_validationAnchor.get();
+    return anchor ? anchor : m_element.get();
 }
 
 bool FormAssociatedCustomElement::computeValidity() const

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -66,7 +66,10 @@ ValidatedFormListedElement::ValidatedFormListedElement(HTMLFormElement* form)
     ASSERT(!supportsReadOnly() || readOnlyBarsFromConstraintValidation());
 }
 
-ValidatedFormListedElement::~ValidatedFormListedElement() = default;
+ValidatedFormListedElement::~ValidatedFormListedElement()
+{
+    ASSERT(!m_validationMessage);
+}
 
 bool ValidatedFormListedElement::willValidate() const
 {
@@ -97,7 +100,7 @@ bool ValidatedFormListedElement::computeWillValidate() const
 void ValidatedFormListedElement::updateVisibleValidationMessage(Ref<HTMLElement> validationAnchor)
 {
     HTMLElement& element = asHTMLElement();
-    if (!element.document().page())
+    if (!element.document().page() || !element.isConnected())
         return;
     String message;
     if (element.renderer() && willValidate())
@@ -367,6 +370,8 @@ void ValidatedFormListedElement::removedFromAncestor(Node::RemovalType removalTy
 
     if (wasInsideDataList)
         updateWillValidateAndValidity();
+
+    ASSERT(!m_validationMessage);
 }
 
 bool ValidatedFormListedElement::computeIsDisabledByFieldsetAncestor() const


### PR DESCRIPTION
#### cdd7bac298f50291538aca17d67cd4c5f054ae7b
<pre>
setValidity of ElementInternals can&apos;t handle missing optional anchor parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=269832">https://bugs.webkit.org/show_bug.cgi?id=269832</a>
<a href="https://rdar.apple.com/123744294">rdar://123744294</a>

Reviewed by Chris Dumez.

Fallback to the custom element when the anchor element wasn&apos;t specified.
This matches the behaviors of Blink and Gecko.
The spec change is tracked in <a href="https://github.com/whatwg/html/issues/10155.">https://github.com/whatwg/html/issues/10155.</a>

Also fix a bug that ValidatedFormListedElement sometimes hits a nullptr crash
when a validation message is created for a disconnected form listed element
by avoid creating a validation message in such a case.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::validationAnchorElement):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::~ValidatedFormListedElement):
(WebCore::ValidatedFormListedElement::updateVisibleValidationMessage):
(WebCore::ValidatedFormListedElement::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/292770@main">https://commits.webkit.org/292770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a159e0f8d028b1d1d12554558370c81e31be8c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25082 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73897 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31102 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46864 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104115 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24081 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17566 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82947 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82342 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17583 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29197 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->