### PR TITLE
[GTK][WPE][Skia] Record all dirty tiles of a layer once, don't record each tile

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
     platform/graphics/skia/SkiaPaintingEngine.h
+    platform/graphics/skia/SkiaRecordingResult.h
     platform/graphics/skia/SkiaReplayCanvas.h
     platform/graphics/skia/SkiaSpanExtras.h
 )

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -61,6 +61,7 @@ platform/graphics/skia/ShareableBitmapSkia.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
+platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -30,8 +30,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WorkerPool.h>
 
-class SkImage;
-
 namespace WebCore {
 
 class BitmapTexturePool;
@@ -40,6 +38,7 @@ class GraphicsContext;
 class GraphicsLayer;
 class IntRect;
 class IntSize;
+class SkiaRecordingResult;
 enum class RenderingMode : uint8_t;
 
 class SkiaPaintingEngine {
@@ -66,18 +65,15 @@ public:
     static float minimumFractionOfTasksUsingGPUPainting();
     static HybridPaintingStrategy hybridPaintingStrategy();
 
-    Ref<CoordinatedTileBuffer> paintLayer(const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
+    bool useThreadedRendering() const { return m_cpuWorkerPool || m_gpuWorkerPool; }
+
+    Ref<CoordinatedTileBuffer> paint(const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
+    Ref<SkiaRecordingResult> record(const GraphicsLayer&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
+    Ref<CoordinatedTileBuffer> replay(const RefPtr<SkiaRecordingResult>&, const IntRect& dirtyRect);
 
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
-    bool paintGraphicsLayerIntoBuffer(Ref<CoordinatedTileBuffer>&, const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const;
-
-    // Threaded rendering
-    Ref<CoordinatedTileBuffer> postPaintingTask(const GraphicsLayer&, RenderingMode, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
-
-    // Main thread rendering
-    Ref<CoordinatedTileBuffer> performPaintingTask(const GraphicsLayer&, RenderingMode, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
 
     bool isHybridMode() const;
     RenderingMode decideHybridRenderingMode(const IntRect& dirtyRect, float contentsScale) const;

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaRecordingResult.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+
+namespace WebCore {
+
+SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaImageToFenceMap&& imageToFenceMap, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
+    : m_picture(WTFMove(picture))
+    , m_imageToFenceMap(WTFMove(imageToFenceMap))
+    , m_recordRect(recordRect)
+    , m_renderingMode(renderingMode)
+    , m_contentsOpaque(contentsOpaque)
+    , m_contentsScale(contentsScale)
+{
+}
+
+SkiaRecordingResult::~SkiaRecordingResult() = default;
+
+Ref<SkiaRecordingResult> SkiaRecordingResult::create(sk_sp<SkPicture>&& picture, SkiaImageToFenceMap&& imageToFenceMap, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
+{
+    return adoptRef(*new SkiaRecordingResult(WTFMove(picture), WTFMove(imageToFenceMap), recordRect, renderingMode, contentsOpaque, contentsScale));
+}
+
+bool SkiaRecordingResult::hasFences()
+{
+    Locker locker { m_imageToFenceMapLock };
+    return !m_imageToFenceMap.isEmpty();
+}
+
+void SkiaRecordingResult::waitForFenceIfNeeded(const SkImage& image)
+{
+    Locker locker { m_imageToFenceMapLock };
+    if (auto fence = m_imageToFenceMap.get(&image))
+        fence->serverWait();
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "GraphicsContextSkia.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkPicture.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+class SkImage;
+
+namespace WebCore {
+
+class SkiaRecordingResult final : public ThreadSafeRefCounted<SkiaRecordingResult> {
+public:
+    virtual ~SkiaRecordingResult();
+    static Ref<SkiaRecordingResult> create(sk_sp<SkPicture>&&, SkiaImageToFenceMap&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
+
+    void waitForFenceIfNeeded(const SkImage&);
+    bool hasFences();
+
+    const sk_sp<SkPicture>& picture() const { return m_picture; }
+    const IntRect& recordRect() const { return m_recordRect; }
+    RenderingMode renderingMode() const { return m_renderingMode; }
+    bool contentsOpaque() const { return m_contentsOpaque; }
+    float contentsScale() const { return m_contentsScale; }
+
+private:
+    SkiaRecordingResult(sk_sp<SkPicture>&&, SkiaImageToFenceMap&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
+
+    sk_sp<SkPicture> m_picture;
+    SkiaImageToFenceMap m_imageToFenceMap WTF_GUARDED_BY_LOCK(m_imageToFenceMapLock);
+    Lock m_imageToFenceMapLock;
+    IntRect m_recordRect;
+    RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
+    bool m_contentsOpaque : 1 { true };
+    float m_contentsScale { 0 };
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -26,30 +26,25 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
-#include "GraphicsContextSkia.h"
 #include "IntSize.h"
+#include "SkiaRecordingResult.h"
 #include <skia/utils/SkNWayCanvas.h>
 #include <wtf/Assertions.h>
 #include <wtf/Function.h>
-#include <wtf/HashMap.h>
-#include <wtf/RefCounted.h>
-#include <wtf/TZoneMalloc.h>
 
 class SkImage;
 
 namespace WebCore {
 
-class GLFence;
-
 class SkiaReplayCanvas final : public SkNWayCanvas, public RefCounted<SkiaReplayCanvas> {
-    WTF_MAKE_TZONE_ALLOCATED(SkiaReplayCanvas);
-    WTF_MAKE_NONCOPYABLE(SkiaReplayCanvas);
 public:
     ~SkiaReplayCanvas() override;
-    static Ref<SkiaReplayCanvas> create(const IntSize&, SkiaImageToFenceMap&&);
+    static Ref<SkiaReplayCanvas> create(const IntSize&, const RefPtr<SkiaRecordingResult>&);
+
+    const sk_sp<SkPicture>& picture() const { return m_recording->picture(); }
 
 private:
-    SkiaReplayCanvas(const IntSize&, SkiaImageToFenceMap&&);
+    SkiaReplayCanvas(const IntSize&, const RefPtr<SkiaRecordingResult>&);
 
     sk_sp<SkImage> waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage*);
 
@@ -80,7 +75,7 @@ private:
     void onDrawTextBlob(const SkTextBlob*, SkScalar x, SkScalar y, const SkPaint&) override;
     void onDrawVerticesObject(const SkVertices*, SkBlendMode, const SkPaint&) override;
 
-    SkiaImageToFenceMap m_imageToFenceMap;
+    RefPtr<SkiaRecordingResult> m_recording;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -51,6 +51,7 @@ class TextureMapperLayer;
 
 #if USE(SKIA)
 class SkiaPaintingEngine;
+class SkiaRecordingResult;
 #endif
 #if USE(CAIRO)
 namespace Cairo {
@@ -182,6 +183,10 @@ public:
     RunLoop* compositingRunLoop() const;
 
     Ref<CoordinatedTileBuffer> paint(const IntRect&);
+#if USE(SKIA)
+    Ref<SkiaRecordingResult> record(const IntRect&);
+    Ref<CoordinatedTileBuffer> replay(const RefPtr<SkiaRecordingResult>&, const IntRect&);
+#endif
     void waitUntilPaintingComplete();
 
 private:


### PR DESCRIPTION
#### 5abe8ab78cbb3a00c4e190faa2b602ed7b199432
<pre>
[GTK][WPE][Skia] Record all dirty tiles of a layer once, don&apos;t record each tile
<a href="https://bugs.webkit.org/show_bug.cgi?id=290614">https://bugs.webkit.org/show_bug.cgi?id=290614</a>

Reviewed by Carlos Garcia Campos.

For each layer, we currently record each dirty tile, then replay in a worker
thread. We can do better and once record a SkPicture of the area spanning all
dirty tiles, and then use the same SkPicture for replaying N times, for each
dirty tile.

Covered by existing tests.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::paint):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::paintGraphicsLayerIntoBuffer const): Deleted.
(WebCore::SkiaPaintingEngine::paintLayer): Deleted.
(WebCore::SkiaPaintingEngine::postPaintingTask): Deleted.
(WebCore::SkiaPaintingEngine::performPaintingTask): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
(WebCore::SkiaPaintingEngine::useThreadedRendering const):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp: Added.
(WebCore::SkiaRecordingResult::SkiaRecordingResult):
(WebCore::SkiaRecordingResult::create):
(WebCore::SkiaRecordingResult::hasFences):
(WebCore::SkiaRecordingResult::waitForFenceIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h: Added.
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
(WebCore::SkiaReplayCanvas::create):
(WebCore::SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::paint):
(WebCore::CoordinatedPlatformLayer::record):
(WebCore::CoordinatedPlatformLayer::replay):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/292929@main">https://commits.webkit.org/292929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bef1631cb8730c71e38cbea2743d7dd25bd7fd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74294 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31474 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47468 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83340 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82761 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29707 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->