### PR TITLE
CompletionHandlerWithFinalizer should adopt the thread assertion of its owned callable when possible

### DIFF
--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -78,10 +78,26 @@ public:
         return std::exchange(m_function, nullptr)(std::forward<In>(in)...);
     }
 
+    ThreadLikeAssertion callThread() const { return m_callThread; }
+
 private:
     Function<Out(In...)> m_function;
     NO_UNIQUE_ADDRESS ThreadLikeAssertion m_callThread;
 };
+
+template <typename CallableType>
+concept HasThreadAssertion = requires(CallableType callable)
+{
+    { callable.callThread() } -> std::same_as<ThreadLikeAssertion>;
+};
+
+template <typename CallableType>
+std::optional<ThreadLikeAssertion> threadAssertionFromCallable(const CallableType& callable)
+{
+    if constexpr (HasThreadAssertion<CallableType>)
+        return callable.callThread();
+    return std::nullopt;
+}
 
 // Wraps a Function to make sure it is called at most once.
 // If the CompletionHandlerWithFinalizer is destroyed and the function hasn't yet been called,
@@ -96,7 +112,8 @@ public:
 
     template<typename CallableType, class = typename std::enable_if<std::is_rvalue_reference<CallableType&&>::value>::type>
     CompletionHandlerWithFinalizer(CallableType&& callable, Function<void(Function<Out(In...)>&)>&& finalizer)
-        : m_function(std::forward<CallableType>(callable))
+        : m_callThread(threadAssertionFromCallable(callable).value_or(ThreadLikeAssertion { }))
+        , m_function(std::forward<CallableType>(callable))
         , m_finalizer(WTFMove(finalizer))
     {
     }
@@ -122,9 +139,9 @@ public:
     }
 
 private:
+    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_callThread;
     Function<Out(In...)> m_function;
     Function<void(Function<Out(In...)>&)> m_finalizer;
-    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_callThread;
 };
 
 namespace Detail {

--- a/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
@@ -27,6 +27,7 @@
 
 #include "Test.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/Function.h>
 #include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -137,6 +138,25 @@ TEST_F(CompletionHandlerTest, ConstructWithSpecificThreadLikeAssertion)
     EXPECT_TRUE(didCall);
 }
 
+TEST_F(CompletionHandlerTest, FinalizerInheritsHandlersThreadAssertion)
+{
+    CompletionHandler<void()> handler;
+    Thread::create("ConstructionThread"_s, [&] {
+        handler = CompletionHandler<void()> { [] { }, CompletionHandlerCallThread::AnyThread };
+    })->waitForCompletion();
+
+    CompletionHandlerWithFinalizer<void()> handlerWithFinalizer { WTFMove(handler), [](auto&& callable) {
+        callable();
+    } };
+
+    bool didDestroy = false;
+    Thread::create("DestructionThread"_s, [&] {
+        auto localHandlerWithFinalizer = WTFMove(handlerWithFinalizer);
+        didDestroy = true;
+    })->waitForCompletion();
+    EXPECT_TRUE(didDestroy);
+}
+
 TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(UncalledHandlerAsserts))
 {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -202,6 +222,19 @@ TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ConstructionThr
         Thread::create("ConstructionThreadHandlerOnThreadAsserts"_s, [&] {
             ch1(); // This should assert.
         })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+}
+
+TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(FinalizerUsesDefaultThreadAssertionForGenericCallable))
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        Function<void()> callable([] { });
+        CompletionHandlerWithFinalizer<void()> finalizer(WTFMove(callable), [](auto&& callable) {
+            callable();
+        });
+        Thread::create("FinalizerWithDefaultThreadAssertionAssertsOnNonCurrentThread"_s, [finalizer = WTFMove(finalizer)] { })->waitForCompletion();
     }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
 }
 


### PR DESCRIPTION
#### 958501daca5ff0654ce5869c7a76bd1e2f42ed32
<pre>
CompletionHandlerWithFinalizer should adopt the thread assertion of its owned callable when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=290581">https://bugs.webkit.org/show_bug.cgi?id=290581</a>
<a href="https://rdar.apple.com/148057986">rdar://148057986</a>

Reviewed by NOBODY (OOPS!).

Currently, the following snippet crashes:

```
CompletionHandlerWithFinalizer&lt;void()&gt; handler {
    CompletionHandler&lt;void()&gt; { [] { }, CompletionHandlerCallThread::AnyThread },
    [](auto&amp;&amp; callable) { callable(); }
};
Thread::create(&quot;NonMainThread&quot;_s, [handler = WTFMove(handler)] {
    })-&gt;waitForCompletion();
```

... even though the callable being wrapped is a CompletionHandler with
its own thread assertion that would allow being called on any thread.

We fix the above issue by imbibing CompletionHandlerWithFinalizer with
the ability to inherit the thread assertion of its owned callable, if
that callable happens to be a CompletionHandler. Or else, we fall back
to the default thread assertion (currentThreadLike).

* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
(WTF::requires):
Introduce a concept that allows us to differentiate between any generic
callable and a CompletionHandler&lt;...&gt;, which has a thread assertion.
(WTF::threadAssertionFromCallable):
(WTF::CompletionHandlerWithFinalizer&lt;Out):
* Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp:
(TestWebKitAPI::TEST_F(CompletionHandlerTest, FinalizerInheritsHandlersThreadAssertion)):
(TestWebKitAPI::TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(FinalizerUsesDefaultThreadAssertionForGenericCallable)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/958501daca5ff0654ce5869c7a76bd1e2f42ed32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31218 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12893 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87867 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47047 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89832 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104262 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95780 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24234 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17670 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/abrupt-completion.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29349 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119407 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24021 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33530 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->