### PR TITLE
AX: 8 properties are unnecessarily cached for every single AXIsolatedObject

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -392,6 +392,19 @@ AXCoreObject* AXCoreObject::nextSiblingIncludingIgnoredOrParent() const
     return parent.get();
 }
 
+String AXCoreObject::autoCompleteValue() const
+{
+    String explicitValue = explicitAutoCompleteValue();
+    return explicitValue.isEmpty() ? "none"_s : explicitValue;
+}
+
+String AXCoreObject::invalidStatus() const
+{
+    auto explicitValue = explicitInvalidStatus();
+    // "false" is the default if no invalid status is explicitly provided (e.g. via aria-invalid).
+    return explicitValue.isEmpty() ? "false"_s : explicitValue;
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::contents()
 {
     if (isTabList())
@@ -759,6 +772,22 @@ bool AXCoreObject::isRootWebArea() const
     RefPtr parent = parentObject();
     // If the parent is a scroll area, and the scroll area has no parent, we are at the root web area.
     return parent && parent->roleValue() == AccessibilityRole::ScrollArea && !parent->parentObject();
+}
+
+String AXCoreObject::popupValue() const
+{
+    String explicitValue = explicitPopupValue();
+    if (!explicitValue.isEmpty())
+        return explicitValue;
+
+    // In ARIA 1.1, the implicit value for combobox became "listbox."
+    if (isComboBox())
+        return "listbox"_s;
+
+    // The spec states that "User agents must treat any value of aria-haspopup that is not
+    // included in the list of allowed values, including an empty string, as if the value
+    // false had been provided."
+    return "false"_s;
 }
 
 bool AXCoreObject::hasPopup() const

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -653,9 +653,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::AncestorFlags:
         stream << "AncestorFlags";
         break;
-    case AXProperty::AutoCompleteValue:
-        stream << "AutoCompleteValue";
-        break;
     case AXProperty::BackgroundColor:
         stream << "BackgroundColor";
         break;
@@ -748,11 +745,23 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
+    case AXProperty::ExplicitAutoCompleteValue:
+        stream << "ExplicitAutoCompleteValue";
+        break;
+    case AXProperty::ExplicitInvalidStatus:
+        stream << "ExplicitInvalidStatus";
+        break;
+    case AXProperty::ExplicitLiveRegionRelevant:
+        stream << "ExplicitLiveRegionRelevant";
+        break;
     case AXProperty::ExplicitLiveRegionStatus:
         stream << "ExplicitLiveRegionStatus";
         break;
     case AXProperty::ExplicitOrientation:
         stream << "ExplicitOrientation";
+        break;
+    case AXProperty::ExplicitPopupValue:
+        stream << "ExplicitPopupValue";
         break;
     case AXProperty::ExtendedDescription:
         stream << "ExtendedDescription";
@@ -827,9 +836,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::InsideLink:
         stream << "InsideLink";
-        break;
-    case AXProperty::InvalidStatus:
-        stream << "InvalidStatus";
         break;
     case AXProperty::IsGrabbed:
         stream << "IsGrabbed";
@@ -995,9 +1001,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::LiveRegionAtomic:
         stream << "LiveRegionAtomic";
         break;
-    case AXProperty::LiveRegionRelevant:
-        stream << "LiveRegionRelevant";
-        break;
     case AXProperty::LocalizedActionVerb:
         stream << "LocalizedActionVerb";
         break;
@@ -1061,9 +1064,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::PlaceholderValue:
         stream << "PlaceholderValue";
         break;
-    case AXProperty::PopupValue:
-        stream << "PopupValue";
-        break;
     case AXProperty::PosInSet:
         stream << "PosInSet";
         break;
@@ -1118,8 +1118,8 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::SortDirection:
         stream << "SortDirection";
         break;
-    case AXProperty::SpeechHint:
-        stream << "SpeechHint";
+    case AXProperty::SpeakAs:
+        stream << "SpeakAs";
         break;
     case AXProperty::StringValue:
         stream << "StringValue";

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4816,7 +4816,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::SetSize, AXProperty::SupportsSetSize } });
             break;
         case AXNotification::SpeakAsChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SpeechHint });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SpeakAs });
             break;
         case AXNotification::TextCompositionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::TextInputMarkedTextMarkerRange });

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1431,16 +1431,6 @@ bool AccessibilityNodeObject::elementAttributeValue(const QualifiedName& attribu
     return equalLettersIgnoringASCIICase(getAttribute(attributeName), "true"_s);
 }
 
-const String AccessibilityNodeObject::liveRegionRelevant() const
-{
-    const auto& relevant = getAttribute(aria_relevantAttr);
-    // Default aria-relevant = "additions text".
-    if (relevant.isEmpty())
-        return "additions text"_s;
-
-    return relevant;
-}
-
 bool AccessibilityNodeObject::liveRegionAtomic() const
 {
     const auto& atomic = getAttribute(aria_atomicAttr);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -184,7 +184,7 @@ protected:
     bool elementAttributeValue(const QualifiedName&) const;
 
     const String explicitLiveRegionStatus() const final { return getAttribute(HTMLNames::aria_liveAttr); }
-    const String liveRegionRelevant() const final;
+    const String explicitLiveRegionRelevant() const final { return getAttribute(HTMLNames::aria_relevantAttr); }
     bool liveRegionAtomic() const final;
 
     String accessKey() const final;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1891,13 +1891,6 @@ std::optional<VisiblePosition> AccessibilityObject::previousLineStartPositionInt
     return startPosition;
 }
 
-OptionSet<SpeakAs> AccessibilityObject::speakAsProperty() const
-{
-    if (auto* style = this->style())
-        return style->speakAs();
-    return { };
-}
-
 InsideLink AccessibilityObject::insideLink() const
 {
     auto* style = this->style();
@@ -1996,7 +1989,7 @@ bool AccessibilityObject::supportsAutoComplete() const
     return (isComboBox() || isARIATextControl()) && hasAttribute(aria_autocompleteAttr);
 }
 
-String AccessibilityObject::autoCompleteValue() const
+String AccessibilityObject::explicitAutoCompleteValue() const
 {
     const AtomString& autoComplete = getAttribute(aria_autocompleteAttr);
     if (equalLettersIgnoringASCIICase(autoComplete, "inline"_s)
@@ -2004,7 +1997,7 @@ String AccessibilityObject::autoCompleteValue() const
         || equalLettersIgnoringASCIICase(autoComplete, "both"_s))
         return autoComplete;
 
-    return "none"_s;
+    return { };
 }
 
 bool AccessibilityObject::contentEditableAttributeIsEnabled(Element& element)
@@ -2319,13 +2312,13 @@ bool AccessibilityObject::ariaIsMultiline() const
     return equalLettersIgnoringASCIICase(getAttribute(aria_multilineAttr), "true"_s);
 }
 
-String AccessibilityObject::invalidStatus() const
+String AccessibilityObject::explicitInvalidStatus() const
 {
-    String grammarValue = "grammar"_s;
-    String falseValue = "false"_s;
-    String spellingValue = "spelling"_s;
-    String trueValue = "true"_s;
-    String undefinedValue = "undefined"_s;
+    static NeverDestroyed<String> grammarValue = "grammar"_s;
+    static NeverDestroyed<String> falseValue = "false"_s;
+    static NeverDestroyed<String> spellingValue = "spelling"_s;
+    static NeverDestroyed<String> trueValue = "true"_s;
+    static NeverDestroyed<String> undefinedValue = "undefined"_s;
 
     // aria-invalid can return false (default), grammar, spelling, or true.
     auto ariaInvalid = getAttributeTrimmed(aria_invalidAttr);
@@ -2337,7 +2330,7 @@ String AccessibilityObject::invalidStatus() const
             if (validatedFormListedElement->willValidate() && !validatedFormListedElement->isValidFormControlElement())
                 return trueValue;
         }
-        return falseValue;
+        return { };
     }
     
     // If "false", "undefined" [sic, string value], empty, or missing, return "false".
@@ -3185,14 +3178,14 @@ bool AccessibilityObject::supportsHasPopup() const
     return hasAttribute(aria_haspopupAttr) || isComboBox();
 }
 
-String AccessibilityObject::popupValue() const
+String AccessibilityObject::explicitPopupValue() const
 {
     auto& hasPopup = getAttribute(aria_haspopupAttr);
     if (hasPopup.isEmpty()) {
-        // In ARIA 1.1, the implicit value for combobox became "listbox."
-        if (isComboBox() || hasDatalist())
+        // In ARIA 1.1, the implicit value for datalists became "listbox."
+        if (hasDatalist())
             return "listbox"_s;
-        return "false"_s;
+        return { };
     }
 
     for (auto& value : { "menu"_s, "listbox"_s, "tree"_s, "grid"_s, "dialog"_s }) {
@@ -3204,11 +3197,7 @@ String AccessibilityObject::popupValue() const
     // aria-haspopup specification states that true must be treated as menu.
     if (equalLettersIgnoringASCIICase(hasPopup, "true"_s))
         return "menu"_s;
-
-    // The spec states that "User agents must treat any value of aria-haspopup that is not
-    // included in the list of allowed values, including an empty string, as if the value
-    // false had been provided."
-    return "false"_s;
+    return { };
 }
 
 bool AccessibilityObject::hasDatalist() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -275,12 +275,12 @@ public:
     bool supportsARIARoleDescription() const;
     bool supportsARIAOwns() const override { return false; }
 
-    String popupValue() const final;
+    String explicitPopupValue() const final;
     bool hasDatalist() const;
     bool supportsHasPopup() const final;
     bool pressedIsPresent() const final;
     bool ariaIsMultiline() const;
-    String invalidStatus() const final;
+    String explicitInvalidStatus() const final;
     bool supportsPressed() const;
     bool supportsExpanded() const final;
     bool supportsChecked() const final;
@@ -636,7 +636,7 @@ public:
     // ARIA live-region features.
     AccessibilityObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String explicitLiveRegionStatus() const override { return String(); }
-    const String liveRegionRelevant() const override { return nullAtom(); }
+    const String explicitLiveRegionRelevant() const override { return nullAtom(); }
     bool liveRegionAtomic() const override { return false; }
     bool isBusy() const override { return false; }
     static bool contentEditableAttributeIsEnabled(Element&);
@@ -646,13 +646,10 @@ public:
     virtual String readOnlyValue() const;
 
     bool supportsAutoComplete() const;
-    String autoCompleteValue() const final;
+    String explicitAutoCompleteValue() const final;
 
     bool hasARIAValueNow() const { return hasAttribute(HTMLNames::aria_valuenowAttr); }
     bool supportsARIAAttributes() const;
-
-    // CSS3 Speech properties.
-    OptionSet<SpeakAs> speakAsProperty() const;
 
     // Make this object visible by scrolling as many nested scrollable views as needed.
     void scrollToMakeVisible() const final;
@@ -748,7 +745,7 @@ public:
     bool preventKeyboardDOMEventDispatch() const final;
     void setPreventKeyboardDOMEventDispatch(bool) final;
     bool fileUploadButtonReturnsValueInTitle() const final;
-    String speechHintAttributeValue() const final;
+    OptionSet<SpeakAs> speakAs() const final;
     bool hasApplePDFAnnotationAttribute() const final { return hasAttribute(HTMLNames::x_apple_pdf_annotationAttr); }
 #endif
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -58,6 +58,22 @@ SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenAttachment, NSString *);
 
 namespace WebCore {
 
+String AXCoreObject::speechHint() const
+{
+    auto speakAs = this->speakAs();
+
+    StringBuilder builder;
+    builder.append((speakAs & SpeakAs::SpellOut) ? "spell-out"_s : "normal"_s);
+    if (speakAs & SpeakAs::Digits)
+        builder.append(" digits"_s);
+    if (speakAs & SpeakAs::LiteralPunctuation)
+        builder.append(" literal-punctuation"_s);
+    if (speakAs & SpeakAs::NoPunctuation)
+        builder.append(" no-punctuation"_s);
+
+    return builder.toString();
+}
+
 // When modifying attributed strings, the range can come from a source which may provide faulty information (e.g. the spell checker).
 // To protect against such cases, the range should be validated before adding or removing attributes.
 bool attributedStringContainsRange(NSAttributedString *attributedString, const NSRange& range)

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -35,18 +35,11 @@
 
 namespace WebCore {
 
-String AccessibilityObject::speechHintAttributeValue() const
+OptionSet<SpeakAs> AccessibilityObject::speakAs() const
 {
-    auto speak = speakAsProperty();
-    NSMutableArray<NSString *> *hints = [NSMutableArray array];
-    [hints addObject:(speak & SpeakAs::SpellOut) ? @"spell-out" : @"normal"];
-    if (speak & SpeakAs::Digits)
-        [hints addObject:@"digits"];
-    if (speak & SpeakAs::LiteralPunctuation)
-        [hints addObject:@"literal-punctuation"];
-    if (speak & SpeakAs::NoPunctuation)
-        [hints addObject:@"no-punctuation"];
-    return [hints componentsJoinedByString:@" "];
+    if (auto* style = this->style())
+        return style->speakAs();
+    return { };
 }
 
 FloatPoint AccessibilityObject::screenRelativePosition() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -261,9 +261,9 @@ private:
     int layoutCount() const final;
     double loadingProgress() const final { return tree()->loadingProgress(); }
     bool supportsARIAOwns() const final { return boolAttributeValue(AXProperty::SupportsARIAOwns); }
-    String popupValue() const final { return stringAttributeValue(AXProperty::PopupValue); }
+    String explicitPopupValue() const final { return stringAttributeValue(AXProperty::ExplicitPopupValue); }
     bool pressedIsPresent() const final;
-    String invalidStatus() const final { return stringAttributeValue(AXProperty::InvalidStatus); }
+    String explicitInvalidStatus() const final { return stringAttributeValue(AXProperty::ExplicitInvalidStatus); }
     bool supportsExpanded() const final { return boolAttributeValue(AXProperty::SupportsExpanded); }
     AccessibilitySortDirection sortDirection() const final { return static_cast<AccessibilitySortDirection>(intAttributeValue(AXProperty::SortDirection)); }
     String identifierAttribute() const final;
@@ -308,7 +308,7 @@ private:
     String accessKey() const final { return stringAttributeValueNullIfMissing(AXProperty::AccessKey); }
     String localizedActionVerb() const final { return stringAttributeValue(AXProperty::LocalizedActionVerb); }
     String actionVerb() const final { return stringAttributeValue(AXProperty::ActionVerb); }
-    String autoCompleteValue() const final { return stringAttributeValue(AXProperty::AutoCompleteValue); }
+    String explicitAutoCompleteValue() const final { return stringAttributeValue(AXProperty::ExplicitAutoCompleteValue); }
     bool isMathElement() const final { return boolAttributeValue(AXProperty::IsMathElement); }
     bool isMathFraction() const final { return boolAttributeValue(AXProperty::IsMathFraction); }
     bool isMathFenced() const final { return boolAttributeValue(AXProperty::IsMathFenced); }
@@ -337,7 +337,7 @@ private:
     void mathPrescripts(AccessibilityMathMultiscriptPairs&) final;
     void mathPostscripts(AccessibilityMathMultiscriptPairs&) final;
 #if PLATFORM(COCOA)
-    String speechHintAttributeValue() const final { return stringAttributeValue(AXProperty::SpeechHint); }
+    OptionSet<SpeakAs> speakAs() const final { return optionSetAttributeValue<SpeakAs>(AXProperty::SpeakAs); }
 #endif
     bool fileUploadButtonReturnsValueInTitle() const final;
 #if PLATFORM(MAC)
@@ -359,7 +359,7 @@ private:
     bool isDetachedFromParent() final;
     AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String explicitLiveRegionStatus() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionStatus); }
-    const String liveRegionRelevant() const final { return stringAttributeValue(AXProperty::LiveRegionRelevant); }
+    const String explicitLiveRegionRelevant() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionRelevant); }
     bool liveRegionAtomic() const final { return boolAttributeValue(AXProperty::LiveRegionAtomic); }
     bool isBusy() const final { return boolAttributeValue(AXProperty::IsBusy); }
     bool isInlineText() const final { return boolAttributeValue(AXProperty::IsInlineText); }
@@ -535,7 +535,7 @@ private:
     ScrollView* scrollView() const final;
     void detachFromParent() final;
 
-    OptionSet<AXAncestorFlag> ancestorFlags() const;
+    OptionSet<AXAncestorFlag> ancestorFlags() const { return optionSetAttributeValue<AXAncestorFlag>(AXProperty::AncestorFlags); }
 
     bool hasDocumentRoleAncestor() const final { return ancestorFlags().contains(AXAncestorFlag::HasDocumentRoleAncestor); }
     bool hasWebApplicationAncestor() const final { return ancestorFlags().contains(AXAncestorFlag::HasWebApplicationAncestor); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -766,8 +766,8 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::SortDirection:
             propertyMap.set(AXProperty::SortDirection, static_cast<int>(axObject.sortDirection()));
             break;
-        case AXProperty::SpeechHint:
-            propertyMap.set(AXProperty::SpeechHint, axObject.speechHintAttributeValue().isolatedCopy());
+        case AXProperty::SpeakAs:
+            propertyMap.set(AXProperty::SpeakAs, axObject.speakAs());
             break;
         case AXProperty::KeyShortcuts:
             propertyMap.set(AXProperty::SupportsKeyShortcuts, axObject.supportsKeyShortcuts());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -95,7 +95,6 @@ enum class AXProperty : uint16_t {
     AccessibilityText,
     ActionVerb,
     AncestorFlags,
-    AutoCompleteValue,
     BackgroundColor,
     BrailleLabel,
     BrailleRoleDescription,
@@ -127,8 +126,12 @@ enum class AXProperty : uint16_t {
     DocumentURI,
     EmbeddedImageDescription,
     ExpandedTextValue,
+    ExplicitAutoCompleteValue,
+    ExplicitInvalidStatus,
+    ExplicitLiveRegionRelevant,
     ExplicitLiveRegionStatus,
     ExplicitOrientation,
+    ExplicitPopupValue,
     ExtendedDescription,
 #if PLATFORM(COCOA)
     Font,
@@ -155,7 +158,6 @@ enum class AXProperty : uint16_t {
     InnerHTML,
     InternalLinkElement,
     InsideLink,
-    InvalidStatus,
     IsGrabbed,
     IsARIATreeGridRow,
     IsAttachment,
@@ -212,7 +214,6 @@ enum class AXProperty : uint16_t {
     ListMarkerText,
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     LiveRegionAtomic,
-    LiveRegionRelevant,
     LocalizedActionVerb,
     MathFencedOpenString,
     MathFencedCloseString,
@@ -234,7 +235,6 @@ enum class AXProperty : uint16_t {
     OuterHTML,
     Path,
     PlaceholderValue,
-    PopupValue,
     PosInSet,
     PreventKeyboardDOMEventDispatch,
     RadioButtonGroup,
@@ -253,7 +253,7 @@ enum class AXProperty : uint16_t {
     SelectedTextRange,
     SetSize,
     SortDirection,
-    SpeechHint,
+    SpeakAs,
     StringValue,
     SubrolePlatformString,
     SupportsDragging,
@@ -300,6 +300,7 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<id>
+    , OptionSet<SpeakAs>
 #endif // PLATFORM(COCOA)
 #if ENABLE(AX_THREAD_TEXT_APIS)
     , RetainPtr<CTFontRef>

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 void AXIsolatedObject::initializePlatformProperties(const Ref<const AccessibilityObject>& object)
 {
     setProperty(AXProperty::HasApplePDFAnnotationAttribute, object->hasApplePDFAnnotationAttribute());
-    setProperty(AXProperty::SpeechHint, object->speechHintAttributeValue().isolatedCopy());
+    setProperty(AXProperty::SpeakAs, object->speakAs());
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (object->isStaticText()) {
         auto style = object->stylesForAttributedString();

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -393,7 +393,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (NSArray<NSString *> *)baseAccessibilitySpeechHint
 {
-    return [(NSString *)self.axBackingObject->speechHintAttributeValue() componentsSeparatedByString:@" "];
+    return [(NSString *)self.axBackingObject->speechHint() componentsSeparatedByString:@" "];
 }
 
 #if HAVE(ACCESSIBILITY_FRAMEWORK)


### PR DESCRIPTION
#### 3cc438654ebc758e803dfa01b3ab638ace726a96
<pre>
AX: 8 properties are unnecessarily cached for every single AXIsolatedObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=290585">https://bugs.webkit.org/show_bug.cgi?id=290585</a>
<a href="https://rdar.apple.com/148061952">rdar://148061952</a>

Reviewed by Chris Fleizach.

Eight properties were unnecessarily cached for every isolated object, and are no longer cached except in the rare case
they are non-default.

AXProperty::ColorValue was always cached because our &quot;check for default value&quot; logic in AXIsolatedObject::setProperty
compared against Color(), which is transparent black, but AccessibilityNodeObject::colorValue returns Color::black
for anything that isn&apos;t a color input, and these are not equal. This is fixed by some special-case handling when
caching and returning AXProperty::ColorValue.

Furthermore, our is-default check for `Color`s is generally much smarter and caches far fewer values, e.g. for properties
like AXProperty::BackgroundColor and AXProperty::LinethroughColor. Prior to this commit, we compare to Color() without
converting to RGBA, which is a lossy conversion. This meant that the colors would be effectively the same as the default,
but still get cached. Now we eagerly convert to SRGBA before comparing colors.

AXProperty::{InvalidStatus, AutoCompleteValue, PopupValue, LiveRegionRelevant} all fell back to returning a non-empty
string in the default case when the corresponding attribute wasn&apos;t present, meaning we always cached something for these
properties. With this commit, we now only cache something when a value is explicitly set.

AXProperty::SpeechHint has been changed to AXProperty::SpeakAs. This propery was similar to the previous group - we always
computed a non-empty string, and thus always cached something.

AXProperty::StringValue used to cache null strings, but not empty ones, as an optimization. Prior to ENABLE(AX_THREAD_TEXT_APIS),
we needed this distinction to know whether we should fallback to using the cached AXProperty::AttributedString as the string value.
However, with ENABLE(AX_THREAD_TEXT_APIS), we now compute attributed strings on-the-fly, and thus don&apos;t need to avoid
considering null string values to be default, allowing us to avoid caching this property ~95% more often (based on data from gmail.com).

AXProperty::SortDirection always used to be cached because our is-default check looked for AccessibilitySortDirection::None,
but for anything that column header or row header, we would return AccessibilitySortDirection::Invalid. This commit addresses
the issue by making Invalid the first variant in the enum, meaning it will be the default, since we cast this enum to an
int before caching it.

This saves roughly ~218 mb of memory on <a href="http://html.spec.whatwg.org.">http://html.spec.whatwg.org.</a>

(567769 objects * 8 fewer properties per object * 48 bytes (sizeof(AXPropertyValueVariant)))

The savings are probably even better considering the significantly smarter Color default checks.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::autoCompleteValue const):
(WebCore::AXCoreObject::invalidStatus const):
(WebCore::AXCoreObject::popupValue const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::liveRegionRelevant const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::liveRegionRelevant const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::speakAs const):
(WebCore::AccessibilityObject::explicitAutoCompleteValue const):
(WebCore::AccessibilityObject::explicitInvalidStatus const):
(WebCore::AccessibilityObject::explicitPopupValue const):
(WebCore::AccessibilityObject::speakAsProperty const): Deleted.
(WebCore::AccessibilityObject::autoCompleteValue const): Deleted.
(WebCore::AccessibilityObject::invalidStatus const): Deleted.
(WebCore::AccessibilityObject::popupValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::speechHint const):
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::AccessibilityObject::speechHintAttributeValue const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::colorValue const):
(WebCore::AXIsolatedObject::optionSetAttributeValue const):
(WebCore::AXIsolatedObject::stringValue const):
(WebCore::AXIsolatedObject::ancestorFlags const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::initializePlatformProperties):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase baseAccessibilitySpeechHint]):

Canonical link: <a href="https://commits.webkit.org/292834@main">https://commits.webkit.org/292834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c1f7f9399ae8cb0bcd3882e6f481557d8dc81f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100163 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12892 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5742 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104263 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83056 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20767 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17739 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29350 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->