### PR TITLE
HDR suppression: All windows the same, suppress when entire app goes to background

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -328,15 +328,7 @@ public:
     void screenDidChangeColorSpace();
     bool shouldDelayWindowOrderingForEvent(NSEvent *);
     bool windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint);
-    void applicationShouldSuppressHDR();
-    void applicationShouldAllowHDR();
-
-    enum class HDRConstrainingReasonAction : bool { Remove, Add };
-    enum class HDRConstrainingReason : uint8_t {
-        WindowIsNotActive = 1 << 0,
-        ShouldSuppressHDR = 1 << 1,
-    };
-    void updateHDRState(HDRConstrainingReasonAction, HDRConstrainingReason);
+    void applicationShouldSuppressHDR(bool);
 
     void accessibilitySettingsDidChange();
 
@@ -1092,7 +1084,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
-    OptionSet<HDRConstrainingReason> m_hdrConstrainingReason { HDRConstrainingReason::WindowIsNotActive };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### fe1a512d85d992c4027e5c138cc0b112e02c16ff
<pre>
HDR suppression: All windows the same, suppress when entire app goes to background
<a href="https://bugs.webkit.org/show_bug.cgi?id=290728">https://bugs.webkit.org/show_bug.cgi?id=290728</a>
<a href="https://rdar.apple.com/146997246">rdar://146997246</a>

Reviewed by Cameron McCormack.

Don&apos;t suppress HDR on windowDidResignKey (i.e., for individual windows).
But keep suppressing when requested by app-wide notifications.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver _applicationShouldBeginSuppressingHDR:]):
(-[WKWindowVisibilityObserver _applicationShouldEndSuppressingHDR:]):
(WebKit::WebViewImpl::windowDidBecomeKey):
(WebKit::WebViewImpl::windowDidResignKey):
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
(-[WKWindowVisibilityObserver _applicationShouldSuppressHDR:]): Deleted.
(-[WKWindowVisibilityObserver _applicationShouldAllowHDR:]): Deleted.
(WebKit::WebViewImpl::updateHDRState): Deleted.
(WebKit::WebViewImpl::applicationShouldAllowHDR): Deleted.

Canonical link: <a href="https://commits.webkit.org/293080@main">https://commits.webkit.org/293080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae3f4a6c55e77d2658875210cc74f2a02fa470f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47987 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100461 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13154 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12922 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104565 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24537 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17894 "Found 1 new test failure: storage/indexeddb/intversion-two-opens-no-versions.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18104 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24499 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29667 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->