### PR TITLE
[css-anchor-position-1] Fix various bugs in position-try shorthand parser and serializer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/parsing/position-try-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/parsing/position-try-parsing-expected.txt
@@ -1,16 +1,16 @@
 
 PASS e.style['position-try'] = "flip-inline" should set the property value
-FAIL e.style['position-try'] = "most-height none" should set the property value assert_equals: serialization should be canonical expected "most-height none" but got "most-height"
+PASS e.style['position-try'] = "most-height none" should set the property value
 PASS e.style['position-try'] = "--bar, --baz" should set the property value
 PASS e.style['position-try'] = "most-inline-size --baz, flip-inline" should set the property value
 PASS e.style['position-try'] = "most-block-size flip-inline flip-block, --bar, --baz" should set the property value
-FAIL e.style['position-try'] = "normal none" should set the property value assert_equals: serialization should be canonical expected "none" but got "normal"
-FAIL e.style['position-try'] = "most-width none" should set the property value assert_equals: serialization should be canonical expected "most-width none" but got "most-width"
+PASS e.style['position-try'] = "normal none" should set the property value
+PASS e.style['position-try'] = "most-width none" should set the property value
 PASS e.style['position-try'] = "normal --foo" should set the property value
-FAIL e.style['position-try'] = "normal --foo, most-width --bar" should not set the property value assert_equals: expected "" but got "--foo, "
-FAIL e.style['position-try'] = "none normal" should not set the property value assert_equals: expected "" but got "normal"
-FAIL e.style['position-try'] = "flip-block most-height" should not set the property value assert_equals: expected "" but got "flip-block"
-FAIL e.style['position-try'] = "most-height, flip-start" should not set the property value assert_equals: expected "" but got "most-height , flip-start"
+PASS e.style['position-try'] = "normal --foo, most-width --bar" should not set the property value
+PASS e.style['position-try'] = "none normal" should not set the property value
+PASS e.style['position-try'] = "flip-block most-height" should not set the property value
+PASS e.style['position-try'] = "most-height, flip-start" should not set the property value
 PASS e.style['position-try'] = "flip-inline" should set position-try-fallbacks
 PASS e.style['position-try'] = "flip-inline" should set position-try-order
 PASS e.style['position-try'] = "flip-inline" should not set unrelated longhands

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -133,6 +133,7 @@ private:
     String serializeGridTemplate() const;
     String serializeOffset() const;
     String serializePageBreak() const;
+    String serializePositionTry() const;
     String serializeLineClamp() const;
     String serializeTextBox() const;
     String serializeTextWrap() const;
@@ -356,7 +357,6 @@ String ShorthandSerializer::serialize()
     case CSSPropertyTextEmphasis:
     case CSSPropertyWebkitTextDecoration:
     case CSSPropertyWebkitTextStroke:
-    case CSSPropertyPositionTry:
         return serializeLonghandsOmittingInitialValues();
     case CSSPropertyBorderColor:
     case CSSPropertyBorderStyle:
@@ -408,6 +408,8 @@ String ShorthandSerializer::serialize()
     case CSSPropertyPageBreakInside:
     case CSSPropertyWebkitColumnBreakInside:
         return serializeBreakInside();
+    case CSSPropertyPositionTry:
+        return serializePositionTry();
     case CSSPropertyTextDecorationSkip:
     case CSSPropertyTextDecoration:
     case CSSPropertyWebkitBackgroundSize:
@@ -1293,6 +1295,18 @@ String ShorthandSerializer::serializePageBreak() const
     default:
         return String();
     }
+}
+
+String ShorthandSerializer::serializePositionTry() const
+{
+    auto positionTryOrderIndex = longhandIndex(0, CSSPropertyPositionTryOrder);
+    auto positionTryFallbacksIndex = longhandIndex(1, CSSPropertyPositionTryFallbacks);
+
+    auto positionTryFallbacksSerialization = serializeLonghandValue(positionTryFallbacksIndex);
+    if (isLonghandInitialValue(positionTryOrderIndex))
+        return positionTryFallbacksSerialization;
+
+    return makeString(serializeLonghandValue(positionTryOrderIndex), " "_s, positionTryFallbacksSerialization);
 }
 
 String ShorthandSerializer::serializeLineClamp() const

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -3009,7 +3009,7 @@ bool CSSPropertyParser::consumePositionTryShorthand(bool important)
 
     addProperty(CSSPropertyPositionTryOrder, CSSPropertyPositionTry, WTFMove(order), important);
     addProperty(CSSPropertyPositionTryFallbacks, CSSPropertyPositionTry, WTFMove(fallbacks), important);
-    return true;
+    return m_range.atEnd();
 }
 
 bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp
@@ -41,9 +41,10 @@ RefPtr<CSSValue> consumePositionTryFallbacks(CSSParserTokenRange& range, const C
     if (auto result = consumeIdent<CSSValueNone>(range))
         return result;
 
-    auto consume = [&](CSSParserTokenRange& range) -> RefPtr<CSSValue> {
-        // <'position-area'>
+    auto consumeFallback = [&](CSSParserTokenRange& range) -> RefPtr<CSSValue> {
+        // Try to parse <'position-area'>
         auto rangeCopy = range;
+        // consumePositionArea accepts 'none', so detect and reject it beforehand.
         if (range.peek().id() == CSSValueNone)
             return nullptr;
         if (auto positionArea = consumePositionArea(range, context))
@@ -51,29 +52,34 @@ RefPtr<CSSValue> consumePositionTryFallbacks(CSSParserTokenRange& range, const C
 
         range = rangeCopy;
 
-        // [<dashed-ident> || <try-tactic>]
+        // Try to parse [<dashed-ident> || <try-tactic>]
+        // <try-tactic> = flip-block || flip-inline || flip-start
         auto tryRuleIdent = consumeDashedIdentRaw(range);
 
-        Vector<CSSValueID, 3> idents;
-        while (auto ident = consumeIdentRaw<CSSValueFlipBlock, CSSValueFlipInline, CSSValueFlipStart>(range)) {
-            if (idents.contains(*ident))
+        Vector<CSSValueID, 3> tryTactics;
+        while (auto tactic = consumeIdentRaw<CSSValueFlipBlock, CSSValueFlipInline, CSSValueFlipStart>(range)) {
+            if (tryTactics.contains(*tactic))
                 return nullptr;
-            idents.append(*ident);
+            tryTactics.append(*tactic);
         }
-
-        CSSValueListBuilder list;
-        for (auto ident : idents)
-            list.append(CSSPrimitiveValue::create(ident));
 
         if (tryRuleIdent.isNull())
             tryRuleIdent = consumeDashedIdentRaw(range);
 
+        CSSValueListBuilder list;
         if (!tryRuleIdent.isNull())
-            list.insert(0, CSSPrimitiveValue::createCustomIdent(tryRuleIdent));
+            list.append(CSSPrimitiveValue::createCustomIdent(tryRuleIdent));
+        for (auto tactic : tryTactics)
+            list.append(CSSPrimitiveValue::create(tactic));
+
+        // At least one @position-try rule ident or tactic must be present.
+        if (list.isEmpty())
+            return nullptr;
 
         return CSSValueList::createSpaceSeparated(WTFMove(list));
     };
-    return consumeListSeparatedBy<',', OneOrMore, ListOptimization::SingleValue>(range, consume);
+
+    return consumeListSeparatedBy<',', OneOrMore, ListOptimization::SingleValue>(range, consumeFallback);
 }
 
 } // namespace CSSPropertyParserHelpers


### PR DESCRIPTION
#### 19966d8fdd43b807d9b7bf6ea89538663f040763
<pre>
[css-anchor-position-1] Fix various bugs in position-try shorthand parser and serializer
<a href="https://rdar.apple.com/148068669">rdar://148068669</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290593">https://bugs.webkit.org/show_bug.cgi?id=290593</a>

Reviewed by Antti Koivisto.

There are some bugs in the parser/serializer code for position-try shorthand:
* The shorthand serializer uses serializeLonghandsOmittingInitialValues,
  however the position-try-fallbacks portion must always be serialized,
  whether it has the initial value or not
* The shorthand parser doesn&apos;t detect when not all tokens have been consumed
* The parser doesn&apos;t reject an empty fallback (a fallback without a
  position-area, nor a @position-try rule ident/tactic)

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/parsing/position-try-parsing-expected.txt:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
    - Use serializePositionTry instead of serializeLonghandsOmittingInitialValues
      for position-try.

(WebCore::ShorthandSerializer::serializePositionTry const):
    - Add specialized serialization function for position-try.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumePositionTryShorthand):
    - Return whether all tokens have been consumed or not. This indicates
      whether parsing is successful or not.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+PositionTry.cpp:
(WebCore::CSSPropertyParserHelpers::consumePositionTryFallbacks):
    - Rearrange code a bit to make it easier to understand.
    - Bail out if an empty fallback is encountered.

Canonical link: <a href="https://commits.webkit.org/292984@main">https://commits.webkit.org/292984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e916bade3d24439b2682a97146687377c524e77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31254 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100212 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12945 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24285 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17716 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83100 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82514 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20857 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17790 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29399 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->