### PR TITLE
Inner container for number controls should not use style `align-items:stretch` for vector-based controls

### DIFF
--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -104,11 +104,6 @@ std::optional<Style::ResolvedStyle> TextControlInnerContainer::resolveCustomStyl
         elementStyle.style->setOverflowY(Overflow::Hidden);
     }
 
-#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
-    if (isNumberInput(shadowHost()) && shadowHost()->document().settings().vectorBasedControlsOnMacEnabled())
-        elementStyle.style->setAlignItems(StyleSelfAlignmentData(ItemPosition::Stretch));
-#endif
-
     return elementStyle;
 }
 


### PR DESCRIPTION
#### 171bc8973139e2814a934d450261cdff06944c66
<pre>
Inner container for number controls should not use style `align-items:stretch` for vector-based controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=290516">https://bugs.webkit.org/show_bug.cgi?id=290516</a>
<a href="https://rdar.apple.com/147998248">rdar://147998248</a>

Reviewed by Wenson Hsieh.

Removed style adjustment from TextControlInnerContainer::resolveCustomStyle which
set CSS property `align-items` to value `stretch` when vector-based controls are
enabled.

* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerContainer::resolveCustomStyle):

Canonical link: <a href="https://commits.webkit.org/292772@main">https://commits.webkit.org/292772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a72bd3c43cc58f815d4f33bb21d8aa0eff25e03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102103 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73909 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31121 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87750 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54245 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104124 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82351 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->