### PR TITLE
AX: Remove unnecessary properties AXProperty::{HasHighlighting, SupportsRangeValue} and optimize live region status caching

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -164,6 +164,15 @@ bool AXCoreObject::isGroup() const
     }
 }
 
+bool AXCoreObject::hasHighlighting() const
+{
+    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentObject()) {
+        if (ancestor->hasMarkTag())
+            return true;
+    }
+    return false;
+}
+
 bool AXCoreObject::hasGridRole() const
 {
     auto role = roleValue();
@@ -702,6 +711,16 @@ bool AXCoreObject::isActiveDescendantOfFocusedContainer() const
     }
 
     return false;
+}
+
+bool AXCoreObject::supportsRangeValue() const
+{
+    return isProgressIndicator()
+        || isSlider()
+        || isScrollbar()
+        || isSpinButton()
+        || (isSplitter() && canSetFocusAttribute())
+        || hasAttachmentTag();
 }
 
 bool AXCoreObject::supportsRequiredAttribute() const

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -748,6 +748,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
+    case AXProperty::ExplicitLiveRegionStatus:
+        stream << "ExplicitLiveRegionStatus";
+        break;
     case AXProperty::ExplicitOrientation:
         stream << "ExplicitOrientation";
         break;
@@ -773,9 +776,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::HasClickHandler:
         stream << "HasClickHandler";
-        break;
-    case AXProperty::HasHighlighting:
-        stream << "HasHighlighting";
         break;
     case AXProperty::HasItalicFont:
         stream << "HasItalicFont";
@@ -998,9 +998,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::LiveRegionRelevant:
         stream << "LiveRegionRelevant";
         break;
-    case AXProperty::LiveRegionStatus:
-        stream << "LiveRegionStatus";
-        break;
     case AXProperty::LocalizedActionVerb:
         stream << "LocalizedActionVerb";
         break;
@@ -1162,9 +1159,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::SupportsPosInSet:
         stream << "SupportsPosInSet";
-        break;
-    case AXProperty::SupportsRangeValue:
-        stream << "SupportsRangeValue";
         break;
     case AXProperty::SupportsSetSize:
         stream << "SupportsSetSize";

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1512,7 +1512,7 @@ void AXObjectCache::handleLiveRegionCreated(Element& element)
     if (liveRegionStatus.isEmpty()) {
         const AtomString& ariaRole = element.attributeWithoutSynchronization(roleAttr);
         if (!ariaRole.isEmpty())
-            liveRegionStatus = AtomString { AccessibilityObject::defaultLiveRegionStatusForRole(AccessibilityObject::ariaRoleToWebCoreRole(ariaRole)) };
+            liveRegionStatus = AtomString { AXCoreObject::defaultLiveRegionStatusForRole(AccessibilityObject::ariaRoleToWebCoreRole(ariaRole)) };
     }
 
     if (AXCoreObject::liveRegionStatusIsEnabled(liveRegionStatus)) {
@@ -2670,7 +2670,7 @@ void AXObjectCache::handleRoleChanged(AccessibilityObject& axObject, Accessibili
 #if PLATFORM(MAC)
     if (axObject.supportsLiveRegion())
         addSortedObject(axObject, PreSortedObjectType::LiveRegion);
-    else if (AXCoreObject::liveRegionStatusIsEnabled(AtomString { AccessibilityObject::defaultLiveRegionStatusForRole(oldRole) }))
+    else if (AXCoreObject::liveRegionStatusIsEnabled(AtomString { AXCoreObject::defaultLiveRegionStatusForRole(oldRole) }))
         removeLiveRegion(axObject);
 #else
     UNUSED_PARAM(oldRole);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -972,31 +972,24 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::radioButtonGr
 unsigned AccessibilityNodeObject::headingLevel() const
 {
     // headings can be in block flow and non-block flow
-    Node* node = this->node();
-    if (!node)
-        return 0;
-
     if (isHeading()) {
-        if (auto level = getIntegralAttribute(aria_levelAttr); level > 0)
+        int level = getIntegralAttribute(aria_levelAttr);
+        if (level > 0)
             return level;
     }
 
-    if (node->hasTagName(h1Tag))
+    const auto& tag = tagName();
+    if (tag == h1Tag)
         return 1;
-
-    if (node->hasTagName(h2Tag))
+    if (tag == h2Tag)
         return 2;
-
-    if (node->hasTagName(h3Tag))
+    if (tag == h3Tag)
         return 3;
-
-    if (node->hasTagName(h4Tag))
+    if (tag == h4Tag)
         return 4;
-
-    if (node->hasTagName(h5Tag))
+    if (tag == h5Tag)
         return 5;
-
-    if (node->hasTagName(h6Tag))
+    if (tag == h6Tag)
         return 6;
 
     return 0;
@@ -1436,15 +1429,6 @@ void AccessibilityNodeObject::changeValueByPercent(float percentChange)
 bool AccessibilityNodeObject::elementAttributeValue(const QualifiedName& attributeName) const
 {
     return equalLettersIgnoringASCIICase(getAttribute(attributeName), "true"_s);
-}
-
-const String AccessibilityNodeObject::liveRegionStatus() const
-{
-    const auto& liveRegionStatus = getAttribute(aria_liveAttr);
-    if (liveRegionStatus.isEmpty())
-        return defaultLiveRegionStatusForRole(roleValue());
-
-    return liveRegionStatus;
 }
 
 const String AccessibilityNodeObject::liveRegionRelevant() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -183,7 +183,7 @@ protected:
 
     bool elementAttributeValue(const QualifiedName&) const;
 
-    const String liveRegionStatus() const final;
+    const String explicitLiveRegionStatus() const final { return getAttribute(HTMLNames::aria_liveAttr); }
     const String liveRegionRelevant() const final;
     bool liveRegionAtomic() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2241,23 +2241,6 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityObject::disclosedRows()
     return result;
 }
 
-const String AccessibilityObject::defaultLiveRegionStatusForRole(AccessibilityRole role)
-{
-    switch (role) {
-    case AccessibilityRole::ApplicationAlertDialog:
-    case AccessibilityRole::ApplicationAlert:
-        return "assertive"_s;
-    case AccessibilityRole::ApplicationLog:
-    case AccessibilityRole::ApplicationStatus:
-        return "polite"_s;
-    case AccessibilityRole::ApplicationTimer:
-    case AccessibilityRole::ApplicationMarquee:
-        return "off"_s;
-    default:
-        return nullAtom();
-    }
-}
-
 String AccessibilityObject::localizedActionVerb() const
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -2802,16 +2785,6 @@ void AccessibilityObject::updateRole()
     }
 }
 
-bool AccessibilityObject::hasHighlighting() const
-{
-    for (Node* node = this->node(); node; node = node->parentNode()) {
-        if (node->hasTagName(markTag))
-            return true;
-    }
-    
-    return false;
-}
-
 SRGBA<uint8_t> AccessibilityObject::colorValue() const
 {
     return Color::black;
@@ -3205,16 +3178,6 @@ AccessibilitySortDirection AccessibilityObject::sortDirection() const
         return AccessibilitySortDirection::Other;
 
     return AccessibilitySortDirection::None;
-}
-
-bool AccessibilityObject::supportsRangeValue() const
-{
-    return isProgressIndicator()
-        || isSlider()
-        || isScrollbar()
-        || isSpinButton()
-        || (isSplitter() && canSetFocusAttribute())
-        || hasAttachmentTag();
 }
 
 bool AccessibilityObject::supportsHasPopup() const
@@ -4097,7 +4060,7 @@ AccessibilityObject* AccessibilityObject::radioGroupAncestor() const
     });
 }
 
-AtomString AccessibilityObject::tagName() const
+const AtomString& AccessibilityObject::tagName() const
 {
     auto* element = this->element();
     return element ? element->localName() : nullAtom();

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -230,7 +230,6 @@ public:
     bool hasSameFontColor(AXCoreObject&) override { return false; }
     bool hasSameStyle(AXCoreObject&) override { return false; }
     bool hasUnderline() const override { return false; }
-    bool hasHighlighting() const final;
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;
 
     WallTime dateTimeValue() const override { return { }; }
@@ -288,7 +287,6 @@ public:
     bool supportsRowCountChange() const;
     AccessibilitySortDirection sortDirection() const final;
     virtual bool canvasHasFallbackContent() const { return false; }
-    bool supportsRangeValue() const final;
     String identifierAttribute() const final;
     String linkRelValue() const final;
     Vector<String> classList() const final;
@@ -573,7 +571,7 @@ public:
     bool hasAttachmentTag() const final { return hasTagName(HTMLNames::attachmentTag); }
     bool hasBodyTag() const final { return hasTagName(HTMLNames::bodyTag); }
     bool hasMarkTag() const final { return hasTagName(HTMLNames::markTag); }
-    AtomString tagName() const;
+    const AtomString& tagName() const;
     bool hasDisplayContents() const;
 
     std::optional<SimpleRange> simpleRange() const final;
@@ -637,11 +635,10 @@ public:
 
     // ARIA live-region features.
     AccessibilityObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
-    const String liveRegionStatus() const override { return String(); }
+    const String explicitLiveRegionStatus() const override { return String(); }
     const String liveRegionRelevant() const override { return nullAtom(); }
     bool liveRegionAtomic() const override { return false; }
     bool isBusy() const override { return false; }
-    static const String defaultLiveRegionStatusForRole(AccessibilityRole);
     static bool contentEditableAttributeIsEnabled(Element&);
     bool hasContentEditableAttributeSet() const;
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2118,7 +2118,7 @@ static RenderObject* rendererForView(WAKView* view)
     // Use this to check if an object is the child of a summary object.
     // And return the summary's parent, which is the expandable details object.
     return Accessibility::findAncestor<AccessibilityObject>(object, true, [&] (const AccessibilityObject& object) {
-        auto tag = object.tagName();
+        const auto& tag = object.tagName();
         if (tag == summaryTag)
             foundSummary = true;
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -107,7 +107,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
         // These properties are cached for all objects, ignored and unignored.
         setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
-        auto tag = object.tagName();
+        const auto& tag = object.tagName();
         if (tag == bodyTag)
             setProperty(AXProperty::TagName, TagName::body);
 #if ENABLE(AX_THREAD_TEXT_APIS)
@@ -192,7 +192,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::InvalidStatus, object.invalidStatus().isolatedCopy());
     setProperty(AXProperty::SupportsExpanded, object.supportsExpanded());
     setProperty(AXProperty::SortDirection, static_cast<int>(object.sortDirection()));
-    setProperty(AXProperty::SupportsRangeValue, object.supportsRangeValue());
 #if !LOG_DISABLED
     // Eagerly cache ID when logging is enabled so that we can log isolated objects without constant deadlocks.
     // Don't cache ID when logging is disabled because we don't expect non-test AX clients to actually request it.
@@ -210,10 +209,9 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::ColorValue, object.colorValue());
     setProperty(AXProperty::ExplicitOrientation, object.explicitOrientation());
     setProperty(AXProperty::HierarchicalLevel, object.hierarchicalLevel());
-    setProperty(AXProperty::LiveRegionStatus, object.liveRegionStatus().isolatedCopy());
+    setProperty(AXProperty::ExplicitLiveRegionStatus, object.explicitLiveRegionStatus().isolatedCopy());
     setProperty(AXProperty::LiveRegionRelevant, object.liveRegionRelevant().isolatedCopy());
     setProperty(AXProperty::LiveRegionAtomic, object.liveRegionAtomic());
-    setProperty(AXProperty::HasHighlighting, object.hasHighlighting());
     setProperty(AXProperty::HasBoldFont, object.hasBoldFont());
     setProperty(AXProperty::HasItalicFont, object.hasItalicFont());
     setProperty(AXProperty::HasPlainText, object.hasPlainText());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -266,7 +266,6 @@ private:
     String invalidStatus() const final { return stringAttributeValue(AXProperty::InvalidStatus); }
     bool supportsExpanded() const final { return boolAttributeValue(AXProperty::SupportsExpanded); }
     AccessibilitySortDirection sortDirection() const final { return static_cast<AccessibilitySortDirection>(intAttributeValue(AXProperty::SortDirection)); }
-    bool supportsRangeValue() const final { return boolAttributeValue(AXProperty::SupportsRangeValue); }
     String identifierAttribute() const final;
     String linkRelValue() const final;
     Vector<String> classList() const final;
@@ -359,7 +358,7 @@ private:
     void setChildrenIDs(Vector<AXID>&&);
     bool isDetachedFromParent() final;
     AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
-    const String liveRegionStatus() const final { return stringAttributeValue(AXProperty::LiveRegionStatus); }
+    const String explicitLiveRegionStatus() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionStatus); }
     const String liveRegionRelevant() const final { return stringAttributeValue(AXProperty::LiveRegionRelevant); }
     bool liveRegionAtomic() const final { return boolAttributeValue(AXProperty::LiveRegionAtomic); }
     bool isBusy() const final { return boolAttributeValue(AXProperty::IsBusy); }
@@ -485,7 +484,6 @@ private:
     bool hasSameFontColor(AXCoreObject&) final;
     bool hasSameStyle(AXCoreObject&) final;
     bool hasUnderline() const final { return boolAttributeValue(AXProperty::HasUnderline); }
-    bool hasHighlighting() const final { return boolAttributeValue(AXProperty::HasHighlighting); }
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;
     Element* element() const final;
     Node* node() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -127,6 +127,7 @@ enum class AXProperty : uint16_t {
     DocumentURI,
     EmbeddedImageDescription,
     ExpandedTextValue,
+    ExplicitLiveRegionStatus,
     ExplicitOrientation,
     ExtendedDescription,
 #if PLATFORM(COCOA)
@@ -137,7 +138,6 @@ enum class AXProperty : uint16_t {
     HasApplePDFAnnotationAttribute,
     HasBoldFont,
     HasClickHandler,
-    HasHighlighting,
     HasItalicFont,
     HasLinethrough,
     HasPlainText,
@@ -213,7 +213,6 @@ enum class AXProperty : uint16_t {
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     LiveRegionAtomic,
     LiveRegionRelevant,
-    LiveRegionStatus,
     LocalizedActionVerb,
     MathFencedOpenString,
     MathFencedCloseString,
@@ -268,7 +267,6 @@ enum class AXProperty : uint16_t {
     SupportsKeyShortcuts,
     SupportsPath,
     SupportsPosInSet,
-    SupportsRangeValue,
     SupportsSetSize,
     TagName,
     TextContentPrefixFromListMarker,

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -417,7 +417,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return "AXCodeStyleGroup"_s;
 
     using namespace HTMLNames;
-    auto tag = tagName();
+    const auto& tag = tagName();
     if (tag == kbdTag)
         return "AXKeyboardInputStyleGroup"_s;
     if (tag == preTag)


### PR DESCRIPTION
#### b0dbae0788e2980f9cf310a979dfeb3d29ff3d65
<pre>
AX: Remove unnecessary properties AXProperty::{HasHighlighting, SupportsRangeValue} and optimize live region status caching
<a href="https://bugs.webkit.org/show_bug.cgi?id=290505">https://bugs.webkit.org/show_bug.cgi?id=290505</a>
<a href="https://rdar.apple.com/147989745">rdar://147989745</a>

Reviewed by Chris Fleizach.

This commit removes AXProperty::HasHighlighting and AXProperty::SupportsRangeValue. These can be expressed in terms of
already-cached properties. Removing them saves memory and avoids one ancestry walk per object created.

This patch features a couple other optimizations:

- Replace AXProperty::LiveRegionStatus with AXProperty::ExplicitLiveRegionStatus so we don&apos;t cache anything if the live
  regions status is computed by default through role alone, saving memory and making each isolated object cheaper to create.

- Make AccessibilityObject::tagName return a const AtomString&amp; instead of an AtomString to avoid an unnecessary string
  copy at callsites.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hasHighlighting const):
(WebCore::AXCoreObject::supportsRangeValue const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::defaultLiveRegionStatusForRole):
(WebCore::AXCoreObject::liveRegionStatus const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::handleRoleChanged):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::headingLevel const):
(WebCore::AccessibilityNodeObject::liveRegionStatus const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::tagName const):
(WebCore::AccessibilityObject::defaultLiveRegionStatusForRole): Deleted.
(WebCore::AccessibilityObject::hasHighlighting const): Deleted.
(WebCore::AccessibilityObject::supportsRangeValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::canvasHasFallbackContent const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper detailParentForSummaryObject:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):

Canonical link: <a href="https://commits.webkit.org/292782@main">https://commits.webkit.org/292782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6d0e9a257731949e3bc82144a435ce34fcdd9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31103 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17581 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29195 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->