### PR TITLE
[WebGPU/WGSL]: PackedVec3 has x, y, z but not r, g, b

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_290633-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_290633-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: no validation error
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/regression/repro_290633.html
+++ b/LayoutTests/fast/webgpu/regression/repro_290633.html
@@ -1,0 +1,30 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@group(0) @binding(0) var<storage, read_write> buf: array<vec3u>;
+
+@compute @workgroup_size(1)
+fn c() {
+  _ = buf[0].r;
+}
+`;
+    let module = device.createShaderModule({code});
+    let computePipeline = device.createComputePipeline({layout: 'auto', compute: {module}});
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    log('Pass')
+    globalThis.testRunner?.dumpAsText();
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -244,9 +244,9 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         {
             IndentationScope scope(m_indent);
             m_body.append(
-                m_indent, "T x;\n"_s,
-                m_indent, "T y;\n"_s,
-                m_indent, "T z;\n"_s,
+                m_indent, "union { T x; T r; };\n"_s,
+                m_indent, "union { T y; T g; };\n"_s,
+                m_indent, "union { T z; T b; };\n"_s,
                 m_indent, "uint8_t __padding[sizeof(T)];\n"_s,
                 m_indent, "\n"_s,
                 m_indent, "PackedVec3() { }\n"_s,


### PR DESCRIPTION
#### 77a35defd1b3e6af2458f2216f6a76ff5345b5b2
<pre>
[WebGPU/WGSL]: PackedVec3 has x, y, z but not r, g, b
<a href="https://bugs.webkit.org/show_bug.cgi?id=290633">https://bugs.webkit.org/show_bug.cgi?id=290633</a>
<a href="https://rdar.apple.com/148091622">rdar://148091622</a>

Reviewed by Tadeu Zagallo.

Allow rgb in addition to xyz.

* LayoutTests/fast/webgpu/regression/repro_290633-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_290633.html: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):

Canonical link: <a href="https://commits.webkit.org/292878@main">https://commits.webkit.org/292878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9184fe6872546160f464bd2c645fa13a2d4c280b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100256 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12987 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87954 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5830 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104359 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24330 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83146 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4785 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24294 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->