### PR TITLE
[JSC] Fix incorrect exit state handling during array allocation sinking

### DIFF
--- a/JSTests/stress/array-allocation-sink-2.js
+++ b/JSTests/stress/array-allocation-sink-2.js
@@ -1,0 +1,5 @@
+//@ runDefault("--validateGraphAtEachPhase=1")
+for (let i = 0; i <= 1e5; i++) {
+    const t1 = Array(128);
+    t1[4] = 128;
+}

--- a/JSTests/stress/array-allocation-sink-3.js
+++ b/JSTests/stress/array-allocation-sink-3.js
@@ -1,0 +1,181 @@
+//@ runDefault("--validateGraphAtEachPhase=1")
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function run(func, a) {
+    let expected;
+    for (let i = 0; i < 1e5; i++) {
+        if (a == undefined)
+            a = [1, 2];
+        let res = func(a);
+        if (i == 0)
+            expected = res;
+        assert(res, expected);
+    }
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 43; // ArrayWithInt32
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1] & 0x8; // ArrayWithInt32
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1]; // ArrayWithContiguous
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1]; // ArrayWithDouble
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test, [0.1, 0.2]);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = { f: 10 }; // ArrayWithContiguous
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test, [0.1, 0.2]);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        a.length = 10; // escape
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[1] = a.length;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        Array[Symbol.species] = 99; // FIXME: Maybe we should not sink
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[0];
+        globalThis.ref = a; // escape
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        Array.prototype[2] = 99; // ArrayPrototypeChainIsSaneWatchpoint = IsInvalidated
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[2];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[0];
+        let sliced = a.slice();  // escape
+        let mapped = a.map(x => x * 2);  // escape
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[10] = 42;  // Out of bounds
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -979,6 +979,10 @@ private:
                     VALIDATE((node), node->entrypointIndex() < m_graph.m_numberOfEntrypoints);
                     break;
 
+                case GetButterfly:
+                    VALIDATE((node), !node->child1()->isPhantomAllocation() || node->child1()->op() == PhantomNewArrayWithConstantSize);
+                    break;
+
                 default:
                     m_graph.doToChildren(
                         node,


### PR DESCRIPTION
#### 74854431b5e558e19bc772cfbbef92e5fd54fbaa
<pre>
[JSC] Fix incorrect exit state handling during array allocation sinking
<a href="https://bugs.webkit.org/show_bug.cgi?id=290587">https://bugs.webkit.org/show_bug.cgi?id=290587</a>
<a href="https://rdar.apple.com/148062353">rdar://148062353</a>

Reviewed by Yusuke Suzuki.

Fixes an issue in the DFG Object Allocation Sinking phase where insertion order of nodes
after PutByVal could lead to inconsistent exit state assumptions. Specifically, a Check
node inserted after a PutHint caused validation to fail because both clobber exit state
and no ExitOK was emitted in between. This patch moves the Check node before the PutHint
to maintain consistent clobbering assumptions and preserve validation correctness.

Also adds special-case validation for GetButterfly nodes referencing phantom allocations,
which are expected to be cleaned up in later phases.

This ensures DFG validation passes cleanly and maintains correctness during OSR exit
handling in optimized array materializations.

* JSTests/stress/array-allocation-sink-2.js: Added.
* JSTests/stress/array-allocation-sink-3.js: Added.
(assert):
(run):
(assert.test):
(run.test):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:

Canonical link: <a href="https://commits.webkit.org/292900@main">https://commits.webkit.org/292900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94411a74887dec218c84e50c6af37d5fd9cb307d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47044 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89824 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104254 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95772 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24226 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17734 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17730 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29341 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119399 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24013 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33528 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->