### PR TITLE
Something else on the page gets selected after cancelling model drag

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3653,6 +3653,11 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
     VisiblePosition caretPosition(renderer->positionForPoint(request.point, HitTestSource::User, nullptr));
     info.caretRect = caretPosition.absoluteCaretBounds(&isInsideFixedPosition);
 #endif
+
+#if ENABLE(MODEL_PROCESS)
+    if (is<HTMLModelElement>(*hitNode))
+        info.prefersDraggingOverTextSelection = true;
+#endif
 }
 
 static void textInteractionPositionInformation(WebPage& page, const HTMLInputElement& input, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)


### PR DESCRIPTION
#### eb4de47a2bee0b9bd913c3d1f2f9be8c89d8290e
<pre>
Something else on the page gets selected after cancelling model drag
<a href="https://bugs.webkit.org/show_bug.cgi?id=290556">https://bugs.webkit.org/show_bug.cgi?id=290556</a>
<a href="https://rdar.apple.com/144430885">rdar://144430885</a>

Reviewed by Wenson Hsieh and Ada Chan.

This PR addresses a bug with dragging a model view, where the drag also triggers a text
selection. Since model elements should prioritize panning and dragging gestures for
model-specific interactions, we should prevent text gesture interactions from triggering.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::selectionPositionInformation):
- Added check to prevent text gestures when the model element is selected

Canonical link: <a href="https://commits.webkit.org/292843@main">https://commits.webkit.org/292843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048b0bec67fd86d2097dc756a40b432d3b2080ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102285 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47729 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31249 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12933 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12687 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47162 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24280 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83092 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20764 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17783 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24243 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->