### PR TITLE
[BMalloc][WTF] Missing check for __ARM_ARCH_6KZ__

### DIFF
--- a/Source/WTF/wtf/PlatformCPU.h
+++ b/Source/WTF/wtf/PlatformCPU.h
@@ -162,6 +162,7 @@
     || defined(__ARM_ARCH_6J__) \
     || defined(__ARM_ARCH_6K__) \
     || defined(__ARM_ARCH_6Z__) \
+    || defined(__ARM_ARCH_6KZ__) \
     || defined(__ARM_ARCH_6ZK__) \
     || defined(__ARM_ARCH_6T2__) \
     || defined(__ARMV6__)

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -177,6 +177,7 @@
 || defined(__ARM_ARCH_6J__) \
 || defined(__ARM_ARCH_6K__) \
 || defined(__ARM_ARCH_6Z__) \
+|| defined(__ARM_ARCH_6KZ__) \
 || defined(__ARM_ARCH_6ZK__) \
 || defined(__ARM_ARCH_6T2__) \
 || defined(__ARMV6__)


### PR DESCRIPTION
#### 090c6ab814db4b4d0c609393106b62bcde4835ed
<pre>
[BMalloc][WTF] Missing check for __ARM_ARCH_6KZ__
<a href="https://bugs.webkit.org/show_bug.cgi?id=290515">https://bugs.webkit.org/show_bug.cgi?id=290515</a>

Reviewed by Justin Michaud.

The official name of the architecture according to the reference manuals
is ARMv6KZ (not ZK, notice the order of the last two letters), and
therefore Clang renamed the corresponding __ARM_ARCH_6??__ macro [1]
while keeping armv6zk (old spelling) as an alias for armv6kz (new
spelling). Therefore even when passing -march=armv6zk in the command
line, the macro that gets set is __ARM_ARCH_6KZ__. Therefore, add a
check for the latter. GCC has received a similar fix [2], but it will
still define the old macro.

[1] <a href="https://reviews.llvm.org/D14568">https://reviews.llvm.org/D14568</a>
[2] <a href="https://gcc.gnu.org/git/?p=gcc.git">https://gcc.gnu.org/git/?p=gcc.git</a>;a=commit;h=39c12541396fe6044a17455be8be6b4964108d89

* Source/WTF/wtf/PlatformCPU.h: Add check for __ARM_ARCH_6KZ__.
* Source/bmalloc/bmalloc/BPlatform.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/292780@main">https://commits.webkit.org/292780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0290f6bbd6cdd54ea0664a173f6667d35c5d762

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46875 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89693 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104122 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95641 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24094 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17577 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82958 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17593 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29207 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119268 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23882 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->