### PR TITLE
Add a console warning if a live capture MediaStreamTrack gets garbage collected

### DIFF
--- a/LayoutTests/fast/mediastream/enumerate-devices-change-event.html
+++ b/LayoutTests/fast/mediastream/enumerate-devices-change-event.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/image-capture-take-photo.html
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset='utf-8'>

--- a/LayoutTests/fast/mediastream/media-stream-renders-first-frame.html
+++ b/LayoutTests/fast/mediastream/media-stream-renders-first-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <video id="video" width=480px height=480px controls ></video>

--- a/LayoutTests/fast/mediastream/mediastream-gc.html
+++ b/LayoutTests/fast/mediastream/mediastream-gc.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <body>
 <script src="../../resources/gc.js"></script>
@@ -10,11 +10,18 @@ promise_test(async () => {
     if (!window.internals)
         return;
 
+    let promise = new Promise((resolve, reject) => {
+        internals.setConsoleMessageListener(resolve);
+        setTimeout(() => reject("internals.setConsoleMessageListener timed out"), 5000);
+    });
+
     for (let counter = 0; counter < 10; ++counter) {
         await navigator.mediaDevices.getUserMedia({audio:true, video : true});
         gc();
     }
     assert_less_than(internals.audioCaptureSourceCount(), 10); 
+
+    assert_equals(await promise, "A capture MediaStreamTrack was destroyed without having been stopped explicitly");
 }, "Media streams can be gced if they are not expected to fire events - 1");
 
 promise_test(async () => {

--- a/LayoutTests/fast/mediastream/mediastreamtrack-audio-clone.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-audio-clone.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html
@@ -17,6 +17,8 @@
     promise_test(async (t) => {
         let constraints = { video: { width: 160 } };
         const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 160 } });
+        t.add_cleanup(() => stream.getVideoTracks()[0].stop());
+
         assert_equals(stream.getVideoTracks()[0].getConstraints().width, 160);
 
         const streamClone = stream.clone();
@@ -26,6 +28,8 @@
 
         const videoTrack = stream.getVideoTracks()[0];
         const videoTrackClone = streamClone.getVideoTracks()[0];
+        t.add_cleanup(() => videoTrack.stop());
+        t.add_cleanup(() => videoTrackClone.stop());
 
         assert_equals(videoTrack.enabled, videoTrackClone.enabled);
         videoTrack.enabled = false;
@@ -39,6 +43,8 @@
         }, "Check cloned track settings after applying width constraints");
 
         const videoTrackClone2 = videoTrackClone.clone();
+        t.add_cleanup(() => videoTrackClone2.stop());
+
         await videoTrackClone.applyConstraints({width: 1280});
         video3.srcObject = new MediaStream([videoTrackClone2]);
         test(() => {
@@ -57,6 +63,9 @@
         const videoTrack = stream.getVideoTracks()[0];
         const videoTrackClone = streamClone.getVideoTracks()[0];
 
+        t.add_cleanup(() => videoTrack.stop());
+        t.add_cleanup(() => videoTrackClone.stop());
+
         assert_equals(videoTrack.enabled, videoTrackClone.enabled);
         videoTrack.enabled = false;
         assert_true(videoTrackClone.enabled);
@@ -69,6 +78,8 @@
         }, "Check cloned track settings after applying height constraints");
 
         const videoTrackClone2 = videoTrackClone.clone();
+        t.add_cleanup(() => videoTrackClone2.stop());
+
         await videoTrackClone.applyConstraints({height: 400});
         video3.srcObject = new MediaStream([videoTrackClone2]);
         test(() => {
@@ -87,6 +98,9 @@
         const videoTrack = stream.getVideoTracks()[0];
         const videoTrackClone = streamClone.getVideoTracks()[0];
 
+        t.add_cleanup(() => videoTrack.stop());
+        t.add_cleanup(() => videoTrackClone.stop());
+
         assert_equals(videoTrack.enabled, videoTrackClone.enabled);
         videoTrack.enabled = false;
         assert_true(videoTrackClone.enabled);
@@ -101,6 +115,8 @@
         }, "Check cloned track settings after applying width+height constraints");
 
         const videoTrackClone2 = videoTrackClone.clone();
+        t.add_cleanup(() => videoTrackClone2.stop());
+
         await videoTrackClone.applyConstraints({width: 400, height: 200});
         video3.srcObject = new MediaStream([videoTrackClone2]);
         test(() => {
@@ -115,6 +131,9 @@
         const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 100, height: 100 } });
         const streamClone = stream.clone();
 
+        t.add_cleanup(() => stream.getVideoTracks()[0].stop());
+        t.add_cleanup(() => streamClone.getVideoTracks()[0].stop());
+
         video1.srcObject = streamClone;
         stream.getVideoTracks()[0].stop();
 
@@ -125,6 +144,9 @@
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 100, height: 100 } });
         const streamClone = stream.clone();
+
+        t.add_cleanup(() => stream.getVideoTracks()[0].stop());
+        t.add_cleanup(() => streamClone.getVideoTracks()[0].stop());
 
         video1.srcObject = stream;
         streamClone.getVideoTracks()[0].stop();
@@ -138,6 +160,8 @@
         stream.clone().getVideoTracks()[0].stop();
         gc();
 
+        t.add_cleanup(() => stream.getVideoTracks()[0].stop());
+
         video1.srcObject = stream;
 
         await video1.play();
@@ -146,7 +170,10 @@
 
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
-        stream.getTracks().forEach(t => t.enabled = false);
+        stream.getTracks().forEach(track => {
+            track.enabled = false;
+            t.add_cleanup(() => track.stop());
+        });
 
         const channel = new MessageChannel();
         const transferringTracks = { audio:stream.getAudioTracks()[0].clone() , video:stream.getVideoTracks()[0].clone() };
@@ -167,7 +194,7 @@
         assert_equals(transferredTracks.video.readyState, "ended", "transferredTracks.video.enabled");
     }, "Transferring a track should preserve enabled and readyState");
 
-    promise_test(async (t) => {
+    promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
         stream.getTracks().forEach(t => t.enabled = false);
         const clone1 = stream.clone();
@@ -176,6 +203,13 @@
 
         stream.getTracks().forEach(t => t.stop());
         const clone2 = stream.clone();
+
+        clone1.getTracks().forEach(track => {
+            test.add_cleanup(() => track.stop());
+        });
+        clone2.getTracks().forEach(track => {
+            test.add_cleanup(() => track.stop());
+        });
 
         clone1.getTracks().forEach(t => assert_equals(t.readyState, "live"));
         clone2.getTracks().forEach(t => assert_equals(t.readyState, "ended"));

--- a/LayoutTests/fast/mediastream/resize-trim.html
+++ b/LayoutTests/fast/mediastream/resize-trim.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <video id="video" autoplay width=480px height=480px controls ></video>

--- a/LayoutTests/fast/mediastream/resources/getUserMedia-to-canvas.js
+++ b/LayoutTests/fast/mediastream/resources/getUserMedia-to-canvas.js
@@ -141,6 +141,8 @@ async function testUserMediaToCanvas(t, subcase) {
         setMockCameraImageOrientation(0);
         await waitForVideoSize(video, realVideoSize[0], realVideoSize[1]);
         debuge.removeChild(video);
+        if (video.srcObject)
+            video.srcObject.getTracks().forEach(t => t.stop());
         video.srcObject = null;
     });
 

--- a/LayoutTests/http/tests/media/media-stream/device-change-event-in-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/device-change-event-in-iframe.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <script src="../../../../resources/js-test-pre.js"></script>
 <body onload="start()">

--- a/LayoutTests/http/wpt/audio-output/setSinkId.https.html
+++ b/LayoutTests/http/wpt/audio-output/setSinkId.https.html
@@ -21,7 +21,9 @@ promise_test(t => {
 }, "setSinkId requires user gesture");
 
 promise_test(async t => {
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    t.add_cleanup(() => stream.getTracks()[0].stop());
+
     const list = await navigator.mediaDevices.enumerateDevices();
     const outputDevicesList = list.filter(({kind}) => kind == "audiooutput");
     assert_not_equals(outputDevicesList.length, 0, "media device list includes at least one audio output device");
@@ -39,7 +41,8 @@ promise_test(async t => {
     internals.settings.setSpeakerSelectionRequiresUserGesture(true);
     t.add_cleanup(() => { internals.settings.setSpeakerSelectionRequiresUserGesture(false); });
 
-    await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     await new Promise(resolve => setTimeout(resolve, 500));
 
     window.testRunner.addMockMicrophoneDevice('NewMicrophone', 'new microphone', { });

--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html
@@ -64,6 +64,7 @@ async function createConnections(test, firstConnectionCallback, secondConnection
 
 promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = stream;
     test.add_cleanup(async () => video.srcObject = null);
@@ -82,6 +83,7 @@ promise_test(async test => {
 
 promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     let pc2;
     await createConnections(test, pc1 => {

--- a/LayoutTests/http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html
+++ b/LayoutTests/http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/webrtc/remove-track.html
+++ b/LayoutTests/webrtc/remove-track.html
@@ -18,6 +18,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const remoteStream = await new Promise((resolve, reject) => {
         createConnections((connection) => {
             firstConnection = connection;
@@ -75,6 +76,7 @@ promise_test((test) => {
 
 promise_test(async t => {
     const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const track = stream.getTracks()[0];
     let pc = new RTCPeerConnection();
     for (let i = 0; i <100; i++) {
@@ -86,6 +88,7 @@ promise_test(async t => {
 
 promise_test(async t => {
     const stream = await navigator.mediaDevices.getUserMedia({video: true});
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const track = stream.getTracks()[0];
     let pc = new RTCPeerConnection();
     for (let i = 0; i <100; i++) {

--- a/LayoutTests/webrtc/video-autoplay.html
+++ b/LayoutTests/webrtc/video-autoplay.html
@@ -27,6 +27,8 @@ promise_test((test) => {
 
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
         findMediaElement();
         video.src = findMediaFile("video", "content/test");
         return video.play().then(() => assert_unreached(), (e) => { assert_equals(e.name, 'NotAllowedError')});
@@ -35,6 +37,8 @@ promise_test((test) => {
 
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
         video.srcObject = stream;
         return waitFor(10);
     }).then(() => {
@@ -44,6 +48,8 @@ promise_test((test) => {
 
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 firstConnection.addTrack(stream.getVideoTracks()[0], stream);

--- a/LayoutTests/webrtc/video-update-often.html
+++ b/LayoutTests/webrtc/video-update-often.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -105,6 +105,14 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
 
 MediaStreamTrack::~MediaStreamTrack()
 {
+    if (isCaptureTrack() && !ended()) {
+        if (RefPtr context = scriptExecutionContext()) {
+            context->postTask([](auto& context) {
+                context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "A capture MediaStreamTrack was destroyed without having been stopped explicitly"_s);
+            });
+        }
+    }
+
     m_private->removeObserver(*this);
     stopTrack();
 


### PR DESCRIPTION
#### e7ee98843e5ba0f240c186866afc706b95b45d34
<pre>
Add a console warning if a live capture MediaStreamTrack gets garbage collected
<a href="https://rdar.apple.com/148105549">rdar://148105549</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290629">https://bugs.webkit.org/show_bug.cgi?id=290629</a>

Reviewed by Jean-Yves Avenard.

This may help web developers becoming aware of bugs like in <a href="https://bugs.webkit.org/show_bug.cgi?id=288372.">https://bugs.webkit.org/show_bug.cgi?id=288372.</a>

* LayoutTests/fast/mediastream/enumerate-devices-change-event.html:
* LayoutTests/fast/mediastream/image-capture-take-photo.html:
* LayoutTests/fast/mediastream/media-stream-renders-first-frame.html:
* LayoutTests/fast/mediastream/mediastream-gc.html:
* LayoutTests/fast/mediastream/mediastreamtrack-audio-clone.html:
* LayoutTests/fast/mediastream/mediastreamtrack-video-clone.html:
* LayoutTests/fast/mediastream/resize-trim.html:
* LayoutTests/fast/mediastream/resources/getUserMedia-to-canvas.js:
(createUserMediaToCanvasTests):
* LayoutTests/http/tests/media/media-stream/device-change-event-in-iframe.html:
* LayoutTests/http/wpt/audio-output/setSinkId.https.html:
* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html:
* LayoutTests/http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html:
* LayoutTests/webrtc/remove-track.html:
* LayoutTests/webrtc/video-autoplay.html:
* LayoutTests/webrtc/video-update-often.html:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::~MediaStreamTrack):

Canonical link: <a href="https://commits.webkit.org/296274@main">https://commits.webkit.org/296274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a890e66456df67e7740de849b08da1f1d5cbc727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81997 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110965 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22493 "layout-tests (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91846 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35088 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90825 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35729 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13483 "layout-tests (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40541 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->