### PR TITLE
Use std::array in MemoryPressureMonitor.cpp

### DIFF
--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -205,33 +205,33 @@ static CString getCgroupControllerPath(FILE* cgroupControllerFile, const char* c
     CString cgroupMemoryControllerPath;
     while (!feof(cgroupControllerFile)) {
         unsigned hierarchyId;
-        char name[CGROUP_NAME_BUFFER_SIZE + 1];
-        char path[maxCgroupPath + 1];
+        std::array<char, CGROUP_NAME_BUFFER_SIZE + 1> name;
+        std::array<char, maxCgroupPath + 1>  path;
         name[0] = path[0] = '\0';
         int scanResult = fscanf(cgroupControllerFile, "%u:", &hierarchyId);
         if (scanResult != 1)
             return CString();
         if (hierarchyId == CGROUP_V2_HIERARCHY) {
-            scanResult = fscanf(cgroupControllerFile, ":%" STRINGIFY(PATH_MAX) "[^\n]", path);
+            scanResult = fscanf(cgroupControllerFile, ":%" STRINGIFY(PATH_MAX) "[^\n]", path.data());
             if (scanResult != 1)
                 return CString();
         } else {
-            scanResult = fscanf(cgroupControllerFile, "%" STRINGIFY(CGROUP_NAME_BUFFER_SIZE) "[^:]:%" STRINGIFY(PATH_MAX) "[^\n]", name, path);
+            scanResult = fscanf(cgroupControllerFile, "%" STRINGIFY(CGROUP_NAME_BUFFER_SIZE) "[^:]:%" STRINGIFY(PATH_MAX) "[^\n]", name.data(), path.data());
             if (scanResult != 2)
                 return CString();
         }
-        if (!strcmp(name, controllerName)) {
-            cgroupMemoryControllerPath = CString(path);
+        if (!strcmp(name.data(), controllerName)) {
+            cgroupMemoryControllerPath = CString(path.data());
             LOG_VERBOSE(MemoryPressure, "memoryControllerName - %s namespace (hierarchy: %d): %s", controllerName, hierarchyId, cgroupMemoryControllerPath.data());
             return cgroupMemoryControllerPath;
         }
-        if (!strcmp(name, "name=systemd")) {
-            cgroupMemoryControllerPath = CString(path);
+        if (!strcmp(name.data(), "name=systemd")) {
+            cgroupMemoryControllerPath = CString(path.data());
             LOG_VERBOSE(MemoryPressure, "memoryControllerName - systemd namespace (hierarchy: %d): %s", hierarchyId, cgroupMemoryControllerPath.data());
             return cgroupMemoryControllerPath;
         }
-        if (!strcmp(name, "")) {
-            cgroupMemoryControllerPath = CString(path);
+        if (!strcmp(name.data(), "")) {
+            cgroupMemoryControllerPath = CString(path.data());
             LOG_VERBOSE(MemoryPressure, "memoryControllerName - empty namespace (hierarchy: %d): %s", hierarchyId, cgroupMemoryControllerPath.data());
             return cgroupMemoryControllerPath;
         }


### PR DESCRIPTION
#### 4b5da3b504fafa3e003d51ac843f080cce6ccb9e
<pre>
Use std::array in MemoryPressureMonitor.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290504">https://bugs.webkit.org/show_bug.cgi?id=290504</a>

Reviewed by Darin Adler.

Use std::array in MemoryPressureMonitor.cpp insted of C-Style Array

* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp:
(WebKit::getCgroupControllerPath):

Canonical link: <a href="https://commits.webkit.org/292761@main">https://commits.webkit.org/292761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34fffebdcdcbf62cac243518a6e8fca9f8fc1166

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97005 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12505 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24083 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82941 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17578 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29192 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23868 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->