### PR TITLE
Add tests for referenceTarget interaction with ARIA attributes

### DIFF
--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt
@@ -1,0 +1,36 @@
+This tests the basic interaction between referenceTarget and aria-activedescendant.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+aria-activedescendant targeting a custom element with shadowrootreferencetarget.
+PASS: combobox1.selectedChildrenCount === 1
+PASS: combobox1.selectedChildAtIndex(0).title === 'AXTitle: Option 2'
+
+ShadowRoot.referenceTarget property works on an imperatively defined custom element.
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option C'
+
+Modifying a ShadowRoot's referenceTarget also updates the accessibility object.
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option A'
+
+Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.
+PASS: combobox2.selectedChildrenCount === 0
+PASS: combobox2.selectedChildrenCount === 1
+PASS: combobox2.selectedChildAtIndex(0).title === 'AXTitle: Option B'
+
+aria-activedescendant works when the linkage is created across two sibling shadow trees.
+PASS: realInput.selectedChildrenCount === 1
+PASS: realInput.selectedChildAtIndex(0).title === 'AXTitle: Option C'
+
+Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.
+PASS: realInput.selectedChildrenCount === 1
+PASS: realInput.selectedChildAtIndex(0).title === 'AXTitle: Option B'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
@@ -1,0 +1,137 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <script src="../../../../resources/accessibility-helper.js"></script>
+  <script src="../../../../resources/js-test.js"></script>
+</head>
+
+<body>
+<div class="container">
+    <input id="combobox1" role="combobox" aria-controls="x-listbox1" aria-activedescendant="x-listbox1">
+    <x-listbox1 id="x-listbox1" role="listbox">
+        <template shadowrootmode="closed" shadowrootreferencetarget="option-2">
+            <div role="option" id="option-1">Option 1</div>
+            <div role="option" id="option-2">Option 2</div>
+            <div role="option" id="option-3">Option 3</div>
+        </template>
+    </x-listbox1>
+</div>
+
+
+<script>
+customElements.define(
+    "x-listbox2",
+    class XListbox2 extends HTMLElement {
+        constructor() {
+            super();
+            this.shadowRoot_ = this.attachShadow({ mode: "closed" });
+            this.shadowRoot_.innerHTML = `
+            <div id="real-listbox" role="listbox">
+                <div id="option-a" role="option">Option A</div>
+                <div id="option-b" role="option">Option B</div>
+                <div id="option-c" role="option">Option C</div>
+            </div>
+            `;
+            this.shadowRoot_.referenceTarget = "option-c";
+        }
+
+        setReferenceTarget(target) {
+            this.shadowRoot_.referenceTarget = target;
+        }
+
+        referenceTargetElement() {
+            return this.shadowRoot_.getElementById(this.shadowRoot_.referenceTarget);
+        }
+    }
+);
+</script>
+
+<div class="container">
+    <input id="combobox2" role="combobox" aria-controls="x-listbox2" aria-activedescendant="x-listbox2">
+    <x-listbox2 id="x-listbox2" role="listbox"></x-listbox2>
+</div>
+
+<script>
+customElements.define(
+    "x-input",
+    class FancyInput extends HTMLElement {
+        static observedAttributes = ["fancylistbox"];
+
+        constructor() {
+            super();
+            this.shadowRoot_ = this.attachShadow({
+                mode: "closed",
+            });
+            this.shadowRoot_.innerHTML = `<input id="real-input">`;
+            this.realInput_ = this.shadowRoot_.getElementById("real-input");
+        }
+
+        attributeChangedCallback(attr, oldValue, newValue) {
+            if (attr === "fancylistbox") {
+                const fancyListbox = newValue ? document.getElementById(newValue) : null;
+                this.realInput_.ariaActiveDescendantElement = fancyListbox;
+            }
+        }
+    }
+);
+</script>
+
+<div class="container">
+    <x-listbox2 id="fancy-listbox" role="listbox"></x-listbox2>
+    <x-input role="combobox" fancylistbox="fancy-listbox"></x-input>
+</div>
+
+<script>
+description("This tests the basic interaction between referenceTarget and aria-activedescendant.");
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    let output = "aria-activedescendant targeting a custom element with shadowrootreferencetarget.\n"
+    var combobox1 = accessibilityController.accessibleElementById("combobox1");
+    output += expect("combobox1.selectedChildrenCount", "1");
+    output += expect("combobox1.selectedChildAtIndex(0).title", "'AXTitle: Option 2'");
+    output += "\n";
+
+    output += "ShadowRoot.referenceTarget property works on an imperatively defined custom element.\n";
+    var combobox2 = accessibilityController.accessibleElementById("combobox2");
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object.\n";
+    const listboxElement = document.getElementById("x-listbox2");
+    listboxElement.setReferenceTarget("option-a");
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option A'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.\n";
+    let referenceTargetElement = listboxElement.referenceTargetElement();
+    referenceTargetElement.id = "option-d";
+    output += expect("combobox2.selectedChildrenCount", "0");
+    referenceTargetElement.nextElementSibling.id = "option-a";
+    output += expect("combobox2.selectedChildrenCount", "1");
+    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+    output += "\n";
+
+    output += "aria-activedescendant works when the linkage is created across two sibling shadow trees.\n";
+    var realInput = accessibilityController.accessibleElementById("real-input");
+    output += expect("realInput.selectedChildrenCount", "1");
+    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
+    output += "\n";
+
+    output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.\n";
+    const fancyListboxElement = document.getElementById("fancy-listbox");
+    fancyListboxElement.setReferenceTarget("option-b");
+    output += expect("realInput.selectedChildrenCount", "1");
+    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+
+</html>

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt
@@ -1,0 +1,18 @@
+This tests that aria-controls referring to a tabpanel indirectly via referenceTarget works still causes the relevant tab element to be selected when the tabpanel receives focus.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+tab2.isSelected should be false initially
+PASS: tab2.isSelected === false
+tab2.isSelected should be true after focusing panel2Item
+PASS: tab2.isSelected === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tab 1
+Tab 2
+Panel 1
+
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+
+<body>
+
+<ul id="tablist-1" role="tablist">
+    <li id="tab-1" role="tab" tabindex="-1">Tab 1</li>
+    <li id="tab-2" role="tab" tabindex="-1" aria-controls="x-panel-2">Tab 2</li>
+</ul>
+
+<div id="panel-1" role="tabpanel">
+    <h3 tabindex="0">Panel 1</h3>
+</div>
+
+<x-panel-2 id="x-panel-2">
+    <template shadowrootmode="open" shadowrootreferencetarget="panel-2">
+        <div id="panel-2" role="tabpanel">
+            <h2 id="item-in-panel-2" tabindex="0">Panel 2</h2>
+        </div>
+    </template>
+</x-panel-2>
+
+<script>
+
+description("This tests that aria-controls referring to a tabpanel indirectly via referenceTarget works still causes the relevant tab element to be selected when the tabpanel receives focus.");
+
+const tabList = accessibilityController.accessibleElementById('tablist-1');
+var tab2 = tabList.childAtIndex(1);
+
+let output = "tab2.isSelected should be false initially\n";
+output += expect("tab2.isSelected", "false");
+
+// we set KB focus to something in x-panel-2, which means that tab2 should become selected
+// because it aria-controls x-panel-2
+const xPanel2 = document.getElementById("x-panel-2");
+const panel2Item = xPanel2.shadowRoot.getElementById("item-in-panel-2");
+panel2Item.focus();
+
+output += "tab2.isSelected should be true after focusing panel2Item\n";
+output += expect("tab2.isSelected", "true");
+
+debug(output);
+finishJSTest();
+
+</script>
+
+</body>
+
+</html>

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt
@@ -1,0 +1,11 @@
+This tests that using aria-describedby to refer to an element indirectly via referenceTarget causes the description to be computed correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: input1.customContent === 'description: Description 1'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html
@@ -1,0 +1,34 @@
+
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+
+<body>
+<div class="container">
+    <input id="input-1" aria-describedby="x-description-1">
+    <x-description-1 id="x-description-1">
+        <template shadowrootmode="closed" shadowrootreferencetarget="description-1">
+        <span>FAIL IF INCLUDED</span>
+        <span id="description-1">Description 1</span>
+        </template>
+    </x-description-1>
+</div>
+
+<script>
+description("This tests that using aria-describedby to refer to an element indirectly via referenceTarget causes the description to be computed correctly.");
+
+var input1 = accessibilityController.accessibleElementById("input-1");
+let output = expect("input1.customContent", "'description: Description 1'");
+
+debug(output);
+finishJSTest();
+
+</script>
+
+</body>
+
+</html>

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-expected.txt
@@ -1,0 +1,15 @@
+Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: group.isAttributeSupported('AXOwns') === true
+PASS: group.childrenCount === 2
+PASS: group.ariaOwnsElementAtIndex(0).domIdentifier === 'inner-span'
+PASS: group.childAtIndex(1).domIdentifier === 'inner-span'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Item 1
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+
+<body>
+<div id="group" role="group" aria-owns="shadow-host">
+    <span>Item 1</span>
+</div>
+
+<fancy-span id="shadow-host">
+    <template shadowrootmode="closed" shadowrootreferencetarget="inner-span">
+        <span id="inner-span" role="radio">Inner span</span>
+    </template>
+</fancy-span>
+
+<script>
+description("Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.");
+
+var group = accessibilityController.accessibleElementById("group");
+
+let output = expect("group.isAttributeSupported('AXOwns')", "true");
+output += expect("group.childrenCount", "2");
+
+output += expect("group.ariaOwnsElementAtIndex(0).domIdentifier", "'inner-span'");
+output += expect("group.childAtIndex(1).domIdentifier", "'inner-span'");
+
+debug(output);
+finishJSTest();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -788,6 +788,7 @@ accessibility/display-contents/tree-and-treeitems.html [ Skip ]
 webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
 
 accessibility/combobox/mac [ Skip ]
+accessibility/shadow-dom/reference-target/mac [ Skip ]
 
 accessibility/textarea-line-for-index.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2709,6 +2709,11 @@ void AXObjectCache::deferAttributeChangeIfNeeded(Element& element, const Qualifi
         relationsNeedUpdate(true);
 }
 
+void AXObjectCache::handleReferenceTargetChanged()
+{
+    relationsNeedUpdate(true);
+}
+
 bool AXObjectCache::shouldProcessAttributeChange(Element* element, const QualifiedName& attrName)
 {
     if (!element)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -385,6 +385,7 @@ public:
     void checkedStateChanged(Element&);
     void autofillTypeChanged(HTMLInputElement&);
     void handleRoleChanged(AccessibilityObject&, AccessibilityRole previousRole);
+    void handleReferenceTargetChanged();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void columnIndexChanged(AccessibilityObject&);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "ShadowRoot.h"
 
+#include "AXObjectCache.h"
 #include "CSSStyleSheet.h"
 #include "ChildListMutationScope.h"
 #include "CustomElementRegistry.h"
@@ -472,7 +473,13 @@ void ShadowRoot::setReferenceTarget(const AtomString& referenceTarget)
     if (!document().settings().shadowRootReferenceTargetEnabled())
         return;
 
+    if (m_referenceTarget == referenceTarget)
+        return;
+
     m_referenceTarget = referenceTarget;
+
+    if (CheckedPtr cache = document().existingAXObjectCache())
+        cache->handleReferenceTargetChanged();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 272197c78d6bdfb7fa06a00ffb6dc861f3ae6399
<pre>
Add tests for referenceTarget interaction with ARIA attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=290601">https://bugs.webkit.org/show_bug.cgi?id=290601</a>

Reviewed by NOBODY (OOPS!).

This adds tests for aria-controls, aria-describedby and aria-owns.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns.html: Added.
</pre>
----------------------------------------------------------------------
#### cb92a92ec0a2a909d955e21383d354c4d20b165d
<pre>
Ensure updating referenceTarget updates the accessibility tree appropriately.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290440">https://bugs.webkit.org/show_bug.cgi?id=290440</a>

Reviewed by NOBODY (OOPS!).

This introduces a method on AXObjectCache to mark relations dirty when a referenceTarget value is changed.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleReferenceTargetChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setReferenceTarget):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272197c78d6bdfb7fa06a00ffb6dc861f3ae6399

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102262 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25254 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100184 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/12665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/5757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47103 "Failed to compile WebKit") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24220 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24043 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->