### PR TITLE
[GTK][WPE] Optimize the case of adding Damage to an empty Damage

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -177,6 +177,78 @@ TEST(Damage, AddRect)
     EXPECT_EQ(damage.rects().size(), 2);
 }
 
+TEST(Damage, AddRects)
+{
+    Damage damage(IntSize { 2048, 1024 });
+    EXPECT_TRUE(damage.add(Vector<IntRect, 1> { { 100, 100, 200, 200 } }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 200, 200));
+
+    // Adding an empty Vector does nothing.
+    EXPECT_FALSE(damage.add(Vector<IntRect, 1> { }));
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding a Vector with empty rets does nothing.
+    EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { } }));
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding more than 4 rectangles will unite.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
+        { 0, 0, 4, 4 },
+        { 200, 0, 4, 4 },
+        { 0, 200, 4, 4 },
+        { 200, 200, 4, 4 },
+        { 128, 128, 4, 4 }
+    }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects()[0], damage.bounds());
+
+    // Adding more than 4 rectangles to a non empty damage should unite too.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
+    EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
+        { 500, 0, 4, 4 },
+        { 300, 200, 4, 4 },
+        { 500, 200, 4, 4 },
+        { 384, 128, 4, 4 }
+    }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects()[1], damage.bounds());
+
+    // Adding more than 4 empty rectangles does nothing.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
+    EXPECT_EQ(damage.rects().size(), 0);
+
+    // Adding more than 4 empty rectangles to a non empty damage does nothing too.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
+    EXPECT_EQ(damage.rects().size(), 1);
+
+    // Adding a Vector to damage in BoundingBox mode always unite damage in bounds.
+    damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
+    EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
+        { 100, 100, 200, 200 },
+        { 300, 300, 200, 200 }
+    }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
+
+    // Adding a Vector to damage in Full mode does nothing.
+    damage = Damage(IntSize { 1024, 768 }, Damage::Mode::Full);
+    EXPECT_FALSE(damage.add(Vector<IntRect, 1> {
+        { 100, 100, 200, 200 },
+        { 300, 300, 200, 200 }
+    }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.rects()[0], damage.bounds());
+    EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
+}
+
 TEST(Damage, AddDamage)
 {
     Damage damage(IntSize { 2048, 1024 });
@@ -197,6 +269,52 @@ TEST(Damage, AddDamage)
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
     EXPECT_EQ(damage.bounds().height(), 400);
+
+    // It's possible to add one Damage to another with different rectangle.
+    damage = Damage(IntSize { 1024, 768 });
+    EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    other = Damage(IntSize { 800, 600 });
+    EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
+    EXPECT_EQ(other.rects().size(), 1);
+    EXPECT_TRUE(damage.add(other));
+    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
+    EXPECT_EQ(damage.rects()[1], IntRect(300, 300, 200, 200));
+
+    // Adding a Damage already united with the same rectangle, just unites every rectangle in the grid.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
+        { 0, 0, 4, 4 },
+        { 300, 0, 4, 4 },
+        { 0, 300, 4, 4 },
+        { 300, 300, 4, 4 },
+        { 128, 128, 4, 4 }
+    }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
+    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
+    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 4, 4));
+    other = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(other.add(Vector<IntRect, 1> {
+        { 10, 10, 4, 4 },
+        { 310, 10, 4, 4 },
+        { 10, 310, 4, 4 },
+        { 310, 310, 4, 4 },
+        { 384, 384, 4, 4 }
+    }));
+    EXPECT_EQ(other.rects().size(), 4);
+    EXPECT_EQ(other.rects()[0], IntRect(10, 10, 4, 4));
+    EXPECT_EQ(other.rects()[1], IntRect(310, 10, 4, 4));
+    EXPECT_EQ(other.rects()[2], IntRect(10, 310, 4, 4));
+    EXPECT_EQ(other.rects()[3], IntRect(310, 310, 78, 78));
+    EXPECT_TRUE(damage.add(other));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
+    EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 14, 14));
+    EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 14, 14));
+    EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
 }
 
 TEST(Damage, Unite)


### PR DESCRIPTION
#### 9993e5909f5124e3c2e5873d12d3479fe38413de
<pre>
[GTK][WPE] Optimize the case of adding Damage to an empty Damage
<a href="https://bugs.webkit.org/show_bug.cgi?id=290613">https://bugs.webkit.org/show_bug.cgi?id=290613</a>

Reviewed by Alejandro G. Castro.

In that case we can directly unite the given damage rects. We can also
optimize the case of unite() when there&apos;s only one rect, since we
already have the unite in m_minimumBoundingRectangle we can just copy it
to the first vector position.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::add):
(WebCore::Damage::cellIndexForRect const):
(WebCore::Damage::unite):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, AddRects)):

Canonical link: <a href="https://commits.webkit.org/293001@main">https://commits.webkit.org/293001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a43df602bccd193b357e92a00a815758f2b7fd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74171 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31356 "Found 1 new test failure: workers/worker-to-worker.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100366 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13069 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104470 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24442 "Hash 2a43df60 for PR 43182 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17847 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83215 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82636 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17986 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29572 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->