### PR TITLE
[JSC] Add FTL VirtualCall node

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -45,8 +45,6 @@ static constexpr bool verbose = false;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CallLinkStatus);
 
 CallLinkStatus::CallLinkStatus(JSValue value)
-    : m_couldTakeSlowPath(false)
-    , m_isProved(false)
 {
     if (!value || !value.isCell()) {
         m_couldTakeSlowPath = true;
@@ -73,12 +71,12 @@ CallLinkStatus CallLinkStatus::computeFor(
     // m_jitData is nullptr when it is tied to LLInt (not Baseline).
     if (callLinkInfo->type() == CallLinkInfo::Type::DataOnly && !profiledBlock->m_jitData) {
         if (exitSiteData.takesSlowPath)
-            return takesSlowPath();
+            return takesSlowPath(callLinkInfo->clearedByVirtual());
 #if ENABLE(DFG_JIT)
         if (profiledBlock->unlinkedCodeBlock()->hasExitSite(DFG::FrequentExitSite(bytecodeIndex, BadConstantValue))) {
             // We could force this to be a closure call, but instead we'll just assume that it
             // takes slow path.
-            return takesSlowPath();
+            return takesSlowPath(callLinkInfo->clearedByVirtual());
         }
 #endif
     }
@@ -141,8 +139,8 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
     const ConcurrentJSLocker&, CallLinkInfo& callLinkInfo)
 {
     if (callLinkInfo.clearedByGC() || callLinkInfo.clearedByVirtual())
-        return takesSlowPath();
-    
+        return takesSlowPath(callLinkInfo.clearedByVirtual());
+
     // Note that despite requiring that the locker is held, this code is racy with respect
     // to the CallLinkInfo: it may get cleared while this code runs! This is because
     // CallLinkInfoBase::unlinkOrUpgrade() may be called from a different CodeBlock than the one that owns
@@ -171,7 +169,7 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
             //
             // Either way, this is telling us that the FTL had been led to believe that it's
             // profitable not to inline anything.
-            return takesSlowPath();
+            return takesSlowPath(callLinkInfo.clearedByVirtual());
         }
         
         CallEdgeList edges = stub->edges();
@@ -211,11 +209,11 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
         // Bail if we didn't find any calls that qualified.
         RELEASE_ASSERT(!!totalCallsToKnown == !!variants.size());
         if (variants.isEmpty())
-            return takesSlowPath();
+            return takesSlowPath(callLinkInfo.clearedByVirtual());
         
         // We require that the distribution of callees is skewed towards a handful of common ones.
         if (totalCallsToKnown / totalCallsToUnknown < Options::minimumCallToKnownRate())
-            return takesSlowPath();
+            return takesSlowPath(callLinkInfo.clearedByVirtual());
         
         RELEASE_ASSERT(totalCallsToKnown);
         RELEASE_ASSERT(variants.size());
@@ -372,6 +370,7 @@ void CallLinkStatus::setProvenConstantCallee(CallVariant variant)
 {
     m_variants = CallVariantList{ variant };
     m_couldTakeSlowPath = false;
+    m_isVirtualCall = false;
     m_isProved = true;
 }
 
@@ -401,6 +400,7 @@ bool CallLinkStatus::finalize(VM& vm)
 void CallLinkStatus::merge(const CallLinkStatus& other)
 {
     m_couldTakeSlowPath |= other.m_couldTakeSlowPath;
+    m_isVirtualCall |= other.m_isVirtualCall;
     
     for (const CallVariant& otherVariant : other.m_variants) {
         bool found = false;
@@ -430,23 +430,8 @@ void CallLinkStatus::dump(PrintStream& out) const
         out.print("Not Set"_s);
         return;
     }
-    
-    CommaPrinter comma;
-    
-    if (m_isProved)
-        out.print(comma, "Statically Proved"_s);
-    
-    if (m_couldTakeSlowPath)
-        out.print(comma, "Could Take Slow Path"_s);
-    
-    if (m_isBasedOnStub)
-        out.print(comma, "Based On Stub"_s);
-    
-    if (!m_variants.isEmpty())
-        out.print(comma, listDump(m_variants));
-    
-    if (m_maxArgumentCountIncludingThisForVarargs)
-        out.print(comma, "maxArgumentCountIncludingThisForVarargs = "_s, m_maxArgumentCountIncludingThisForVarargs);
+
+    out.print("isProved:(", m_isProved, "),couldTakeSlowPath:(", m_couldTakeSlowPath, "),isBasedOnStub:(", m_isBasedOnStub, "),isVirtualCall:(", m_isVirtualCall, "),maxArgumentCountIncludingThisForVarargs:(", m_maxArgumentCountIncludingThisForVarargs, "),", listDump(m_variants));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.h
@@ -49,10 +49,11 @@ public:
     {
     }
     
-    static CallLinkStatus takesSlowPath()
+    static CallLinkStatus takesSlowPath(bool isVirtualCall)
     {
         CallLinkStatus result;
         result.m_couldTakeSlowPath = true;
+        result.m_isVirtualCall = isVirtualCall;
         return result;
     }
     
@@ -92,6 +93,8 @@ public:
     explicit operator bool() const { return isSet(); }
     
     bool couldTakeSlowPath() const { return m_couldTakeSlowPath; }
+
+    bool isVirtualCall() const { return m_isVirtualCall; }
     
     void setCouldTakeSlowPath(bool value) { m_couldTakeSlowPath = value; }
     
@@ -126,9 +129,10 @@ private:
     void accountForExits(ExitSiteData, ExitingInlineKind);
     
     CallVariantList m_variants;
-    bool m_couldTakeSlowPath { false };
-    bool m_isProved { false };
-    bool m_isBasedOnStub { false };
+    bool m_couldTakeSlowPath : 1 { false };
+    bool m_isProved : 1 { false };
+    bool m_isBasedOnStub : 1 { false };
+    bool m_isVirtualCall : 1 { false };
     uint8_t m_maxArgumentCountIncludingThisForVarargs { 0 }; // More than UINT8_MAX will be recorded as UINT8_MAX.
 };
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -990,7 +990,7 @@ static_assert(sizeof(CodeBlock) <= 224, "Keep it small for memory saving");
 #endif
 
 template <typename ExecutableType>
-void ScriptExecutable::prepareForExecution(VM& vm, JSFunction* function, JSScope* scope, CodeSpecializationKind kind, CodeBlock*& resultCodeBlock)
+void ScriptExecutable::prepareForExecution(VM& vm, JSScope* scope, CodeSpecializationKind kind, CodeBlock*& resultCodeBlock)
 {
     if (hasJITCodeFor(kind)) {
         if constexpr (std::is_same<ExecutableType, EvalExecutable>::value)
@@ -1006,7 +1006,7 @@ void ScriptExecutable::prepareForExecution(VM& vm, JSFunction* function, JSScope
         return;
     }
 
-    prepareForExecutionImpl(vm, function, scope, kind, resultCodeBlock);
+    prepareForExecutionImpl(vm, scope, kind, resultCodeBlock);
 }
 
 #define CODEBLOCK_LOG_EVENT(codeBlock, summary, details) \

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -186,7 +186,7 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
         }
 
         CodeBlock** codeBlockSlot = calleeFrame->addressOfCodeBlock();
-        functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee, scope, kind, *codeBlockSlot);
+        functionExecutable->prepareForExecution<FunctionExecutable>(vm, scope, kind, *codeBlockSlot);
         RETURN_IF_EXCEPTION(throwScope, nullptr);
 
         codeBlock = *codeBlockSlot;
@@ -257,7 +257,7 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
         }
 
         CodeBlock** codeBlockSlot = calleeFrame->addressOfCodeBlock();
-        functionExecutable->prepareForExecution<FunctionExecutable>(vm, function, scope, kind, *codeBlockSlot);
+        functionExecutable->prepareForExecution<FunctionExecutable>(vm, scope, kind, *codeBlockSlot);
         RETURN_IF_EXCEPTION(throwScope, nullptr);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5252,6 +5252,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case DirectTailCallInlinedCaller:
     case CallCustomAccessorGetter:
     case CallCustomAccessorSetter:
+    case VirtualCall:
         clobberWorld();
         makeHeapTopForNode(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1461,6 +1461,8 @@ ByteCodeParser::Terminality ByteCodeParser::handleCall(
     if (kind == InlineCallFrame::SetterCall && ecmaMode.isStrict())
         addToGraph(CheckNotJSCast, OpInfo(NullSetterFunction::info()), callTarget);
     Node* callNode = addCall(result, op, OpInfo(), callTarget, argumentCountIncludingThis, registerOffset, prediction);
+    if (!inlineCallFrame() && callLinkStatus.isVirtualCall())
+        m_graph.m_slowCall.add(callNode);
     ASSERT(callNode->op() != TailCallVarargs && callNode->op() != TailCallForwardVarargs);
     return callNode->op() == TailCall ? Terminal : NonTerminal;
 }
@@ -2399,9 +2401,11 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleInlining(
     if (couldTakeSlowPath) {
         if (kind == InlineCallFrame::SetterCall && ecmaMode.isStrict())
             addToGraph(CheckNotJSCast, OpInfo(NullSetterFunction::info()), myCallTargetNode);
-        addCall(
+        Node* callNode = addCall(
             result, callOp, OpInfo(), myCallTargetNode, argumentCountIncludingThis,
             registerOffset, prediction);
+        if (!inlineCallFrame() && callLinkStatus.isVirtualCall())
+            m_graph.m_slowCall.add(callNode);
         VERBOSE_LOG("We added a call in the slow path\n");
     } else {
         addToGraph(CheckBadValue);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -763,6 +763,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ArraySplice:
     case Call:
     case DirectCall:
+    case VirtualCall:
     case TailCallInlinedCaller:
     case DirectTailCallInlinedCaller:
     case Construct:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -291,6 +291,7 @@ bool doesGC(Graph& graph, Node* node)
     case CallForwardVarargs:
     case CallObjectConstructor:
     case CallVarargs:
+    case VirtualCall:
     case CheckTierUpAndOSREnter:
     case CheckTierUpAtReturn:
     case CheckTierUpInLoop:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3091,7 +3091,10 @@ private:
         }
 
         case Call: {
-            attemptToMakeCallDOM(node);
+            if (attemptToMakeCallDOM(node))
+                break;
+            if (attemptToMakeVirtualCall(node))
+                break;
             break;
         }
 
@@ -3389,6 +3392,7 @@ private:
         case MakeAtomString:
         case CallCustomAccessorGetter:
         case CallCustomAccessorSetter:
+        case VirtualCall:
             break;
 #else // not ASSERT_ENABLED
         default:
@@ -4806,6 +4810,39 @@ private:
         fixupCheckJSCast(checkSubClass);
         fixupCallDOM(node);
         RELEASE_ASSERT(node->child1().node() == thisNode);
+        return true;
+    }
+
+    bool attemptToMakeVirtualCall(Node* node)
+    {
+        // If the Call is placed in the top-level function (not inlined function),
+        // then IC's feedback will be the same since nothing will narrow candidates down.
+        // Thus we can use VirtualCall even in DFG.
+        // if (node->origin.semantic.inlineCallFrame()) {
+        //     // While node is placed in inlined function, the feedback says that it is a virtual call.
+        //     // If it is in DFG, then it is possible that feedback is coming from Baseline so we still
+        //     // have a chance to narrow candidates down, but if it is in FTL, we no longer have such an
+        //     // opportunity. Thus we can just use virtual call.
+        //     if (!m_graph.m_plan.isFTL())
+        //         return false;
+        // }
+
+        if (!m_graph.m_plan.isFTL())
+            return false;
+
+        if (!m_graph.m_slowCall.contains(node))
+            return false;
+
+        Edge& callee = m_graph.child(node, 0);
+        if (!callee->shouldSpeculateFunction())
+            return false;
+
+        auto* executable = m_insertionSet.insertNode(m_indexInBlock, SpecNone, GetExecutable, node->origin, Edge(callee.node(), FunctionUse));
+        node->setOp(VirtualCall);
+        AdjacencyList adjacencyList = m_graph.copyVarargChildren(node);
+        m_graph.m_varArgChildren.append(Edge(executable, KnownCellUse));
+        adjacencyList.setNumChildren(adjacencyList.numChildren() + 1);
+        node->children = adjacencyList;
         return true;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1354,6 +1354,7 @@ public:
 
     UncheckedKeyHashSet<Node*> m_slowGetByVal;
     UncheckedKeyHashSet<Node*> m_slowPutByVal;
+    UncheckedKeyHashSet<Node*> m_slowCall;
 
 private:
     template<typename Visitor> void visitChildrenImpl(Visitor&);

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -143,6 +143,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case ConstructVarargs:
     case CallForwardVarargs:
     case ConstructForwardVarargs:
+    case VirtualCall:
     case CreateActivation:
     case MaterializeCreateActivation:
     case MaterializeNewObject:

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -299,6 +299,7 @@ void Node::convertToDirectCall(FrozenValue* executable)
     NodeType newOp = LastNodeType;
     switch (op()) {
     case Call:
+    case VirtualCall:
         newOp = DirectCall;
         break;
     case Construct:
@@ -327,7 +328,7 @@ void Node::convertToCallWasm(FrozenValue* callee)
 
 void Node::convertToCallDOM(Graph& graph)
 {
-    ASSERT(op() == Call);
+    ASSERT(op() == Call || op() == VirtualCall);
     ASSERT(signature());
 
     Edge edges[3];

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1021,7 +1021,7 @@ public:
         return m_opInfo2.as<FrozenValue*>()->value();
     }
 
-    bool hasArgumentsChild()
+    bool hasArgumentsChild() const
     {
         switch (op()) {
         case GetMyArgumentByVal:
@@ -2044,6 +2044,7 @@ public:
         case GetPrivateName:
         case GetPrivateNameById:
         case Call:
+        case VirtualCall:
         case DirectCall:
         case TailCallInlinedCaller:
         case DirectTailCallInlinedCaller:
@@ -3461,7 +3462,14 @@ public:
     {
         // Note that this does not include TailCall node types intentionally.
         // CallDOM node types are always converted from Call.
-        return op() == Call || op() == CallDOM;
+        switch (op()) {
+        case Call:
+        case VirtualCall:
+        case CallDOM:
+            return true;
+        default:
+            return false;
+        }
     }
 
     const DOMJIT::Signature* signature()
@@ -3550,6 +3558,51 @@ public:
     bool hasBucketOwnerType()
     {
         return op() == MapIterationNext || op() == MapIterationEntry || op() == MapIterationEntryKey || op() == MapIterationEntryValue || op() == MapStorage || op() == MapStorageOrSentinel;
+    }
+
+
+    bool hasNumberOfPassedArguments() const
+    {
+        switch (op()) {
+        case Call:
+        case VirtualCall:
+        case TailCall:
+        case TailCallInlinedCaller:
+        case Construct:
+        case CallDirectEval:
+        case DirectCall:
+        case DirectConstruct:
+        case DirectTailCall:
+        case DirectTailCallInlinedCaller:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    unsigned numberOfPassedArguments()
+    {
+        ASSERT(hasNumberOfPassedArguments());
+        switch (op()) {
+        case Call:
+        case TailCall:
+        case TailCallInlinedCaller:
+        case Construct:
+        case DirectCall:
+        case DirectConstruct:
+        case DirectTailCall:
+        case DirectTailCallInlinedCaller:
+            return numChildren() - 1;
+        case VirtualCall:
+            // It holds |executable| additionally in varargs tail.
+            return numChildren() - 1 - 1;
+        case CallDirectEval:
+            // It holds |this| and |scope| additionally in varargs tail.
+            return numChildren() - 1 - 2;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return 0;
+        }
     }
 
     unsigned numberOfBoundArguments()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -373,6 +373,7 @@ namespace JSC { namespace DFG {
     /* Calls. */\
     macro(Call, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(DirectCall, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
+    macro(VirtualCall, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(Construct, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(DirectConstruct, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(CallVarargs, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5111,7 +5111,7 @@ JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo* cal
         FunctionExecutable* functionExecutable = static_cast<FunctionExecutable*>(executable);
         RELEASE_ASSERT(isCall(kind) || functionExecutable->constructAbility() != ConstructAbility::CannotConstruct);
 
-        functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee, jsScope, kind, codeBlock);
+        functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsScope, kind, codeBlock);
         OPERATION_RETURN_IF_EXCEPTION(scope);
 
         unsigned argumentStackSlots = callLinkInfo->maxArgumentCountIncludingThis();
@@ -5559,6 +5559,29 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationTriggerOSREntryNow, char*, (VM* vmPoi
     dataLogLnIf(Options::verboseOSR(), *codeBlock, ": Entered triggerOSREntryNow with executeCounter = ", codeBlock->dfgJITData()->tierUpCounter());
 
     return tierUpCommon(vm, callFrame, bytecodeIndex, true);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationVirtualCallWithoutFeedback, ExecutableBase*, (JSGlobalObject* globalObject, JSFunction* callee, ExecutableBase* executable))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    NativeCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    DeferTraps deferTraps(vm); // We can't jettison if we're going to call this CodeBlock.
+    if (!executable->isHostFunction()) {
+        FunctionExecutable* functionExecutable = jsCast<FunctionExecutable*>(executable);
+        CodeBlock* codeBlockSlot = nullptr;
+        functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee->scope(), CodeForCall, codeBlockSlot);
+        OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+
+    // FIXME: Support wasm IC.
+    // https://bugs.webkit.org/show_bug.cgi?id=220339
+    executable->entrypointFor(CodeForCall, MustCheckArity);
+    if (UNLIKELY(scope.exception()))
+        OPERATION_RETURN(scope, nullptr);
+    OPERATION_RETURN(scope, executable);
 }
 
 #endif // ENABLE(FTL_JIT)

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -39,6 +39,7 @@ namespace JSC {
 
 class DateInstance;
 class DirectCallLinkInfo;
+class ExecutableBase;
 class JSBigInt;
 class JSBoundFunction;
 class JSPropertyNameEnumerator;
@@ -439,6 +440,8 @@ JSC_DECLARE_JIT_OPERATION(operationInt64ToBigInt, EncodedJSValue, (JSGlobalObjec
 JSC_DECLARE_JIT_OPERATION(operationProcessTypeProfilerLogDFG, void, (VM*));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationTriggerReoptimizationNow, void, (CodeBlock* baselineCodeBlock, CodeBlock* optimizedCodeBlock, OSRExitBase*));
+
+JSC_DECLARE_JIT_OPERATION(operationVirtualCallWithoutFeedback, ExecutableBase*, (JSGlobalObject*, JSFunction*, ExecutableBase*));
 
 #if USE(JSVALUE32_64)
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationRandom, double, (JSGlobalObject*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1037,6 +1037,7 @@ private:
         case MultiGetByOffset:
         case Call:
         case DirectCall:
+        case VirtualCall:
         case TailCallInlinedCaller:
         case DirectTailCallInlinedCaller:
         case Construct:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -620,6 +620,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case RegExpMatchFastGlobal:
     case Call:
     case DirectCall:
+    case VirtualCall:
     case TailCallInlinedCaller:
     case DirectTailCallInlinedCaller:
     case Construct:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -506,6 +506,9 @@ void SpeculativeJIT::emitCall(Node* node)
     case CallDirectEval:
         callType = CallLinkInfo::Call;
         break;
+    case VirtualCall:
+        callType = CallLinkInfo::Call;
+        break;
     case TailCall:
         callType = CallLinkInfo::TailCall;
         isTail = true;
@@ -688,7 +691,7 @@ void SpeculativeJIT::emitCall(Node* node)
     } else {
         // The call instruction's first child is either the function (normal call) or the
         // receiver (method call). subsequent children are the arguments.
-        numPassedArgs = node->op() == CallDirectEval ? node->numChildren() - 3 : node->numChildren() - 1;
+        numPassedArgs = node->numberOfPassedArguments();
         numAllocatedArgs = numPassedArgs;
         
         if (functionExecutable) {
@@ -3956,6 +3959,7 @@ void SpeculativeJIT::compile(Node* node)
         break;
 
     case DFG::Call:
+    case VirtualCall:
     case TailCall:
     case TailCallInlinedCaller:
     case Construct:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -609,6 +609,9 @@ void SpeculativeJIT::emitCall(Node* node)
     case DFG::Call:
         callType = CallLinkInfo::Call;
         break;
+    case VirtualCall:
+        callType = CallLinkInfo::Call;
+        break;
     case CallDirectEval:
         callType = CallLinkInfo::Call;
         break;
@@ -685,7 +688,6 @@ void SpeculativeJIT::emitCall(Node* node)
         DFG_CRASH(m_graph, node, "bad node type");
         break;
     }
-    UNUSED_VARIABLE(isConstruct);
 
     GPRReg calleeGPR = InvalidGPRReg;
     GPRReg callLinkInfoGPR = InvalidGPRReg;
@@ -794,7 +796,7 @@ void SpeculativeJIT::emitCall(Node* node)
     } else {
         // The call instruction's first child is the function; the subsequent children are the
         // arguments.
-        numPassedArgs = node->op() == CallDirectEval ? node->numChildren() - 3 : node->numChildren() - 1;
+        numPassedArgs = node->numberOfPassedArguments();
         numAllocatedArgs = numPassedArgs;
         
         if (functionExecutable) {
@@ -852,7 +854,7 @@ void SpeculativeJIT::emitCall(Node* node)
             shuffleData.numParameters = codeBlock()->numParameters();
             
             for (unsigned i = 0; i < numPassedArgs; ++i) {
-                Edge argEdge = m_graph.varArgChild(node, i + 1);
+                Edge argEdge = m_graph.child(node, i + 1);
                 GenerationInfo& info = generationInfo(argEdge.node());
                 if (!isDirect)
                     use(argEdge);
@@ -5547,6 +5549,7 @@ void SpeculativeJIT::compile(Node* node)
         break;
 
     case DFG::Call:
+    case VirtualCall:
     case TailCall:
     case TailCallInlinedCaller:
     case Construct:

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1415,6 +1415,9 @@ private:
             break;
         }
 
+        case VirtualCall:
+            break;
+
         case Call:
         case Construct:
         case TailCallInlinedCaller:
@@ -1619,41 +1622,54 @@ private:
 
             // We gave up inlining a wrapped function, but still, we can inline bound function's wrapper by extracting it.
             // This also wipes bound-function thunk call which is suboptimal compared to directly calling a wrapped function here.
-            if (executable->intrinsic() == BoundFunctionCallIntrinsic && function && (m_node->op() == Call || m_node->op() == TailCall || m_node->op() == TailCallInlinedCaller)) {
-                JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(function);
-                if (JSFunction* targetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction())) {
-                    auto* targetExecutable = targetFunction->executable();
-                    if ((boundFunction->boundArgsLength() + m_node->numChildren()) <= Options::maximumDirectCallStackSize()) {
-                        if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(targetExecutable)) {
-                            // We need to update m_parameterSlots before we get to the backend, but we don't
-                            // want to do too much of this.
-                            unsigned numAllocatedArgs = static_cast<unsigned>(functionExecutable->parameterCount()) + 1;
-                            if (numAllocatedArgs <= Options::maximumDirectCallStackSize())
-                                m_graph.m_parameterSlots = std::max(m_graph.m_parameterSlots, Graph::parameterSlotsForArgCount(numAllocatedArgs));
+            if (executable->intrinsic() == BoundFunctionCallIntrinsic && function) {
+                bool didFold = false;
+                switch (m_node->op()) {
+                case Call:
+                case TailCall:
+                case TailCallInlinedCaller: {
+                    JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(function);
+                    if (JSFunction* targetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction())) {
+                        auto* targetExecutable = targetFunction->executable();
+                        if ((boundFunction->boundArgsLength() + m_node->numChildren()) <= Options::maximumDirectCallStackSize()) {
+                            if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(targetExecutable)) {
+                                // We need to update m_parameterSlots before we get to the backend, but we don't
+                                // want to do too much of this.
+                                unsigned numAllocatedArgs = static_cast<unsigned>(functionExecutable->parameterCount()) + 1;
+                                if (numAllocatedArgs <= Options::maximumDirectCallStackSize())
+                                    m_graph.m_parameterSlots = std::max(m_graph.m_parameterSlots, Graph::parameterSlotsForArgCount(numAllocatedArgs));
+                            }
+
+                            unsigned firstChild = m_graph.m_varArgChildren.size();
+                            m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, targetFunction)); // |callee|.
+                            m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, boundFunction->boundThis())); // |this|
+
+                            boundFunction->forEachBoundArg([&](JSValue argument) {
+                                m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, argument));
+                                return IterationStatus::Continue;
+                            });
+
+                            // First one is |callee|, second one is |this|.
+                            for (unsigned index = 2; index < m_node->numChildren(); ++index)
+                                m_graph.m_varArgChildren.append(m_graph.child(m_node, index));
+
+                            m_node->children = AdjacencyList(AdjacencyList::Variable, firstChild, m_graph.m_varArgChildren.size() - firstChild);
+                            m_graph.m_parameterSlots = std::max(m_graph.m_parameterSlots, Graph::parameterSlotsForArgCount(m_node->numChildren() - 1));
+
+                            m_graph.m_plan.recordedStatuses().addCallLinkStatus(m_node->origin.semantic, CallLinkStatus(CallVariant(targetExecutable)));
+                            m_node->convertToDirectCall(m_graph.freeze(targetExecutable));
+                            m_changed = true;
+                            didFold = true;
+                            break;
                         }
-
-                        unsigned firstChild = m_graph.m_varArgChildren.size();
-                        m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, targetFunction)); // |callee|.
-                        m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, boundFunction->boundThis())); // |this|
-
-                        boundFunction->forEachBoundArg([&](JSValue argument) {
-                            m_graph.m_varArgChildren.append(m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, argument));
-                            return IterationStatus::Continue;
-                        });
-
-                        // First one is |callee|, second one is |this|.
-                        for (unsigned index = 2; index < m_node->numChildren(); ++index)
-                            m_graph.m_varArgChildren.append(m_graph.child(m_node, index));
-
-                        m_node->children = AdjacencyList(AdjacencyList::Variable, firstChild, m_graph.m_varArgChildren.size() - firstChild);
-                        m_graph.m_parameterSlots = std::max(m_graph.m_parameterSlots, Graph::parameterSlotsForArgCount(m_node->numChildren() - 1));
-
-                        m_graph.m_plan.recordedStatuses().addCallLinkStatus(m_node->origin.semantic, CallLinkStatus(CallVariant(targetExecutable)));
-                        m_node->convertToDirectCall(m_graph.freeze(targetExecutable));
-                        m_changed = true;
-                        break;
                     }
+                    break;
                 }
+                default:
+                    break;
+                }
+                if (didFold)
+                    break;
             }
 
             if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable)) {

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -186,6 +186,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StoreBarrier:
     case FencedStoreBarrier:
     case Call:
+    case VirtualCall:
     case DirectCall:
     case TailCall:
     case DirectTailCall:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1451,6 +1451,7 @@ private:
         case Call:
         case TailCallInlinedCaller:
         case Construct:
+        case VirtualCall:
             compileCallOrConstruct();
             break;
         case DirectCall:
@@ -11828,9 +11829,10 @@ IGNORE_CLANG_WARNINGS_END
     void compileCallOrConstruct()
     {
         Node* node = m_node;
-        unsigned numArgs = node->numChildren() - 1;
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        unsigned numArgs = node->numberOfPassedArguments();
 
-        LValue jsCallee = lowJSValue(m_graph.varArgChild(node, 0));
+        LValue jsCallee = lowJSValue(m_graph.child(node, 0));
 
         unsigned frameSize = (CallFrame::headerSizeInRegisters + numArgs) * sizeof(EncodedJSValue);
         unsigned alignedFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(frameSize);
@@ -11852,6 +11854,8 @@ IGNORE_CLANG_WARNINGS_END
         // Make sure that the callee goes into GPR0 because that's where the slow path thunks expect the
         // callee to be.
         arguments.append(ConstrainedValue(jsCallee, ValueRep::reg(BaselineJITRegisters::Call::calleeGPR)));
+        if (m_node->op() == VirtualCall)
+            arguments.append(ConstrainedValue(lowCell(m_graph.child(node, 1 + numArgs)), ValueRep::SomeRegister));
 
         auto addArgument = [&] (LValue value, VirtualRegister reg, int offset) {
             intptr_t offsetFromSP =
@@ -11862,13 +11866,14 @@ IGNORE_CLANG_WARNINGS_END
         addArgument(jsCallee, VirtualRegister(CallFrameSlot::callee), 0);
         addArgument(m_out.constInt32(numArgs), VirtualRegister(CallFrameSlot::argumentCountIncludingThis), PayloadOffset);
         for (unsigned i = 0; i < numArgs; ++i)
-            addArgument(lowJSValue(m_graph.varArgChild(node, 1 + i)), virtualRegisterForArgumentIncludingThis(i), 0);
+            addArgument(lowJSValue(m_graph.child(node, 1 + i)), virtualRegisterForArgumentIncludingThis(i), 0);
 
         PatchpointValue* patchpoint = m_out.patchpoint(Int64);
         patchpoint->appendVector(arguments);
+        if (m_node->op() == VirtualCall)
+            patchpoint->numGPScratchRegisters = 1;
 
-        RefPtr<PatchpointExceptionHandle> exceptionHandle =
-            preparePatchpointForExceptions(patchpoint);
+        RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
         patchpoint->append(m_notCellMask, ValueRep::reg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::reg(GPRInfo::numberTagRegister));
@@ -11888,15 +11893,58 @@ IGNORE_CLANG_WARNINGS_END
 
                 exceptionHandle->scheduleExitCreationForUnwind(params, callSiteIndex);
 
-                jit.store32(
-                    CCallHelpers::TrustedImm32(callSiteIndex.bits()),
-                    CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
+                jit.store32(CCallHelpers::TrustedImm32(callSiteIndex.bits()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
-                auto* callLinkInfo = state->addCallLinkInfo(nodeSemanticOrigin);
-                callLinkInfo->setUpCall(nodeOp == Construct ? CallLinkInfo::Construct : CallLinkInfo::Call);
+                switch (nodeOp) {
+                case Construct: {
+                    auto* callLinkInfo = state->addCallLinkInfo(nodeSemanticOrigin);
+                    callLinkInfo->setUpCall(CallLinkInfo::Construct);
+                    CallLinkInfo::emitFastPath(jit, callLinkInfo);
+                    jit.addPtr(CCallHelpers::TrustedImm32(-params.proc().frameSize()), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
+                    break;
+                }
+                case Call:
+                case TailCallInlinedCaller: {
+                    auto* callLinkInfo = state->addCallLinkInfo(nodeSemanticOrigin);
+                    callLinkInfo->setUpCall(CallLinkInfo::Call);
+                    CallLinkInfo::emitFastPath(jit, callLinkInfo);
+                    jit.addPtr(CCallHelpers::TrustedImm32(-params.proc().frameSize()), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
+                    break;
+                }
+                case VirtualCall: {
+                    Box<CCallHelpers::JumpList> exceptions = exceptionHandle->scheduleExitCreation(params)->jumps(jit);
+                    GPRReg calleeGPR = params[1].gpr();
+                    GPRReg executableGPR = params[2].gpr();
+                    GPRReg scratchGPR = params.gpScratch(0);
 
-                CallLinkInfo::emitFastPath(jit, callLinkInfo);
-                jit.addPtr(CCallHelpers::TrustedImm32(-params.proc().frameSize()), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
+                    jit.loadPtr(CCallHelpers::Address(executableGPR, ExecutableBase::offsetOfJITCodeWithArityCheckFor(CodeForCall)), scratchGPR);
+                    auto slow = jit.branchTestPtr(CCallHelpers::Zero, scratchGPR);
+
+                    CCallHelpers::Label mainPath = jit.label();
+                    auto isNative = jit.branchIfNotType(executableGPR, FunctionExecutableType);
+                    jit.transferPtr(CCallHelpers::Address(executableGPR, FunctionExecutable::offsetOfCodeBlockFor(CodeForCall)), CCallHelpers::calleeFrameCodeBlockBeforeCall());
+                    isNative.link(&jit);
+                    jit.call(scratchGPR, JSEntryPtrTag);
+                    jit.addPtr(CCallHelpers::TrustedImm32(-params.proc().frameSize()), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
+
+                    params.addLatePath(
+                        [=](CCallHelpers& jit) {
+                            AllowMacroScratchRegisterUsage allowScratch(jit);
+                            slow.link(&jit);
+                            jit.store32(CCallHelpers::TrustedImm32(callSiteIndex.bits()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
+                            callOperation(
+                                *state, params.unavailableRegisters(), jit,
+                                codeOrigin, exceptions.get(), operationVirtualCallWithoutFeedback,
+                                executableGPR, CCallHelpers::TrustedImmPtr(globalObject), calleeGPR, executableGPR).call();
+                            jit.loadPtr(CCallHelpers::Address(executableGPR, ExecutableBase::offsetOfJITCodeWithArityCheckFor(CodeForCall)), scratchGPR);
+                            jit.jump().linkTo(mainPath, &jit);
+                        });
+                    break;
+                }
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                    break;
+                }
             });
 
         setJSValue(patchpoint);
@@ -11911,7 +11959,7 @@ IGNORE_CLANG_WARNINGS_END
         ExecutableBase* executable = node->castOperand<ExecutableBase*>();
         FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable);
 
-        unsigned numPassedArgs = node->numChildren() - 1;
+        unsigned numPassedArgs = node->numberOfPassedArguments();
         unsigned numAllocatedArgs = numPassedArgs;
 
         if (functionExecutable) {
@@ -12145,7 +12193,7 @@ IGNORE_CLANG_WARNINGS_END
     void compileTailCall()
     {
         Node* node = m_node;
-        unsigned numArgs = node->numChildren() - 1;
+        unsigned numArgs = node->numberOfPassedArguments();
 
         // It seems counterintuitive that this is needed given that tail calls don't create a new frame
         // on the stack. However, the tail call slow path builds the frame at SP instead of FP before
@@ -12846,7 +12894,7 @@ IGNORE_CLANG_WARNINGS_END
     void compileCallDirectEval()
     {
         Node* node = m_node;
-        unsigned numArgs = node->numChildren() - 3; // callee, thisValue, scope
+        unsigned numArgs = node->numberOfPassedArguments(); // callee, thisValue, scope
 
         LValue jsCallee = lowJSValue(m_graph.varArgChild(node, 0));
         LValue thisValue = lowJSValue(m_graph.varArgChild(node, node->numChildren() - 2));

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -48,6 +48,7 @@
 #include "JSMapIterator.h"
 #include "JSSetIterator.h"
 #include "RegExpObject.h"
+#include "RepatchInlines.h"
 #include "ResourceExhaustion.h"
 #include "VMTrapsInlines.h"
 #include <wtf/Assertions.h>

--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -73,7 +73,7 @@ public:
             return;
         }
 
-        auto* newCodeBlock = m_vm.interpreter.prepareForCachedCall(*this, function);
+        auto* newCodeBlock = m_vm.interpreter.prepareForCachedCall(*this);
         if (UNLIKELY(scope.exception()))
             return;
         m_numParameters = newCodeBlock->numParameters();
@@ -125,7 +125,7 @@ public:
     {
         VM& vm = m_vm;
         auto scope = DECLARE_THROW_SCOPE(vm);
-        auto* codeBlock = m_vm.interpreter.prepareForCachedCall(*this, this->function());
+        auto* codeBlock = m_vm.interpreter.prepareForCachedCall(*this);
         RETURN_IF_EXCEPTION(scope, void());
         m_protoCallFrame.setCodeBlock(codeBlock);
     }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1180,7 +1180,7 @@ failedJSONP:
         ProgramCodeBlock* codeBlock;
         {
             CodeBlock* tempCodeBlock;
-            program->prepareForExecution<ProgramExecutable>(vm, nullptr, scope, CodeForCall, tempCodeBlock);
+            program->prepareForExecution<ProgramExecutable>(vm, scope, CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
             codeBlock = jsCast<ProgramCodeBlock*>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
@@ -1275,7 +1275,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
         CodeBlock* newCodeBlock = nullptr;
         if (isJSCall) {
             // Compile the callee:
-            functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(function), functionScope, CodeForCall, newCodeBlock);
+            functionExecutable->prepareForExecution<FunctionExecutable>(vm, functionScope, CodeForCall, newCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
@@ -1374,7 +1374,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
         CodeBlock* newCodeBlock = nullptr;
         if (isJSConstruct) {
             // Compile the callee:
-            constructData.js.functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(constructor), scope, CodeForConstruct, newCodeBlock);
+            constructData.js.functionExecutable->prepareForExecution<FunctionExecutable>(vm, scope, CodeForConstruct, newCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, nullptr);
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
@@ -1402,7 +1402,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
     return asObject(JSValue::decode(result));
 }
 
-CodeBlock* Interpreter::prepareForCachedCall(CachedCall& cachedCall, JSFunction* function)
+CodeBlock* Interpreter::prepareForCachedCall(CachedCall& cachedCall)
 {
     VM& vm = this->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -1410,7 +1410,7 @@ CodeBlock* Interpreter::prepareForCachedCall(CachedCall& cachedCall, JSFunction*
 
     // Compile the callee:
     CodeBlock* newCodeBlock;
-    cachedCall.functionExecutable()->prepareForExecution<FunctionExecutable>(vm, function, cachedCall.scope(), CodeForCall, newCodeBlock);
+    cachedCall.functionExecutable()->prepareForExecution<FunctionExecutable>(vm, cachedCall.scope(), CodeForCall, newCodeBlock);
     RETURN_IF_EXCEPTION(throwScope, { });
 
     ASSERT(newCodeBlock);
@@ -1476,7 +1476,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
     EvalCodeBlock* codeBlock;
     {
         CodeBlock* tempCodeBlock;
-        eval->prepareForExecution<EvalExecutable>(vm, nullptr, scope, CodeForCall, tempCodeBlock);
+        eval->prepareForExecution<EvalExecutable>(vm, scope, CodeForCall, tempCodeBlock);
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
         codeBlock = jsCast<EvalCodeBlock*>(tempCodeBlock);
         ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
@@ -1593,7 +1593,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         // Reload CodeBlock. It is possible that we replaced CodeBlock while setting up the environment.
         {
             CodeBlock* tempCodeBlock;
-            eval->prepareForExecution<EvalExecutable>(vm, nullptr, scope, CodeForCall, tempCodeBlock);
+            eval->prepareForExecution<EvalExecutable>(vm, scope, CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
             codeBlock = jsCast<EvalCodeBlock*>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
@@ -1661,7 +1661,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
         ModuleProgramCodeBlock* codeBlock;
         {
             CodeBlock* tempCodeBlock;
-            executable->prepareForExecution<ModuleProgramExecutable>(vm, nullptr, scope, CodeForCall, tempCodeBlock);
+            executable->prepareForExecution<ModuleProgramExecutable>(vm, scope, CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
             codeBlock = jsCast<ModuleProgramCodeBlock*>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == numberOfArguments + 1);

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -167,7 +167,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
     private:
         enum ExecutionFlag { Normal, InitializeAndReturn };
         
-        CodeBlock* prepareForCachedCall(CachedCall&, JSFunction*);
+        CodeBlock* prepareForCachedCall(CachedCall&);
 
         JSValue executeCachedCall(CachedCall&);
         JSValue executeBoundCall(VM&, JSBoundFunction*, const ArgList&);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -194,7 +194,7 @@ static inline UGPRPair materializeTargetCode(VM& vm, JSFunction* targetFunction)
         if (!executable->isHostFunction()) {
             JSScope* scope = targetFunction->scopeUnchecked();
             FunctionExecutable* functionExecutable = static_cast<FunctionExecutable*>(executable);
-            functionExecutable->prepareForExecution<FunctionExecutable>(vm, targetFunction, scope, CodeForCall, codeBlockSlot);
+            functionExecutable->prepareForExecution<FunctionExecutable>(vm, scope, CodeForCall, codeBlockSlot);
             RETURN_IF_EXCEPTION(throwScope, encodeResult(nullptr, nullptr));
         }
         return encodeResult(executable->entrypointFor(CodeForCall, MustCheckArity).taggedPtr(), codeBlockSlot);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2109,7 +2109,7 @@ static inline UGPRPair setUpCall(CallFrame* calleeFrame, CodeSpecializationKind 
             LLINT_CALL_THROW(globalObject, createNotAConstructorError(globalObject, callee));
 
         CodeBlock** codeBlockSlot = calleeFrame->addressOfCodeBlock();
-        functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee, scope, kind, *codeBlockSlot);
+        functionExecutable->prepareForExecution<FunctionExecutable>(vm, scope, kind, *codeBlockSlot);
         LLINT_CALL_CHECK_EXCEPTION(globalObject);
 
         CodeBlock* codeBlock = *codeBlockSlot;

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -248,7 +248,7 @@ bool ScriptExecutable::hasClearableCode() const
     return false;
 }
 
-CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunction* function, JSScope* scope)
+CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSScope* scope)
 {
     VM& vm = scope->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -262,7 +262,6 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         EvalExecutable* executable = jsCast<EvalExecutable*>(this);
         RELEASE_ASSERT(kind == CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
-        RELEASE_ASSERT(!function);
 
         // FIXME: There might be a case that executable->unlinkedCodeBlock() will be a nullptr 
         // since ScriptExecutable::clearCode might be triggered due to limited memory usage. 
@@ -275,7 +274,6 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         ProgramExecutable* executable = jsCast<ProgramExecutable*>(this);
         RELEASE_ASSERT(kind == CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
-        RELEASE_ASSERT(!function);
         RELEASE_AND_RETURN(throwScope, ProgramCodeBlock::create(vm, executable, executable->unlinkedCodeBlock(), scope));
     }
 
@@ -283,7 +281,6 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         ModuleProgramExecutable* executable = jsCast<ModuleProgramExecutable*>(this);
         RELEASE_ASSERT(kind == CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
-        RELEASE_ASSERT(!function);
 
         UnlinkedModuleProgramCodeBlock* unlinkedCodeBlock = executable->getUnlinkedCodeBlock(globalObject);
         RETURN_IF_EXCEPTION(throwScope, nullptr);
@@ -292,7 +289,6 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
     }
 
     RELEASE_ASSERT(classInfo() == FunctionExecutable::info());
-    RELEASE_ASSERT(function);
     FunctionExecutable* executable = jsCast<FunctionExecutable*>(this);
     RELEASE_ASSERT(!executable->codeBlockFor(kind));
     ParserError error;
@@ -386,7 +382,7 @@ static void setupJIT(VM& vm, CodeBlock* codeBlock)
 #endif
 }
 
-void ScriptExecutable::prepareForExecutionImpl(VM& vm, JSFunction* function, JSScope* scope, CodeSpecializationKind kind, CodeBlock*& resultCodeBlock)
+void ScriptExecutable::prepareForExecutionImpl(VM& vm, JSScope* scope, CodeSpecializationKind kind, CodeBlock*& resultCodeBlock)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     DeferGCForAWhile deferGC(vm);
@@ -397,7 +393,7 @@ void ScriptExecutable::prepareForExecutionImpl(VM& vm, JSFunction* function, JSS
         return;
     }
 
-    CodeBlock* codeBlock = newCodeBlockFor(kind, function, scope);
+    CodeBlock* codeBlock = newCodeBlockFor(kind, scope);
     RETURN_IF_EXCEPTION(throwScope, void());
 
     ASSERT(codeBlock);

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -94,7 +94,7 @@ public:
     void recordParse(CodeFeatures, LexicallyScopedFeatures, bool hasCapturedVariables, int lastLine, unsigned endColumn);
     void installCode(CodeBlock*);
     void installCode(VM&, CodeBlock*, CodeType, CodeSpecializationKind, Profiler::JettisonReason);
-    CodeBlock* newCodeBlockFor(CodeSpecializationKind, JSFunction*, JSScope*);
+    CodeBlock* newCodeBlockFor(CodeSpecializationKind, JSScope*);
     CodeBlock* newReplacementCodeBlockFor(CodeSpecializationKind);
 
     void clearCode(IsoCellSet&);
@@ -120,14 +120,14 @@ public:
     // to point to it. This forces callers to have a CodeBlock* in a register or on the stack that will be marked
     // by conservative GC if a GC happens after we create the CodeBlock.
     template <typename ExecutableType>
-    void prepareForExecution(VM&, JSFunction*, JSScope*, CodeSpecializationKind, CodeBlock*&);
+    void prepareForExecution(VM&, JSScope*, CodeSpecializationKind, CodeBlock*&);
 
     ScriptExecutable* topLevelExecutable();
     JSArray* createTemplateObject(JSGlobalObject*, JSTemplateObjectDescriptor*);
 
 private:
     friend class ExecutableBase;
-    void prepareForExecutionImpl(VM&, JSFunction*, JSScope*, CodeSpecializationKind, CodeBlock*&);
+    void prepareForExecutionImpl(VM&, JSScope*, CodeSpecializationKind, CodeBlock*&);
 
     bool hasClearableCode() const;
 


### PR DESCRIPTION
#### 368083f7c7f173d4978e3bd183fec1df64ca6019
<pre>
[JSC] Add FTL VirtualCall node
<a href="https://bugs.webkit.org/show_bug.cgi?id=290549">https://bugs.webkit.org/show_bug.cgi?id=290549</a>
<a href="https://rdar.apple.com/148034566">rdar://148034566</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::ScriptExecutable::prepareForExecution):
* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::linkFor):
(JSC::virtualForWithFunction):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleCall):
(JSC::DFG::ByteCodeParser::handleInlining):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::attemptToMakeVirtualCall):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToDirectCall):
(JSC::DFG::Node::convertToCallDOM):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasArgumentsChild const):
(JSC::DFG::Node::hasHeapPrediction):
(JSC::DFG::Node::hasSignature const):
(JSC::DFG::Node::hasNumberOfPassedArguments const):
(JSC::DFG::Node::numberOfPassedArguments):
(JSC::DFG::Node::hasArgumentsChild): Deleted.
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::CachedCall):
(JSC::CachedCall::relink):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
(JSC::Interpreter::prepareForCachedCall):
(JSC::Interpreter::executeEval):
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::materializeTargetCode):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::setUpCall):
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::ScriptExecutable::newCodeBlockFor):
(JSC::ScriptExecutable::prepareForExecutionImpl):
* Source/JavaScriptCore/runtime/ScriptExecutable.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/368083f7c7f173d4978e3bd183fec1df64ca6019

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7454 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102719 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25691 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/102719 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88261 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/102719 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47584 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90289 "Found 38 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/es5/defineIndexProperty.js.default, stress/array-prototype-methods-set-length.js.ftl-eager-no-cjit-b3o1, stress/const-semantics.js.ftl-no-cjit-no-put-stack-validate, stress/const-semantics.js.ftl-no-cjit-validate-sampling-profiler, stress/const-tdz.js.bytecode-cache, stress/const-tdz.js.default, stress/const-tdz.js.ftl-no-cjit-no-put-stack-validate, stress/const-tdz.js.ftl-no-cjit-validate-sampling-profiler, stress/date-toLocaleString.js.ftl-eager-no-cjit-b3o1, stress/intl-collator.js.ftl-eager-no-cjit-b3o1 ... (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83074 "Found 2 new API test failures: TestWebKitAPI.ApplePay.ApplePayAvailableInFrame, TestWebKitAPI.WKWebExtensionAPITabs.ExecuteScriptJSONTypes (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104720 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96235 "Found 35 new JSC stress test failures: stress/array-prototype-methods-set-length.js.ftl-eager-no-cjit-b3o1, stress/const-semantics.js.ftl-no-cjit-no-put-stack-validate, stress/const-semantics.js.ftl-no-cjit-validate-sampling-profiler, stress/const-tdz.js.bytecode-cache, stress/const-tdz.js.default, stress/const-tdz.js.ftl-no-cjit-no-put-stack-validate, stress/const-tdz.js.ftl-no-cjit-validate-sampling-profiler, stress/date-toLocaleString.js.ftl-eager-no-cjit-b3o1, stress/intl-collator.js.ftl-eager-no-cjit-b3o1, stress/intl-durationformat.js.ftl-eager-no-cjit-b3o1 ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24693 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18008 "Found 2 new test failures: fast/workers/use-machine-stack.html imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83418 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82847 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29823 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24476 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33646 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->