### PR TITLE
WKWebExtension keyCommand should return a UICommand instead of a UIKeyCommand for commands that don't have a keyboard shortcut

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h
@@ -27,7 +27,7 @@
 #import <WebKit/WKFoundation.h>
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKeyCommand.h>
+#import <UIKit/UICommand.h>
 #endif
 
 @class WKWebExtensionContext;
@@ -93,12 +93,12 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Command)
 #if TARGET_OS_IPHONE
 /*!
  @abstract A key command representation of the web extension command for use in the responder chain.
- @discussion Provides a ``UIKeyCommand`` instance representing the web extension command, ready for integration in the app.
+ @discussion Provides a ``UICommand`` instance representing the web extension command, ready for integration in the app.
  The key command is fully configured with the necessary input key and modifier flags to perform the associated command upon activation.
  It can be included in a view controller or other responder's ``keyCommands`` property, enabling keyboard activation and discoverability
  of the web extension command.
  */
-@property (nonatomic, readonly, copy, nullable) UIKeyCommand *keyCommand;
+@property (nonatomic, readonly, copy, nullable) UICommand *keyCommand;
 #endif // TARGET_OS_IPHONE
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -124,7 +124,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 }
 
 #if PLATFORM(IOS_FAMILY)
-- (UIKeyCommand *)keyCommand
+- (UICommand *)keyCommand
 {
     return _webExtensionCommand->keyCommand();
 }
@@ -212,7 +212,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 }
 
 #if PLATFORM(IOS_FAMILY)
-- (UIKeyCommand *)keyCommand
+- (UICommand *)keyCommand
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
@@ -38,7 +38,7 @@
 
 #if TARGET_OS_IPHONE
 @class UIMenuElement;
-@class UIKeyCommand;
+@class UICommand;
 #else
 @class NSEvent;
 @class NSMenuItem;
@@ -583,12 +583,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 #if TARGET_OS_IPHONE
 /*!
  @abstract Performs the command associated with the given key command.
- @discussion This method checks for a command corresponding to the provided ``UIKeyCommand`` and performs it, if available. The app should use this method to perform
+ @discussion This method checks for a command corresponding to the provided ``UICommand`` and performs it, if available. The app should use this method to perform
  any extension commands at an appropriate time in the app's responder object that handles the ``performWebExtensionCommandForKeyCommand:`` action.
  @param keyCommand The key command received by the first responder.
- @result Returns `YES` if a command corresponding to the UIKeyCommand was found and performed, `NO` otherwise.
+ @result Returns `YES` if a command corresponding to the UICommand was found and performed, `NO` otherwise.
  */
-- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand NS_SWIFT_NAME(performCommand(for:));
+- (BOOL)performCommandForKeyCommand:(UICommand *)keyCommand NS_SWIFT_NAME(performCommand(for:));
 #endif
 
 #if TARGET_OS_OSX

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -576,9 +576,9 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
 }
 
 #if TARGET_OS_IPHONE
-- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand
+- (BOOL)performCommandForKeyCommand:(UICommand *)keyCommand
 {
-    NSParameterAssert([keyCommand isKindOfClass:UIKeyCommand.class]);
+    NSParameterAssert([keyCommand isKindOfClass:UICommand.class]);
 
     return Ref { *_webExtensionContext }->performCommand(keyCommand);
 }
@@ -1166,7 +1166,7 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 }
 
 #if TARGET_OS_IPHONE
-- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand
+- (BOOL)performCommandForKeyCommand:(UICommand *)keyCommand
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -51,7 +51,7 @@
 #if PLATFORM(IOS_FAMILY)
 @implementation _WKWebExtensionKeyCommand
 
-+ (UIKeyCommand *)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags identifier:(NSString *)identifier
++ (UICommand *)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags identifier:(NSString *)identifier extensionIdentifier:(NSString *)extensionIdentifier
 {
     RELEASE_ASSERT(title);
     RELEASE_ASSERT(input);
@@ -61,9 +61,15 @@
         @"title": title,
         @"activation": input,
         @"identifier": identifier,
+        @"extensionIdentifier": extensionIdentifier,
     };
 
-    auto *command = [UIKeyCommand commandWithTitle:title image:image action:@selector(performWebExtensionCommandForKeyCommand:) input:input modifierFlags:modifierFlags propertyList:propertyList];
+    UICommand *command;
+    if (input.length)
+        command = [UIKeyCommand commandWithTitle:title image:image action:@selector(performWebExtensionCommandForKeyCommand:) input:input modifierFlags:modifierFlags propertyList:propertyList];
+    else
+        command = [UICommand commandWithTitle:title image:image action:@selector(performWebExtensionCommandForKeyCommand:) propertyList:propertyList];
+
     if (!command)
         return nil;
 
@@ -295,14 +301,19 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
 }
 
 #if PLATFORM(IOS_FAMILY)
-UIKeyCommand *WebExtensionCommand::keyCommand() const
+UICommand *WebExtensionCommand::keyCommand() const
 {
-    return [_WKWebExtensionKeyCommand commandWithTitle:description() image:nil input:activationKey() modifierFlags:modifierFlags().toRaw() identifier:identifier()];
+    return [_WKWebExtensionKeyCommand commandWithTitle:description() image:nil input:activationKey() modifierFlags:modifierFlags().toRaw() identifier:identifier() extensionIdentifier:m_extensionContext->uniqueIdentifier()];
 }
 
-bool WebExtensionCommand::matchesKeyCommand(UIKeyCommand *keyCommand) const
+bool WebExtensionCommand::matchesKeyCommand(UICommand *command) const
 {
-    return keyCommand.modifierFlags == modifierFlags().toRaw() && [keyCommand.input isEqual:activationKey()] && [keyCommand.propertyList[@"identifier"] isEqual:identifier()];
+    if ([command isKindOfClass:UIKeyCommand.class]) {
+        UIKeyCommand *keyCommand = (UIKeyCommand *)command;
+        return keyCommand.modifierFlags == modifierFlags().toRaw() && [keyCommand.input isEqual:activationKey()] && [keyCommand.propertyList[@"identifier"] isEqual:identifier()] && [keyCommand.propertyList[@"extensionIdentifier"] isEqual:m_extensionContext->uniqueIdentifier()];
+    }
+
+    return [command.propertyList[@"identifier"] isEqual:identifier()] && [command.propertyList[@"extensionIdentifier"] isEqual:m_extensionContext->uniqueIdentifier()];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2987,7 +2987,7 @@ void WebExtensionContext::resetCommands()
 }
 
 #if TARGET_OS_IPHONE
-WebExtensionCommand* WebExtensionContext::commandMatchingKeyCommand(UIKeyCommand *keyCommand)
+WebExtensionCommand* WebExtensionContext::commandMatchingKeyCommand(UICommand *keyCommand)
 {
     ASSERT(keyCommand);
     for (auto& command : commands()) {
@@ -2998,7 +2998,7 @@ WebExtensionCommand* WebExtensionContext::commandMatchingKeyCommand(UIKeyCommand
     return nullptr;
 }
 
-bool WebExtensionContext::performCommand(UIKeyCommand *keyCommand)
+bool WebExtensionContext::performCommand(UICommand *keyCommand)
 {
     ASSERT(isLoaded());
     if (!isLoaded())

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -34,7 +34,7 @@
 #include <wtf/text/WTFString.h>
 
 #if defined(__OBJC__) && PLATFORM(IOS_FAMILY)
-#include <UIKit/UIKeyCommand.h>
+#include <UIKit/UICommand.h>
 #endif
 
 OBJC_CLASS WKWebExtensionCommand;
@@ -44,15 +44,15 @@ OBJC_CLASS NSEvent;
 OBJC_CLASS NSMenuItem;
 using CocoaMenuItem = NSMenuItem;
 #else
-OBJC_CLASS UIKeyCommand;
+OBJC_CLASS UICommand;
 OBJC_CLASS UIMenuElement;
 using CocoaMenuItem = UIMenuElement;
 #endif
 
 #if defined(__OBJC__) && PLATFORM(IOS_FAMILY)
-@interface _WKWebExtensionKeyCommand : UIKeyCommand
+@interface _WKWebExtensionKeyCommand : UICommand
 
-+ (UIKeyCommand *)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags identifier:(NSString *)identifier;
++ (UICommand *)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags identifier:(NSString *)identifier extensionIdentifier:(NSString *)extensionIdentifier;
 
 @end
 #endif // PLATFORM(IOS_FAMILY)
@@ -99,8 +99,8 @@ public:
     CocoaMenuItem *platformMenuItem() const;
 
 #if PLATFORM(IOS_FAMILY)
-    UIKeyCommand *keyCommand() const;
-    bool matchesKeyCommand(UIKeyCommand *) const;
+    UICommand *keyCommand() const;
+    bool matchesKeyCommand(UICommand *) const;
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -495,8 +495,8 @@ public:
     void resetCommands();
 
 #if TARGET_OS_IPHONE
-    WebExtensionCommand* commandMatchingKeyCommand(UIKeyCommand *);
-    bool performCommand(UIKeyCommand *);
+    WebExtensionCommand* commandMatchingKeyCommand(UICommand *);
+    bool performCommand(UICommand *);
 #endif
 #if USE(APPKIT)
     WebExtensionCommand* command(NSEvent *);


### PR DESCRIPTION
#### 881f2ec2ae5181eefd24b39c7c30c2c472aeb0fa
<pre>
WKWebExtension keyCommand should return a UICommand instead of a UIKeyCommand for commands that don&apos;t have a keyboard shortcut
<a href="https://bugs.webkit.org/show_bug.cgi?id=290555">https://bugs.webkit.org/show_bug.cgi?id=290555</a>
<a href="https://rdar.apple.com/147957175">rdar://147957175</a>

Reviewed by NOBODY (OOPS!).

Having multiple UIKeyCommands with the same modifier flags and keyboard shortcut can lead to a crash. This is an issue
when we are trying to create multiple UIKeyCommands without a shortcut. UICommand is the better analogue here, so we
should adopt it where we can.

This means generalizing some of the APIs to take/generate UICommands instead of UIKeyCommands, and putting some logic in
_WKWebExtensionKeyCommand to create the right type of command.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand keyCommand]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext performCommandForKeyCommand:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(+[_WKWebExtensionKeyCommand commandWithTitle:image:input:modifierFlags:identifier:extensionIdentifier:]):
(WebKit::WebExtensionCommand::keyCommand const):
(WebKit::WebExtensionCommand::matchesKeyCommand const):
(+[_WKWebExtensionKeyCommand commandWithTitle:image:input:modifierFlags:identifier:]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::commandMatchingKeyCommand):
(WebKit::WebExtensionContext::performCommand):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/881f2ec2ae5181eefd24b39c7c30c2c472aeb0fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102182 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25174 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/73966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12836 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12590 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46956 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24175 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/83940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/23963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->