### PR TITLE
[JSC] Refactor Loop Unrolling to Use DFGCloneHelper

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2218,6 +2218,7 @@
 		FEF9AD642D8B985E005821C5 /* SourceProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF9AD612D8B9848005821C5 /* SourceProfiler.h */; };
 		FEFD6FC61D5E7992008F2F0B /* JSStringInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF1D8E872CE7C9BF00E211DD /* VerifierSlotVisitorScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF31EC8E2D947F0500D9CB81 /* DFGCloneHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */; };
 		FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6184,6 +6185,8 @@
 		FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringInlines.h; sourceTree = "<group>"; };
 		FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VerifierSlotVisitorScope.h; sourceTree = "<group>"; };
 		FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OrderedHashTable.cpp; sourceTree = "<group>"; };
+		FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGCloneHelper.h; path = dfg/DFGCloneHelper.h; sourceTree = "<group>"; };
+		FF31EC8C2D947F0500D9CB81 /* DFGCloneHelper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGCloneHelper.cpp; path = dfg/DFGCloneHelper.cpp; sourceTree = "<group>"; };
 		FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegExpSubstringGlobalAtomCache.h; sourceTree = "<group>"; };
 		FF3394AB2CB4948E004AFF6A /* RegExpSubstringGlobalAtomCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpSubstringGlobalAtomCache.cpp; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
@@ -9197,6 +9200,8 @@
 				A77A423B17A0BBFD00A8DB81 /* DFGClobberSet.h */,
 				0F3C1F181B868E7900ABB08B /* DFGClobbersExitState.cpp */,
 				0F3C1F191B868E7900ABB08B /* DFGClobbersExitState.h */,
+				FF31EC8C2D947F0500D9CB81 /* DFGCloneHelper.cpp */,
+				FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */,
 				E349A77F2491F159001BA336 /* DFGCodeOriginPool.cpp */,
 				E349A7802491F15A001BA336 /* DFGCodeOriginPool.h */,
 				0F04396B1B03DC0B009598B7 /* DFGCombinedLiveness.cpp */,
@@ -10813,6 +10818,7 @@
 				A77A424017A0BBFD00A8DB81 /* DFGClobberize.h in Headers */,
 				A77A424217A0BBFD00A8DB81 /* DFGClobberSet.h in Headers */,
 				0F3C1F1B1B868E7900ABB08B /* DFGClobbersExitState.h in Headers */,
+				FF31EC8E2D947F0500D9CB81 /* DFGCloneHelper.h in Headers */,
 				E349A7812491F161001BA336 /* DFGCodeOriginPool.h in Headers */,
 				0F04396E1B03DC0B009598B7 /* DFGCombinedLiveness.h in Headers */,
 				0F7B294D14C3CD4C007C3DB1 /* DFGCommon.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -345,6 +345,7 @@ dfg/DFGCleanUpPhase.cpp
 dfg/DFGClobberSet.cpp
 dfg/DFGClobberize.cpp
 dfg/DFGClobbersExitState.cpp
+dfg/DFGCloneHelper.cpp
 dfg/DFGCodeOriginPool.cpp
 dfg/DFGCombinedLiveness.cpp
 dfg/DFGCommon.cpp

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DFGCloneHelper.h"
+
+#if ENABLE(DFG_JIT)
+
+#include "DFGBasicBlockInlines.h"
+
+namespace JSC { namespace DFG {
+
+namespace {
+
+enum class NodeCloneStatus {
+    Common, // Use shared logic to clone this node
+    Special, // Requires special handling for cloning
+    PreCloned, // Cloned earlier (e.g. Phi), shouldn't reach cloneNodeImpl
+    Unsupported // Not yet supported, future work
+};
+
+NodeCloneStatus nodeCloneStatusFor(NodeType op)
+{
+    switch (op) {
+#define HANDLE_CASE(op, kind) \
+    case op:                  \
+        return NodeCloneStatus::kind;
+        FOR_EACH_NODE_CLONE_STATUS(HANDLE_CASE)
+#undef HANDLE_CASE
+    default:
+        return NodeCloneStatus::Unsupported;
+    }
+}
+
+} // anonymous namespace
+
+bool CloneHelper::isNodeCloneable(Graph& graph, HashSet<Node*>& cloneableCache, Node* node)
+{
+    if (cloneableCache.contains(node))
+        return true;
+
+    bool result = true;
+    switch (nodeCloneStatusFor(node->op())) {
+    case NodeCloneStatus::Common:
+    case NodeCloneStatus::Special: {
+        graph.doToChildrenWithCheck(node, [&](Edge& edge) {
+            if (isNodeCloneable(graph, cloneableCache, edge.node()))
+                return IterationStatus::Continue;
+            result = false;
+            return IterationStatus::Done;
+        });
+        return result;
+    }
+    case NodeCloneStatus::PreCloned:
+        break;
+    case NodeCloneStatus::Unsupported:
+        result = false;
+    }
+
+    if (result)
+        cloneableCache.add(node);
+    return result;
+}
+
+Node* CloneHelper::cloneNode(BasicBlock* into, Node* node)
+{
+    ASSERT(node);
+    auto iter = m_nodeClones.find(node);
+    if (iter != m_nodeClones.end())
+        return iter->value;
+    Node* result = cloneNodeImpl(into, node);
+    ASSERT(result);
+    m_nodeClones.add(node, result);
+    return result;
+}
+
+Node* CloneHelper::cloneNodeImpl(BasicBlock* into, Node* node)
+{
+#if ASSERT_ENABLED
+    m_graph.doToChildren(node, [&](Edge& e) {
+        ASSERT(e.node()->owner == node->owner);
+    });
+#endif
+
+    auto cloneEdge = [&](Edge& edge) {
+        return edge ? Edge(cloneNode(into, edge.node()), edge.useKind()) : Edge();
+    };
+
+    switch (nodeCloneStatusFor(node->op())) {
+    case NodeCloneStatus::Common: {
+        if (node->hasVarArgs()) {
+            size_t firstChild = m_graph.m_varArgChildren.size();
+
+            uint32_t validChildrenCount = 0;
+            m_graph.doToChildren(node, [&](Edge& edge) {
+                m_graph.m_varArgChildren.append(cloneEdge(edge));
+                ++validChildrenCount;
+            });
+
+            uint32_t expectedCount = m_graph.numChildren(node);
+            for (uint32_t i = validChildrenCount; i < expectedCount; ++i)
+                m_graph.m_varArgChildren.append(Edge());
+
+            Node* clone = into->cloneAndAppend(m_graph, node);
+            clone->children.setFirstChild(firstChild);
+            return clone;
+        }
+
+        Node* clone = into->cloneAndAppend(m_graph, node);
+        clone->child1() = cloneEdge(node->child1());
+        clone->child2() = cloneEdge(node->child2());
+        clone->child3() = cloneEdge(node->child3());
+        return clone;
+    }
+
+    case NodeCloneStatus::Special:
+        switch (node->op()) {
+        case Branch: {
+            Node* clone = into->cloneAndAppend(m_graph, node);
+            clone->setOpInfo(OpInfo(m_graph.m_branchData.add(WTFMove(*node->branchData()))));
+            clone->child1() = cloneEdge(node->child1());
+            return clone;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
+        }
+
+    case NodeCloneStatus::PreCloned:
+        RELEASE_ASSERT_NOT_REACHED(); // e.g. Phi
+        return nullptr;
+
+    case NodeCloneStatus::Unsupported:
+        dataLogLn("Node not cloneable: ", node->op());
+        RELEASE_ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DFG_JIT)
+
+#include "Forward.h"
+
+namespace JSC { namespace DFG {
+
+class Graph;
+class BasicBlock;
+struct Node;
+
+class CloneHelper {
+public:
+    CloneHelper(Graph& graph, UncheckedKeyHashMap<Node*, Node*>& nodeClones)
+        : m_graph(graph)
+        , m_nodeClones(nodeClones)
+    {
+    }
+
+    static bool isNodeCloneable(Graph&, HashSet<Node*>&, Node*);
+    Node* cloneNode(BasicBlock*, Node*);
+    Node* cloneNodeImpl(BasicBlock*, Node*);
+
+private:
+    Graph& m_graph;
+    UncheckedKeyHashMap<Node*, Node*>& m_nodeClones;
+};
+
+#define FOR_EACH_NODE_CLONE_STATUS(CLONE_STATUS) \
+    CLONE_STATUS(ArithAdd, Common) \
+    CLONE_STATUS(ArithBitAnd, Common) \
+    CLONE_STATUS(ArithBitLShift, Common) \
+    CLONE_STATUS(ArithBitNot, Common) \
+    CLONE_STATUS(ArithBitOr, Common) \
+    CLONE_STATUS(ArithBitRShift, Common) \
+    CLONE_STATUS(ArithBitXor, Common) \
+    CLONE_STATUS(ArithDiv, Common) \
+    CLONE_STATUS(ArithMod, Common) \
+    CLONE_STATUS(ArithMul, Common) \
+    CLONE_STATUS(ArithSub, Common) \
+    CLONE_STATUS(ArrayifyToStructure, Common) \
+    CLONE_STATUS(AssertNotEmpty, Common) \
+    CLONE_STATUS(BitURShift, Common) \
+    CLONE_STATUS(Branch, Special) \
+    CLONE_STATUS(Check, Common) \
+    CLONE_STATUS(CheckArray, Common) \
+    CLONE_STATUS(CheckStructure, Common) \
+    CLONE_STATUS(CheckVarargs, Common) \
+    CLONE_STATUS(CompareEq, Common) \
+    CLONE_STATUS(CompareGreater, Common) \
+    CLONE_STATUS(CompareGreaterEq, Common) \
+    CLONE_STATUS(CompareLess, Common) \
+    CLONE_STATUS(CompareLessEq, Common) \
+    CLONE_STATUS(CompareStrictEq, Common) \
+    CLONE_STATUS(DoubleRep, Common) \
+    CLONE_STATUS(ExitOK, Common) \
+    CLONE_STATUS(FilterCallLinkStatus, Common) \
+    CLONE_STATUS(Flush, Common) \
+    CLONE_STATUS(GetButterfly, Common) \
+    CLONE_STATUS(GetByVal, Common) \
+    CLONE_STATUS(GetLocal, Common) \
+    CLONE_STATUS(InvalidationPoint, Common) \
+    CLONE_STATUS(JSConstant, Common) \
+    CLONE_STATUS(Jump, Common) \
+    CLONE_STATUS(LoopHint, Common) \
+    CLONE_STATUS(MovHint, Common) \
+    CLONE_STATUS(NewArrayWithConstantSize, Common) \
+    CLONE_STATUS(NewArrayWithSize, Common) \
+    CLONE_STATUS(PhantomLocal, Common) \
+    CLONE_STATUS(Phi, PreCloned) \
+    CLONE_STATUS(PurifyNaN, Common) \
+    CLONE_STATUS(PutByVal, Common) \
+    CLONE_STATUS(PutByValAlias, Common) \
+    CLONE_STATUS(SetArgumentDefinitely, Common) \
+    CLONE_STATUS(SetLocal, Common) \
+    CLONE_STATUS(ValueRep, Common) \
+    CLONE_STATUS(ValueToInt32, Common) \
+    CLONE_STATUS(ZombieHint, Common)
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)


### PR DESCRIPTION
#### 91b72777aecbc20988f1ecaab5bd38d501c9da71
<pre>
[JSC] Refactor Loop Unrolling to Use DFGCloneHelper
<a href="https://bugs.webkit.org/show_bug.cgi?id=290520">https://bugs.webkit.org/show_bug.cgi?id=290520</a>
<a href="https://rdar.apple.com/148001458">rdar://148001458</a>

Reviewed by Justin Michaud.

This patch:
1. Introduced DFGCloneHelper to encapsulate node cloning logic
   for the loop unrolling phase.
2. Moved isNodeCloneable, cloneNode, and cloneNodeImpl from DFGLoopUnrollingPhase.cpp
   into the new helper class.
3. Simplifies and modularizes the unrolling phase, improving maintainability
   and separation of concerns.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/dfg/DFGCloneHelper.cpp: Added.
(JSC::DFG::LoopUnrollingCloneHelper::isNodeCloneable):
(JSC::DFG::LoopUnrollingCloneHelper::cloneNode):
(JSC::DFG::LoopUnrollingCloneHelper::cloneNodeImpl):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h: Added.
(JSC::DFG::LoopUnrollingCloneHelper::LoopUnrollingCloneHelper):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::canCloneLoop):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
(JSC::DFG::LoopUnrollingPhase::isNodeCloneable): Deleted.
(JSC::DFG::LoopUnrollingPhase::cloneNode): Deleted.
(JSC::DFG::LoopUnrollingPhase::cloneNodeImpl): Deleted.

Canonical link: <a href="https://commits.webkit.org/292839@main">https://commits.webkit.org/292839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e470a6ba150ffc8e06c0015638d3ba9301255a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47619 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74092 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12591 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5677 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46949 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89767 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104197 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95715 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83013 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24545 "Failed to checkout and rebase branch from PR 43099") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82414 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20772 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17673 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29284 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119342 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23956 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33522 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->