### PR TITLE
Update Stagemode transform subscription call

### DIFF
--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -27,6 +27,7 @@ import Combine
 import RealityKit
 import Spatial
 import Foundation
+@_spi(Observation) import RealityFoundation
 @_spi(RealityKit) import RealityKit
 import WebKitSwift
 import os
@@ -219,8 +220,8 @@ final public class WKStageModeInteractionDriver: NSObject {
     
     private func subscribeToPitchChanges() {
         withObservationTracking {
-#if canImport(RealityFoundation, _version: 380)
-            _ = self.interactionContainer.proto_observableComponents[Transform.self]
+#if canImport(RealityFoundation, _version: 395)
+            _ = self.interactionContainer.proto_observable.components[Transform.self]
 #endif
         } onChange: {
             Task { @MainActor in
@@ -240,9 +241,9 @@ final public class WKStageModeInteractionDriver: NSObject {
     
     private func subscribeToYawChanges() {
         withObservationTracking {
-#if canImport(RealityFoundation, _version: 380)
+#if canImport(RealityFoundation, _version: 395)
             // By default, we do not care about the proxy, but we use the update to set the deceleration of the turntable container
-            _ = turntableAnimationProxyEntity.proto_observableComponents[Transform.self]
+            _ = turntableAnimationProxyEntity.proto_observable.components[Transform.self]
 #endif
         } onChange: {
             Task { @MainActor in


### PR DESCRIPTION
#### 016be815e2d725350f670fd1d473647976086bd3
<pre>
Update Stagemode transform subscription call
<a href="https://bugs.webkit.org/show_bug.cgi?id=290560">https://bugs.webkit.org/show_bug.cgi?id=290560</a>
<a href="https://rdar.apple.com/147070385">rdar://147070385</a>

Reviewed by Ada Chan.

This PR updates the calls for transform updates to reflect latest guidance on
how to subscribe to transform updates on the model.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.subscribeToPitchChanges):
(WKStageModeInteractionDriver.subscribeToYawChanges):

Canonical link: <a href="https://commits.webkit.org/294098@main">https://commits.webkit.org/294098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9346f1608fe86ab23aa50dca048c8cdef90bd00b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51392 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76753 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33791 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15767 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108295 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27921 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20510 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003b.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7699 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21925 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33112 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->