### PR TITLE
Web Inspector: Timelines: support exporting and importing data from worker targets

### DIFF
--- a/LayoutTests/inspector/timeline/timeline-recording-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-recording-expected.txt
@@ -49,10 +49,7 @@ Export Data:
     "<filtered>"
   ],
   "memoryPressureEvents": [],
-  "sampleStackTraces": [
-    "<filtered>"
-  ],
-  "sampleDurations": [
+  "samples": [
     "<filtered>"
   ]
 }

--- a/LayoutTests/inspector/timeline/timeline-recording.html
+++ b/LayoutTests/inspector/timeline/timeline-recording.html
@@ -81,7 +81,7 @@ function test()
 
             InspectorTest.log("Export Data:");
             let filterValue = new Set(["startTime", "endTime", "time", "displayName"]);
-            let filterArray = new Set(["records", "markers", "sampleStackTraces", "sampleDurations"]);
+            let filterArray = new Set(["records", "markers", "samples"]);
             InspectorTest.json(exportData, (key, value) => {
                 if (filterValue.has(key))
                     return "<filtered>";

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -512,12 +512,18 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     scriptForIdentifier(id, target)
     {
+        if (target instanceof WI.ImportedTarget)
+            return null;
+
         console.assert(target instanceof WI.Target);
         return this.dataForTarget(target).scriptForIdentifier(id);
     }
 
     scriptsForURL(url, target)
     {
+        if (target instanceof WI.ImportedTarget)
+            return [];
+
         // FIXME: This may not be safe. A Resource's URL may differ from a Script's URL.
         console.assert(target instanceof WI.Target);
         return this.dataForTarget(target).scriptsForURL(url);

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -448,6 +448,7 @@
     <script src="Models/HeapAllocationsInstrument.js"></script>
     <script src="Models/HeapAllocationsTimelineRecord.js"></script>
     <script src="Models/HeapSnapshotRootPath.js"></script>
+    <script src="Models/ImportedTarget.js"></script>
     <script src="Models/IndexedDatabase.js"></script>
     <script src="Models/IndexedDatabaseObjectStore.js"></script>
     <script src="Models/IndexedDatabaseObjectStoreIndex.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
@@ -44,14 +44,12 @@ WI.HeapAllocationsTimelineRecord = class HeapAllocationsTimelineRecord extends W
         // it is not perfect but does what we want. It asynchronously creates
         // a heap snapshot at the right time, and insert it into the active
         // recording, which on an import should be the newly imported recording.
-        let {timestamp, title, snapshotStringData} = json;
+        let {target, timestamp, title, snapshotStringData} = json;
 
-        return await new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             workerProxy.createImportedSnapshot(snapshotStringData, title, ({objectId, snapshot: serializedSnapshot}) => {
-                // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
-                const target = null;
-                let snapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
+                let snapshot = WI.HeapSnapshotProxy.deserialize(target ? WI.ImportedTarget.import(target) : null, objectId, serializedSnapshot);
                 snapshot.snapshotStringData = snapshotStringData;
                 resolve(new WI.HeapAllocationsTimelineRecord(timestamp, snapshot));
             });
@@ -60,9 +58,8 @@ WI.HeapAllocationsTimelineRecord = class HeapAllocationsTimelineRecord extends W
 
     toJSON()
     {
-        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
-
         return {
+            target: this._heapSnapshot.target.exportData(),
             type: this.type,
             timestamp: this._timestamp,
             title: WI.TimelineTabContentView.displayNameForRecord(this),

--- a/Source/WebInspectorUI/UserInterface/Models/ImportedTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ImportedTarget.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.ImportedTarget = class ImportedTarget
+{
+    constructor(identifier, type, name, url)
+    {
+        this._identifier = identifier;
+        this._type = type;
+        this._name = name;
+        this._url = url;
+    }
+
+    // Import / Export
+
+    static import(json)
+    {
+        let {identifier, type, name, url} = json;
+
+        for (let existing of WI.ImportedTarget._forIdentifierMap.values()) {
+            if (existing._identifier === identifier && existing._type === type && existing._name === name && existing._url === url)
+                return existing;
+        }
+
+        let target = new WI.ImportedTarget(identifier, type, name, url);
+
+        WI.ImportedTarget._forIdentifierMap.set(target.identifier, target);
+
+        return target;
+    }
+
+    exportData()
+    {
+        return {
+            identifier: this._identifier,
+            type: this._type,
+            name: this._name,
+            url: this._url,
+        };
+    }
+
+    // Static
+
+    static forIdentifier(targetId)
+    {
+        return WI.ImportedTarget._forIdentifierMap.get(targetId) || null;
+    }
+
+    // Public
+
+    get identifier() { return this._identifier; }
+    get type() { return this._type; }
+    get name() { return this._name; }
+    get url() { return this._url; }
+
+    get isDestroyed() { return true; }
+
+    get displayName() { return this._name; }
+
+    hasDomain(domainName)
+    {
+        console.assert(false, "not reached");
+        return false;
+    }
+
+    hasCommand(qualifiedName, parameterName)
+    {
+        console.assert(false, "not reached");
+        return false;
+    }
+
+    hasEvent(qualifiedName, parameterName)
+    {
+        console.assert(false, "not reached");
+        return false;
+    }
+};
+
+WI.ImportedTarget._forIdentifierMap = new Map;

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js
@@ -32,6 +32,15 @@ WI.ScriptTimeline = class ScriptTimeline extends WI.Timeline
         return Array.from(this._callingContextTreesForTarget.keys());
     }
 
+    get imported()
+    {
+        for (let target of this._callingContextTreesForTarget.keys()) {
+            if (target instanceof WI.ImportedTarget)
+                return true;
+        }
+        return false;
+    }
+
     reset(suppressEvents)
     {
         this._callingContextTreesForTarget = new Map;

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js
@@ -49,15 +49,12 @@ WI.ScriptTimelineRecord = class ScriptTimelineRecord extends WI.TimelineRecord
 
     static async fromJSON(json)
     {
-        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
-        let target = WI.assumingMainTarget();
-
-        let {eventType, startTime, endTime, stackTrace, sourceCodeLocation, details, profilePayload, extraDetails} = json;
+        let {target, eventType, startTime, endTime, stackTrace, sourceCodeLocation, details, profilePayload, extraDetails} = json;
 
         if (typeof details === "object" && details.__type === "GarbageCollection")
             details = WI.GarbageCollection.fromJSON(details);
 
-        return new WI.ScriptTimelineRecord(target, eventType, startTime, endTime, {stackTrace, sourceCodeLocation, details, profilePayload, target, extraDetails});
+        return new WI.ScriptTimelineRecord(target ? WI.ImportedTarget.import(target) : WI.assumingMainTarget(), eventType, startTime, endTime, {stackTrace, sourceCodeLocation, details, profilePayload, extraDetails});
     }
 
     toJSON()
@@ -65,9 +62,9 @@ WI.ScriptTimelineRecord = class ScriptTimelineRecord extends WI.TimelineRecord
         // FIXME: stackTrace
         // FIXME: sourceCodeLocation
         // FIXME: profilePayload
-        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
 
         return {
+            target: this._target.exportData(),
             type: this.type,
             eventType: this._eventType,
             startTime: this.startTime,

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -171,6 +171,18 @@ WI.Target = class Target extends WI.Object
         });
     }
 
+    // Import / Export
+
+    exportData()
+    {
+        // Only expected to be used by timeline recordings for `WI.ImportedTarget`.
+        return {
+            identifier: this._identifier,
+            type: this._type,
+            name: this.displayName,
+        };
+    }
+
     // Public
 
     get parentTarget() { return this._parentTarget; }

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js
@@ -27,9 +27,9 @@ WI.HeapSnapshotNodeProxy = class HeapSnapshotNodeProxy
 {
     constructor(target, snapshotObjectId, {id, className, size, retainedSize, internal, isObjectType, isElementType, gcRoot, dead, dominatorNodeIdentifier, hasChildren})
     {
-        console.assert(target instanceof WI.Target, target);
+        console.assert(!target || target instanceof WI.Target || target instanceof WI.ImportedTarget, target);
 
-        this._target = target;
+        this._target = target || null;
         this._proxyObjectId = snapshotObjectId;
 
         this.id = id;
@@ -55,6 +55,11 @@ WI.HeapSnapshotNodeProxy = class HeapSnapshotNodeProxy
     // Public
 
     get target() { return this._target; }
+
+    get imported()
+    {
+        return !this._target || this._target instanceof WI.ImportedTarget;
+    }
 
     // Proxied
 

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotProxy.js
@@ -27,11 +27,11 @@ WI.HeapSnapshotProxy = class HeapSnapshotProxy extends WI.Object
 {
     constructor(target, snapshotObjectId, identifier, title, totalSize, totalObjectCount, liveSize, categories)
     {
-        console.assert(target instanceof WI.Target, target);
+        console.assert(!target || target instanceof WI.Target || target instanceof WI.ImportedTarget, target);
 
         super();
 
-        this._target = target;
+        this._target = target || null;
         this._proxyObjectId = snapshotObjectId;
 
         this._identifier = identifier;
@@ -78,7 +78,6 @@ WI.HeapSnapshotProxy = class HeapSnapshotProxy extends WI.Object
     get totalObjectCount() { return this._totalObjectCount; }
     get liveSize() { return this._liveSize; }
     get categories() { return this._categories; }
-    get imported() { return !this._target; }
     get invalid() { return this._proxyObjectId === 0; }
 
     get snapshotStringData()
@@ -89,6 +88,11 @@ WI.HeapSnapshotProxy = class HeapSnapshotProxy extends WI.Object
     set snapshotStringData(data)
     {
         this._snapshotStringData = data;
+    }
+
+    get imported()
+    {
+        return !this._target || this._target instanceof WI.ImportedTarget;
     }
 
     updateForCollectionEvent(event)

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
@@ -66,7 +66,6 @@ WI.HeapSnapshotWorkerProxy = class HeapSnapshotWorkerProxy extends WI.Object
 
     createImportedSnapshot(snapshotStringData, title, callback)
     {
-        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
         const targetId = null;
         this.performAction("createSnapshot", targetId, snapshotStringData, title, callback);
     }

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -172,6 +172,7 @@
     <script src="Models/Gradient.js"></script>
     <script src="Models/HeapAllocationsInstrument.js"></script>
     <script src="Models/HeapAllocationsTimelineRecord.js"></script>
+    <script src="Models/ImportedTarget.js"></script>
     <script src="Models/IndexedDatabase.js"></script>
     <script src="Models/IndexedDatabaseObjectStore.js"></script>
     <script src="Models/IndexedDatabaseObjectStoreIndex.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
@@ -409,7 +409,6 @@ WI.HeapAllocationsTimelineView = class HeapAllocationsTimelineView extends WI.Ti
             let snapshotStringData = result.text;
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             workerProxy.createImportedSnapshot(snapshotStringData, result.filename, ({objectId, snapshot: serializedSnapshot}) => {
-                // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
                 const target = null;
                 let snapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
                 snapshot.snapshotStringData = snapshotStringData;

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
@@ -276,17 +276,18 @@ WI.HeapSnapshotObjectGraphDataGridTree = class HeapSnapshotObjectGraphDataGridTr
                 this.appendChild(new WI.HeapSnapshotInstanceDataGridNode(instance, this));
         });
 
-        let rootClassName = this.heapSnapshot.target.type === WI.TargetType.Worker ? "DedicatedWorkerGlobalScope" : "Window";
-        this.heapSnapshot.instancesWithClassName(rootClassName, (instances) => {
-            for (let instance of instances) {
-                // FIXME: Why is the window.Window Function classified as a Window?
-                // In any case, ignore objects not dominated by the root, as they
-                // are probably not what we want.
-                if (instance.dominatorNodeIdentifier === 0)
-                    this.appendChild(new WI.HeapSnapshotInstanceDataGridNode(instance, this));
-            }
+        for (let rootClassName of ["Window", "DedicatedWorkerGlobalScope"]) {
+            this.heapSnapshot.instancesWithClassName(rootClassName, (instances) => {
+                for (let instance of instances) {
+                    // FIXME: Why is the window.Window Function classified as a Window?
+                    // In any case, ignore objects not dominated by the root, as they
+                    // are probably not what we want.
+                    if (instance.dominatorNodeIdentifier === 0)
+                        this.appendChild(new WI.HeapSnapshotInstanceDataGridNode(instance, this));
+                }
 
-            this.didPopulate();
-        });
+                this.didPopulate();
+            });
+        }
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js
@@ -58,7 +58,7 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
 
     iconClassName()
     {
-        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
+        let script = this._getScript();
         if (!script || !script.url)
             return "native-icon";
         if (this._node.name === "(program)")
@@ -128,9 +128,11 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
     {
         if (columnIdentifier === "function") {
             let filterableData = [this.displayName()];
-            let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
+
+            let script = this._getScript();
             if (script && script.url && this._node.line >= 0 && this._node.column >= 0)
                 filterableData.push(script.url);
+
             return filterableData;
         }
 
@@ -138,6 +140,14 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
     }
 
     // Private
+
+    _getScript()
+    {
+        return WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target)
+            || WI.debuggerManager.scriptsForURL(this._node.url, this._tree.target).firstValue
+            || WI.networkManager.resourcesForURL(this._node.url).firstValue
+            || null;
+    }
 
     _updateChildrenForModifiers()
     {
@@ -230,7 +240,7 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
         let titleElement = fragment.appendChild(document.createElement("span"));
         titleElement.textContent = title;
 
-        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
+        let script = this._getScript();;
         if (script && script.url && this._node.line >= 0 && this._node.column >= 0) {
             // Convert from 1-based line and column to 0-based.
             let sourceCodeLocation = script.createSourceCodeLocation(this._node.line - 1, this._node.column - 1);

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
@@ -51,7 +51,7 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
         let targets = this.representedObject.targets;
 
         this._selectedTarget = null;
-        this._displayedTarget = targets.includes(WI.mainTarget) ? WI.mainTarget : (targets.firstValue || WI.assumingMainTarget());
+        this._displayedTarget = (!this.representedObject.imported && targets.includes(WI.mainTarget)) ? WI.mainTarget : (targets.firstValue || WI.assumingMainTarget());
 
         this._pathComponentForTarget = new Map(targets.map((target) => [target, this._createTargetPathComponent(target)]));
         this._sortTargetPathComponents();
@@ -147,7 +147,9 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
 
     restoreFromCookie(cookie)
     {
-        this._displayedTarget = WI.targetManager.targetForIdentifier(cookie[WI.ScriptClusterTimelineView.TargetIdentifierCookieKey]);
+        let targetId = cookie[WI.ScriptClusterTimelineView.TargetIdentifierCookieKey];
+        this._displayedTarget = this.representedObject.imported ? WI.ImportedTarget.forIdentifier(targetId) : WI.targetManager.targetForIdentifier(targetId);
+
         this._currentContentViewSetting.value = cookie[WI.ScriptClusterTimelineView.ViewIdentifierCookieKey];
         this._updateCurrentContentView();
     }
@@ -229,7 +231,7 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
 
         if (!this._selectedTarget) {
             console.assert(this._pathComponentForTarget.size >= 1, this._pathComponentForTarget);
-            let displayedTarget = this._pathComponentForTarget.has(WI.mainTarget) ? WI.mainTarget : this._pathComponentForTarget.firstKey;
+            let displayedTarget = (!this.representedObject.imported && this._pathComponentForTarget.has(WI.mainTarget)) ? WI.mainTarget : this._pathComponentForTarget.firstKey;
             if (displayedTarget !== this._displayedTarget) {
                 this._displayedTarget = displayedTarget;
                 this._updateCurrentContentView();

--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js
@@ -433,6 +433,8 @@ HeapSnapshot = class HeapSnapshot
 
     // Public
 
+    get imported() { return !this._targetId; }
+
     serialize()
     {
         return {

--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js
@@ -47,7 +47,7 @@ HeapSnapshotWorker = class HeapSnapshotWorker
         this._snapshots = [];
     }
 
-    createSnapshot(targetId, snapshotString, title, imported)
+    createSnapshot(targetId, snapshotString, title)
     {
         let objectId = this._nextObjectId++;
         let snapshot = new HeapSnapshot(targetId, objectId, snapshotString, title);


### PR DESCRIPTION
#### 5d6c6dd65e724fa1ccdbf390ceeee95dd6a89775
<pre>
Web Inspector: Timelines: support exporting and importing data from worker targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=287738">https://bugs.webkit.org/show_bug.cgi?id=287738</a>
&lt;<a href="https://rdar.apple.com/problem/145330533">rdar://problem/145330533</a>&gt;

Reviewed by BJ Burg.

This will allow developers to share timeline recordings of `Worker` with others, just like what&apos;s already possible for the main execution context.

* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.exportData): Added.
* Source/WebInspectorUI/UserInterface/Models/ImportedTarget.js: Added.
(WI.ImportedTarget):
(WI.ImportedTarget.import):
(WI.ImportedTarget.prototype.exportData):
(WI.ImportedTarget.prototype.forIdentifier):
(WI.ImportedTarget.prototype.get identifier):
(WI.ImportedTarget.prototype.get type):
(WI.ImportedTarget.prototype.get name):
(WI.ImportedTarget.prototype.get url):
(WI.ImportedTarget.prototype.get isDestroyed):
(WI.ImportedTarget.prototype.get displayName):
(WI.ImportedTarget.prototype.hasDomain):
(WI.ImportedTarget.prototype.hasCommand):
(WI.ImportedTarget.prototype.hasEvent):
Add a model object to represent a target that did exist when the timeline recording was captured.

* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording):
(WI.TimelineRecording.async import):
(WI.TimelineRecording.prototype.exportData):
(WI.TimelineRecording.prototype.reset):
(WI.TimelineRecording.prototype.updateCallingContextTrees):
* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js:
(WI.HeapAllocationsTimelineRecord.async fromJSON):
(WI.HeapAllocationsTimelineRecord.prototype.toJSON):
* Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js:
(WI.ScriptTimelineRecord.async fromJSON):
(WI.ScriptTimelineRecord.prototype.toJSON):
Include the `WI.Target` data in the exported data to create a `WI.ImportedTarget` when (re)imported.

* Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js:
(WI.ScriptTimeline.prototype.get imported): Added.
Provide a way for `WI.ScriptClusterTimelineView` to know if a timeline recording is imported since it doesn&apos;t have access to the `WI.TimelineRecording`.

* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js:
(WI.HeapSnapshotWorkerProxy.prototype.createImportedSnapshot):
* Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js:
(WI.HeapAllocationsTimelineView.prototype._importButtonNavigationItemClicked):
Remove the FIXME comment since imported snapshots will have a `null` target in the `HeapSnapshotWorker` since the `WI.Target` (and `WI.ImportedTarget`) only exist in the main execution context.

* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js:
(WI.HeapSnapshotObjectGraphDataGridTree.prototype.populateTopLevel):
Just query for all kinds of global objects instead of deciding based on the `WI.TargetType`.

* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotProxy.js:
(WI.HeapSnapshotProxy):
(WI.HeapSnapshotProxy.prototype.get imported):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js:
(WI.HeapSnapshotNodeProxy):
(WI.HeapSnapshotNodeProxy.prototype.get imported): Added.
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js:
(WI.HeapSnapshotInstanceDataGridNode.logHeapSnapshotNode):
(WI.HeapSnapshotInstanceDataGridNode.prototype.createCellContent):
(WI.HeapSnapshotInstanceDataGridNode.prototype._getRemoteObject):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateWindowPreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populatePreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateRemoteObject):
(WI.HeapSnapshotInstanceDataGridNode.prototype._mouseoverHandler):
Prevent imported heap snaphots from using `Heap` commands.

* Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js:
(WI.ScriptClusterTimelineView):
(WI.ScriptClusterTimelineView.prototype.restoreFromCookie):
(WI.ScriptClusterTimelineView.prototype._handleTargetAdded):
Only default to the `WI.mainTarget` if the timeline recording is not imported.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.scriptForIdentifier):
(WI.DebuggerManager.prototype.scriptsForURL):
Drive-by: Add a fastpath for `WI.ImportedTarget`.

* Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js:
(WI.ProfileDataGridNode.prototype.iconClassName):
(WI.ProfileDataGridNode.prototype.filterableDataForColumn):
(WI.ProfileDataGridNode.prototype._getScript): Added.
(WI.ProfileDataGridNode.prototype._displayContent):
Drive-by: Attempt to get the `WI.Script` (or `WI.Resource`) via the URL if viewing an imported timeline recording so that if the developer has imported the recording onto the same website then they can see source code locations.

* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
(HeapSnapshot.prototype.get imported): Added.
* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js:
(HeapSnaphotWorker.prototype.createSnapshot):
Drive-by: Add missing method now that `imported` is no longer given as a separate argument.

* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Test.html:

* LayoutTests/inspector/timeline/timeline-recording.html:
* LayoutTests/inspector/timeline/timeline-recording-expected.txt:

Canonical link: <a href="https://commits.webkit.org/292991@main">https://commits.webkit.org/292991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b8e60c19990c6a818b5eb87cbe2e45ca64b6a95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48157 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25706 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13292 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47599 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104735 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24708 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84402 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82849 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27403 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18303 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24669 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->