### PR TITLE
Address Safer CPP Warnings in AnimationEffect.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -271,7 +271,6 @@ accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
-animation/AnimationEffect.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationTimeline.cpp
 animation/AnimationTimelinesController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -125,7 +125,6 @@ accessibility/mac/AXObjectCacheMac.mm
 accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 accessibility/mac/WebAccessibilityObjectWrapperMac.mm
-animation/AnimationEffect.cpp
 animation/AnimationTimeline.cpp
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -59,7 +59,7 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
 
 EffectTiming AnimationEffect::getBindingsTiming() const
 {
-    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+    if (RefPtr styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
         styleOriginatedAnimation->flushPendingStyleChanges();
 
     EffectTiming timing;
@@ -73,7 +73,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     else
         timing.duration = autoAtom();
     timing.direction = m_timing.direction;
-    timing.easing = m_timing.timingFunction->cssText();
+    timing.easing = RefPtr { m_timing.timingFunction }->cssText();
     return timing;
 }
 
@@ -101,7 +101,7 @@ BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<WebAnimationTime
 
 ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
 {
-    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+    if (RefPtr styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
         styleOriginatedAnimation->flushPendingStyleChanges();
     return getComputedTiming();
 }
@@ -134,7 +134,7 @@ ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<WebAnimati
     computedTiming.iterations = m_timing.iterations;
     computedTiming.duration = computedDuration;
     computedTiming.direction = m_timing.direction;
-    computedTiming.easing = m_timing.timingFunction->cssText();
+    computedTiming.easing = RefPtr { m_timing.timingFunction }->cssText();
     computedTiming.endTime = m_timing.endTime;
     computedTiming.activeDuration = m_timing.activeDuration;
     computedTiming.localTime = data.localTime;
@@ -150,7 +150,7 @@ ExceptionOr<void> AnimationEffect::bindingsUpdateTiming(Document& document, std:
 {
     auto retVal = updateTiming(document, timing);
     if (!retVal.hasException() && timing) {
-        if (auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation()))
+        if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation()))
             cssAnimation->effectTimingWasUpdatedUsingBindings(*timing);
     }
     return retVal;
@@ -248,8 +248,8 @@ ExceptionOr<void> AnimationEffect::updateTiming(Document& document, std::optiona
     if (auto direction = timing->direction)
         setDirection(*direction);
 
-    if (m_animation)
-        m_animation->effectTimingDidChange();
+    if (RefPtr animation = m_animation.get())
+        animation->effectTimingDidChange();
 
     return { };
 }
@@ -441,15 +441,16 @@ void AnimationEffect::updateComputedTimingPropertiesIfNeeded()
     }();
 
     auto rangeDuration = [&] -> std::optional<WebAnimationTime> {
-        if (!m_animation)
+        RefPtr animation = m_animation.get();
+        if (!animation)
             return std::nullopt;
 
-        RefPtr timeline = m_animation->timeline();
+        RefPtr timeline = animation->timeline();
         if (!timeline)
             return std::nullopt;
 
         if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(timeline)) {
-            auto interval = scrollTimeline->intervalForAttachmentRange(m_animation->range());
+            auto interval = scrollTimeline->intervalForAttachmentRange(animation->range());
             return interval.second - interval.first;
         }
 


### PR DESCRIPTION
#### 04976445ff23b60636e104853a41d9225a5e3839
<pre>
Address Safer CPP Warnings in AnimationEffect.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290553">https://bugs.webkit.org/show_bug.cgi?id=290553</a>
<a href="https://rdar.apple.com/problem/148041002">rdar://problem/148041002</a>

Reviewed by Ryosuke Niwa.

Address Safer CPP Warnings in AnimationEffect.cpp

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::getBindingsComputedTiming):
(WebCore::AnimationEffect::getComputedTiming):
(WebCore::AnimationEffect::bindingsUpdateTiming):
(WebCore::AnimationEffect::updateTiming):
(WebCore::AnimationEffect::updateComputedTimingPropertiesIfNeeded):

Canonical link: <a href="https://commits.webkit.org/292823@main">https://commits.webkit.org/292823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60fa18f93487f6c25de577bab511f34018a04039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74075 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100231 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12961 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47195 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83118 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20757 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29418 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->