### PR TITLE
dNR: Implement the optional filter parameter of getDynamicRules and getSessionRules

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -350,9 +350,13 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
     }).get()];
 }
 
-void WebExtensionContext::declarativeNetRequestGetDynamicRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetDynamicRules(Vector<double>&& filter, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
-    [declarativeNetRequestDynamicRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
+    auto *ruleIDs = createNSArray(filter, [this](auto ruleID) -> NSNumber * {
+        return m_dynamicRulesIDs.contains(ruleID) ? @(ruleID) : nil;
+    }).get();
+
+    [declarativeNetRequestDynamicRulesStore() getRulesWithRuleIDs:ruleIDs completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
             completionHandler(toWebExtensionError(@"declarativeNetRequest.getDynamicRules()", nullString(), errorMessage));
             return;
@@ -388,9 +392,13 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
     updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestDynamicRulesStore(), @"dynamic", apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
 
-void WebExtensionContext::declarativeNetRequestGetSessionRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetSessionRules(Vector<double>&& filter, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
-    [declarativeNetRequestSessionRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
+    auto *ruleIDs = createNSArray(filter, [this](auto ruleID) -> NSNumber * {
+        return m_sessionRulesIDs.contains(ruleID) ? @(ruleID) : nil;
+    }).get();
+
+    [declarativeNetRequestSessionRulesStore() getRulesWithRuleIDs:ruleIDs completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
             completionHandler(toWebExtensionError(@"declarativeNetRequest.getSessionRules()", nullString(), errorMessage));
             return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4858,7 +4858,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
     };
 
     auto addDynamicAndStaticRules = [this, protectedThis = Ref { *this }, addStaticRulesets = WTFMove(addStaticRulesets), allJSONData = RetainPtr { allJSONData }] () mutable {
-        [declarativeNetRequestDynamicRulesStore() getRulesWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, addStaticRulesets = WTFMove(addStaticRulesets), allJSONData = RetainPtr { allJSONData }](NSArray *rules, NSString *errorMessage) mutable {
+        [declarativeNetRequestDynamicRulesStore() getRulesWithRuleIDs:@[] completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, addStaticRulesets = WTFMove(addStaticRulesets), allJSONData = RetainPtr { allJSONData }](NSArray *rules, NSString *errorMessage) mutable {
             if (!rules.count) {
                 m_dynamicRulesIDs.clear();
                 addStaticRulesets();
@@ -4882,7 +4882,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
         }).get()];
     };
 
-    [declarativeNetRequestSessionRulesStore() getRulesWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, addDynamicAndStaticRules = WTFMove(addDynamicAndStaticRules), allJSONData = RetainPtr { allJSONData }](NSArray *rules, NSString *errorMessage) mutable {
+    [declarativeNetRequestSessionRulesStore() getRulesWithRuleIDs:@[] completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, addDynamicAndStaticRules = WTFMove(addDynamicAndStaticRules), allJSONData = RetainPtr { allJSONData }](NSArray *rules, NSString *errorMessage) mutable {
         if (!rules.count) {
             m_sessionRulesIDs.clear();
             addDynamicAndStaticRules();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(_WKWebExtensionDeclarativeNetRequestStorageType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase;
 
-- (void)getRulesWithCompletionHandler:(void (^)(NSArray<NSDictionary<NSString *, id> *> *rules, NSString *errorMessage))completionHandler;
+- (void)getRulesWithRuleIDs:(NSArray<NSNumber *> *)ruleIDs completionHandler:(void (^)(NSArray<NSDictionary<NSString *, id> *> *rules, NSString *errorMessage))completionHandler;
 - (void)updateRulesByRemovingIDs:(NSArray<NSNumber *> *)ruleIDs addRules:(NSArray<NSDictionary<NSString *, id> *> *)rules completionHandler:(void (^)(NSString *errorMessage))completionHandler;
 
 @end

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -795,9 +795,9 @@ private:
     size_t declarativeNetRequestEnabledRulesetCount() { return m_enabledStaticRulesetIDs.size(); }
     void declarativeNetRequestToggleRulesets(const Vector<String>& rulesetIdentifiers, bool newValue, NSMutableDictionary *rulesetIdentifiersToEnabledState);
     void declarativeNetRequestGetMatchedRules(std::optional<WebExtensionTabIdentifier>, std::optional<WallTime> minTimeStamp, CompletionHandler<void(Expected<Vector<WebExtensionMatchedRuleParameters>, WebExtensionError>&&)>&&);
-    void declarativeNetRequestGetDynamicRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
+    void declarativeNetRequestGetDynamicRules(Vector<double>&& filter, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
     void declarativeNetRequestUpdateDynamicRules(String&& rulesToAddJSON, Vector<double>&& ruleIDsToDelete, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void declarativeNetRequestGetSessionRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
+    void declarativeNetRequestGetSessionRules(Vector<double>&& filter, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
     void declarativeNetRequestUpdateSessionRules(String&& rulesToAddJSON, Vector<double>&& ruleIDsToDelete, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -66,9 +66,9 @@ messages -> WebExtensionContext {
     [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestDisplayActionCountAsBadgeText(bool result) -> (Expected<void, WebKit::WebExtensionError> result)
     [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestIncrementActionCount(WebKit::WebExtensionTabIdentifier tabIdentifier, double increment) -> (Expected<void, WebKit::WebExtensionError> result)
     [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestGetMatchedRules(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp) -> (Expected<Vector<WebKit::WebExtensionMatchedRuleParameters>, WebKit::WebExtensionError> result)
-    [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestGetDynamicRules() -> (Expected<String, WebKit::WebExtensionError> result)
+    [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestGetDynamicRules(Vector<double> ruleIDs) -> (Expected<String, WebKit::WebExtensionError> result)
     [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestUpdateDynamicRules(String rulesToAddJSON, Vector<double> ruleIdsToRemove) -> (Expected<void, WebKit::WebExtensionError> result)
-    [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestGetSessionRules() -> (Expected<String, WebKit::WebExtensionError> result)
+    [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestGetSessionRules(Vector<double> ruleIDs) -> (Expected<String, WebKit::WebExtensionError> result)
     [Validator=isDeclarativeNetRequestMessageAllowed] DeclarativeNetRequestUpdateSessionRules(String rulesToAddJSON, Vector<double> ruleIdsToRemove) -> (Expected<void, WebKit::WebExtensionError> result)
 
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -61,6 +61,8 @@ static NSString * const actionCountIncrementKey = @"increment";
 static NSString * const getMatchedRulesTabIDKey = @"tabId";
 static NSString * const getMatchedRulesMinTimeStampKey = @"minTimeStamp";
 
+static NSString * const getDynamicOrSessionRulesRuleIDsKey = @"ruleIds";
+
 static NSString * const addRulesKey = @"addRules";
 static NSString * const removeRulesKey = @"removeRuleIds";
 
@@ -138,9 +140,24 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIDeclarativeNetRequest::getDynamicRules(Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIDeclarativeNetRequest::getDynamicRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetDynamicRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+    NSString *outExceptionString;
+
+    static NSDictionary<NSString *, id> *keyTypes = @{
+        getDynamicOrSessionRulesRuleIDsKey: @[ NSNumber.class ]
+    };
+
+    if (!validateDictionary(filter, nil, nil, keyTypes, &outExceptionString)) {
+        callback->reportError(outExceptionString);
+        return;
+    }
+
+    Vector<double> ruleIDs;
+    for (NSNumber *ruleID in filter[getDynamicOrSessionRulesRuleIDsKey])
+        ruleIDs.append(ruleID.doubleValue);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetDynamicRules(WTFMove(ruleIDs)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -194,9 +211,24 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIDeclarativeNetRequest::getSessionRules(Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIDeclarativeNetRequest::getSessionRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetSessionRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+    NSString *outExceptionString;
+
+    static NSDictionary<NSString *, id> *keyTypes = @{
+        getDynamicOrSessionRulesRuleIDsKey: @[ NSNumber.class ]
+    };
+
+    if (!validateDictionary(filter, nil, nil, keyTypes, &outExceptionString)) {
+        callback->reportError(outExceptionString);
+        return;
+    }
+
+    Vector<double> ruleIDs;
+    for (NSNumber *ruleID in filter[getDynamicOrSessionRulesRuleIDsKey])
+        ruleIDs.append(ruleID.doubleValue);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetSessionRules(WTFMove(ruleIDs)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
@@ -44,10 +44,10 @@ public:
     void getEnabledRulesets(Ref<WebExtensionCallbackHandler>&&);
 
     void updateDynamicRules(NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getDynamicRules(Ref<WebExtensionCallbackHandler>&&);
+    void getDynamicRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&);
 
     void updateSessionRules(NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getSessionRules(Ref<WebExtensionCallbackHandler>&&);
+    void getSessionRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&);
 
     void getMatchedRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
@@ -33,10 +33,10 @@
     void getEnabledRulesets([Optional, CallbackHandler] function callback);
 
     [RaisesException] void updateDynamicRules([NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    void getDynamicRules([Optional, CallbackHandler] function callback);
+    void getDynamicRules([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void updateSessionRules([NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    void getSessionRules([Optional, CallbackHandler] function callback);
+    void getSessionRules([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void getMatchedRules([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -520,6 +520,69 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
     Util::run(&receivedActionNotification);
 }
 
+TEST(WKWebExtensionAPIDeclarativeNetRequest, GetSessionRules)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let sessionRules = await browser.declarativeNetRequest.getSessionRules()",
+        @"browser.test.assertEq(sessionRules.length, 0)",
+
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'foo' } }] })",
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 2, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'bar' } }] })",
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 3, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'baz' } }] })",
+
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: 1 }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: '' }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: true }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: { } }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: function foo() { } }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: [ '' ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: [ true ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: [ { } ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getSessionRules({ ruleIds: [ function foo() { } ] }))",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ })",
+        @"sessionRules = sessionRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(sessionRules.length, 3)",
+        @"browser.test.assertEq(sessionRules[0].id, 1)",
+        @"browser.test.assertEq(sessionRules[1].id, 2)",
+        @"browser.test.assertEq(sessionRules[2].id, 3)",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ ruleIds: [ ] })",
+        @"sessionRules = sessionRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(sessionRules.length, 3)",
+        @"browser.test.assertEq(sessionRules[0].id, 1)",
+        @"browser.test.assertEq(sessionRules[1].id, 2)",
+        @"browser.test.assertEq(sessionRules[2].id, 3)",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ ruleIds: [ 1 ] })",
+        @"browser.test.assertEq(sessionRules.length, 1)",
+        @"browser.test.assertEq(sessionRules[0].id, 1)",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ ruleIds: [ 1, 2 ] })",
+        @"sessionRules = sessionRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(sessionRules.length, 2)",
+        @"browser.test.assertEq(sessionRules[0].id, 1)",
+        @"browser.test.assertEq(sessionRules[1].id, 2)",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ ruleIds: [ 1, 2, 3 ] })",
+        @"sessionRules = sessionRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(sessionRules.length, 3)",
+        @"browser.test.assertEq(sessionRules[0].id, 1)",
+        @"browser.test.assertEq(sessionRules[1].id, 2)",
+        @"browser.test.assertEq(sessionRules[2].id, 3)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+    };
+
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+}
+
 TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
 {
     TestWebKitAPI::HTTPServer server({
@@ -584,6 +647,69 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     [webView loadRequest:server.requestWithLocalhost()];
 
     Util::run(&receivedActionNotification);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, GetDynamicRules)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let dynamicRules = await browser.declarativeNetRequest.getDynamicRules()",
+        @"browser.test.assertEq(dynamicRules.length, 0)",
+
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'foo' } }] })",
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 2, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'bar' } }] })",
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 3, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'baz' } }] })",
+
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: 1 }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: '' }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: true }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: { } }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: function foo() { } }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ '' ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ true ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ { } ] }))",
+        @"browser.test.assertRejects(browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ function foo() { } ] }))",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ })",
+        @"dynamicRules = dynamicRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(dynamicRules.length, 3)",
+        @"browser.test.assertEq(dynamicRules[0].id, 1)",
+        @"browser.test.assertEq(dynamicRules[1].id, 2)",
+        @"browser.test.assertEq(dynamicRules[2].id, 3)",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ ] })",
+        @"dynamicRules = dynamicRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(dynamicRules.length, 3)",
+        @"browser.test.assertEq(dynamicRules[0].id, 1)",
+        @"browser.test.assertEq(dynamicRules[1].id, 2)",
+        @"browser.test.assertEq(dynamicRules[2].id, 3)",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ 1 ] })",
+        @"browser.test.assertEq(dynamicRules.length, 1)",
+        @"browser.test.assertEq(dynamicRules[0].id, 1)",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ 1, 2 ] })",
+        @"dynamicRules = dynamicRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(dynamicRules.length, 2)",
+        @"browser.test.assertEq(dynamicRules[0].id, 1)",
+        @"browser.test.assertEq(dynamicRules[1].id, 2)",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ ruleIds: [ 1, 2, 3 ] })",
+        @"dynamicRules = dynamicRules.sort((a, b) => { a.id < b.id })",
+        @"browser.test.assertEq(dynamicRules.length, 3)",
+        @"browser.test.assertEq(dynamicRules[0].id, 1)",
+        @"browser.test.assertEq(dynamicRules[1].id, 2)",
+        @"browser.test.assertEq(dynamicRules[2].id, 3)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+    };
+
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)


### PR DESCRIPTION
#### d6b240ab340c771414e1243bdc8da362e941451f
<pre>
dNR: Implement the optional filter parameter of getDynamicRules and getSessionRules
<a href="https://bugs.webkit.org/show_bug.cgi?id=290589">https://bugs.webkit.org/show_bug.cgi?id=290589</a>
<a href="https://rdar.apple.com/147782333">rdar://147782333</a>

Reviewed by Timothy Hatcher.

This patch implements the filter parameter of the getDynamicRules and the
getSessionRules dNR methods.

This parameter is an object that has an optional ruleIds array of numbers,
which defines which rules to return.

Wrote new tests to validate this change.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestGetDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestGetSessionRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm:
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore getRulesWithRuleIDs:completionHandler:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _getRulesWithRuleIDs:errorMessage:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore getRulesWithCompletionHandler:]): Deleted.
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _getRulesWithOutErrorMessage:]): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::getDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getSessionRules):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, GetSessionRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, GetDynamicRules)):

Canonical link: <a href="https://commits.webkit.org/292892@main">https://commits.webkit.org/292892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f67a32b0db3fb473430be0e13e1e4d1639516ca2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47858 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74147 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31338 "Found 1 new test failure: workers/worker-to-worker.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104436 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24407 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17794 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/abrupt-completion.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83191 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82610 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17953 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29538 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->