### PR TITLE
Fix a possible crash in ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()

### DIFF
--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -327,12 +327,14 @@ public final class WKSRKEntity: NSObject {
                 await MainActor.run {
                     entity.components[ImageBasedLightComponent.self] = .init(source: .single(environment))
                     entity.components[ImageBasedLightReceiverComponent.self] = .init(imageBasedLight: entity)
+                    Logger.realityKitEntity.info("Successfully applied IBL to entity")
+                    completion(true)
                 }
-                Logger.realityKitEntity.info("Successfully applied IBL to entity")
-                completion(true)
             } catch {
-                Logger.realityKitEntity.error("Cannot load environment resource from CGImage.")
-                completion(false)
+                await MainActor.run {
+                    Logger.realityKitEntity.error("Cannot load environment resource from CGImage.")
+                    completion(false)
+                }
             }
         }
     }


### PR DESCRIPTION
#### b6778e5a42d46b01c8d7b1ea74e5c82522f03146
<pre>
Fix a possible crash in ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()
<a href="https://bugs.webkit.org/show_bug.cgi?id=290634">https://bugs.webkit.org/show_bug.cgi?id=290634</a>
<a href="https://rdar.apple.com/147826538">rdar://147826538</a>

Reviewed by Mike Wyrzykowski.

Check whether the ModelProcessModelPlayerProxy is still around before accessing
it in the completion handler of applyIBLData.

Also, make sure the applyIBLData&apos;s completion handler is called from the main thread.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease):
* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
Make sure completion handler for WKSRKENtity.applyIBL(data:completion:) is
called from the main thread.

Canonical link: <a href="https://commits.webkit.org/292856@main">https://commits.webkit.org/292856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2984e46268c9891c9874c791cfde296b85d398b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74117 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12758 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24346 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83160 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20783 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/27134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4798 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24310 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->