### PR TITLE
[WGSL] Can't pack/unpack nested arrays

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl
@@ -8,8 +8,28 @@ struct S {
 
 @group(0) @binding(0) var<storage, read> s : S;
 
+
+struct S0 {
+  @align(4)
+  x: u32,
+}
+
+struct S1 {
+  x: array<array<S0, 1>, 1>,
+}
+
+@group(0) @binding(1) var<storage, read_write> s1: S1;
+
+struct S2 {
+  f: array<array<vec3f, 1>, 1>,
+}
+
+@group(0) @binding(2) var<storage, read_write> s2: S2;
+
 @compute @workgroup_size(1)
 fn main()
 {
-  _ = s.x;
+  { var x = s.x; }
+  { var x = s1.x[0][0].x; }
+  { var x = s2.f; }
 }

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -18,7 +18,7 @@ struct T {
 }
 
 struct U {
-    // CHECK: array<type\d::PackedType, 1> field\d
+    // CHECK: array<__PackedType<type\d>, 1> field\d
     ts: array<T>,
 }
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -64,6 +64,18 @@ fn main() -> @location(0) vec4<f32> {
 
 using namespace metal;
 
+template<typename T>
+struct __UnpackedTypeImpl;
+
+template<typename T>
+struct __PackedTypeImpl;
+
+template<typename T>
+using __UnpackedType = typename __UnpackedTypeImpl<T>::Type;
+
+template<typename T>
+using __PackedType = typename __PackedTypeImpl<T>::Type;
+
 [[fragment]] vec<float, 4> function0()
 {
     return vec<float, 4>(1., 0., 0., 1.);
@@ -87,6 +99,18 @@ fn main(@builtin(position) position : vec4<f32>,
 #include <metal_types>
 
 using namespace metal;
+
+template<typename T>
+struct __UnpackedTypeImpl;
+
+template<typename T>
+struct __PackedTypeImpl;
+
+template<typename T>
+using __UnpackedType = typename __UnpackedTypeImpl<T>::Type;
+
+template<typename T>
+using __PackedType = typename __PackedTypeImpl<T>::Type;
 
 [[fragment]] void function0(vec<float, 4> parameter0 [[position]], unsigned parameter1 [[sample_id]], unsigned parameter2 [[sample_mask]])
 {


### PR DESCRIPTION
#### 9aaba3240736ae4c115b1a3e397687ae71c9ed53
<pre>
[WGSL] Can&apos;t pack/unpack nested arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=290536">https://bugs.webkit.org/show_bug.cgi?id=290536</a>
<a href="https://rdar.apple.com/147752033">rdar://147752033</a>

Reviewed by Mike Wyrzykowski.

The signature of the packing helpers for arrays only worked for vec3 and structs,
but not for nested arrays. To address the recursion we introduce two helper types
`__UnpackedType&lt;T&gt;` and `__PackedType&lt;T&gt;` to the mapping from T to their packed/
unpacked counterparts.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl:
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/293084@main">https://commits.webkit.org/293084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5804076f6cd52f0a344ba987a7ea0785268f8bc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48324 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74475 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6304 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6381 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24875 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84552 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20928 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18482 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->