### PR TITLE
[JSC] Fix the missing option and reland 292744@main

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -419,6 +419,9 @@ public:
 
     bool shouldUnrollLoop(LoopData& data)
     {
+        if (Options::disallowLoopUnrollingForNonInnermost() && !data.loop->isInnerMostLoop())
+            return false;
+
         uint32_t totalNodeCount = 0;
         uint32_t maxLoopUnrollingBodyNodeSize = data.isOperandConstant() ? Options::maxLoopUnrollingBodyNodeSize() : Options::maxPartialLoopUnrollingBodyNodeSize();
         for (uint32_t i = 0; i < data.loopSize(); ++i) {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -581,6 +581,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
     v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
     v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, disallowLoopUnrollingForNonInnermost, false, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingCount, 2, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingBodyNodeSize, 200, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingIterationCount, 4, Normal, nullptr) \

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -41,13 +41,15 @@ public:
         : m_graph(nullptr)
         , m_header(nullptr)
         , m_outerLoopIndex(UINT_MAX)
+        , m_innerLoopIndex(UINT_MAX)
     {
     }
-    
+
     NaturalLoop(Graph& graph, typename Graph::Node header, unsigned index)
         : m_graph(&graph)
         , m_header(header)
         , m_outerLoopIndex(UINT_MAX)
+        , m_innerLoopIndex(UINT_MAX)
         , m_index(index)
     {
     }
@@ -78,6 +80,7 @@ public:
     unsigned index() const { return m_index; }
     
     bool isOuterMostLoop() const { return m_outerLoopIndex == UINT_MAX; }
+    bool isInnerMostLoop() const { return m_innerLoopIndex == UINT_MAX; }
     
     void dump(PrintStream& out) const
     {
@@ -106,6 +109,7 @@ private:
     typename Graph::Node m_header;
     Vector<typename Graph::Node, 4> m_body;
     unsigned m_outerLoopIndex;
+    unsigned m_innerLoopIndex;
     unsigned m_index;
 };
 
@@ -235,6 +239,8 @@ public:
             RELEASE_ASSERT(m_innerMostLoopIndices[loop.header()][0] == i);
         
             loop.m_outerLoopIndex = m_innerMostLoopIndices[loop.header()][1];
+            if (loop.m_outerLoopIndex != UINT_MAX)
+                m_loops[loop.m_outerLoopIndex].m_innerLoopIndex = loop.index();
         }
     
         if (selfCheck) {


### PR DESCRIPTION
#### b2c8bb449351a6091e9d493282c8d6a93e731156
<pre>
[JSC] Fix the missing option and reland 292744@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=290510">https://bugs.webkit.org/show_bug.cgi?id=290510</a>
<a href="https://rdar.apple.com/147990841">rdar://147990841</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

Previously, 292744@main was landed with the verboseLoopUnrolling option removed.
That patch was later reverted in 292745@main. This patch fixes the issue and relands 292744@main.

* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::shouldUnrollLoop):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoop::NaturalLoop):
(WTF::NaturalLoop::isInnerMostLoop const):
(WTF::NaturalLoops::NaturalLoops):

Canonical link: <a href="https://commits.webkit.org/292778@main">https://commits.webkit.org/292778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c331cba628d6730cbab2e6c8dceebc85243d687f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73906 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46869 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95635 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24088 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82953 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17587 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29201 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119262 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23876 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->