### PR TITLE
Address more safer CPP failures in WebKit/GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1327,7 +1327,7 @@ void GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary()
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     ASSERT(!m_routingArbitrator);
     m_routingArbitrator = LocalAudioSessionRoutingArbitrator::create(*this);
-    protectedGPUProcess()->protectedAudioSessionManager()->session().setRoutingArbitrationClient(m_routingArbitrator.get());
+    protectedGPUProcess()->protectedAudioSessionManager()->protectedSession()->setRoutingArbitrationClient(m_routingArbitrator.get());
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -38,6 +38,7 @@
 #include "RemoteRenderingBackend.h"
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
+#include <WebCore/GraphicsContext.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/WebGPU.h>

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -66,8 +66,8 @@ void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParam
 void GPUProcess::updateProcessName()
 {
 #if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)m_uiProcessName];
-    auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
+    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)m_uiProcessName];
+    auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
     ASSERT_UNUSED(result, result == noErr);
 #endif
 }
@@ -76,7 +76,7 @@ void GPUProcess::updateProcessName()
 void GPUProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)
 {
     // Need to overide the default, because service has a different bundle ID.
-    NSBundle *webKit2Bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+    RetainPtr webKit2Bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
 
     sandboxParameters.setOverrideSandboxProfilePath([webKit2Bundle pathForResource:@"com.apple.WebKit.GPUProcess" ofType:@"sb"]);
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -57,23 +57,22 @@ RemoteAudioTrackProxy::RemoteAudioTrackProxy(GPUConnectionToWebProcess& connecti
 
 RemoteAudioTrackProxy::~RemoteAudioTrackProxy()
 {
-    Ref { m_trackPrivate }->removeClient(m_clientId);
+    m_trackPrivate->removeClient(m_clientId);
 }
 
 AudioTrackPrivateRemoteConfiguration RemoteAudioTrackProxy::configuration()
 {
-    Ref trackPrivate = m_trackPrivate;
     return {
         {
-            trackPrivate->id(),
-            trackPrivate->label(),
-            trackPrivate->language(),
-            trackPrivate->startTimeVariance(),
-            trackPrivate->trackIndex(),
+            m_trackPrivate->id(),
+            m_trackPrivate->label(),
+            m_trackPrivate->language(),
+            m_trackPrivate->startTimeVariance(),
+            m_trackPrivate->trackIndex(),
         },
-        trackPrivate->enabled(),
-        trackPrivate->kind(),
-        trackPrivate->configuration(),
+        m_trackPrivate->enabled(),
+        m_trackPrivate->kind(),
+        m_trackPrivate->configuration(),
     };
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setEnabled(bool enabled)
     {
         m_enabled = enabled;
-        Ref { m_trackPrivate }->setEnabled(enabled);
+        m_trackPrivate->setEnabled(enabled);
     }
     bool operator==(const WebCore::AudioTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 
@@ -84,7 +84,7 @@ private:
     void configurationChanged();
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
-    Ref<WebCore::AudioTrackPrivate> m_trackPrivate;
+    const Ref<WebCore::AudioTrackPrivate> m_trackPrivate;
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
     bool m_enabled { false };

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -388,22 +388,25 @@ std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitiali
     segmentInfo.duration = segment.duration;
 
     segmentInfo.audioTracks = segment.audioTracks.map([&](const InitializationSegment::AudioTrackInformation& audioTrackInfo) {
-        auto id = audioTrackInfo.track->id();
-        remoteMediaPlayerProxy->addRemoteAudioTrackProxy(*audioTrackInfo.protectedTrack());
+        RefPtr track = audioTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteAudioTrackProxy(*track);
         m_mediaDescriptions.try_emplace(id, *audioTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*audioTrackInfo.description), id };
     });
 
     segmentInfo.videoTracks = segment.videoTracks.map([&](const InitializationSegment::VideoTrackInformation& videoTrackInfo) {
-        auto id = videoTrackInfo.track->id();
-        remoteMediaPlayerProxy->addRemoteVideoTrackProxy(*videoTrackInfo.protectedTrack());
+        RefPtr track = videoTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteVideoTrackProxy(*track);
         m_mediaDescriptions.try_emplace(id, *videoTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*videoTrackInfo.description), id };
     });
 
     segmentInfo.textTracks = segment.textTracks.map([&](const InitializationSegment::TextTrackInformation& textTrackInfo) {
-        auto id = textTrackInfo.track->id();
-        remoteMediaPlayerProxy->addRemoteTextTrackProxy(*textTrackInfo.protectedTrack());
+        RefPtr track = textTrackInfo.track;
+        auto id = track->id();
+        remoteMediaPlayerProxy->addRemoteTextTrackProxy(*track);
         m_mediaDescriptions.try_emplace(id, *textTrackInfo.protectedDescription());
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*textTrackInfo.description), id };
     });

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -58,29 +58,28 @@ RemoteTextTrackProxy::RemoteTextTrackProxy(GPUConnectionToWebProcess& connection
 
 RemoteTextTrackProxy::~RemoteTextTrackProxy()
 {
-    Ref { m_trackPrivate }->removeClient(m_clientId);
+    m_trackPrivate->removeClient(m_clientId);
 }
 
 TextTrackPrivateRemoteConfiguration& RemoteTextTrackProxy::configuration()
 {
     static NeverDestroyed<TextTrackPrivateRemoteConfiguration> configuration;
 
-    Ref trackPrivate = m_trackPrivate;
-    configuration->trackId = trackPrivate->id();
-    configuration->label = trackPrivate->label();
-    configuration->language = trackPrivate->language();
-    configuration->trackIndex = trackPrivate->trackIndex();
-    configuration->inBandMetadataTrackDispatchType = trackPrivate->inBandMetadataTrackDispatchType();
-    configuration->startTimeVariance = trackPrivate->startTimeVariance();
+    configuration->trackId = m_trackPrivate->id();
+    configuration->label = m_trackPrivate->label();
+    configuration->language = m_trackPrivate->language();
+    configuration->trackIndex = m_trackPrivate->trackIndex();
+    configuration->inBandMetadataTrackDispatchType = m_trackPrivate->inBandMetadataTrackDispatchType();
+    configuration->startTimeVariance = m_trackPrivate->startTimeVariance();
 
-    configuration->cueFormat = trackPrivate->cueFormat();
-    configuration->isClosedCaptions = trackPrivate->isClosedCaptions();
-    configuration->isSDH = trackPrivate->isSDH();
-    configuration->containsOnlyForcedSubtitles = trackPrivate->containsOnlyForcedSubtitles();
-    configuration->isMainProgramContent = trackPrivate->isMainProgramContent();
-    configuration->isEasyToRead = trackPrivate->isEasyToRead();
-    configuration->isDefault = trackPrivate->isDefault();
-    configuration->kind = trackPrivate->kind();
+    configuration->cueFormat = m_trackPrivate->cueFormat();
+    configuration->isClosedCaptions = m_trackPrivate->isClosedCaptions();
+    configuration->isSDH = m_trackPrivate->isSDH();
+    configuration->containsOnlyForcedSubtitles = m_trackPrivate->containsOnlyForcedSubtitles();
+    configuration->isMainProgramContent = m_trackPrivate->isMainProgramContent();
+    configuration->isEasyToRead = m_trackPrivate->isEasyToRead();
+    configuration->isDefault = m_trackPrivate->isDefault();
+    configuration->kind = m_trackPrivate->kind();
 
     return configuration.get();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -93,7 +93,7 @@ private:
     void configurationChanged();
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
-    Ref<WebCore::InbandTextTrackPrivate> m_trackPrivate;
+    const Ref<WebCore::InbandTextTrackPrivate> m_trackPrivate;
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
     size_t m_clientId { 0 };

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -138,7 +138,7 @@ void RemoteVideoFrameObjectHeap::pixelBuffer(RemoteVideoFrameReadReference&& rea
         return;
     }
 
-    auto pixelBuffer = videoFrame->pixelBuffer();
+    RetainPtr pixelBuffer = videoFrame->pixelBuffer();
     ASSERT(pixelBuffer);
     completionHandler(WTFMove(pixelBuffer));
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -56,23 +56,22 @@ RemoteVideoTrackProxy::RemoteVideoTrackProxy(GPUConnectionToWebProcess& connecti
 
 RemoteVideoTrackProxy::~RemoteVideoTrackProxy()
 {
-    Ref { m_trackPrivate }->removeClient(m_clientRegistrationId);
+    m_trackPrivate->removeClient(m_clientRegistrationId);
 }
 
 VideoTrackPrivateRemoteConfiguration RemoteVideoTrackProxy::configuration()
 {
-    Ref trackPrivate = m_trackPrivate;
     return {
         {
-            trackPrivate->id(),
-            trackPrivate->label(),
-            trackPrivate->language(),
-            trackPrivate->startTimeVariance(),
-            trackPrivate->trackIndex(),
+            m_trackPrivate->id(),
+            m_trackPrivate->label(),
+            m_trackPrivate->language(),
+            m_trackPrivate->startTimeVariance(),
+            m_trackPrivate->trackIndex(),
         },
-        trackPrivate->selected(),
-        trackPrivate->kind(),
-        trackPrivate->configuration(),
+        m_trackPrivate->selected(),
+        m_trackPrivate->kind(),
+        m_trackPrivate->configuration(),
     };
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -63,7 +63,7 @@ public:
     void setSelected(bool selected)
     {
         m_selected = selected;
-        Ref { m_trackPrivate }->setSelected(selected);
+        m_trackPrivate->setSelected(selected);
     }
     bool operator==(const WebCore::VideoTrackPrivate& track) const { return track == m_trackPrivate.get(); }
 
@@ -84,7 +84,7 @@ private:
     void updateConfiguration();
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
-    Ref<WebCore::VideoTrackPrivate> m_trackPrivate;
+    const Ref<WebCore::VideoTrackPrivate> m_trackPrivate;
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
     bool m_selected { false };

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -73,7 +73,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    auto* layer = protectedPlayer()->platformLayer();
+    RetainPtr layer = protectedPlayer()->platformLayer();
     if (layer && !m_inlineLayerHostingContext) {
         LayerHostingContextOptions contextOptions;
 #if USE(EXTENSIONKIT)
@@ -84,7 +84,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 #endif
         m_inlineLayerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
         if (m_configuration.videoLayerSize.isEmpty())
-            m_configuration.videoLayerSize = enclosingIntRect(WebCore::FloatRect(layer.frame)).size();
+            m_configuration.videoLayerSize = enclosingIntRect(WebCore::FloatRect(layer.get().frame)).size();
         auto& size = m_configuration.videoLayerSize;
         [layer setFrame:CGRectMake(0, 0, size.width(), size.height())];
         protectedConnection()->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextIdChanged(m_inlineLayerHostingContext->contextID(), size), m_id);
@@ -96,7 +96,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
     }
 
     if (m_inlineLayerHostingContext)
-        m_inlineLayerHostingContext->setRootLayer(layer);
+        m_inlineLayerHostingContext->setRootLayer(layer.get());
 
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
 }

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,4 +1,3 @@
-GPUProcess/graphics/WebGPU/RemoteGPU.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/IPC/Connection.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,14 +1,6 @@
 AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
-GPUProcess/GPUConnectionToWebProcess.cpp
-GPUProcess/media/RemoteAudioTrackProxy.cpp
-GPUProcess/media/RemoteAudioTrackProxy.h
-GPUProcess/media/RemoteSourceBufferProxy.cpp
-GPUProcess/media/RemoteTextTrackProxy.cpp
-GPUProcess/media/RemoteTextTrackProxy.h
-GPUProcess/media/RemoteVideoTrackProxy.cpp
-GPUProcess/media/RemoteVideoTrackProxy.h
 GeneratedSerializers.mm
 NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
 Platform/IPC/ArgumentCoders.h


### PR DESCRIPTION
#### 4678be2481c3603a10183210a6bb3a71edda39fc
<pre>
Address more safer CPP failures in WebKit/GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=290562">https://bugs.webkit.org/show_bug.cgi?id=290562</a>

Reviewed by Mike Wyrzykowski.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::updateProcessName):
(WebKit::GPUProcess::initializeSandbox):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
(WebKit::RemoteAudioTrackProxy::~RemoteAudioTrackProxy):
(WebKit::RemoteAudioTrackProxy::configuration):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::createInitializationSegmentInfo):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::~RemoteTextTrackProxy):
(WebKit::RemoteTextTrackProxy::configuration):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::pixelBuffer):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::~RemoteVideoTrackProxy):
(WebKit::RemoteVideoTrackProxy::configuration):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):

Canonical link: <a href="https://commits.webkit.org/292799@main">https://commits.webkit.org/292799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57716be459ac45bca74b87d3575884bec5e93422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100171 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12658 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47066 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89841 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20739 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24207 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->