### PR TITLE
[css-anchor-position-1] Implement swapping due to a try-tactic for position-area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL anchor-scroll-position-try-013 assert_equals: Anchored element should be at the top of anchor expected 159 but got 209
-FAIL anchor-scroll-position-try-013 1 assert_equals: Anchored element should be at the bottom of anchor expected 159 but got 109
-FAIL anchor-scroll-position-try-013 2 assert_equals: Anchored element should be at the top of anchor expected 119 but got 169
+PASS anchor-scroll-position-try-013
+FAIL anchor-scroll-position-try-013 1 assert_equals: Anchored element should be at the bottom of anchor expected 159 but got 59
+PASS anchor-scroll-position-try-013 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL anchor-scroll-position-try-014 assert_equals: Anchored element should be at the bottom of anchor expected 44 but got -6
-FAIL anchor-scroll-position-try-014 1 assert_equals: Anchored element should be at the top of anchor expected 9 but got 59
-FAIL anchor-scroll-position-try-014 2 assert_equals: Anchored element should be at the bottom of anchor expected 59 but got 9
+PASS anchor-scroll-position-try-014
+FAIL anchor-scroll-position-try-014 1 assert_equals: Anchored element should be at the top of anchor expected 9 but got 109
+PASS anchor-scroll-position-try-014 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+PASS Starts rendering with flip-block
 FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
 PASS Base position without fallback now successful
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+PASS Starts rendering with flip-block
 FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
 FAIL No successful position, last successful invalidated by position-try-fallbacks change assert_equals: expected -50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+PASS Starts rendering with flip-block
 FAIL No successful position, keep flip-block assert_equals: expected 250 but got 0
 PASS Base position without fallback now successful
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Starts rendering with flip-block assert_equals: expected 200 but got 0
+PASS Starts rendering with flip-block
 FAIL No successful position (with intermediate successful), keep flip-block assert_equals: expected 250 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt
@@ -52,10 +52,10 @@ PASS Placement: --bottom, --top
 PASS Placement: --bottom, --right, --top
 PASS Placement: --bottom, --right, --left, --top
 PASS Placement: --bottom, --left, --top, --right
-FAIL Placement: --right flip-inline assert_equals: offsetLeft expected 40 but got 140
-FAIL Placement: --bottom flip-block assert_equals: offsetLeft expected 95 but got 140
-FAIL Placement: --left flip-start assert_equals: offsetLeft expected 95 but got 40
-FAIL Placement: --left flip-inline, --top assert_equals: offsetLeft expected 95 but got 40
-FAIL Placement: --top flip-block, --left assert_equals: offsetLeft expected 40 but got 95
+PASS Placement: --right flip-inline
+PASS Placement: --bottom flip-block
+PASS Placement: --left flip-start
+PASS Placement: --left flip-inline, --top
+PASS Placement: --top flip-block, --left
 PASS Placement: --left flip-start flip-block, --left
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-position-area-expected.txt
@@ -1,133 +1,133 @@
 
-FAIL flip-inline, position-area:left top, ltr horizontal-tb assert_equals: expected "right top" but got "left top"
-FAIL flip-inline, position-area:left bottom, ltr horizontal-tb assert_equals: expected "right bottom" but got "left bottom"
-FAIL flip-inline, position-area:right bottom, ltr horizontal-tb assert_equals: expected "left bottom" but got "right bottom"
-FAIL flip-inline, position-area:right top, ltr horizontal-tb assert_equals: expected "left top" but got "right top"
-FAIL flip-block, position-area:left top, ltr horizontal-tb assert_equals: expected "left bottom" but got "left top"
-FAIL flip-block, position-area:left bottom, ltr horizontal-tb assert_equals: expected "left top" but got "left bottom"
-FAIL flip-block, position-area:right bottom, ltr horizontal-tb assert_equals: expected "right top" but got "right bottom"
-FAIL flip-block, position-area:right top, ltr horizontal-tb assert_equals: expected "right bottom" but got "right top"
-FAIL flip-block flip-inline, position-area:left top, ltr horizontal-tb assert_equals: expected "right bottom" but got "left top"
-FAIL flip-block flip-inline, position-area:left bottom, ltr horizontal-tb assert_equals: expected "right top" but got "left bottom"
-FAIL flip-block flip-inline, position-area:right bottom, ltr horizontal-tb assert_equals: expected "left top" but got "right bottom"
-FAIL flip-block flip-inline, position-area:right top, ltr horizontal-tb assert_equals: expected "left bottom" but got "right top"
+PASS flip-inline, position-area:left top, ltr horizontal-tb
+PASS flip-inline, position-area:left bottom, ltr horizontal-tb
+PASS flip-inline, position-area:right bottom, ltr horizontal-tb
+PASS flip-inline, position-area:right top, ltr horizontal-tb
+PASS flip-block, position-area:left top, ltr horizontal-tb
+PASS flip-block, position-area:left bottom, ltr horizontal-tb
+PASS flip-block, position-area:right bottom, ltr horizontal-tb
+PASS flip-block, position-area:right top, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:left top, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:left bottom, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:right bottom, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:right top, ltr horizontal-tb
 PASS flip-start, position-area:left top, ltr horizontal-tb
-FAIL flip-start, position-area:left bottom, ltr horizontal-tb assert_equals: expected "right top" but got "left bottom"
+PASS flip-start, position-area:left bottom, ltr horizontal-tb
 PASS flip-start, position-area:right bottom, ltr horizontal-tb
-FAIL flip-start, position-area:right top, ltr horizontal-tb assert_equals: expected "left bottom" but got "right top"
-FAIL flip-block flip-start, position-area:left top, ltr horizontal-tb assert_equals: expected "right top" but got "left top"
-FAIL flip-block flip-start, position-area:left bottom, ltr horizontal-tb assert_equals: expected "left top" but got "left bottom"
-FAIL flip-block flip-start, position-area:right bottom, ltr horizontal-tb assert_equals: expected "left bottom" but got "right bottom"
-FAIL flip-block flip-start, position-area:right top, ltr horizontal-tb assert_equals: expected "right bottom" but got "right top"
-FAIL flip-inline flip-start, position-area:left top, ltr horizontal-tb assert_equals: expected "left bottom" but got "left top"
-FAIL flip-inline flip-start, position-area:left bottom, ltr horizontal-tb assert_equals: expected "right bottom" but got "left bottom"
-FAIL flip-inline flip-start, position-area:right bottom, ltr horizontal-tb assert_equals: expected "right top" but got "right bottom"
-FAIL flip-inline flip-start, position-area:right top, ltr horizontal-tb assert_equals: expected "left top" but got "right top"
-FAIL flip-block flip-inline flip-start, position-area:left top, ltr horizontal-tb assert_equals: expected "right bottom" but got "left top"
+PASS flip-start, position-area:right top, ltr horizontal-tb
+PASS flip-block flip-start, position-area:left top, ltr horizontal-tb
+PASS flip-block flip-start, position-area:left bottom, ltr horizontal-tb
+PASS flip-block flip-start, position-area:right bottom, ltr horizontal-tb
+PASS flip-block flip-start, position-area:right top, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:left top, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:left bottom, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:right bottom, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:right top, ltr horizontal-tb
+PASS flip-block flip-inline flip-start, position-area:left top, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:left bottom, ltr horizontal-tb
-FAIL flip-block flip-inline flip-start, position-area:right bottom, ltr horizontal-tb assert_equals: expected "left top" but got "right bottom"
+PASS flip-block flip-inline flip-start, position-area:right bottom, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:right top, ltr horizontal-tb
-FAIL flip-block flip-inline, position-area:span-left span-top, ltr horizontal-tb assert_equals: expected "span-right span-bottom" but got "span-left span-top"
-FAIL flip-inline, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-start y-start"
-FAIL flip-inline, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-start y-end"
-FAIL flip-inline, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-end y-end"
-FAIL flip-inline, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-end y-start"
-FAIL flip-block, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-start y-start"
-FAIL flip-block, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-start y-end"
-FAIL flip-block, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-end y-end"
-FAIL flip-block, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-end y-start"
-FAIL flip-block flip-inline, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-start y-start"
-FAIL flip-block flip-inline, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-start y-end"
-FAIL flip-block flip-inline, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-end y-end"
-FAIL flip-block flip-inline, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-end y-start"
+PASS flip-block flip-inline, position-area:span-left span-top, ltr horizontal-tb
+PASS flip-inline, position-area:x-start y-start, ltr horizontal-tb
+PASS flip-inline, position-area:x-start y-end, ltr horizontal-tb
+PASS flip-inline, position-area:x-end y-end, ltr horizontal-tb
+PASS flip-inline, position-area:x-end y-start, ltr horizontal-tb
+PASS flip-block, position-area:x-start y-start, ltr horizontal-tb
+PASS flip-block, position-area:x-start y-end, ltr horizontal-tb
+PASS flip-block, position-area:x-end y-end, ltr horizontal-tb
+PASS flip-block, position-area:x-end y-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:x-start y-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:x-start y-end, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:x-end y-end, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:x-end y-start, ltr horizontal-tb
 PASS flip-start, position-area:x-start y-start, ltr horizontal-tb
-FAIL flip-start, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-start y-end"
+PASS flip-start, position-area:x-start y-end, ltr horizontal-tb
 PASS flip-start, position-area:x-end y-end, ltr horizontal-tb
-FAIL flip-start, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-end y-start"
-FAIL flip-block flip-start, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-start y-start"
-FAIL flip-block flip-start, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-start y-end"
-FAIL flip-block flip-start, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-end y-end"
-FAIL flip-block flip-start, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-end y-start"
-FAIL flip-inline flip-start, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-start y-end" but got "x-start y-start"
-FAIL flip-inline flip-start, position-area:x-start y-end, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-start y-end"
-FAIL flip-inline flip-start, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-end y-start" but got "x-end y-end"
-FAIL flip-inline flip-start, position-area:x-end y-start, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-end y-start"
-FAIL flip-block flip-inline flip-start, position-area:x-start y-start, ltr horizontal-tb assert_equals: expected "x-end y-end" but got "x-start y-start"
+PASS flip-start, position-area:x-end y-start, ltr horizontal-tb
+PASS flip-block flip-start, position-area:x-start y-start, ltr horizontal-tb
+PASS flip-block flip-start, position-area:x-start y-end, ltr horizontal-tb
+PASS flip-block flip-start, position-area:x-end y-end, ltr horizontal-tb
+PASS flip-block flip-start, position-area:x-end y-start, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:x-start y-start, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:x-start y-end, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:x-end y-end, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:x-end y-start, ltr horizontal-tb
+PASS flip-block flip-inline flip-start, position-area:x-start y-start, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:x-start y-end, ltr horizontal-tb
-FAIL flip-block flip-inline flip-start, position-area:x-end y-end, ltr horizontal-tb assert_equals: expected "x-start y-start" but got "x-end y-end"
+PASS flip-block flip-inline flip-start, position-area:x-end y-end, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:x-end y-start, ltr horizontal-tb
-FAIL flip-block flip-inline, position-area:span-x-start span-y-start, ltr horizontal-tb assert_equals: expected "span-x-end span-y-end" but got "span-x-start span-y-start"
-FAIL flip-block flip-inline, position-area:x-self-start y-self-start, ltr horizontal-tb assert_equals: expected "x-self-end y-self-end" but got "x-self-start y-self-start"
-FAIL flip-block flip-inline, position-area:span-x-self-start span-y-self-start, ltr horizontal-tb assert_equals: expected "span-x-self-end span-y-self-end" but got "span-x-self-start span-y-self-start"
-FAIL flip-inline, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-start inline-start"
-FAIL flip-inline, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-end inline-start"
-FAIL flip-inline, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-end inline-end"
-FAIL flip-inline, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-start inline-end"
-FAIL flip-block, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-start inline-start"
-FAIL flip-block, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-end inline-start"
-FAIL flip-block, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-end inline-end"
-FAIL flip-block, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-start inline-end"
-FAIL flip-block flip-inline, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-start inline-start"
-FAIL flip-block flip-inline, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-end inline-start"
-FAIL flip-block flip-inline, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-end inline-end"
-FAIL flip-block flip-inline, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-start inline-end"
+PASS flip-block flip-inline, position-area:span-x-start span-y-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:x-self-start y-self-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:span-x-self-start span-y-self-start, ltr horizontal-tb
+PASS flip-inline, position-area:block-start inline-start, ltr horizontal-tb
+PASS flip-inline, position-area:block-end inline-start, ltr horizontal-tb
+PASS flip-inline, position-area:block-end inline-end, ltr horizontal-tb
+PASS flip-inline, position-area:block-start inline-end, ltr horizontal-tb
+PASS flip-block, position-area:block-start inline-start, ltr horizontal-tb
+PASS flip-block, position-area:block-end inline-start, ltr horizontal-tb
+PASS flip-block, position-area:block-end inline-end, ltr horizontal-tb
+PASS flip-block, position-area:block-start inline-end, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:block-start inline-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:block-end inline-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:block-end inline-end, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:block-start inline-end, ltr horizontal-tb
 PASS flip-start, position-area:block-start inline-start, ltr horizontal-tb
-FAIL flip-start, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-end inline-start"
+PASS flip-start, position-area:block-end inline-start, ltr horizontal-tb
 PASS flip-start, position-area:block-end inline-end, ltr horizontal-tb
-FAIL flip-start, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-start inline-end"
-FAIL flip-block flip-start, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-start inline-start"
-FAIL flip-block flip-start, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-end inline-start"
-FAIL flip-block flip-start, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-end inline-end"
-FAIL flip-block flip-start, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-start inline-end"
-FAIL flip-inline flip-start, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-start" but got "block-start inline-start"
-FAIL flip-inline flip-start, position-area:block-end inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-end inline-start"
-FAIL flip-inline flip-start, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-end" but got "block-end inline-end"
-FAIL flip-inline flip-start, position-area:block-start inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-start inline-end"
-FAIL flip-block flip-inline flip-start, position-area:block-start inline-start, ltr horizontal-tb assert_equals: expected "block-end inline-end" but got "block-start inline-start"
+PASS flip-start, position-area:block-start inline-end, ltr horizontal-tb
+PASS flip-block flip-start, position-area:block-start inline-start, ltr horizontal-tb
+PASS flip-block flip-start, position-area:block-end inline-start, ltr horizontal-tb
+PASS flip-block flip-start, position-area:block-end inline-end, ltr horizontal-tb
+PASS flip-block flip-start, position-area:block-start inline-end, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:block-start inline-start, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:block-end inline-start, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:block-end inline-end, ltr horizontal-tb
+PASS flip-inline flip-start, position-area:block-start inline-end, ltr horizontal-tb
+PASS flip-block flip-inline flip-start, position-area:block-start inline-start, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:block-end inline-start, ltr horizontal-tb
-FAIL flip-block flip-inline flip-start, position-area:block-end inline-end, ltr horizontal-tb assert_equals: expected "block-start inline-start" but got "block-end inline-end"
+PASS flip-block flip-inline flip-start, position-area:block-end inline-end, ltr horizontal-tb
 PASS flip-block flip-inline flip-start, position-area:block-start inline-end, ltr horizontal-tb
-FAIL flip-block flip-inline, position-area:span-block-start span-inline-start, ltr horizontal-tb assert_equals: expected "span-block-end span-inline-end" but got "span-block-start span-inline-start"
-FAIL flip-block flip-inline, position-area:self-block-start self-inline-start, ltr horizontal-tb assert_equals: expected "self-block-end self-inline-end" but got "self-block-start self-inline-start"
-FAIL flip-block flip-inline, position-area:span-self-block-start span-self-inline-start, ltr horizontal-tb assert_equals: expected "span-self-block-end span-self-inline-end" but got "span-self-block-start span-self-inline-start"
+PASS flip-block flip-inline, position-area:span-block-start span-inline-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:self-block-start self-inline-start, ltr horizontal-tb
+PASS flip-block flip-inline, position-area:span-self-block-start span-self-inline-start, ltr horizontal-tb
 FAIL , position-area:start end, ltr horizontal-tb assert_equals: expected "start end" but got "block-start inline-end"
-FAIL flip-block, position-area:start end, ltr horizontal-tb assert_equals: expected "end" but got "block-start inline-end"
-FAIL flip-inline, position-area:start end, ltr horizontal-tb assert_equals: expected "start" but got "block-start inline-end"
-FAIL flip-block flip-inline, position-area:start end, ltr horizontal-tb assert_equals: expected "end start" but got "block-start inline-end"
+FAIL flip-block, position-area:start end, ltr horizontal-tb assert_equals: expected "end" but got "block-end inline-end"
+FAIL flip-inline, position-area:start end, ltr horizontal-tb assert_equals: expected "start" but got "block-start inline-start"
+FAIL flip-block flip-inline, position-area:start end, ltr horizontal-tb assert_equals: expected "end start" but got "block-end inline-start"
 FAIL flip-start, position-area:start, ltr horizontal-tb assert_equals: expected "start" but got "block-start inline-start"
 FAIL flip-start, position-area:end, ltr horizontal-tb assert_equals: expected "end" but got "block-end inline-end"
-FAIL flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "end start" but got "block-start inline-end"
-FAIL flip-block flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "end" but got "block-start inline-end"
-FAIL flip-inline flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "start" but got "block-start inline-end"
+FAIL flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "end start" but got "block-end inline-start"
+FAIL flip-block flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "end" but got "block-end inline-end"
+FAIL flip-inline flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "start" but got "block-start inline-start"
 FAIL flip-block flip-inline flip-start, position-area:start end, ltr horizontal-tb assert_equals: expected "start end" but got "block-start inline-end"
-FAIL flip-block flip-inline, position-area:span-start span-end, ltr horizontal-tb assert_equals: expected "span-end span-start" but got "span-block-start span-inline-end"
-FAIL flip-block flip-inline, position-area:self-start self-end, ltr horizontal-tb assert_equals: expected "self-end self-start" but got "self-block-start self-inline-end"
-FAIL flip-block flip-inline, position-area:span-self-start span-self-end, ltr horizontal-tb assert_equals: expected "span-self-end span-self-start" but got "span-self-block-start span-self-inline-end"
+FAIL flip-block flip-inline, position-area:span-start span-end, ltr horizontal-tb assert_equals: expected "span-end span-start" but got "span-block-end span-inline-start"
+FAIL flip-block flip-inline, position-area:self-start self-end, ltr horizontal-tb assert_equals: expected "self-end self-start" but got "self-block-end self-inline-start"
+FAIL flip-block flip-inline, position-area:span-self-start span-self-end, ltr horizontal-tb assert_equals: expected "span-self-end span-self-start" but got "span-self-block-end span-self-inline-start"
 PASS flip-block, position-area:left center, ltr horizontal-tb
-FAIL flip-block, position-area:center top, ltr horizontal-tb assert_equals: expected "center bottom" but got "center top"
+PASS flip-block, position-area:center top, ltr horizontal-tb
 PASS flip-block, position-area:center, ltr horizontal-tb
-FAIL flip-block, position-area:start center, ltr horizontal-tb assert_equals: expected "end center" but got "block-start center"
+FAIL flip-block, position-area:start center, ltr horizontal-tb assert_equals: expected "end center" but got "block-end center"
 FAIL flip-block, position-area:center start, ltr horizontal-tb assert_equals: expected "center start" but got "center inline-start"
-FAIL flip-inline, position-area:center start, ltr horizontal-tb assert_equals: expected "center end" but got "center inline-start"
-FAIL flip-start, position-area:center start, ltr horizontal-tb assert_equals: expected "start center" but got "center inline-start"
+FAIL flip-inline, position-area:center start, ltr horizontal-tb assert_equals: expected "center end" but got "center inline-end"
+FAIL flip-start, position-area:center start, ltr horizontal-tb assert_equals: expected "start center" but got "block-start center"
 PASS flip-block, position-area:left span-all, ltr horizontal-tb
-FAIL flip-block, position-area:span-all top, ltr horizontal-tb assert_equals: expected "bottom" but got "top"
+PASS flip-block, position-area:span-all top, ltr horizontal-tb
 PASS flip-block, position-area:span-all, ltr horizontal-tb
-FAIL flip-block, position-area:start span-all, ltr horizontal-tb assert_equals: expected "end span-all" but got "block-start"
+FAIL flip-block, position-area:start span-all, ltr horizontal-tb assert_equals: expected "end span-all" but got "block-end"
 FAIL flip-block, position-area:span-all start, ltr horizontal-tb assert_equals: expected "span-all start" but got "inline-start"
-FAIL flip-inline, position-area:span-all start, ltr horizontal-tb assert_equals: expected "span-all end" but got "inline-start"
-FAIL flip-start, position-area:span-all start, ltr horizontal-tb assert_equals: expected "start span-all" but got "inline-start"
-FAIL flip-block, position-area:left span-top, ltr horizontal-tb assert_equals: expected "left span-bottom" but got "left span-top"
-FAIL flip-inline, position-area:left span-top, ltr horizontal-tb assert_equals: expected "right span-top" but got "left span-top"
-FAIL flip-start, position-area:span-block-start inline-end, ltr horizontal-tb assert_equals: expected "block-end span-inline-start" but got "span-block-start inline-end"
-FAIL flip-block, position-area:left top, ltr vertical-rl assert_equals: expected "right top" but got "left top"
+FAIL flip-inline, position-area:span-all start, ltr horizontal-tb assert_equals: expected "span-all end" but got "inline-end"
+FAIL flip-start, position-area:span-all start, ltr horizontal-tb assert_equals: expected "start span-all" but got "block-start"
+PASS flip-block, position-area:left span-top, ltr horizontal-tb
+PASS flip-inline, position-area:left span-top, ltr horizontal-tb
+PASS flip-start, position-area:span-block-start inline-end, ltr horizontal-tb
+PASS flip-block, position-area:left top, ltr vertical-rl
 PASS , position-area:x-start y-start, rtl horizontal-tb
-FAIL flip-block, position-area:x-start y-start, rtl horizontal-tb assert_equals: expected "x-start y-end" but got "x-start y-start"
-FAIL flip-inline, position-area:x-start y-start, rtl horizontal-tb assert_equals: expected "x-end y-start" but got "x-start y-start"
-FAIL flip-block, position-area:x-end y-start, ltr vertical-rl assert_equals: expected "x-start y-start" but got "x-end y-start"
-FAIL flip-inline, position-area:x-end y-start, ltr vertical-rl assert_equals: expected "x-end y-end" but got "x-end y-start"
-FAIL flip-inline, position-area:start end, rtl horizontal-tb assert_equals: expected "start" but got "block-start inline-end"
-FAIL flip-inline, position-area:start end, ltr vertical-rl assert_equals: expected "start" but got "block-start inline-end"
-FAIL flip-block, position-area:start end, rtl horizontal-tb assert_equals: expected "end" but got "block-start inline-end"
-FAIL flip-block, position-area:start end, ltr vertical-rl assert_equals: expected "end" but got "block-start inline-end"
+PASS flip-block, position-area:x-start y-start, rtl horizontal-tb
+PASS flip-inline, position-area:x-start y-start, rtl horizontal-tb
+PASS flip-block, position-area:x-end y-start, ltr vertical-rl
+PASS flip-inline, position-area:x-end y-start, ltr vertical-rl
+FAIL flip-inline, position-area:start end, rtl horizontal-tb assert_equals: expected "start" but got "block-start inline-start"
+FAIL flip-inline, position-area:start end, ltr vertical-rl assert_equals: expected "start" but got "block-start inline-start"
+FAIL flip-block, position-area:start end, rtl horizontal-tb assert_equals: expected "end" but got "block-end inline-end"
+FAIL flip-block, position-area:start end, ltr vertical-rl assert_equals: expected "end" but got "block-end inline-end"
 

--- a/Source/WebCore/rendering/style/PositionArea.cpp
+++ b/Source/WebCore/rendering/style/PositionArea.cpp
@@ -164,10 +164,9 @@ ItemPosition PositionArea::defaultAlignmentForAxis(BoxAxis physicalAxis, Writing
     return containerWritingMode.isBlockFlipped() ? flip(alignment) : alignment;
 }
 
-WTF::TextStream& operator<<(WTF::TextStream& ts, const PositionAreaSpan& span)
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionAreaAxis axis)
 {
-    ts << "{ axis: "_s;
-    switch (span.axis()) {
+    switch (axis) {
     case PositionAreaAxis::Horizontal: ts << "horizontal"_s; break;
     case PositionAreaAxis::Vertical:   ts << "vertical"_s; break;
     case PositionAreaAxis::X:          ts << 'x'; break;
@@ -176,8 +175,12 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PositionAreaSpan& span)
     case PositionAreaAxis::Inline:     ts << "inline"_s; break;
     }
 
-    ts << ", track: "_s;
-    switch (span.track()) {
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionAreaTrack track)
+{
+    switch (track) {
     case PositionAreaTrack::Start:     ts << "start"_s; break;
     case PositionAreaTrack::SpanStart: ts << "span-start"_s; break;
     case PositionAreaTrack::End:       ts << "end"_s; break;
@@ -186,18 +189,26 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PositionAreaSpan& span)
     case PositionAreaTrack::SpanAll:   ts << "span-all"_s; break;
     }
 
-    ts << ", self: "_s;
-    switch (span.self()) {
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionAreaSelf self)
+{
+    switch (self) {
     case PositionAreaSelf::No:  ts << "no"_s; break;
     case PositionAreaSelf::Yes: ts << "yes"_s; break;
     }
 
-    ts << " }"_s;
-
     return ts;
 }
 
-WTF::TextStream& operator<<(WTF::TextStream& ts, const PositionArea& positionArea)
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionAreaSpan span)
+{
+    ts << "{ axis: "_s << span.axis() << ", track: "_s << span.track() << ", self: "_s << span.self() << " }"_s;
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PositionArea positionArea)
 {
     ts << "{ span1: "_s << positionArea.blockOrXAxis() << ", span2: "_s << positionArea.inlineOrYAxis() << " }"_s;
     return ts;

--- a/Source/WebCore/rendering/style/PositionArea.h
+++ b/Source/WebCore/rendering/style/PositionArea.h
@@ -47,6 +47,32 @@ enum class PositionAreaAxis : uint8_t {
     Block  = 0b111,
 };
 
+WTF::TextStream& operator<<(WTF::TextStream&, PositionAreaAxis);
+
+// Get the opposite axis of a given axis.
+static inline PositionAreaAxis oppositePositionAreaAxis(PositionAreaAxis axis)
+{
+    switch (axis) {
+    case PositionAreaAxis::Horizontal:
+        return PositionAreaAxis::Vertical;
+    case PositionAreaAxis::Vertical:
+        return PositionAreaAxis::Horizontal;
+
+    case PositionAreaAxis::X:
+        return PositionAreaAxis::Y;
+    case PositionAreaAxis::Y:
+        return PositionAreaAxis::X;
+
+    case PositionAreaAxis::Block:
+        return PositionAreaAxis::Inline;
+    case PositionAreaAxis::Inline:
+        return PositionAreaAxis::Block;
+    }
+
+    ASSERT_NOT_REACHED();
+    return PositionAreaAxis::Horizontal;
+}
+
 static inline bool isPositionAreaAxisLogical(const PositionAreaAxis positionAxis)
 {
     static const uint8_t axisBit = 0b100;
@@ -88,6 +114,8 @@ enum class PositionAreaTrack : uint8_t {
     SpanAll   = 0b111, // All tracks along the axis.
 };
 
+WTF::TextStream& operator<<(WTF::TextStream&, PositionAreaTrack);
+
 static inline PositionAreaTrack flipPositionAreaTrack(PositionAreaTrack track)
 {
     // We need to cast values out of the enum type restrictions in order to do math.
@@ -114,6 +142,8 @@ enum class PositionAreaSelf : bool {
     // Use the writing mode of the element itself.
     Yes
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, PositionAreaSelf);
 
 // A span in the position-area. position-area requires two spans of opposite
 // axis to determine the containing block area.
@@ -155,7 +185,7 @@ private:
     uint8_t m_self : 1;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, const PositionAreaSpan&);
+WTF::TextStream& operator<<(WTF::TextStream&, PositionAreaSpan);
 
 // A position-area is formed by two spans of opposite axes, that uniquely determine
 // the area of the containing block.
@@ -180,6 +210,6 @@ private:
     PositionAreaSpan m_inlineOrYAxis;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, const PositionArea&);
+WTF::TextStream& operator<<(WTF::TextStream&, PositionArea);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0942066d2a6f912865487ac2d673bebd5178c13d
<pre>
[css-anchor-position-1] Implement swapping due to a try-tactic for position-area
<a href="https://rdar.apple.com/146814606">rdar://146814606</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289589">https://bugs.webkit.org/show_bug.cgi?id=289589</a>

Reviewed by Antti Koivisto.

This commit implements swapping due to a try-tactic [1] for position-area.
This is done at style building time; BuilderConverter::convertPositionArea
will flip position-area as specified by the position-try fallback. This is
needed instead of flipping position-area at layout time, because
position-area should compute to the flipped value.

There are some remaining test failures in try-tactic-position-area.html;
these has to do with how position-area should be computed. The test expects
the computed value of position-area to use axis-ambiguous keywords, when the
specified value also uses those keywords (e.g: &apos;start end&apos; computes to
&apos;start end&apos;). However, WebKit currently computes to their axis-unambiguous
equivalent (e.g: &apos;start end&apos; computes to &apos;block-start block-end&apos;).
This issue is tracked in [2].

[1]: <a href="https://drafts.csswg.org/css-anchor-position-1/#swap-due-to-a-try-tactic">https://drafts.csswg.org/css-anchor-position-1/#swap-due-to-a-try-tactic</a>
[2]: <a href="https://github.com/w3c/csswg-drafts/issues/11828">https://github.com/w3c/csswg-drafts/issues/11828</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-in-position-try-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-position-area-expected.txt:
* Source/WebCore/rendering/style/PositionArea.cpp:
(WebCore::operator&lt;&lt;):
    - Implemented operator&lt;&lt;(TextStream ts, PositionArea{Axis,Track,Self})
      operator&lt;&lt;(TextStream ts, PositionAreaSpan) will use these functions instead.
    - operator&lt;&lt; that takes references were changed to take values.

* Source/WebCore/rendering/style/PositionArea.h:
(WebCore::oppositePositionAreaAxis):
    - See below.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::flipPositionAreaByLogicalAxis):
    - Added function to flip position-area by a logical axis (block/inline).

(WebCore::Style::mirrorPositionAreaAcrossDiagonal):
    - Added function to flip position-area according to flip-start.

(WebCore::Style::BuilderConverter::convertPositionArea):
    - Added code to flip position-area according to the fallback try tactic,
      if specified.

(WebCore::Style::BuilderConverter::convertPositionTryFallbacks):
    - Tightened parsing a bit by rejecting the CSS value if duplicate
      tactics are found.

(WebCore::Style::positionAreaOppositeAxis): Deleted.
    - Renamed to oppositePositionAreaAxis, and moved to PositionArea.h

Canonical link: <a href="https://commits.webkit.org/293219@main">https://commits.webkit.org/293219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/269ddfc12c144340cf06cf5f35fc2a6653f058ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74745 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31918 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101179 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13717 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105668 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->