### PR TITLE
Add InvalidStateError when trying to set entityTransform when stagemode is not none

### DIFF
--- a/LayoutTests/model-element/model-element-entity-transform-expected.txt
+++ b/LayoutTests/model-element/model-element-entity-transform-expected.txt
@@ -1,3 +1,7 @@
+PASS function() {
+        model.entityTransform = scaledTransform;
+        assert_3d_matrix_not_equals(model.entityTransform, scaledTransform);
+    } threw exception InvalidStateError: Transform is read-only unless StageMode is set to 'none'.
 
 PASS <model> with empty source has entityTransform = identity
 PASS <model> gets the updated entityTransform after change

--- a/LayoutTests/model-element/model-element-entity-transform.html
+++ b/LayoutTests/model-element/model-element-entity-transform.html
@@ -5,6 +5,7 @@
 <script src="../resources/testharnessreport.js"></script>
 <script src="resources/model-element-test-utils.js"></script>
 <script src="resources/model-utils.js"></script>
+<script src="../resources/js-test-pre.js"></script>
 <body>
 <script>
 'use strict';
@@ -68,6 +69,11 @@ promise_test(async t => {
     assert_3d_matrix_not_equals(model.entityTransform, scaledTransform);
     assert_3d_matrix_not_equals(model.entityTransform, originalTransform);
     let orbitFitTransform = model.entityTransform;
+
+    shouldThrowErrorName(function() {
+        model.entityTransform = scaledTransform;
+        assert_3d_matrix_not_equals(model.entityTransform, scaledTransform);
+    }, "InvalidStateError");
 
     model.stageMode = "none";
     await new Promise((resolve) => t.step_timeout(resolve, 100));

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -454,7 +454,7 @@ const DOMMatrixReadOnly& HTMLModelElement::entityTransform() const
 ExceptionOr<void> HTMLModelElement::setEntityTransform(const DOMMatrixReadOnly& transform)
 {
     if (supportsStageModeInteraction())
-        return { };
+        return Exception { ExceptionCode::InvalidStateError,  "Transform is read-only unless StageMode is set to 'none'"_s };
 
     auto player = m_modelPlayer;
     if (!player) {


### PR DESCRIPTION
#### b961b17efc4a7afb731c99c9bc12cefac6550ff4
<pre>
Add InvalidStateError when trying to set entityTransform when stagemode is not none
<a href="https://bugs.webkit.org/show_bug.cgi?id=290578">https://bugs.webkit.org/show_bug.cgi?id=290578</a>
<a href="https://rdar.apple.com/146995513">rdar://146995513</a>

Reviewed by Ada Chan.

This PR adds an exception when web developers try to set the entityTransform of the model element
when it is in StageMode orbit. This will notify users of expected behavior, rather than quietly
failing to set the Javascript transform without reason.

* LayoutTests/model-element/model-element-entity-transform-expected.txt:
* LayoutTests/model-element/model-element-entity-transform.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setEntityTransform):
- Updated call to return an InvalidStateError and updated layout tests

Canonical link: <a href="https://commits.webkit.org/292965@main">https://commits.webkit.org/292965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843dceb6a2c0bd99d0f684a096101551b82fcaa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25658 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100583 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47551 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27369 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18254 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24621 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->