### PR TITLE
[JSC] VirtualCalls should not have profiling when it is used for top-tier

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -241,7 +241,7 @@ void DataOnlyCallLinkInfo::initialize(VM& vm, CodeBlock* owner, CallType callTyp
     m_callType = callType;
     m_mode = static_cast<unsigned>(Mode::Init);
     if (UNLIKELY(!Options::useLLIntICs()))
-        setVirtualCall(vm);
+        setVirtualCall(vm, /* isTopTier */ false);
 }
 
 std::tuple<CodeBlock*, BytecodeIndex> CallLinkInfo::retrieveCaller(JSCell* owner)
@@ -270,18 +270,18 @@ void CallLinkInfo::reset(VM&)
 void CallLinkInfo::revertCall(VM& vm)
 {
     if (UNLIKELY(!Options::useLLIntICs() && type() == CallLinkInfo::Type::DataOnly))
-        setVirtualCall(vm);
+        setVirtualCall(vm, /* isTopTier */ false);
     else
         reset(vm);
 }
 
-void CallLinkInfo::setVirtualCall(VM& vm)
+void CallLinkInfo::setVirtualCall(VM& vm, bool isTopTier)
 {
     reset(vm);
     m_callee.clear();
     *std::bit_cast<uintptr_t*>(m_callee.slot()) = polymorphicCalleeMask;
     m_codeBlock = nullptr; // PolymorphicCallStubRoutine will set CodeBlock inside it.
-    m_monomorphicCallDestination = vm.getCTIVirtualCall(callMode()).code().template retagged<JSEntryPtrTag>();
+    m_monomorphicCallDestination = vm.getCTIVirtualCall(callMode(), isTopTier).code().template retagged<JSEntryPtrTag>();
 
     setClearedByVirtual();
     m_mode = static_cast<unsigned>(Mode::Virtual);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -153,7 +153,7 @@ public:
     void setStub(Ref<PolymorphicCallStubRoutine>&&);
     void clearStub();
 
-    void setVirtualCall(VM&);
+    void setVirtualCall(VM&, bool isTopTier);
 
     void revertCall(VM&);
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -74,18 +74,18 @@
 
 namespace JSC {
 
-static void linkSlowFor(VM& vm, CallLinkInfo& callLinkInfo)
-{
-    if (callLinkInfo.type() == CallLinkInfo::Type::Optimizing)
-        callLinkInfo.setVirtualCall(vm);
-}
-
 void linkMonomorphicCall(VM& vm, JSCell* owner, CallLinkInfo& callLinkInfo, CodeBlock* calleeCodeBlock, JSObject* callee, CodePtr<JSEntryPtrTag> codePtr)
 {
     ASSERT(!callLinkInfo.stub());
 
     CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
+#if ENABLE(WEBASSEMBLY)
+    bool isWebAssembly = owner->inherits<JSWebAssemblyModule>();
+#else
+    bool isWebAssembly = false;
+#endif
+    bool notUsingCounting = isWebAssembly || callerCodeBlock->jitType() == JITCode::topTierJIT();
 
     if (UNLIKELY(Options::forceICFailure()))
         return;
@@ -102,7 +102,9 @@ void linkMonomorphicCall(VM& vm, JSCell* owner, CallLinkInfo& callLinkInfo, Code
 
     if (callLinkInfo.specializationKind() == CodeForCall)
         return;
-    linkSlowFor(vm, callLinkInfo);
+
+    if (callLinkInfo.type() == CallLinkInfo::Type::Optimizing)
+        callLinkInfo.setVirtualCall(vm, notUsingCounting);
 }
 
 CodePtr<JSEntryPtrTag> jsToWasmICCodePtr(CodeSpecializationKind kind, JSObject* callee)
@@ -127,11 +129,6 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
     // GC jettisons CodeBlocks, changes CallLinkInfo etc. and breaks assumption done before and after this call.
     DeferGCForAWhile deferGCForAWhile(vm);
 
-    if (!newVariant) {
-        callLinkInfo.setVirtualCall(vm);
-        return;
-    }
-
     CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
 #if ENABLE(WEBASSEMBLY)
@@ -139,6 +136,13 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
 #else
     bool isWebAssembly = false;
 #endif
+    bool notUsingCounting = isWebAssembly || callerCodeBlock->jitType() == JITCode::topTierJIT();
+
+    if (!newVariant) {
+        callLinkInfo.setVirtualCall(vm, notUsingCounting);
+        return;
+    }
+
     bool isTailCall = callLinkInfo.isTailCall();
 
     bool isClosureCall = false;
@@ -178,7 +182,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
 
     // We use list.size() instead of callSlots.size() because we respect CallVariant size for now.
     if (list.size() > maxPolymorphicCallVariantListSize) {
-        callLinkInfo.setVirtualCall(vm);
+        callLinkInfo.setVirtualCall(vm, notUsingCounting);
         return;
     }
 
@@ -193,7 +197,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
             // If we cannot handle a callee, because we don't have a CodeBlock,
             // assume that it's better for this whole thing to be a virtual call.
             if (!codeBlock) {
-                callLinkInfo.setVirtualCall(vm);
+                callLinkInfo.setVirtualCall(vm, notUsingCounting);
                 return;
             }
         }
@@ -243,7 +247,6 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
         callSlots.append(WTFMove(slot));
     }
 
-    bool notUsingCounting = isWebAssembly || callerCodeBlock->jitType() == JITCode::topTierJIT();
     if (callSlots.isEmpty())
         notUsingCounting = true;
 

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -27,6 +27,8 @@
 
 #include "ErrorInstance.h"
 #include "FrameTracers.h"
+#include "JSWebAssemblyInstance.h"
+#include "JSWebAssemblyModule.h"
 #include "LLIntEntrypoint.h"
 #include "Repatch.h"
 
@@ -151,7 +153,15 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
                     linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(internalFunction));
                     break;
                 }
-                callLinkInfo->setVirtualCall(vm);
+                CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
+                ASSERT(owner);
+#if ENABLE(WEBASSEMBLY)
+                bool isWebAssembly = owner->inherits<JSWebAssemblyModule>();
+#else
+                bool isWebAssembly = false;
+#endif
+                bool notUsingCounting = isWebAssembly || callerCodeBlock->jitType() == JITCode::topTierJIT();
+                callLinkInfo->setVirtualCall(vm, notUsingCounting);
                 break;
             }
             case CallLinkInfo::Mode::Virtual:
@@ -214,7 +224,16 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
             linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(callee));
             break;
         }
-        callLinkInfo->setVirtualCall(vm);
+
+        CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
+        ASSERT(owner);
+#if ENABLE(WEBASSEMBLY)
+        bool isWebAssembly = owner->inherits<JSWebAssemblyModule>();
+#else
+        bool isWebAssembly = false;
+#endif
+        bool notUsingCounting = isWebAssembly || callerCodeBlock->jitType() == JITCode::topTierJIT();
+        callLinkInfo->setVirtualCall(vm, notUsingCounting);
         break;
     }
     case CallLinkInfo::Mode::Virtual:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -897,7 +897,7 @@ void SpeculativeJIT::emitCall(Node* node)
         addPtr(TrustedImm32(requiredBytes), stackPointerRegister);
         loadValue(calleeFrameSlot(CallFrameSlot::callee), JSValueRegs { GPRInfo::regT1, GPRInfo::regT0 });
         loadLinkableConstant(callLinkInfoConstant, GPRInfo::regT2);
-        emitVirtualCallWithoutMovingGlobalObject(vm(), GPRInfo::regT2, CallMode::Regular);
+        emitVirtualCallWithoutMovingGlobalObject(vm(), GPRInfo::regT2, CallMode::Regular, /* isTopTier */ true);
         
         done.link(this);
         setResultAndResetStack();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -986,7 +986,7 @@ void SpeculativeJIT::emitCall(Node* node)
         addPtr(TrustedImm32(requiredBytes), stackPointerRegister);
         load64(calleeFrameSlot(CallFrameSlot::callee), GPRInfo::regT0);
         loadLinkableConstant(callLinkInfoConstant, GPRInfo::regT2);
-        emitVirtualCallWithoutMovingGlobalObject(vm(), GPRInfo::regT2, CallMode::Regular);
+        emitVirtualCallWithoutMovingGlobalObject(vm(), GPRInfo::regT2, CallMode::Regular, /* isTopTier */ false);
         
         done.link(this);
         setResultAndResetStack();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12924,7 +12924,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 jit.addPtr(CCallHelpers::TrustedImm32(requiredBytes), CCallHelpers::stackPointerRegister);
                 jit.load64(CCallHelpers::calleeFrameSlot(CallFrameSlot::callee), BaselineJITRegisters::Call::calleeGPR);
-                jit.emitVirtualCall(vm, callLinkInfo);
+                jit.emitVirtualCall(vm, callLinkInfo, /* isTopTier */ true);
 
                 done.link(&jit);
                 jit.addPtr(

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1223,16 +1223,16 @@ void AssemblyHelpers::restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl(GP
 #endif // NUMBER_OF_CALLEE_SAVES_REGISTERS > 0
 }
 
-void AssemblyHelpers::emitVirtualCall(VM& vm, CallLinkInfo* info)
+void AssemblyHelpers::emitVirtualCall(VM& vm, CallLinkInfo* info, bool isTopTier)
 {
     move(TrustedImmPtr(info), GPRInfo::regT2);
-    emitVirtualCallWithoutMovingGlobalObject(vm, GPRInfo::regT2, info->callMode());
+    emitVirtualCallWithoutMovingGlobalObject(vm, GPRInfo::regT2, info->callMode(), isTopTier);
 }
 
-void AssemblyHelpers::emitVirtualCallWithoutMovingGlobalObject(VM& vm, GPRReg callLinkInfoGPR, CallMode callMode)
+void AssemblyHelpers::emitVirtualCallWithoutMovingGlobalObject(VM& vm, GPRReg callLinkInfoGPR, CallMode callMode, bool isTopTier)
 {
     move(callLinkInfoGPR, GPRInfo::regT2);
-    nearCallThunk(CodeLocationLabel<JITStubRoutinePtrTag> { vm.getCTIVirtualCall(callMode).code() });
+    nearCallThunk(CodeLocationLabel<JITStubRoutinePtrTag> { vm.getCTIVirtualCall(callMode, isTopTier).code() });
 }
 
 #if USE(JSVALUE64)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1965,8 +1965,8 @@ public:
         functor(TypeofType::Undefined, true);
     }
     
-    void emitVirtualCall(VM&, CallLinkInfo*);
-    void emitVirtualCallWithoutMovingGlobalObject(VM&, GPRReg callLinkInfoGPR, CallMode);
+    void emitVirtualCall(VM&, CallLinkInfo*, bool isTopTier);
+    void emitVirtualCallWithoutMovingGlobalObject(VM&, GPRReg callLinkInfoGPR, CallMode, bool isTopTier);
     
     void makeSpaceOnStackForCCall();
     void reclaimSpaceOnStackForCCall();

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -189,7 +189,7 @@ void JIT::compileCallDirectEvalSlowCase(const JSInstruction* instruction, Vector
     static_assert(noOverlap(BaselineJITRegisters::Call::calleeJSR, BaselineJITRegisters::Call::callLinkInfoGPR, regT3));
     loadValue(Address(stackPointerRegister, sizeof(Register) * CallFrameSlot::callee - sizeof(CallerFrameAndPC)), BaselineJITRegisters::Call::calleeJSR);
     materializePointerIntoMetadata(bytecode, OpCallDirectEval::Metadata::offsetOfCallLinkInfo(), BaselineJITRegisters::Call::callLinkInfoGPR);
-    emitVirtualCallWithoutMovingGlobalObject(*m_vm, BaselineJITRegisters::Call::callLinkInfoGPR, CallMode::Regular);
+    emitVirtualCallWithoutMovingGlobalObject(*m_vm, BaselineJITRegisters::Call::callLinkInfoGPR, CallMode::Regular, /* isTopTier */ false);
     resetSP();
 }
 

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -67,6 +67,9 @@ class NativeExecutable;
     macro(VirtualThunkForRegularCall, virtualThunkForRegularCall) \
     macro(VirtualThunkForTailCall, virtualThunkForTailCall) \
     macro(VirtualThunkForConstruct, virtualThunkForConstruct) \
+    macro(VirtualTopTierThunkForRegularCall, virtualTopTierThunkForRegularCall) \
+    macro(VirtualTopTierThunkForTailCall, virtualTopTierThunkForTailCall) \
+    macro(VirtualTopTierThunkForConstruct, virtualTopTierThunkForConstruct) \
     macro(PolymorphicThunk, polymorphicThunk) \
     macro(PolymorphicThunkForClosure, polymorphicThunkForClosure) \
     macro(PolymorphicTopTierThunk, polymorphicTopTierThunk) \

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -198,7 +198,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowAtPrologueGenerator(VM& 
 // path virtual call so that we can enable fast tail calls for megamorphic
 // virtual calls by using the shuffler.
 // https://bugs.webkit.org/show_bug.cgi?id=148831
-static MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkFor(VM& vm, CallMode mode, CodeSpecializationKind kind)
+static MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkFor(VM& vm, CallMode mode, CodeSpecializationKind kind, bool isTopTier)
 {
     // The callee is in regT0 (for JSVALUE32_64, the tag is in regT1).
     // The return address is on the stack, or in the link register. We will hence
@@ -215,9 +215,9 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkFor(VM& vm, CallMode mo
 
     // This is a slow path execution, and regT2 contains the CallLinkInfo. Count the
     // slow path execution for the profiler.
-    jit.add32(
-        CCallHelpers::TrustedImm32(1),
-        CCallHelpers::Address(GPRInfo::regT2, CallLinkInfo::offsetOfSlowPathCount()));
+    // If it is top-tier code, then we do not need to count these feedback anymore.
+    if (!isTopTier)
+        jit.add32(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(GPRInfo::regT2, CallLinkInfo::offsetOfSlowPathCount()));
 
     // FIXME: we should have a story for eliminating these checks. In many cases,
     // the DFG knows that the value is definitely a cell, or definitely a function.
@@ -297,17 +297,32 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkFor(VM& vm, CallMode mo
 
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForRegularCall(VM& vm)
 {
-    return virtualThunkFor(vm, CallMode::Regular, CodeForCall);
+    return virtualThunkFor(vm, CallMode::Regular, CodeForCall, /* isTopTier */ false);
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForTailCall(VM& vm)
 {
-    return virtualThunkFor(vm, CallMode::Tail, CodeForCall);
+    return virtualThunkFor(vm, CallMode::Tail, CodeForCall, /* isTopTier */ false);
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForConstruct(VM& vm)
 {
-    return virtualThunkFor(vm, CallMode::Construct, CodeForConstruct);
+    return virtualThunkFor(vm, CallMode::Construct, CodeForConstruct, /* isTopTier */ false);
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForRegularCall(VM& vm)
+{
+    return virtualThunkFor(vm, CallMode::Regular, CodeForCall, /* isTopTier */ true);
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForTailCall(VM& vm)
+{
+    return virtualThunkFor(vm, CallMode::Tail, CodeForCall, /* isTopTier */ true);
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForConstruct(VM& vm)
+{
+    return virtualThunkFor(vm, CallMode::Construct, CodeForConstruct, /* isTopTier */ true);
 }
 
 enum class ClosureMode : uint8_t { No, Yes };

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -56,6 +56,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> polymorphicTopTierThunkForClosure(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForRegularCall(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForTailCall(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkForConstruct(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForRegularCall(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForTailCall(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> virtualTopTierThunkForConstruct(VM&);
 
 MacroAssemblerCodeRef<JITThunkPtrTag> nativeCallGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> nativeCallWithDebuggerHookGenerator(VM&);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -833,21 +833,22 @@ MacroAssemblerCodeRef<JSEntryPtrTag> VM::getCTIThrowExceptionFromCallSlowPath()
     return LLInt::callToThrow(*this).template retagged<JSEntryPtrTag>();
 }
 
-MacroAssemblerCodeRef<JITStubRoutinePtrTag> VM::getCTIVirtualCall(CallMode callMode)
+MacroAssemblerCodeRef<JITStubRoutinePtrTag> VM::getCTIVirtualCall(CallMode callMode, bool isTopTier)
 {
 #if ENABLE(JIT)
     if (Options::useJIT()) {
         switch (callMode) {
         case CallMode::Regular:
-            return getCTIStub(CommonJITThunkID::VirtualThunkForRegularCall).template retagged<JITStubRoutinePtrTag>();
+            return getCTIStub(isTopTier ? CommonJITThunkID::VirtualTopTierThunkForRegularCall : CommonJITThunkID::VirtualThunkForRegularCall).template retagged<JITStubRoutinePtrTag>();
         case CallMode::Tail:
-            return getCTIStub(CommonJITThunkID::VirtualThunkForTailCall).template retagged<JITStubRoutinePtrTag>();
+            return getCTIStub(isTopTier ? CommonJITThunkID::VirtualTopTierThunkForTailCall : CommonJITThunkID::VirtualThunkForTailCall).template retagged<JITStubRoutinePtrTag>();
         case CallMode::Construct:
-            return getCTIStub(CommonJITThunkID::VirtualThunkForConstruct).template retagged<JITStubRoutinePtrTag>();
+            return getCTIStub(isTopTier ? CommonJITThunkID::VirtualTopTierThunkForConstruct : CommonJITThunkID::VirtualThunkForConstruct).template retagged<JITStubRoutinePtrTag>();
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
 #endif
+    UNUSED_PARAM(isTopTier);
     switch (callMode) {
     case CallMode::Regular:
         return LLInt::getCodeRef<JITStubRoutinePtrTag>(llint_virtual_call_trampoline);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -631,7 +631,7 @@ public:
 
     CodePtr<JSEntryPtrTag> getCTIInternalFunctionTrampolineFor(CodeSpecializationKind);
     MacroAssemblerCodeRef<JSEntryPtrTag> getCTIThrowExceptionFromCallSlowPath();
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> getCTIVirtualCall(CallMode);
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> getCTIVirtualCall(CallMode, bool isTopTier);
 
     static constexpr ptrdiff_t exceptionOffset()
     {


### PR DESCRIPTION
#### 895f08728d8663e929d0abe94f3288dd29a9ff81
<pre>
[JSC] VirtualCalls should not have profiling when it is used for top-tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=290604">https://bugs.webkit.org/show_bug.cgi?id=290604</a>
<a href="https://rdar.apple.com/148075897">rdar://148075897</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::DataOnlyCallLinkInfo::initialize):
(JSC::CallLinkInfo::revertCall):
(JSC::CallLinkInfo::setVirtualCall):
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkMonomorphicCall):
(JSC::linkPolymorphicCall):
(JSC::linkSlowFor): Deleted.
* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::linkFor):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitVirtualCall):
(JSC::AssemblyHelpers::emitVirtualCallWithoutMovingGlobalObject):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileCallDirectEvalSlowCase):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::virtualThunkFor):
(JSC::virtualThunkForRegularCall):
(JSC::virtualThunkForTailCall):
(JSC::virtualThunkForConstruct):
(JSC::virtualTopTierThunkForRegularCall):
(JSC::virtualTopTierThunkForTailCall):
(JSC::virtualTopTierThunkForConstruct):
* Source/JavaScriptCore/jit/ThunkGenerators.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::getCTIVirtualCall):
* Source/JavaScriptCore/runtime/VM.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/895f08728d8663e929d0abe94f3288dd29a9ff81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47712 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100190 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12923 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5770 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47110 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89860 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104290 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95808 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24262 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17700 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/abrupt-completion.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82504 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17766 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29377 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119435 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24049 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33537 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->