### PR TITLE
AX: Some properties are unnecessarily cached for every single table cell

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -913,6 +913,20 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::columnHeaders()
     return headers;
 }
 
+std::optional<AXID> AXCoreObject::rowGroupAncestorID() const
+{
+    if (!hasCellRole())
+        return { };
+
+    auto* rowGroup = Accessibility::findAncestor<AXCoreObject>(*this, /* includeSelf */ false, [] (const auto& ancestor) {
+        return ancestor.hasRowGroupTag();
+    });
+
+    if (!rowGroup)
+        return std::nullopt;
+    return rowGroup->objectID();
+}
+
 bool AXCoreObject::isTableCellInSameRowGroup(AXCoreObject& otherTableCell)
 {
     auto ancestorID = rowGroupAncestorID();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -875,14 +875,14 @@ public:
     virtual bool isRowHeader() const { return false; }
     bool isTableCellInSameRowGroup(AXCoreObject&);
     bool isTableCellInSameColGroup(AXCoreObject*);
-    virtual std::optional<AXID> rowGroupAncestorID() const { return std::nullopt; }
+    std::optional<AXID> rowGroupAncestorID() const;
     virtual String cellScope() const { return { }; }
     // Returns the start location and row span of the cell.
     virtual std::pair<unsigned, unsigned> rowIndexRange() const = 0;
     // Returns the start location and column span of the cell.
     virtual std::pair<unsigned, unsigned> columnIndexRange() const = 0;
-    virtual int axColumnIndex() const = 0;
-    virtual int axRowIndex() const = 0;
+    virtual std::optional<unsigned> axColumnIndex() const = 0;
+    virtual std::optional<unsigned> axRowIndex() const = 0;
 
     // Table column support.
     bool isTableColumn() const { return roleValue() == AccessibilityRole::Column; }
@@ -1496,6 +1496,8 @@ public:
     virtual bool hasAttachmentTag() const = 0;
     virtual bool hasBodyTag() const = 0;
     virtual bool hasMarkTag() const = 0;
+    virtual bool hasRowGroupTag() const = 0;
+
     virtual String innerHTML() const = 0;
     virtual String outerHTML() const = 0;
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1091,9 +1091,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::Rows:
         stream << "Rows";
         break;
-    case AXProperty::RowGroupAncestorID:
-        stream << "RowGroupAncestorID";
-        break;
     case AXProperty::RowHeader:
         stream << "RowHeader";
         break;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1891,6 +1891,12 @@ std::optional<VisiblePosition> AccessibilityObject::previousLineStartPositionInt
     return startPosition;
 }
 
+bool AccessibilityObject::hasRowGroupTag() const
+{
+    const auto& tag = tagName();
+    return tag == theadTag || tag == tbodyTag || tag == tfootTag;
+}
+
 InsideLink AccessibilityObject::insideLink() const
 {
     auto* style = this->style();

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -158,8 +158,8 @@ public:
     std::pair<unsigned, unsigned> rowIndexRange() const override { return { 0, 1 }; }
     // Returns the start location and column span of the cell.
     std::pair<unsigned, unsigned> columnIndexRange() const override { return { 0, 1 }; }
-    int axColumnIndex() const override { return -1; }
-    int axRowIndex() const override { return -1; }
+    std::optional<unsigned> axColumnIndex() const override { return std::nullopt; }
+    std::optional<unsigned> axRowIndex() const override { return std::nullopt; }
 
     // Table column support.
     unsigned columnIndex() const override { return 0; }
@@ -571,6 +571,8 @@ public:
     bool hasAttachmentTag() const final { return hasTagName(HTMLNames::attachmentTag); }
     bool hasBodyTag() const final { return hasTagName(HTMLNames::bodyTag); }
     bool hasMarkTag() const final { return hasTagName(HTMLNames::markTag); }
+    bool hasRowGroupTag() const final;
+
     const AtomString& tagName() const;
     bool hasDisplayContents() const;
 

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -240,17 +240,6 @@ bool AccessibilityTableCell::isRowHeader() const
     return false;
 }
     
-std::optional<AXID> AccessibilityTableCell::rowGroupAncestorID() const
-{
-    auto* rowGroup = Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (const auto& ancestor) {
-        return ancestor.hasTagName(theadTag) || ancestor.hasTagName(tbodyTag) || ancestor.hasTagName(tfootTag);
-    });
-    if (!rowGroup)
-        return std::nullopt;
-
-    return rowGroup->objectID();
-}
-    
 String AccessibilityTableCell::expandedTextValue() const
 {
     return getAttribute(abbrAttr);
@@ -369,7 +358,7 @@ AccessibilityObject* AccessibilityTableCell::titleUIElement() const
     return axObjectCache()->getOrCreate(*headerCell);
 }
     
-int AccessibilityTableCell::axColumnIndex() const
+std::optional<unsigned> AccessibilityTableCell::axColumnIndex() const
 {
     if (int value = getIntegralAttribute(aria_colindexAttr); value >= 1)
         return value;
@@ -380,10 +369,10 @@ int AccessibilityTableCell::axColumnIndex() const
     if (m_axColIndexFromRow != -1 && parentRow())
         return m_axColIndexFromRow;
 
-    return -1;
+    return { };
 }
     
-int AccessibilityTableCell::axRowIndex() const
+std::optional<unsigned> AccessibilityTableCell::axRowIndex() const
 {
     // ARIA 1.1: Authors should place aria-rowindex on each row. Authors may also place
     // aria-rowindex on all of the children or owned elements of each row.
@@ -393,7 +382,7 @@ int AccessibilityTableCell::axRowIndex() const
     if (RefPtr parentRow = this->parentRow())
         return parentRow->axRowIndex();
 
-    return -1;
+    return { };
 }
 
 unsigned AccessibilityTableCell::rowSpan() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -47,8 +47,6 @@ public:
     bool isColumnHeader() const final;
     bool isRowHeader() const final;
 
-    std::optional<AXID> rowGroupAncestorID() const final;
-
     virtual AccessibilityTable* parentTable() const;
 
     // Returns the start location and row span of the cell.
@@ -58,8 +56,8 @@ public:
 
     AccessibilityChildrenVector rowHeaders() final;
 
-    int axColumnIndex() const final;
-    int axRowIndex() const final;
+    std::optional<unsigned> axColumnIndex() const final;
+    std::optional<unsigned> axRowIndex() const final;
     unsigned colSpan() const;
     unsigned rowSpan() const;
     void incrementEffectiveRowSpan() { ++m_effectiveRowSpan; }

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -164,28 +164,28 @@ void AccessibilityTableRow::addChildren()
     // column in that set, then authors may place aria-colindex on each row, setting the value to the index of the first column of the set."
     // Update child cells' axColIndex if there's an aria-colindex value set for the row. So the cell doesn't have to go through the siblings
     // to calculate the index.
-    int colIndex = axColumnIndex();
-    if (colIndex == -1)
+    std::optional colIndex = axColumnIndex();
+    if (!colIndex)
         return;
 
     unsigned index = 0;
     for (const auto& cell : unignoredChildren()) {
         if (auto* tableCell = dynamicDowncast<AccessibilityTableCell>(cell.get()))
-            tableCell->setAXColIndexFromRow(colIndex + index);
+            tableCell->setAXColIndexFromRow(*colIndex + index);
         index++;
     }
 }
 
-int AccessibilityTableRow::axColumnIndex() const
+std::optional<unsigned> AccessibilityTableRow::axColumnIndex() const
 {
     int value = getIntegralAttribute(aria_colindexAttr);
-    return value >= 1 ? value : -1;
+    return value >= 1 ? std::optional(value) : std::nullopt;
 }
 
-int AccessibilityTableRow::axRowIndex() const
+std::optional<unsigned> AccessibilityTableRow::axRowIndex() const
 {
     int value = getIntegralAttribute(aria_rowindexAttr);
-    return value >= 1 ? value : -1;
+    return value >= 1 ? std::optional(value) : std::nullopt;
 }
     
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -53,8 +53,8 @@ public:
     
     void addChildren() final;
 
-    int axColumnIndex() const final;
-    int axRowIndex() const final;
+    std::optional<unsigned> axColumnIndex() const final;
+    std::optional<unsigned> axRowIndex() const final;
 
 protected:
     explicit AccessibilityTableRow(AXID, RenderObject&);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -880,13 +880,11 @@ UncheckedKeyHashMap<String, String> AccessibilityObjectAtspi::attributes() const
     if (columnCount)
         map.add("colcount"_s, String::number(columnCount));
 
-    int rowIndex = m_coreObject->axRowIndex();
-    if (rowIndex != -1)
-        map.add("rowindex"_s, String::number(rowIndex));
+    if (std::optional rowIndex = m_coreObject->axRowIndex())
+        map.add("rowindex"_s, String::number(*rowIndex));
 
-    int columnIndex = m_coreObject->axColumnIndex();
-    if (columnIndex != -1)
-        map.add("colindex"_s, String::number(columnIndex));
+    if (std::optional columnIndex = m_coreObject->axColumnIndex())
+        map.add("colindex"_s, String::number(*columnIndex));
 
     if (auto* cell = dynamicDowncast<AccessibilityTableCell>(m_coreObject.get())) {
         int rowSpan = cell->axRowSpan();

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1375,8 +1375,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (!tableCell)
         return NSNotFound;
     
-    NSInteger rowIndex = tableCell->axRowIndex();
-    return rowIndex > 0 ? rowIndex : NSNotFound;
+    std::optional rowIndex = tableCell->axRowIndex();
+    return rowIndex ? *rowIndex : NSNotFound;
 }
 
 - (NSUInteger)accessibilityARIAColumnIndex
@@ -1387,8 +1387,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (!tableCell)
         return NSNotFound;
     
-    NSInteger columnIndex = tableCell->axColumnIndex();
-    return columnIndex > 0 ? columnIndex : NSNotFound;
+    std::optional columnIndex = tableCell->axColumnIndex();
+    return columnIndex ? *columnIndex : NSNotFound;
 }
 
 - (NSRange)accessibilityRowRange

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -115,6 +115,12 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::TagName, TagName::mark);
         else if (tag == attachmentTag)
             setProperty(AXProperty::TagName, TagName::attachment);
+        else if (tag == theadTag)
+            setProperty(AXProperty::TagName, TagName::thead);
+        else if (tag == tbodyTag)
+            setProperty(AXProperty::TagName, TagName::tbody);
+        else if (tag == tfootTag)
+            setProperty(AXProperty::TagName, TagName::tfoot);
 
         setProperty(AXProperty::TextRuns, object.textRuns());
         setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
@@ -314,7 +320,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::IsColumnHeader, object.isColumnHeader());
         setProperty(AXProperty::IsRowHeader, object.isRowHeader());
         setProperty(AXProperty::CellScope, object.cellScope().isolatedCopy());
-        setProperty(AXProperty::RowGroupAncestorID, object.rowGroupAncestorID());
     }
 
     if (object.isTableColumn())
@@ -649,6 +654,7 @@ void AXIsolatedObject::setProperty(AXProperty propertyName, AXPropertyValueVaria
         [] (TagName& tag) { return tag == TagName::Unknown; },
         [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
         [] (std::optional<AccessibilityOrientation>& typedValue) { return !typedValue; },
+        [] (std::optional<unsigned>& typedValue) { return !typedValue; },
         [] (OptionSet<SpeakAs>& typedValue) { return typedValue.isEmpty(); },
         [](auto&) {
             ASSERT_NOT_REACHED();
@@ -1841,6 +1847,12 @@ Vector<AXTextMarkerRange> AXIsolatedObject::misspellingRanges() const
             return axObject->misspellingRanges();
         return { };
     });
+}
+
+bool AXIsolatedObject::hasRowGroupTag() const
+{
+    auto tag = propertyValue<TagName>(AXProperty::TagName);
+    return tag == TagName::thead || tag == TagName::tbody || tag == TagName::tfoot;
 }
 
 bool AXIsolatedObject::hasSameFont(AXCoreObject& otherObject)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -68,6 +68,7 @@ public:
     bool hasAttachmentTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::attachment; }
     bool hasBodyTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::body; }
     bool hasMarkTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::mark; }
+    bool hasRowGroupTag() const final;
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -208,12 +209,11 @@ private:
     std::pair<unsigned, unsigned> rowIndexRange() const final { return indexRangePairAttributeValue(AXProperty::RowIndexRange); }
     // Returns the start location and column span of the cell.
     std::pair<unsigned, unsigned> columnIndexRange() const final { return indexRangePairAttributeValue(AXProperty::ColumnIndexRange); }
-    int axColumnIndex() const final { return intAttributeValue(AXProperty::AXColumnIndex); }
-    int axRowIndex() const final { return intAttributeValue(AXProperty::AXRowIndex); }
+    std::optional<unsigned> axColumnIndex() const final { return propertyValue<std::optional<unsigned>>(AXProperty::AXColumnIndex); }
+    std::optional<unsigned> axRowIndex() const final { return propertyValue<std::optional<unsigned>>(AXProperty::AXRowIndex); }
     bool isColumnHeader() const final { return boolAttributeValue(AXProperty::IsColumnHeader); }
     bool isRowHeader() const final { return boolAttributeValue(AXProperty::IsRowHeader); }
     String cellScope() const final { return stringAttributeValue(AXProperty::CellScope); }
-    std::optional<AXID> rowGroupAncestorID() const final { return propertyValue<Markable<AXID>>(AXProperty::RowGroupAncestorID); }
 
     // Table column support.
     unsigned columnIndex() const final { return unsignedAttributeValue(AXProperty::ColumnIndex); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -244,7 +244,6 @@ enum class AXProperty : uint16_t {
     RolePlatformString,
     RoleDescription,
     Rows,
-    RowGroupAncestorID,
     RowHeader,
     RowHeaders,
     RowIndex,
@@ -296,7 +295,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AXProperty);
 using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>, TagName, std::optional<AccessibilityOrientation>
+using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, std::optional<unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>, TagName, std::optional<AccessibilityOrientation>
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<id>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1511,11 +1511,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         if ([attributeName isEqualToString:NSAccessibilityRowHeaderUIElementsAttribute])
             return makeNSArray(backingObject->rowHeaders());
 
-        if ([attributeName isEqualToString:NSAccessibilityARIAColumnIndexAttribute])
-            return @(backingObject->axColumnIndex());
+        if ([attributeName isEqualToString:NSAccessibilityARIAColumnIndexAttribute]) {
+            if (std::optional columnIndex = backingObject->axColumnIndex())
+                return @(*columnIndex);
+            return @(-1);
+        }
 
-        if ([attributeName isEqualToString:NSAccessibilityARIARowIndexAttribute])
-            return @(backingObject->axRowIndex());
+        if ([attributeName isEqualToString:NSAccessibilityARIARowIndexAttribute]) {
+            if (std::optional rowIndex = backingObject->axRowIndex())
+                return @(*rowIndex);
+            return @(-1);
+        }
     }
 
     if (backingObject->isTree()) {


### PR DESCRIPTION
#### a8701da2405e214fce03617867c66e35485dd6af
<pre>
AX: Some properties are unnecessarily cached for every single table cell
<a href="https://bugs.webkit.org/show_bug.cgi?id=290639">https://bugs.webkit.org/show_bug.cgi?id=290639</a>
<a href="https://rdar.apple.com/148115441">rdar://148115441</a>

Reviewed by Chris Fleizach.

AXProperty::RowGroupAncestorID used to be cached for every single table cell. We can compute this on-demand off the
main-thread if we cache whether objects have a thead, tbody, or tfoot tag, which this commit does. This saves memory
and avoids one ancestry walk per table cell created.

AXProperty::{AXColumnIndex, AXRowIndex} were int properties, and returned -1 in the most common case where there is
no aria-rowindex or aria-colindex. With this commit, the return type of these functions is changed to std::optional&lt;unsigned&gt;
better encoding the intent of the function instead of using a magic -1 value. This also has the side effect of only
caching AXProperty::{AXColumnIndex, AXRowIndex} when there is a non-default value to cache, saving memory.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::rowGroupAncestorID const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::rowGroupAncestorID const): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::hasRowGroupTag const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::axColumnIndex const):
(WebCore::AccessibilityTableCell::axRowIndex const):
(WebCore::AccessibilityTableCell::rowGroupAncestorID const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::addChildren):
(WebCore::AccessibilityTableRow::axColumnIndex const):
(WebCore::AccessibilityTableRow::axRowIndex const):
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::attributes const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityARIAColumnIndex]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::hasRowGroupTag const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/292898@main">https://commits.webkit.org/292898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/116b7a765a8aaf4d7043a6656dc2362e352b8209

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47857 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31337 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47300 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82843 "Found 10 new API test failures: TestWebKitAPI.LockdownMode.SVGFonts, TestWebKitAPI.LockdownMode.AllowedFontLoadingAPI, TestWebKitAPI.LockdownMode.NotSupportedFontLoadingAPI, TestWebKitAPI.ServiceWorkers.LockdownModeInServiceWorkerProcess, TestWebKitAPI.LockdownMode.NotAllowedFontLoadingAPI, TestWebKitAPI.LockdownMode.AllowedFont, TestWebKitAPI.ProcessSwap.NavigatingToLockdownMode, TestWebKitAPI.LockdownMode.NotAllowedFont, TestWebKitAPI.ProcessSwap.LockdownModeSystemSettingChange, TestWebKitAPI.ProcessSwap.CannotDisableLockdownModeWithoutBrowserEntitlement (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104435 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24406 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17795 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.htm (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82611 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17952 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29537 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->