### PR TITLE
Web Inspector: don't create a regex when searching by exact case-sensitive string

### DIFF
--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
@@ -132,21 +132,44 @@ static Ref<Protocol::GenericTypes::SearchMatch> buildObjectForSearchMatch(size_t
         .release();
 }
 
-RegularExpression createRegularExpressionForSearchString(const String& searchString, bool caseSensitive, SearchStringType type)
+Searcher createSearcherForString(const String& string, SearchType type, SearchCaseSensitive caseSensitive)
+{
+    if (type == SearchType::ExactString && caseSensitive == SearchCaseSensitive::Yes)
+        return string;
+    return createRegularExpressionForString(string, type, caseSensitive);
+}
+
+bool searcherMatchesText(const Searcher& searcher, const String& text)
+{
+    return WTF::switchOn(searcher,
+        [&] (const String& string) {
+            return string == text;
+        },
+        [&] (const RegularExpression& regex) {
+            return regex.match(text) != -1;
+        });
+}
+
+RegularExpression createRegularExpressionForString(const String& string, SearchType type, SearchCaseSensitive caseSensitive)
 {
     String pattern;
     switch (type) {
-    case SearchStringType::Regex:
-        pattern = searchString;
+    case SearchType::Regex:
+        pattern = string;
         break;
-    case SearchStringType::ExactString:
-        pattern = makeString('^', escapeStringForRegularExpressionSource(searchString), '$');
+    case SearchType::ExactString:
+        pattern = makeString('^', escapeStringForRegularExpressionSource(string), '$');
         break;
-    case SearchStringType::ContainsString:
-        pattern = escapeStringForRegularExpressionSource(searchString);
+    case SearchType::ContainsString:
+        pattern = escapeStringForRegularExpressionSource(string);
         break;
     }
-    return caseSensitive ? RegularExpression(pattern) : RegularExpression(pattern, { Flags::IgnoreCase });
+
+    OptionSet<Flags> flags;
+    if (caseSensitive == SearchCaseSensitive::No)
+        flags.add(Flags::IgnoreCase);
+
+    return RegularExpression(pattern, flags);
 }
 
 int countRegularExpressionMatches(const RegularExpression& regex, const String& content)
@@ -171,8 +194,9 @@ int countRegularExpressionMatches(const RegularExpression& regex, const String& 
 Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>> searchInTextByLines(const String& text, const String& query, const bool caseSensitive, const bool isRegex)
 {
     auto result = JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>::create();
-    auto searchStringType = isRegex ? ContentSearchUtilities::SearchStringType::Regex : ContentSearchUtilities::SearchStringType::ContainsString;
-    auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(query, caseSensitive, searchStringType);
+    auto searchType = isRegex ? ContentSearchUtilities::SearchType::Regex : ContentSearchUtilities::SearchType::ContainsString;
+    auto searchCaseSensitive = caseSensitive ? ContentSearchUtilities::SearchCaseSensitive::Yes : ContentSearchUtilities::SearchCaseSensitive::No;
+    auto regex = ContentSearchUtilities::createRegularExpressionForString(query, searchType, searchCaseSensitive);
     for (const auto& match : getRegularExpressionMatchesByLines(regex, text))
         result->addItem(buildObjectForSearchMatch(match.first, match.second));
     return result;

--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.h
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.h
@@ -39,8 +39,14 @@ namespace Inspector {
 
 namespace ContentSearchUtilities {
 
-enum class SearchStringType { Regex, ExactString, ContainsString };
-JS_EXPORT_PRIVATE JSC::Yarr::RegularExpression createRegularExpressionForSearchString(const String& searchString, bool caseSensitive, SearchStringType);
+enum class SearchType { Regex, ExactString, ContainsString };
+enum class SearchCaseSensitive { No, Yes };
+
+using Searcher = std::variant<String, JSC::Yarr::RegularExpression>;
+JS_EXPORT_PRIVATE Searcher createSearcherForString(const String&, SearchType, SearchCaseSensitive);
+JS_EXPORT_PRIVATE bool searcherMatchesText(const Searcher&, const String& text);
+
+JS_EXPORT_PRIVATE JSC::Yarr::RegularExpression createRegularExpressionForString(const String&, SearchType, SearchCaseSensitive);
 
 JS_EXPORT_PRIVATE int countRegularExpressionMatches(const JSC::Yarr::RegularExpression&, const String&);
 JS_EXPORT_PRIVATE Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>> searchInTextByLines(const String& text, const String& query, const bool caseSensitive, const bool isRegex);

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "Breakpoint.h"
+#include "ContentSearchUtilities.h"
 #include "Debugger.h"
 #include "DebuggerPrimitives.h"
 #include "InspectorAgentBase.h"
@@ -289,7 +290,7 @@ private:
         // This is only used for the breakpoint configuration (i.e. it's irrelevant when comparing).
         RefPtr<JSC::Breakpoint> specialBreakpoint;
 
-        // Avoid having to (re)match the regex each time a function as called.
+        // Avoid having to (re)match the searcher each time a function as called.
         UncheckedKeyHashSet<String> knownMatchingSymbols;
 
         inline bool operator==(const SymbolicBreakpoint& other) const
@@ -302,7 +303,7 @@ private:
         bool matches(const String&);
 
     private:
-        std::optional<JSC::Yarr::RegularExpression> m_symbolMatchRegex;
+        std::optional<ContentSearchUtilities::Searcher> m_symbolSearcher;
     };
     Vector<SymbolicBreakpoint> m_symbolicBreakpoints;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -473,14 +473,14 @@ void InspectorDOMDebuggerAgent::breakOnURLIfNeeded(const String& url)
     if (!ScriptDisallowedScope::isScriptAllowedInMainThread())
         return;
 
-    constexpr bool caseSensitive = false;
+    constexpr auto searchCaseSensitive = ContentSearchUtilities::SearchCaseSensitive::No;
 
     auto breakpointURL = emptyString();
     auto breakpoint = m_pauseOnAllURLsBreakpoint.copyRef();
     if (!breakpoint) {
         for (auto& [query, textBreakpoint] : m_urlTextBreakpoints) {
-            auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(query, caseSensitive, ContentSearchUtilities::SearchStringType::ContainsString);
-            if (regex.match(url) != -1) {
+            auto searcher = ContentSearchUtilities::createSearcherForString(query, ContentSearchUtilities::SearchType::ContainsString, searchCaseSensitive);
+            if (ContentSearchUtilities::searcherMatchesText(searcher, url)) {
                 breakpoint = textBreakpoint.copyRef();
                 breakpointURL = query;
                 break;
@@ -489,8 +489,8 @@ void InspectorDOMDebuggerAgent::breakOnURLIfNeeded(const String& url)
     }
     if (!breakpoint) {
         for (auto& [query, regexBreakpoint] : m_urlRegexBreakpoints) {
-            auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(query, caseSensitive, ContentSearchUtilities::SearchStringType::Regex);
-            if (regex.match(url) != -1) {
+            auto searcher = ContentSearchUtilities::createSearcherForString(query, ContentSearchUtilities::SearchType::Regex, searchCaseSensitive);
+            if (ContentSearchUtilities::searcherMatchesText(searcher, url)) {
                 breakpoint = regexBreakpoint.copyRef();
                 breakpointURL = query;
                 break;
@@ -524,11 +524,12 @@ bool InspectorDOMDebuggerAgent::EventBreakpoint::matches(const String& eventName
     if (m_knownMatchingEventNames.contains(eventName))
         return true;
 
-    if (!m_eventNameMatchRegex) {
-        auto searchStringType = isRegex ? ContentSearchUtilities::SearchStringType::Regex : ContentSearchUtilities::SearchStringType::ExactString;
-        m_eventNameMatchRegex = ContentSearchUtilities::createRegularExpressionForSearchString(this->eventName, caseSensitive, searchStringType);
+    if (!m_eventNameSearcher) {
+        auto searchType = isRegex ? ContentSearchUtilities::SearchType::Regex : ContentSearchUtilities::SearchType::ExactString;
+        auto searchCaseSensitive = caseSensitive ? ContentSearchUtilities::SearchCaseSensitive::Yes : ContentSearchUtilities::SearchCaseSensitive::No;
+        m_eventNameSearcher = ContentSearchUtilities::createSearcherForString(this->eventName, searchType, searchCaseSensitive);
     }
-    if (m_eventNameMatchRegex->match(eventName) == -1)
+    if (!ContentSearchUtilities::searcherMatchesText(*m_eventNameSearcher, eventName))
         return false;
 
     m_knownMatchingEventNames.add(eventName);

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
@@ -120,8 +120,9 @@ private:
         bool matches(const String&);
 
     private:
-        // Avoid having to (re)match the regex each time an event is dispatched.
-        std::optional<JSC::Yarr::RegularExpression> m_eventNameMatchRegex;
+        std::optional<Inspector::ContentSearchUtilities::Searcher> m_eventNameSearcher;
+
+        // Avoid having to (re)match the searcher each time an event is dispatched.
         HashSet<String> m_knownMatchingEventNames;
     };
     Vector<EventBreakpoint> m_listenerBreakpoints;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -35,6 +35,7 @@
 #include "InspectorPageAgent.h"
 #include "InspectorWebAgentBase.h"
 #include "WebSocket.h"
+#include <JavaScriptCore/ContentSearchUtilities.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/RegularExpression.h>
@@ -246,7 +247,21 @@ private:
         bool isRegex { false };
         Inspector::Protocol::Network::NetworkStage networkStage { Inspector::Protocol::Network::NetworkStage::Response };
 
-        friend bool operator==(const Intercept&, const Intercept&) = default;
+        inline bool operator==(const Intercept& other) const
+        {
+            return url == other.url
+                && caseSensitive == other.caseSensitive
+                && isRegex == other.isRegex
+                && networkStage == other.networkStage;
+        }
+
+        bool matches(const String& url, Inspector::Protocol::Network::NetworkStage);
+
+    private:
+        std::optional<Inspector::ContentSearchUtilities::Searcher> m_urlSearcher;
+
+        // Avoid having to (re)match the searcher each time a URL is requested.
+        HashSet<String> m_knownMatchingURLs;
     };
     Vector<Intercept> m_intercepts;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<PendingInterceptRequest>> m_pendingInterceptRequests;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -875,8 +875,9 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::
 {
     auto result = JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>::create();
 
-    auto searchStringType = (isRegex && *isRegex) ? ContentSearchUtilities::SearchStringType::Regex : ContentSearchUtilities::SearchStringType::ContainsString;
-    auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(text, caseSensitive && *caseSensitive, searchStringType);
+    auto searchType = (isRegex && *isRegex) ? ContentSearchUtilities::SearchType::Regex : ContentSearchUtilities::SearchType::ContainsString;
+    auto searchCaseSensitive = (caseSensitive && *caseSensitive) ? ContentSearchUtilities::SearchCaseSensitive::Yes : ContentSearchUtilities::SearchCaseSensitive::No;
+    auto regex = ContentSearchUtilities::createRegularExpressionForString(text, searchType, searchCaseSensitive);
 
     for (Frame* frame = &m_inspectedPage->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);


### PR DESCRIPTION
#### 35b88e1f0340e1bd10162a408df14ddd9b923cb7
<pre>
Web Inspector: don&apos;t create a regex when searching by exact case-sensitive string
<a href="https://bugs.webkit.org/show_bug.cgi?id=290507">https://bugs.webkit.org/show_bug.cgi?id=290507</a>

Reviewed by BJ Burg.

Most developers will probably be creating symbolic breakpoints and blackboxing and etc. with exact case-sensitive strings as that&apos;s the default behavior (i.e. they have to uncheck a box to change this).

As such, we should have a fast path to just do `==` in that case instead of having to regex escape the string and add `^` before and `$` after.

There are no new tests as the end result behavior should be the same (just more efficinet).

* Source/JavaScriptCore/inspector/ContentSearchUtilities.h:
* Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp:
(Inspector::ContentSearchUtilities::createSearcherForString): Added.
(Inspector::ContentSearchUtilities::searcherMatchesText): Added.
(Inspector::ContentSearchUtilities::createRegularExpressionForString): Renamed from `createRegularExpressionForSearchString`.
(Inspector::ContentSearchUtilities::searchInTextByLines):
Create a new `Searcher` type that&apos;s either a `String` for exact case-sensitive matching or a `RegularExpression` for all other cases.
When checking if it matches text, do a quicker `==` check if it&apos;s the former instead of a full regex match for the latter.

* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::setBlackboxConfiguration):
(Inspector::InspectorDebuggerAgent::BlackboxedScript::matches):
(Inspector::InspectorDebuggerAgent::SymbolicBreakpoint::matches):
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
(WebCore::InspectorDOMDebuggerAgent::breakOnURLIfNeeded):
(WebCore::InspectorDOMDebuggerAgent::EventBreakpoint::matches):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::shouldIntercept):
(WebCore::InspectorNetworkAgent::Intercept::matches):
(WebCore::InspectorNetworkAgent::Intercept::operator== const):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::searchInResources):
None of these care about where in the text the regex matches, instead just caring if it matches at all, so we can use this new fast path.

Canonical link: <a href="https://commits.webkit.org/292774@main">https://commits.webkit.org/292774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d40d4df6ab18ab77797af5749e51203971daf100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73939 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31151 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100062 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12804 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46914 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104166 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95680 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/82999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82397 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17638 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29247 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119307 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23921 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->