### PR TITLE
Fixed Bugzilla comment timestamps to not use relative time

### DIFF
--- a/Websites/bugs.webkit.org/template/en/custom/bug/comments.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/comments.html.tmpl
@@ -254,37 +254,6 @@
     [% END %]
 
   [% END %]
-  <script>
-    const commentDateTimeFormatter = new Intl.RelativeTimeFormat(undefined, {numeric: 'auto'});
-    const DIVISIONS = [
-      { amount: 60, name: "seconds" },
-      { amount: 60, name: "minutes" },
-      { amount: 24, name: "hours" },
-      { amount: 7, name: "days" }
-    ];
-    function formatTimeAgo(date) {
-      let duration = (date - new Date()) / 1000
-    
-      for (let i = 0; i < DIVISIONS.length; i++) {
-        const division = DIVISIONS[i]
-        if (Math.abs(duration) < division.amount) {
-          return commentDateTimeFormatter.format(Math.round(duration), division.name)
-        }
-        duration /= division.amount
-      }
-      
-      return date.toLocaleDateString(undefined, {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      }) + " " + date.toLocaleTimeString(undefined, { timeZoneName: "short" });
-    }
-    [...document.getElementsByClassName("torelativedatetime")].forEach(element => {
-      let commentDateTime = new Date(element.getAttribute('data-ts').replace(' ','T') + '.000-0800');
-      element.innerHTML = formatTimeAgo(commentDateTime);
-    });
-  </script>
   
   [% IF user.settings.comment_box_position.value == 'after_comments' %]
       [% PROCESS comment_box %]


### PR DESCRIPTION
#### b01dfa1d075c0a566b2571c27f4f436e6184520f
<pre>
Fixed Bugzilla comment timestamps to not use relative time
<a href="https://bugs.webkit.org/show_bug.cgi?id=290058">https://bugs.webkit.org/show_bug.cgi?id=290058</a>
<a href="https://rdar.apple.com/147946170">rdar://147946170</a>

Reviewed by Alexey Proskuryakov.

Canonical link: <a href="https://commits.webkit.org/292873@main">https://commits.webkit.org/292873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/505415be9766c08c1d4aa8afb6c32221decc6567

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31313 "Found 1 new test failure: http/tests/security/no-indexeddb-from-sandbox.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54456 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12759 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83166 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82577 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4796 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15717 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24312 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->