### PR TITLE
Fix the Vision Simulator Public SDK build after 292765@main

### DIFF
--- a/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd
+++ b/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd
@@ -96,5 +96,14 @@ exports:
                 _$s14LinearMediaKit8PlayablePAAE18overScenePublisher7Combine03AnyG0VySo7UISceneCSgSgs5NeverOGvg, _$s14LinearMediaKit8PlayablePAAE19videoAssetPublisher7Combine03AnyG0Vys13OpaquePointerVSgs5NeverOGvg,
                 _$s14LinearMediaKit8PlayablePAAE28fullscreenPlacementPublisher7Combine03AnyG0VyAA010FullscreenF0Os5NeverOGvg,
                 _$s14LinearMediaKit8PlayablePAAE29allowSceneAdjustmentPublisher7Combine03AnyH0VySbs5NeverOGvg, _$s14LinearMediaKit8PlayablePAAE35interstitialTimelineRangesPublisher7Combine03AnyH0VySaySNySdGGs5NeverOGvg,
-                _$s14LinearMediaKit8PlayablePAAE8setMuted_8metadataySb_AA12MuteMetadataVtF]
+                _$s14LinearMediaKit8PlayablePAAE8setMuted_8metadataySb_AA12MuteMetadataVtF,
+                _$s14LinearMediaKit11ContentTypeO17makeSpatialEntity13videoMetadata8extrudedAA12Peculiarable_07RealityC00H0CXcSgAA0g5VideoJ0VSg_SbtFZ,
+                _$s14LinearMediaKit12PeculiarModeO6portalyA2CmFWC,
+                _$s14LinearMediaKit12PeculiarModeO9immersiveyA2CmFWC,
+                _$s14LinearMediaKit12PeculiarModeOMa,
+                _$s14LinearMediaKit12PeculiarableP10screenModeAA08PeculiarF0OvsTj,
+                _$s14LinearMediaKit12PeculiarableP16setVideoMetaData2toyAA07SpatialF8MetadataVSg_tFTj,
+                _$s14LinearMediaKit20SpatialVideoMetadataVMa,
+                _$s14LinearMediaKit20SpatialVideoMetadataVMn,
+                _$s14LinearMediaKit20SpatialVideoMetadataV5width6height20horizontalFOVDegrees8baseline19disparityAdjustment25isRecommendedForImmersiveACs5Int32V_AKS3fSbtcfC]
 ...


### PR DESCRIPTION
#### b42e3948d611be0a059e0edd7a19924dac7a82d3
<pre>
Fix the Vision Simulator Public SDK build after 292765@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=290637">https://bugs.webkit.org/show_bug.cgi?id=290637</a>
<a href="https://rdar.apple.com/148110481">rdar://148110481</a>

Unreviewed build fix. Added necessary symbols to LinearMediaKit.tbd in WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk.

* WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/System/Library/PrivateFrameworks/LinearMediaKit.framework/LinearMediaKit.tbd:

Canonical link: <a href="https://commits.webkit.org/292831@main">https://commits.webkit.org/292831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829810e7c464e928cebbd7614abb66709bdc62b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97261 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/16886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7100 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/17179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/102346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100264 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/17179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/17179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/17179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/104367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15688 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/25698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->