### PR TITLE
AX: Implement nameFrom: heading

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_heading.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_heading.tentative-expected.txt
@@ -31,28 +31,10 @@ Not this one
 More article content.
 
 
-FAIL alertdialog role, name from heading assert_equals: <div role="alertdialog" data-expectedlabel="alertdialog role heading contents" data-testname="alertdialog role, name from heading" class="ex-label">
-  <h2>alertdialog role heading contents</h2>
-  <p>More alertdialog content.</p>
-</div> expected "alertdialog role heading contents" but got ""
-FAIL article role, name from heading assert_equals: <div role="article" data-expectedlabel="article role heading contents" data-testname="article role, name from heading" class="ex-label">
-  <h2>article role heading contents</h2>
-  <p>More article content.</p>
-</div> expected "article role heading contents" but got ""
-FAIL dialog role, name from heading assert_equals: <div role="dialog" data-expectedlabel="dialog role heading contents" data-testname="dialog role, name from heading" class="ex-label">
-  <h2>dialog role heading contents</h2>
-  <p>More dialog content.</p>
-</div> expected "dialog role heading contents" but got ""
+PASS alertdialog role, name from heading
+PASS article role, name from heading
+PASS dialog role, name from heading
 PASS group role, verify name is NOT from heading
-FAIL native dialog element, name from heading assert_equals: <dialog open="" data-expectedlabel="dialog heading contents" data-testname="native dialog element, name from heading" class="ex-label">
-  <h2>dialog heading contents</h2>
-  <p>More dialog content.</p>
-</dialog> expected "dialog heading contents" but got ""
-FAIL article role, name from DFS heading assert_equals: <div role="article" data-expectedlabel="article role simple DFS" data-testname="article role, name from DFS heading" class="ex-label">
-  <div role="group">
-    <h3>article role simple DFS</h3>
-  </div>
-  <h2>Not this one</h2>
-  <p>More article content.</p>
-</div> expected "article role simple DFS" but got ""
+PASS native dialog element, name from heading
+PASS article role, name from DFS heading
 

--- a/LayoutTests/platform/ios/accessibility/dialog-slotted-content-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/dialog-slotted-content-expected.txt
@@ -1,7 +1,7 @@
 This test ensures that slotted content inside dialogs is accessible.
 
 WebArea AXLabel:
-    ApplicationDialog AXLabel: web dialog
+    ApplicationDialog AXLabel: Hello world, web dialog
         Heading AXLabel: Hello world
             StaticText AXLabel: Hello world
         Button AXLabel: Non-slotted button

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1148,6 +1148,7 @@ static bool isVisibleText(AccessibilityTextSource textSource)
     case AccessibilityTextSource::Visible:
     case AccessibilityTextSource::Children:
     case AccessibilityTextSource::LabelByElement:
+    case AccessibilityTextSource::Heading:
         return true;
     case AccessibilityTextSource::Alternative:
     case AccessibilityTextSource::Summary:
@@ -1176,6 +1177,7 @@ static bool isDescriptiveText(AccessibilityTextSource textSource)
     case AccessibilityTextSource::Title:
     case AccessibilityTextSource::Subtitle:
     case AccessibilityTextSource::Action:
+    case AccessibilityTextSource::Heading:
         return false;
     }
 }
@@ -1199,7 +1201,7 @@ String AXCoreObject::descriptionAttributeValue() const
 
     StringBuilder returnText;
     for (const auto& text : textOrder) {
-        if (text.textSource == AccessibilityTextSource::Alternative) {
+        if (text.textSource == AccessibilityTextSource::Alternative || text.textSource == AccessibilityTextSource::Heading) {
             returnText.append(text.text);
             break;
         }
@@ -1246,7 +1248,7 @@ String AXCoreObject::titleAttributeValue() const
 
     for (const auto& text : textOrder) {
         // If we have alternative text, then we should not expose a title.
-        if (text.textSource == AccessibilityTextSource::Alternative)
+        if (text.textSource == AccessibilityTextSource::Alternative || text.textSource == AccessibilityTextSource::Heading)
             break;
 
         // Once we encounter visible text, or the text from our children that should be used foremost.

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -562,6 +562,7 @@ enum class AccessibilityTextSource {
     Title,
     Subtitle,
     Action,
+    Heading,
 };
 
 using AXEditingStyleValueVariant = Variant<String, bool, int>;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -475,6 +475,9 @@ TextStream& operator<<(TextStream& stream, AccessibilityTextSource source)
     case AccessibilityTextSource::Action:
         stream << "Action";
         break;
+    case AccessibilityTextSource::Heading:
+        stream << "Heading";
+        break;
     }
     return stream;
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -346,6 +346,21 @@ bool AccessibilityObject::accessibleNameDerivesFromContent() const
     return true;
 }
 
+// https://github.com/w3c/aria/pull/1860
+// If accname cannot be derived from content or author, accname can be derived on permitted roles
+// from the first descendant element node with a heading role.
+bool AccessibilityObject::accessibleNameDerivesFromHeading() const
+{
+    switch (roleValue()) {
+    case AccessibilityRole::ApplicationAlertDialog:
+    case AccessibilityRole::ApplicationDialog:
+    case AccessibilityRole::DocumentArticle:
+        return true;
+    default:
+        return false;
+    }
+}
+
 String AccessibilityObject::computedLabel()
 {
     // This method is being called by WebKit inspector, which may happen at any time, so we need to update our backing store now.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -414,6 +414,7 @@ public:
     virtual String ariaDescribedByAttribute() const { return String(); }
     const String placeholderValue() const final;
     bool accessibleNameDerivesFromContent() const;
+    bool accessibleNameDerivesFromHeading() const;
     String brailleLabel() const override { return getAttribute(HTMLNames::aria_braillelabelAttr); }
     String brailleRoleDescription() const override { return getAttribute(HTMLNames::aria_brailleroledescriptionAttr); }
     String embeddedImageDescription() const final;


### PR DESCRIPTION
#### 6eb2b6af4dd8b9c0bd8810a7f6c1dd7e9dc24583
<pre>
AX: Implement nameFrom: heading
<a href="https://bugs.webkit.org/show_bug.cgi?id=257186">https://bugs.webkit.org/show_bug.cgi?id=257186</a>
<a href="https://rdar.apple.com/109700680">rdar://109700680</a>

Reviewed by Tyler Wilcock.

This PR adds a nameFrom: heading fallback for determining the accessible name of
dialog, alert dialog and article elements. In the absence of a name that has been
provided by an author or by content, a name may be derived for these elements using
a depth-first search for a descendant heading element node
(using the existing DOM descendantsOfType&lt;&gt; iterator). This PR also adds an additional
AccessibilityTextSource::Heading for label type categorization and to facilitate accessibility logging.

* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_heading.tentative-expected.txt: Updated due to PR.
* LayoutTests/platform/ios/accessibility/dialog-slotted-content-expected.txt: Updated due to new test expectation.
Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isVisibleText):
(WebCore::AXCoreObject::isDescriptiveText):
(WebCore::AXCoreObject::descriptionAttributeValue() const):
(WebCore::AXCoreObject::titleAttributeValue() const):
Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::AccessibilityTextSource):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::TextStream&amp; operator):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::alternativeText const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::accessibleNameDerivesFromHeading() const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::accessibleNameDerivesFromHeading() const):

Canonical link: <a href="https://commits.webkit.org/294335@main">https://commits.webkit.org/294335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c2625468f22b4b88a408a135d29a40c38e3d2f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/103504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77272 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51441 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108969 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21027 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86243 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 33 flakes 98 failures; Uploaded test results; 14 flakes 76 failures; Compiled WebKit; 2 flakes 73 failures; Found 1 new test failure: imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/video-tag.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85809 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8251 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/22711 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33804 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->