### PR TITLE
[WPE] Fix build in Ubuntu 20.04

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h
@@ -27,6 +27,7 @@
 
 #if USE(ATK)
 #include "WPEToplevel.h"
+#include "atk/ATKCompat.h"
 #include <atk/atk.h>
 #include <glib-object.h>
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(ATK)
+#include "atk/ATKCompat.h"
 #include <atk/atk.h>
 #include <glib-object.h>
 #include <wpe/WPEToplevel.h>

--- a/Source/WebKit/WPEPlatform/wpe/atk/ATKCompat.h
+++ b/Source/WebKit/WPEPlatform/wpe/atk/ATKCompat.h
@@ -26,19 +26,11 @@
 #pragma once
 
 #if USE(ATK)
-#include "atk/ATKCompat.h"
 #include <atk/atk.h>
-#include <glib-object.h>
-#include <wpe/WPEView.h>
-#include <wpe/WPEViewAccessible.h>
+#if !ATK_CHECK_VERSION(2, 38, 0)
 
-G_BEGIN_DECLS
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(AtkSocket, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(AtkObject, g_object_unref)
 
-#define WPE_TYPE_VIEW_ACCESSIBLE_ATK (wpe_view_accessible_atk_get_type())
-G_DECLARE_FINAL_TYPE (WPEViewAccessibleAtk, wpe_view_accessible_atk, WPE, VIEW_ACCESSIBLE_ATK, AtkSocket)
-
-WPEViewAccessible* wpeViewAccessibleAtkNew(WPEView*);
-
-G_END_DECLS
-
-#endif // USE(ATK)
+#endif
+#endif


### PR DESCRIPTION
#### 3ad6fde11a43e86c2f56abd924cc31941ca7df36
<pre>
[WPE] Fix build in Ubuntu 20.04
<a href="https://bugs.webkit.org/show_bug.cgi?id=290618">https://bugs.webkit.org/show_bug.cgi?id=290618</a>

Reviewed by Carlos Garcia Campos.

G_DECLARE_FINAL_TYPE() can only be used with types that have
defined an autoptr-cleanup function for the parent types, ideally
with G_DEFINE_AUTOPTR_CLEANUP_FUNC(). ATK only added those in
version 2.38, so distributions using earlier versions will
fail to build due to the missing autoptr-cleanup functions.

Add a compatibility header that will only be built in when
the ATK version is below 2.38.0, that will define the autoptr
cleanup function for the ATK types that are used in WPEPlatform.

* Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h:
* Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h:
* Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.h:
* Source/WebKit/WPEPlatform/wpe/atk/ATKCompat.h: added

Canonical link: <a href="https://commits.webkit.org/292815@main">https://commits.webkit.org/292815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3edb9898a712256b07187cad601482dd9a419868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31269 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100227 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/12956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12710 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47191 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104327 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82527 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17806 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15680 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24263 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24086 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25659 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->