### PR TITLE
Remove IPC::Decoder.m_allowedClasses on new platforms

### DIFF
--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -143,19 +143,29 @@ public:
     template<typename T, typename = IsObjCObject<T>>
     std::optional<RetainPtr<T>> decodeWithAllowedClasses(const AllowedClassHashSet& allowedClasses = { getClass<T>() })
     {
+#if HAVE(WK_SECURE_CODING_NSURLREQUEST)
+        UNUSED_PARAM(allowedClasses);
+#else
         m_allowedClasses = allowedClasses;
+#endif
         return IPC::decodeRequiringAllowedClasses<T>(*this);
     }
 
     template<typename T, typename = IsNotObjCObject<T>>
     std::optional<T> decodeWithAllowedClasses(const AllowedClassHashSet& allowedClasses)
     {
+#if HAVE(WK_SECURE_CODING_NSURLREQUEST)
+        UNUSED_PARAM(allowedClasses);
+#else
         m_allowedClasses = allowedClasses;
+#endif
         return decode<T>();
     }
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     AllowedClassHashSet& allowedClasses() { return m_allowedClasses; }
-#endif
+#endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)
+#endif // __OBJC__
 
     std::optional<Attachment> takeLastAttachment();
 
@@ -182,7 +192,7 @@ private:
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;
 #endif
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     AllowedClassHashSet m_allowedClasses;
 #endif
 

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -190,13 +190,15 @@ static inline bool isObjectClassAllowed(id object, const AllowedClassHashSet& al
 template<typename T, typename>
 std::optional<RetainPtr<T>> decodeRequiringAllowedClasses(Decoder& decoder)
 {
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     auto allowedClasses = decoder.allowedClasses();
 #endif
     auto result = decodeObjectDirectlyRequiringAllowedClasses<T>(decoder);
     if (!result)
         return std::nullopt;
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     ASSERT(!*result || isObjectClassAllowed((*result).get(), allowedClasses));
+#endif
     return { *result };
 }
 
@@ -206,7 +208,9 @@ std::optional<T> decodeRequiringAllowedClasses(Decoder& decoder)
     auto result = decodeObjectDirectlyRequiringAllowedClasses<T>(decoder);
     if (!result)
         return std::nullopt;
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     ASSERT(!*result || isObjectClassAllowed((*result).get(), decoder.allowedClasses()));
+#endif
     return { *result };
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -140,21 +140,24 @@ RetainPtr<id> CoreIPCNSCFObject::toID() const
 
 bool CoreIPCNSCFObject::valueIsAllowed(IPC::Decoder& decoder, ObjectValue& value)
 {
+#if HAVE(WK_SECURE_CODING_NSURLREQUEST)
+    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(value);
+    return true;
+#else
     // The Decoder always has a set of allowedClasses,
     // but we only check that set when considering SecureCoding classes
     Class objectClass;
     WTF::switchOn(value,
-#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
         [&](CoreIPCSecureCoding& object) {
             objectClass = object.objectClass();
-        },
-#endif
-        [&](auto& object) {
+        }, [&](auto& object) {
             objectClass = nullptr;
         }
     );
 
     return !objectClass || decoder.allowedClasses().contains(objectClass);
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3725d306de716bf0f41323728a7d1a5d8879ef72
<pre>
Remove IPC::Decoder.m_allowedClasses on new platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=290493">https://bugs.webkit.org/show_bug.cgi?id=290493</a>
<a href="https://rdar.apple.com/147976480">rdar://147976480</a>

Reviewed by Brady Eidson.

m_allowedClasses was used to verify the types decoded when we decoded
an id&lt;NSSecureCoding&gt;, but that is only used on platforms that don&apos;t
have WK_SECURE_CODING_NSURLREQUEST.  On new platforms we can remove the
member variable and save memory.

* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeWithAllowedClasses):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::decodeRequiringAllowedClasses):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::CoreIPCNSCFObject::valueIsAllowed):

Canonical link: <a href="https://commits.webkit.org/292760@main">https://commits.webkit.org/292760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f3142f9237f4a4676e8e13dedd93ea798c109c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31077 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12478 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104065 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24036 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17547 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82316 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17539 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->