### PR TITLE
[Cocoa] [Page color sampler] Make viewport-constrained element detection via hit-testing cheaper

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container-expected.txt
@@ -1,0 +1,5 @@
+PASS edgeColors.top is "rgb(255, 100, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            font-family: system-ui;
+        }
+
+        .relative {
+            position: relative;
+            z-index: 100;
+            width: 100%;
+            height: 100%;
+        }
+
+        header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 80px;
+            background: rgb(255, 100, 0);
+            color: white;
+        }
+
+        .tall {
+            width: 10px;
+            height: 2000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        edgeColors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColors.top", "rgb(255, 100, 0)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="relative">
+    <header></header>
+</div>
+<div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1923,8 +1923,15 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
             return { };
 
         using enum HitTestRequest::Type;
+        static constexpr OptionSet hitTestOptions {
+            ReadOnly,
+            DisallowUserAgentShadowContent,
+            IgnoreClipping,
+            ViewportConstrainedLayersOnly,
+        };
+
         HitTestResult result { hitTestLocationForSide(side) };
-        if (!document->hitTest({ HitTestSource::User, { ReadOnly, DisallowUserAgentShadowContent, IgnoreClipping } }, result))
+        if (!document->hitTest({ HitTestSource::User, hitTestOptions }, result))
             return { };
 
         RefPtr hitNode = result.innerNonSharedNode();

--- a/Source/WebCore/rendering/HitTestRequest.h
+++ b/Source/WebCore/rendering/HitTestRequest.h
@@ -51,6 +51,7 @@ public:
         // When using list-based testing, continue hit testing even after a hit has been found.
         IncludeAllElementsUnderPoint = 1 << 16,
         PenEvent = 1 << 17,
+        ViewportConstrainedLayersOnly = 1 << 18,
     };
 
     static constexpr OptionSet defaultTypes = { Type::ReadOnly, Type::Active, Type::DisallowUserAgentShadowContent };
@@ -100,6 +101,7 @@ public:
     bool resultIsElementList() const { return m_type.contains(Type::CollectMultipleElements); }
     bool includesAllElementsUnderPoint() const { return m_type.contains(Type::IncludeAllElementsUnderPoint); }
     bool userTriggered() const { return m_source == HitTestSource::User; }
+    bool viewportConstrainedLayersOnly() const { return m_type.contains(Type::ViewportConstrainedLayersOnly); }
 
     // Convenience functions
     bool touchMove() const { return move() && touchEvent(); }

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -436,8 +436,12 @@ public:
     void updateDescendantDependentFlags();
     bool descendantDependentFlagsAreDirty() const
     {
-        return m_visibleDescendantStatusDirty || m_visibleContentStatusDirty || m_hasSelfPaintingLayerDescendantDirty
-            || m_hasNotIsolatedBlendingDescendantsStatusDirty || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty;
+        return m_visibleDescendantStatusDirty
+            || m_visibleContentStatusDirty
+            || m_hasSelfPaintingLayerDescendantDirty
+            || m_hasViewportConstrainedDescendantStatusDirty
+            || m_hasNotIsolatedBlendingDescendantsStatusDirty
+            || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty;
     }
 
     bool isPaintingSVGResourceLayer() const { return m_isPaintingSVGResourceLayer; }
@@ -1236,6 +1240,9 @@ private:
     bool has3DTransformedDescendant() const { ASSERT(!m_3DTransformedDescendantStatusDirty); return m_has3DTransformedDescendant; }
     bool has3DTransformedAncestor() const { return m_has3DTransformedAncestor; }
 
+    void setAncestorChainHasViewportConstrainedDescendant();
+    void dirtyAncestorChainHasViewportConstrainedDescendantStatus();
+
     bool hasFixedAncestor() const { return m_hasFixedAncestor; }
     bool hasPaginatedAncestor() const { return m_hasPaginatedAncestor; }
 
@@ -1327,6 +1334,9 @@ private:
     // significant savings, especially if the tree has lots of non-self-painting layers grouped together (e.g. table cells).
     bool m_hasSelfPaintingLayerDescendant : 1;
     bool m_hasSelfPaintingLayerDescendantDirty : 1;
+
+    bool m_hasViewportConstrainedDescendant : 1;
+    bool m_hasViewportConstrainedDescendantStatusDirty : 1;
 
     bool m_usedTransparency : 1; // Tracks whether we need to close a transparent layer, i.e., whether
                                  // we ended up painting this layer or any descendants (and therefore need to


### PR DESCRIPTION
#### f032cd8e06dd0743423cc29b690a34f86df17cde
<pre>
[Cocoa] [Page color sampler] Make viewport-constrained element detection via hit-testing cheaper
<a href="https://bugs.webkit.org/show_bug.cgi?id=290603">https://bugs.webkit.org/show_bug.cgi?id=290603</a>
<a href="https://rdar.apple.com/148074350">rdar://148074350</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Add support for a new hit-test request option to ignore everything except for viewport-constrained
(fixed/sticky) containers, and deploy it when detecting fixed container edges. See below for more
details.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html: Added.

Add a new layout test to verify that fixed-position containers underneath positioned ancestors are
still detected by hit-testing. This exercises the new `m_hasViewportConstrainedDescendant` flag in
`RenderLayer` (see below).

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/rendering/HitTestRequest.h:

Add and adopt the new hit-test option.

(WebCore::HitTestRequest::viewportConstrainedLayersOnly const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::RenderLayer):
(WebCore::RenderLayer::addChild):
(WebCore::RenderLayer::removeChild):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::dirtyAncestorChainHasSelfPaintingLayerDescendantStatus):
(WebCore::RenderLayer::setAncestorChainHasViewportConstrainedDescendant):
(WebCore::RenderLayer::dirtyAncestorChainHasViewportConstrainedDescendantStatus):

Add support for a new flag, `m_hasViewportConstrainedDescendant`, that can be used to check whether
or not a `RenderLayer` has at least 1 descendant that is viewport-constrained. This follows the same
pattern for computation/invalidation as the existing `m_hasSelfPaintingLayerDescendant` flag (and
similar other cached bits on the layer).

(WebCore::RenderLayer::updateDescendantDependentFlags):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::hitTestLayer):

If the new hit test option is set, ignore layers that do not represent viewport-constrained objects,
or do not have descendant layers that represent viewport-constrained objects.

* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/292956@main">https://commits.webkit.org/292956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/901d1c91f87d8d08c239615b1a47d0637f6875fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74159 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31348 "Found 1 new test failure: workers/worker-to-worker.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100351 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13055 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104455 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24426 "Hash 901d1c91 for PR 43168 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17805 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83206 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27167 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17971 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29557 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->