### PR TITLE
[ARMv7] Allow run-javascriptcore-tests to run arm tests on arm64 linux

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -583,7 +583,7 @@ if (defined $archs) {
 
 # For running tests, arm64e should map to arm64
 $archs = "arm64" if $archs eq "arm64e";
-if ($archs ne nativeArchitecture($remotes) && (nativeArchitecture($remotes) ne "arm64" || !isAppleMacWebKit())) {
+if ($archs ne nativeArchitecture($remotes) && nativeArchitecture($remotes) ne "arm64") {
     die "Cannot run tests with $archs on this machine";
 }
 
@@ -833,7 +833,7 @@ sub runJSCStressTests
         "/usr/bin/env", "ruby", "Tools/Scripts/run-jsc-stress-tests",
         "-j", jscPath($productDir), "-o", $jscStressResultsDir, "--arch", $archs);
 
-    if (nativeArchitecture($remotes) ne $archs) {
+    if (nativeArchitecture($remotes) ne $archs && $archs ne "arm") {
         push(@jscStressDriverCmd, "--force-architecture");
         push(@jscStressDriverCmd, $archs);
     }

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -534,6 +534,8 @@ sub determineNativeArchitecture($)
         $output = "arm64";
     }
 
+    $output = "x86_64" if $output =~ /amd64/i;
+    $output = "arm64" if $output =~ /aarch64/i;
     $output = "arm" if $output =~ m/^armv[78]l$/;
     $nativeArchitectureMap{@{$remotes}} = $output;
 }
@@ -579,6 +581,7 @@ sub determineArchitecture
 
     $architecture = 'x86_64' if $architecture =~ /amd64/i;
     $architecture = 'arm64' if $architecture =~ /aarch64/i;
+    $architecture = "arm" if $architecture =~ m/^armv[78]l$/;
 }
 
 sub xcodeBuildRequestsInRecencyOrder


### PR DESCRIPTION
#### aee0e19df3e70985f385fcec41acdca0f25b0e6e
<pre>
[ARMv7] Allow run-javascriptcore-tests to run arm tests on arm64 linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=290635">https://bugs.webkit.org/show_bug.cgi?id=290635</a>

Reviewed by NOBODY (OOPS!).

On linux arm64 systems like the Thelio Astra, we can also run userspace armv7 binaries
with an aarch64 kernel. This patch makes the test runner accept this configuration,
without affecting x86 rosetta runs on macos. It is possible that we might run arm64
tests when we intend to run arm tests without an error now; the container should be carefully set up
to avoid this instead.

* Tools/Scripts/run-javascriptcore-tests:
(runJSCStressTests):
* Tools/Scripts/webkitdirs.pm:
(determineNativeArchitecture):
(determineArchitecture):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aee0e19df3e70985f385fcec41acdca0f25b0e6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74111 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100262 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12997 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87960 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54448 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47228 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/89935 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24336 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17750 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/abrupt-completion.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82559 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24300 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119507 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24122 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33553 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->