### PR TITLE
Address more Safer CPP failures in UIProcess/RemoteLayerTree

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -95,7 +95,6 @@ UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
 UIProcess/Downloads/DownloadProxy.cpp
-UIProcess/RemoteLayerTree/RemoteScrollingTree.h
 UIProcess/RemotePageDrawingAreaProxy.cpp
 UIProcess/WebsiteData/WebsiteDataStore.cpp
 UIProcess/mac/WebContextMenuProxyMac.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -139,15 +139,15 @@ void RemoteAcceleratedEffectStack::initEffectsFromMainThread(PlatformLayer *laye
     }
 
     if (m_affectedLayerProperties.contains(LayerProperty::Opacity)) {
-        auto *opacity = @(computedValues.opacity);
-        m_opacityPresentationModifier = adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"opacity" initialValue:opacity additive:NO group:m_presentationModifierGroup.get()]);
+        RetainPtr opacity = @(computedValues.opacity);
+        m_opacityPresentationModifier = adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"opacity" initialValue:opacity.get() additive:NO group:m_presentationModifierGroup.get()]);
         [layer addPresentationModifier:m_opacityPresentationModifier.get()];
     }
 
     if (m_affectedLayerProperties.contains(LayerProperty::Transform)) {
         auto computedTransform = computedValues.computedTransformationMatrix(m_bounds);
-        auto *transform = [NSValue valueWithCATransform3D:computedTransform];
-        m_transformPresentationModifier = adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"transform" initialValue:transform additive:NO group:m_presentationModifierGroup.get()]);
+        RetainPtr transform = [NSValue valueWithCATransform3D:computedTransform];
+        m_transformPresentationModifier = adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"transform" initialValue:transform.get() additive:NO group:m_presentationModifierGroup.get()]);
         [layer addPresentationModifier:m_transformPresentationModifier.get()];
     }
 
@@ -164,14 +164,14 @@ void RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread(MonotonicTime
         WebCore::PlatformCAFilters::updatePresentationModifiers(computedValues.filter, m_filterPresentationModifiers);
 
     if (m_opacityPresentationModifier) {
-        auto *opacity = @(computedValues.opacity);
-        [m_opacityPresentationModifier setValue:opacity];
+        RetainPtr opacity = @(computedValues.opacity);
+        [m_opacityPresentationModifier setValue:opacity.get()];
     }
 
     if (m_transformPresentationModifier) {
         auto computedTransform = computedValues.computedTransformationMatrix(m_bounds);
-        auto *transform = [NSValue valueWithCATransform3D:computedTransform];
-        [m_transformPresentationModifier setValue:transform];
+        RetainPtr transform = [NSValue valueWithCATransform3D:computedTransform];
+        [m_transformPresentationModifier setValue:transform.get()];
     }
 
     [m_presentationModifierGroup flush];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -500,7 +500,7 @@ void RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator()
 void RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator(IntSize contentsSize, bool rootLayerChanged, float scale, const IntPoint& scrollPosition)
 {
     // Make sure we're the last sublayer.
-    CALayer *rootLayer = m_remoteLayerTreeHost->rootLayer();
+    RetainPtr rootLayer = m_remoteLayerTreeHost->rootLayer();
     [m_tileMapHostLayer removeFromSuperlayer];
     [rootLayer addSublayer:m_tileMapHostLayer.get()];
 
@@ -549,14 +549,14 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
     [m_tileMapHostLayer setMasksToBounds:YES];
     [m_tileMapHostLayer setBorderWidth:2];
 
-    CGColorSpaceRef colorSpace = sRGBColorSpaceRef();
+    RetainPtr colorSpace = sRGBColorSpaceRef();
     {
         const CGFloat components[] = { 1, 1, 1, 0.6 };
-        RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace, components));
+        RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace.get(), components));
         [m_tileMapHostLayer setBackgroundColor:color.get()];
 
         const CGFloat borderComponents[] = { 0, 0, 0, 1 };
-        RetainPtr<CGColorRef> borderColor = adoptCF(CGColorCreate(colorSpace, borderComponents));
+        RetainPtr<CGColorRef> borderColor = adoptCF(CGColorCreate(colorSpace.get(), borderComponents));
         [m_tileMapHostLayer setBorderColor:borderColor.get()];
     }
     
@@ -566,7 +566,7 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
 
     {
         const CGFloat components[] = { 0, 1, 0, 1 };
-        RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace, components));
+        RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace.get(), components));
         [m_exposedRectIndicatorLayer setBorderColor:color.get()];
     }
 }
@@ -652,7 +652,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
         didRefreshDisplay(connection.ptr());
 
     static Seconds activityStateUpdateTimeout = [] {
-        if (id value = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitOverrideActivityStateUpdateTimeout"])
+        if (RetainPtr<id> value = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitOverrideActivityStateUpdateTimeout"])
             return Seconds([value doubleValue]);
         return Seconds::fromMilliseconds(250);
     }();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -137,7 +137,7 @@ bool RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled() const
 #if PLATFORM(MAC)
 bool RemoteLayerTreeHost::updateBannerLayers(const RemoteLayerTreeTransaction& transaction)
 {
-    auto scrolledContentsLayer = layerForID(transaction.scrolledContentsLayerID());
+    RetainPtr scrolledContentsLayer = layerForID(transaction.scrolledContentsLayerID());
     if (!scrolledContentsLayer)
         return false;
 
@@ -156,8 +156,8 @@ bool RemoteLayerTreeHost::updateBannerLayers(const RemoteLayerTreeTransaction& t
     if (!page)
         return false;
 
-    bool headerBannerLayerChanged = updateBannerLayer(page->headerBannerLayer(), scrolledContentsLayer);
-    bool footerBannerLayerChanged = updateBannerLayer(page->footerBannerLayer(), scrolledContentsLayer);
+    bool headerBannerLayerChanged = updateBannerLayer(page->headerBannerLayer(), scrolledContentsLayer.get());
+    bool footerBannerLayerChanged = updateBannerLayer(page->footerBannerLayer(), scrolledContentsLayer.get());
     return headerBannerLayerChanged || footerBannerLayerChanged;
 }
 #endif
@@ -338,7 +338,7 @@ void RemoteLayerTreeHost::animationDidStart(std::optional<WebCore::PlatformLayer
     if (!m_drawingArea)
         return;
 
-    CALayer *layer = layerForID(layerID);
+    RetainPtr layer = layerForID(layerID);
     if (!layer)
         return;
 
@@ -359,7 +359,7 @@ void RemoteLayerTreeHost::animationDidEnd(std::optional<WebCore::PlatformLayerId
     if (!m_drawingArea)
         return;
 
-    CALayer *layer = layerForID(layerID);
+    RetainPtr layer = layerForID(layerID);
     if (!layer)
         return;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -162,7 +162,7 @@ private:
 
     void initializeLayer();
 
-    WebCore::PlatformLayerIdentifier m_layerID;
+    const WebCore::PlatformLayerIdentifier m_layerID;
     Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostingIdentifier;
     Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -260,8 +260,8 @@ RemoteLayerTreeNode* RemoteLayerTreeNode::forCALayer(CALayer *layer)
 NSString *RemoteLayerTreeNode::appendLayerDescription(NSString *description, CALayer *layer)
 {
     auto layerID = WebKit::RemoteLayerTreeNode::layerID(layer);
-    NSString *layerDescription = [NSString stringWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, layer.name ? layer.name : @""];
-    return [description stringByAppendingString:layerDescription];
+    RetainPtr layerDescription = [NSString stringWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, layer.name ? layer.name : @""];
+    return [description stringByAppendingString:layerDescription.get()];
 }
 
 void RemoteLayerTreeNode::addToHostingNode(RemoteLayerTreeNode& hostingNode)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -115,8 +115,8 @@ static CALayer *findTileGridContainerLayer(CALayer *layer)
         if (layerName == TileController::tileGridContainerLayerName())
             return currLayer;
 
-        if (CALayer *foundLayer = findTileGridContainerLayer(currLayer))
-            return foundLayer;
+        if (RetainPtr foundLayer = findTileGridContainerLayer(currLayer))
+            return foundLayer.autorelease();
     }
 
     return nil;
@@ -124,9 +124,9 @@ static CALayer *findTileGridContainerLayer(CALayer *layer)
 
 unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRect& visibleRect) const
 {
-    CALayer *rootLayer = m_drawingArea->remoteLayerTreeHost().rootLayer();
+    RetainPtr rootLayer = m_drawingArea->remoteLayerTreeHost().rootLayer();
 
-    CALayer *tileGridContainer = findTileGridContainerLayer(rootLayer);
+    RetainPtr tileGridContainer = findTileGridContainerLayer(rootLayer.get());
     if (!tileGridContainer) {
         NSLog(@"Failed to find TileGrid Container Layer");
         return UINT_MAX;
@@ -139,7 +139,7 @@ unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRec
     Region paintedVisibleTileRegion;
 
     for (CALayer *tileLayer : [tileGridContainer sublayers]) {
-        FloatRect tileRect = [tileLayer convertRect:[tileLayer bounds] toLayer:tileGridContainer];
+        FloatRect tileRect = [tileLayer convertRect:[tileLayer bounds] toLayer:tileGridContainer.get()];
     
         tileRect.intersect(visibleRectExcludingToolbar);
         

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -106,7 +106,7 @@ public:
     }
 
 private:
-    Ref<RemoteScrollingTree> m_scrollingTree;
+    const Ref<RemoteScrollingTree> m_scrollingTree;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -433,8 +433,8 @@ static std::optional<ScrollingNodeID> scrollingNodeIDForLayer(CALayer *layer)
 
 static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNodeID, CALayer *hitLayer)
 {
-    for (CALayer *layer = hitLayer; layer; layer = [layer superlayer]) {
-        auto nodeID = scrollingNodeIDForLayer(layer);
+    for (RetainPtr layer = hitLayer; layer; layer = [layer superlayer]) {
+        auto nodeID = scrollingNodeIDForLayer(layer.get());
         if (nodeID == scrollingNodeID)
             return true;
 


### PR DESCRIPTION
#### fb4ecb91c6e2d27beef3f9604f678d23bd872912
<pre>
Address more Safer CPP failures in UIProcess/RemoteLayerTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=290600">https://bugs.webkit.org/show_bug.cgi?id=290600</a>

Reviewed by Charlie Wolfe.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromMainThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator):
(WebKit::RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateBannerLayers):
(WebKit::RemoteLayerTreeHost::animationDidStart):
(WebKit::RemoteLayerTreeHost::animationDidEnd):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::appendLayerDescription):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
(WebKit::findTileGridContainerLayer):
(WebKit::RemoteLayerTreeScrollingPerformanceData::blankPixelCount const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):
(WebKit::transientZoomTransformOverrideAnimation):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeTransientZoomFromLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::isScrolledBy):

Canonical link: <a href="https://commits.webkit.org/292830@main">https://commits.webkit.org/292830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b77e8fdc9c854c5da9372f2d02b27b19cfa6961

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47758 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12720 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104336 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24309 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83129 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82537 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17824 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15687 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->