### PR TITLE
AX: [AX Thread Text APIs] atLineBoundaryForDirection doesn't return true for positions right before <br> tags

### DIFF
--- a/LayoutTests/accessibility/mac/line-boundary-at-br-expected.txt
+++ b/LayoutTests/accessibility/mac/line-boundary-at-br-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that next line end appropriately finds the next line when there are
+ tags.
+
+PASS: textChild.indexForTextMarker(currentMarker) === 5
+PASS: textChild.indexForTextMarker(currentMarker) === 6
+PASS: textChild.indexForTextMarker(currentMarker) === 12
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello
+
+world

--- a/LayoutTests/accessibility/mac/line-boundary-at-br.html
+++ b/LayoutTests/accessibility/mac/line-boundary-at-br.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="content">Hello<br><br>world</p>
+    
+<script>
+
+var textChild, startMarker, range, currentMarker, lineRange;
+if (window.accessibilityController) {
+    let output = "This test verifies that next line end appropriately finds the next line when there are <br> tags.\n\n";
+    textChild = accessibilityController.accessibleElementById("content").childAtIndex(0);
+
+    range = textChild.textMarkerRangeForElement(textChild);
+    startMarker = textChild.startTextMarkerForTextMarkerRange(range);
+    currentMarker = textChild.nextLineEndTextMarkerForTextMarker(startMarker);
+    output += expect("textChild.indexForTextMarker(currentMarker)", "5");
+
+    currentMarker = textChild.nextLineEndTextMarkerForTextMarker(currentMarker);
+    output += expect("textChild.indexForTextMarker(currentMarker)", "6");
+
+    currentMarker = textChild.nextLineEndTextMarkerForTextMarker(currentMarker);
+    output += expect("textChild.indexForTextMarker(currentMarker)", "12");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -948,6 +948,7 @@ accessibility/mac/content-editable-attributed-string.html [ Skip ]
 accessibility/mac/lazy-spellchecking.html [ Skip ]
 accessibility/mac/spellcheck-with-voiceover.html [ Skip ]
 accessibility/text-marker/text-marker-range-with-unordered-markers.html
+accessibility/mac/line-boundary-at-br.html [ Skip ]
 
 accessibility/aria-controlled-table-row-visibility.html [ Skip ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2429,4 +2429,7 @@ svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg [ Failure ]
 
 [ x86_64 ] imported/w3c/web-platform-tests/css/css-values/attr-all-types.html [ Failure ]
 
+# webkit.org/b/290848 : AX: accessibility/mac/line-boundary-at-br.html asserts on Debug
+[ Debug ] accessibility/mac/line-boundary-at-br.html [ Skip ]
+
 webkit.org/b/290874 fast/text/international/generic-font-family-language-traditional.html [ ImageOnlyFailure ]

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -948,6 +948,7 @@ public:
 #if ENABLE(MODEL_ELEMENT)
     bool isModel() const { return roleValue() == AccessibilityRole::Model; }
 #endif
+    bool isLineBreak() const { return roleValue() == AccessibilityRole::LineBreak; }
 
     bool isLandmark() const;
     virtual bool isKeyboardFocusable() const = 0;

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -798,6 +798,11 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction) const
 bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTextRuns* runs, size_t runIndex) const
 {
     auto* nextObjectWithRuns = findObjectWithRuns(*isolatedObject(), direction);
+    // If the next object is a line break, it will often have the same line index as the previous static text
+    // (even though it is a newline). In this case, advance one object to check the next line index.
+    if (nextObjectWithRuns && nextObjectWithRuns->isLineBreak())
+        nextObjectWithRuns = findObjectWithRuns(*nextObjectWithRuns, direction);
+
     auto* nextRuns = nextObjectWithRuns ? nextObjectWithRuns->textRuns() : nullptr;
     // If there are more runs in the same containing block with the same line, we are not at a start or end and can exit early.
     // No need to continue searching when the containing block changes.


### PR DESCRIPTION
#### f93fbfa916089591ea755ab954c66dcbd9531e87
<pre>
AX: [AX Thread Text APIs] atLineBoundaryForDirection doesn&apos;t return true for positions right before &lt;br&gt; tags
<a href="https://bugs.webkit.org/show_bug.cgi?id=290596">https://bugs.webkit.org/show_bug.cgi?id=290596</a>
<a href="https://rdar.apple.com/148071140">rdar://148071140</a>

Reviewed by Tyler Wilcock.

For markup such as the following

```
Hello&lt;br&gt;world
```

It was possible for us to get into an infinite loop when finding the `lineIndex` for a text
marker at the end of `Hello`, but before the `&lt;br&gt;`. This is because `atLineBoundaryForDirection`
would not consider this position to be a line boundary, even though this is at the end of the
rendered line, since line breaks have the same line ID as the content prior. To fix this, we need
to stop considering line breaks in our calculation for line boundaries.

* LayoutTests/accessibility/mac/line-boundary-at-br-expected.txt: Added.
* LayoutTests/accessibility/mac/line-boundary-at-br.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isLineBreak const):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::atLineBoundaryForDirection const):

Canonical link: <a href="https://commits.webkit.org/293063@main">https://commits.webkit.org/293063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45d43429d59616645184a41fc321064834722fbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25907 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54852 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47801 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84589 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27556 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24870 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24692 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/28006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->