### PR TITLE
[WTF] Fix build failures when MALLOC_HEAP_BREAKDOWN enabled

### DIFF
--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -28,7 +28,6 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
-#include "AnimationMalloc.h"
 #include "Document.h"
 #include "LocalDOMWindow.h"
 #include "Page.h"

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include "AcceleratedEffect.h"
+#include "AnimationMalloc.h"
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
 

--- a/Source/WebCore/animation/FrameRateAligner.cpp
+++ b/Source/WebCore/animation/FrameRateAligner.cpp
@@ -27,7 +27,6 @@
 #include "FrameRateAligner.h"
 
 namespace WebCore {
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FrameRateAligner);
 
 FrameRateAligner::FrameRateAligner() = default;
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -63,6 +63,7 @@ static_assert(sizeof(StyleRuleBase) == sizeof(SameSizeAsStyleRuleBase), "StyleRu
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleBase);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRule);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleNestedDeclarations);
 
 Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet& parentSheet) const
 {

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -39,6 +39,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLImageLoader);
+
 HTMLImageLoader::HTMLImageLoader(Element& element)
     : ImageLoader(element)
 {

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -26,6 +26,7 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLImageLoader);
 class HTMLImageLoader final : public ImageLoader {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLImageLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageLoader);

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -42,6 +42,7 @@
 
 namespace WebCore::Style::Interpolation {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Animation);
 // MARK: - Standard property interpolation support
 
 static void interpolateStandardProperty(CSSPropertyID property, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation compositeOperation, IterationCompositeOperation iterationCompositeOperation, double currentIteration, const Client& client)

--- a/Source/WebCore/style/StyleInterpolationWrapperBase.h
+++ b/Source/WebCore/style/StyleInterpolationWrapperBase.h
@@ -44,6 +44,7 @@ namespace Style::Interpolation {
 
 struct Context;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Animation);
 class WrapperBase {
     WTF_MAKE_NONCOPYABLE(WrapperBase);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);

--- a/Source/WebCore/svg/SVGImageLoader.cpp
+++ b/Source/WebCore/svg/SVGImageLoader.cpp
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SVGImageLoader);
+
 SVGImageLoader::SVGImageLoader(SVGImageElement& element)
     : ImageLoader(element)
 {

--- a/Source/WebCore/svg/SVGImageLoader.h
+++ b/Source/WebCore/svg/SVGImageLoader.h
@@ -25,6 +25,7 @@ namespace WebCore {
 
 class SVGImageElement;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SVGImageLoader);
 class SVGImageLoader final : public ImageLoader {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SVGImageLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGImageLoader);


### PR DESCRIPTION
#### 15927b4021419ab37c35d7a7deb505db14a8bd20
<pre>
[WTF] Fix build failures when MALLOC_HEAP_BREAKDOWN enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=290524">https://bugs.webkit.org/show_bug.cgi?id=290524</a>

Reviewed by Simon Fraser.

* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
* Source/WebCore/animation/FrameRateAligner.cpp:
* Source/WebCore/css/StyleRule.cpp:
* Source/WebCore/html/HTMLImageLoader.cpp:
* Source/WebCore/html/HTMLImageLoader.h:
* Source/WebCore/style/StyleInterpolation.cpp:
* Source/WebCore/style/StyleInterpolationWrapperBase.h:
* Source/WebCore/svg/SVGImageLoader.cpp:
* Source/WebCore/svg/SVGImageLoader.h:

Canonical link: <a href="https://commits.webkit.org/292810@main">https://commits.webkit.org/292810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53dba0ae715f172ae4d39ca48f46995be6b502d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25103 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73915 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31128 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24104 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17586 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82964 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82359 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20746 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17605 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29217 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->