### PR TITLE
Address safer CPP failures in platform/network/cocoa

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -264,7 +264,7 @@ JSValue JSAPIGlobalObject::moduleLoaderEvaluate(JSGlobalObject* globalObject, JS
     if ([moduleLoaderDelegate respondsToSelector:@selector(willEvaluateModule:)] || [moduleLoaderDelegate respondsToSelector:@selector(didEvaluateModule:)]) {
         String moduleKey = key.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        url = [NSURL URLWithString:static_cast<NSString *>(moduleKey)];
+        url = [NSURL URLWithString:moduleKey.createNSString().get()];
     }
 
     if ([moduleLoaderDelegate respondsToSelector:@selector(willEvaluateModule:)])

--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -77,7 +77,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     URL cachePathURL([cachePath absoluteURL]);
     if (!cachePathURL.protocolIsFile()) {
-        createError([NSString stringWithFormat:@"Cache path `%@` is not a local file", static_cast<NSURL *>(cachePathURL)], error);
+        createError([NSString stringWithFormat:@"Cache path `%@` is not a local file", cachePathURL.createNSURL().get()], error);
         return false;
     }
 
@@ -85,25 +85,25 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     if (auto fileType = FileSystem::fileType(systemPath)) {
         if (*fileType != FileSystem::FileType::Regular) {
-            createError([NSString stringWithFormat:@"Cache path `%@` already exists and is not a file", static_cast<NSString *>(systemPath)], error);
+            createError([NSString stringWithFormat:@"Cache path `%@` already exists and is not a file", systemPath.createNSString().get()], error);
             return false;
         }
     }
 
     String directory = FileSystem::parentPath(systemPath);
     if (directory.isNull()) {
-        createError([NSString stringWithFormat:@"Cache path `%@` does not contain in a valid directory", static_cast<NSString *>(systemPath)], error);
+        createError([NSString stringWithFormat:@"Cache path `%@` does not contain in a valid directory", systemPath.createNSString().get()], error);
         return false;
     }
 
     if (FileSystem::fileType(directory) != FileSystem::FileType::Directory) {
-        createError([NSString stringWithFormat:@"Cache directory `%@` is not a directory or does not exist", static_cast<NSString *>(directory)], error);
+        createError([NSString stringWithFormat:@"Cache directory `%@` is not a directory or does not exist", directory.createNSString().get()], error);
         return false;
     }
 
 #if USE(APPLE_INTERNAL_SDK)
     if (rootless_check_datavault_flag(FileSystem::fileSystemRepresentation(directory).data(), nullptr)) {
-        createError([NSString stringWithFormat:@"Cache directory `%@` is not a data vault", static_cast<NSString *>(directory)], error);
+        createError([NSString stringWithFormat:@"Cache directory `%@` is not a data vault", directory.createNSString().get()], error);
         return false;
     }
 #endif
@@ -133,15 +133,15 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     URL filePathURL([filePath absoluteURL]);
     if (!filePathURL.protocolIsFile())
-        return createError([NSString stringWithFormat:@"File path %@ is not a local file", static_cast<NSURL *>(filePathURL)], error);
+        return createError([NSString stringWithFormat:@"File path %@ is not a local file", filePathURL.createNSURL().get()], error);
 
     String systemPath = filePathURL.fileSystemPath();
     auto fileData = FileSystem::mapFile(systemPath, FileSystem::MappedFileMode::Shared);
     if (!fileData)
-        return createError([NSString stringWithFormat:@"File at path %@ could not be mapped.", static_cast<NSString *>(systemPath)], error);
+        return createError([NSString stringWithFormat:@"File at path %@ could not be mapped.", systemPath.createNSString().get()], error);
 
     if (!charactersAreAllASCII(fileData->span()))
-        return createError([NSString stringWithFormat:@"Not all characters in file at %@ are ASCII.", static_cast<NSString *>(systemPath)], error);
+        return createError([NSString stringWithFormat:@"Not all characters in file at %@ are ASCII.", systemPath.createNSString().get()], error);
 
     auto result = adoptNS([[JSScript alloc] init]);
     result->m_virtualMachine = vm;

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -243,7 +243,7 @@ void RemoteInspector::sendMessageToRemote(TargetID targetIdentifier, const Strin
     if (!targetConnection)
         return;
 
-    NSData *messageData = [static_cast<NSString *>(message) dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *messageData = [message.createNSString() dataUsingEncoding:NSUTF8StringEncoding];
     NSUInteger messageLength = messageData.length;
     const NSUInteger maxChunkSize = 2 * 1024 * 1024; // 2 Mebibytes
 

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -368,10 +368,18 @@ inline CFHashCode safeCFHash(CFTypeRef a)
     return a ? CFHash(a) : 0;
 }
 
+template<typename T, typename U>
+ALWAYS_INLINE void lazyInitialize(const RetainPtr<T>& ptr, RetainPtr<U>&& obj)
+{
+    RELEASE_ASSERT(!ptr);
+    const_cast<RetainPtr<T>&>(ptr) = std::move(obj);
+}
+
 } // namespace WTF
 
 using WTF::RetainPtr;
 using WTF::adoptCF;
+using WTF::lazyInitialize;
 using WTF::retainPtr;
 using WTF::safeCFEqual;
 using WTF::safeCFHash;

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -235,6 +235,8 @@ public:
 #if USE(FOUNDATION)
     WTF_EXPORT_PRIVATE URL(NSURL *);
     WTF_EXPORT_PRIVATE operator NSURL *() const;
+    WTF_EXPORT_PRIVATE RetainPtr<NSURL> createNSURL() const;
+    WTF_EXPORT_PRIVATE static NSURL *emptyNSURL();
 #endif
 
 #if USE(GLIB)
@@ -265,7 +267,7 @@ private:
     friend WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
 
 #if USE(CF)
-    static RetainPtr<CFURLRef> emptyCFURL();
+    static CFURLRef emptyCFURL();
 #endif
 
     String m_string;

--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -39,7 +39,7 @@ namespace WTF {
 
 size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<String>& languageList, bool& exactMatch)
 {
-    auto matchedLanguages = retainPtr([NSLocale matchedLanguagesFromAvailableLanguages:createNSArray(languageList).get() forPreferredLanguages:@[ static_cast<NSString *>(language) ]]);
+    auto matchedLanguages = retainPtr([NSLocale matchedLanguagesFromAvailableLanguages:createNSArray(languageList).get() forPreferredLanguages:@[ language.createNSString().get() ]]);
     if (![matchedLanguages count]) {
         exactMatch = false;
         return notFound;

--- a/Source/WTF/wtf/cocoa/URLCocoa.mm
+++ b/Source/WTF/wtf/cocoa/URLCocoa.mm
@@ -50,11 +50,22 @@ URL::operator NSURL *() const
     return createCFURL().bridgingAutorelease();
 }
 
-RetainPtr<CFURLRef> URL::emptyCFURL()
+RetainPtr<NSURL> URL::createNSURL() const
+{
+    return bridge_cast(createCFURL());
+}
+
+CFURLRef URL::emptyCFURL()
 {
     // We use the toll-free bridge to create an empty value that is distinct from null that no CFURL function can create.
     // FIXME: When we originally wrote this, we thought that creating empty CF URLs was valuable; can we do without it now?
-    return bridge_cast(adoptNS([[NSURL alloc] initWithString:@""]));
+    return bridge_cast(emptyNSURL());
+}
+
+NSURL *URL::emptyNSURL()
+{
+    static const NeverDestroyed<RetainPtr<NSURL>> emptyURL = adoptNS([[NSURL alloc] initWithString:@""]);
+    return emptyURL.get().get();
 }
 
 bool URL::hostIsIPAddress(StringView host)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -511,6 +511,7 @@ public:
 
 #ifdef __OBJC__
     WTF_EXPORT_PRIVATE operator NSString *();
+    WTF_EXPORT_PRIVATE RetainPtr<NSString> createNSString();
 #endif
 
 #if STRING_STATS

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -249,7 +249,7 @@ public:
     // Given Cocoa idioms, this is a more useful default. Clients that need to preserve the
     // null string can check isNull explicitly.
     operator NSString *() const;
-    WTF_EXPORT_PRIVATE RetainPtr<NSString> protectedNSString() const;
+    WTF_EXPORT_PRIVATE RetainPtr<NSString> createNSString() const;
 #endif
 
 #if OS(WINDOWS)

--- a/Source/WTF/wtf/text/cocoa/StringCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringCocoa.mm
@@ -26,11 +26,11 @@
 
 namespace WTF {
 
-RetainPtr<NSString> String::protectedNSString() const
+RetainPtr<NSString> String::createNSString() const
 {
-    if (!m_impl)
-        return @"";
-    SUPPRESS_UNCOUNTED_ARG return static_cast<NSString *>(*m_impl);
+    if (RefPtr impl = m_impl)
+        return impl->createNSString();
+    return @"";
 }
 
 RetainPtr<id> makeNSArrayElement(const String& vectorElement)

--- a/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringImplCocoa.mm
@@ -22,12 +22,18 @@
 #import "StringImpl.h"
 
 #import "RetainPtr.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {
 
 StringImpl::operator NSString *()
 {
     return createCFString().bridgingAutorelease();
+}
+
+RetainPtr<NSString> StringImpl::createNSString()
+{
+    return bridge_cast(createCFString());
 }
 
 }

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
@@ -42,7 +42,7 @@ std::optional<PaymentMerchantSession> PaymentMerchantSession::fromJS(JSC::JSGlob
     if (!jsonString)
         return std::nullopt;
 
-    auto dictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[(NSString *)jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]);
+    auto dictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString().get() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]);
     if (!dictionary || ![dictionary isKindOfClass:[NSDictionary class]])
         return std::nullopt;
 

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -101,22 +101,22 @@ std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *d
 NSDictionary *NotificationData::dictionaryRepresentation() const
 {
     RetainPtr result = adoptNS(@{
-        WebNotificationDefaultActionURLKey : (NSString *)navigateURL.string(),
-        WebNotificationTitleKey : (NSString *)title,
-        WebNotificationBodyKey : (NSString *)body,
-        WebNotificationIconURLKey : (NSString *)iconURL,
-        WebNotificationTagKey : (NSString *)tag,
-        WebNotificationLanguageKey : (NSString *)language,
-        WebNotificationOriginKey : (NSString *)originString,
+        WebNotificationDefaultActionURLKey : navigateURL.string().createNSString().get(),
+        WebNotificationTitleKey : title.createNSString().get(),
+        WebNotificationBodyKey : body.createNSString().get(),
+        WebNotificationIconURLKey : iconURL.createNSString().get(),
+        WebNotificationTagKey : tag.createNSString().get(),
+        WebNotificationLanguageKey : language.createNSString().get(),
+        WebNotificationOriginKey : originString.createNSString().get(),
         WebNotificationDirectionKey : @((unsigned long)direction),
-        WebNotificationServiceWorkerRegistrationURLKey : (NSString *)serviceWorkerRegistrationURL.string(),
-        WebNotificationUUIDStringKey : (NSString *)notificationID.toString(),
+        WebNotificationServiceWorkerRegistrationURLKey : serviceWorkerRegistrationURL.string().createNSString().get(),
+        WebNotificationUUIDStringKey : notificationID.toString().createNSString().get(),
         WebNotificationSessionIDKey : @(sourceSession.toUInt64()),
         WebNotificationDataKey: toNSData(data).autorelease(),
     }.mutableCopy);
 
     if (contextIdentifier)
-        result.get()[WebNotificationContextUUIDStringKey] = (NSString *)contextIdentifier->toString();
+        result.get()[WebNotificationContextUUIDStringKey] = contextIdentifier->toString().createNSString().get();
 
     if (silent != std::nullopt)
         result.get()[WebNotificationSilentKey] = @(*silent);

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1083,7 +1083,6 @@ platform/mock/RTCNotifiersMock.cpp
 platform/mock/TimerEventBasedMock.h
 platform/mock/mediasource/MockMediaSourcePrivate.cpp
 platform/network/SynchronousLoaderClient.cpp
-platform/network/cocoa/RangeResponseGenerator.mm
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
 platform/text/BidiContext.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -209,16 +209,6 @@ platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/CertificateInfoCFNet.cpp
-platform/network/cocoa/CookieCocoa.mm
-platform/network/cocoa/CookieStorageObserver.mm
-platform/network/cocoa/CredentialCocoa.mm
-platform/network/cocoa/NetworkLoadMetrics.mm
-platform/network/cocoa/NetworkStorageSessionCocoa.mm
-platform/network/cocoa/ProtectionSpaceCocoa.mm
-platform/network/cocoa/RangeResponseGenerator.mm
-platform/network/cocoa/ResourceRequestCocoa.mm
-platform/network/cocoa/ResourceResponseCocoa.mm
-platform/network/cocoa/WebCoreNSURLSession.mm
 platform/network/mac/CredentialStorageMac.mm
 platform/network/mac/NetworkStateNotifierMac.cpp
 platform/network/mac/ResourceErrorMac.mm

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -116,13 +116,13 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
 void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 {
     auto notificationName = notificationPlatformName(AXNotification::AnnouncementRequested).createNSString();
-    NSString *nsMessage = static_cast<NSString *>(message);
+    RetainPtr nsMessage = message.createNSString();
     if (RefPtr root = getOrCreate(m_document->view())) {
         [root->wrapper() accessibilityOverrideProcessNotification:notificationName.get() notificationData:[nsMessage dataUsingEncoding:NSUTF8StringEncoding]];
 
         // To simulate AX notifications for LayoutTests on the simulator, call
         // the wrapper's accessibilityPostedNotification.
-        [root->wrapper() accessibilityPostedNotification:notificationName.get() userInfo:@{ notificationName.get() : nsMessage }];
+        [root->wrapper() accessibilityPostedNotification:notificationName.get() userInfo:@{ notificationName.get() : nsMessage.get() }];
     }
 }
 

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2346,7 +2346,7 @@ static String preferredFilenameForElement(const HTMLImageElement& element)
     auto urlString = element.imageSourceURL();
 
     auto suggestedName = [&] -> String {
-        RetainPtr url = static_cast<NSURL *>(element.document().completeURL(urlString));
+        RetainPtr url = element.document().completeURL(urlString).createNSURL();
         if (!url)
             url = [NSURL _web_URLWithString:[urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:nil];
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -252,7 +252,7 @@ public:
     WEBCORE_EXPORT static String cookiePartitionIdentifier(const ResourceRequest&);
     static String cookiePartitionIdentifier(const URL&);
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT static NSHTTPCookie *capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
+    WEBCORE_EXPORT static RetainPtr<NSHTTPCookie> capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
     WEBCORE_EXPORT static NSHTTPCookie *setCookiePartition(NSHTTPCookie *, NSString*);
 #endif

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -107,7 +107,7 @@ void CookieStorageObserver::startObserving(WTF::Function<void()>&& callback)
 
     if (!m_hasRegisteredInternalsForNotifications) {
         if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
-            auto internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
+            RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
             [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
         }
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
@@ -51,7 +51,7 @@ public:
 
     WEBCORE_EXPORT bool isEmpty() const;
 
-    bool encodingRequiresPlatformData() const { return m_nsCredential && encodingRequiresPlatformData(m_nsCredential.get()); }
+    bool encodingRequiresPlatformData() const { return m_nsCredential && encodingRequiresPlatformData(RetainPtr { m_nsCredential }.get()); }
 
     WEBCORE_EXPORT NSURLCredential *nsCredential() const;
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -62,18 +62,18 @@ static CredentialPersistence toCredentialPersistence(NSURLCredentialPersistence 
 Credential::Credential(const Credential& original, CredentialPersistence persistence)
     : CredentialBase(original, persistence)
 {
-    NSURLCredential *originalNSURLCredential = original.m_nsCredential.get();
+    RetainPtr originalNSURLCredential = original.m_nsCredential;
     if (!originalNSURLCredential)
         return;
 
-    if (NSString *user = originalNSURLCredential.user)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user password:originalNSURLCredential.password persistence:toNSURLCredentialPersistence(persistence)]);
-    else if (SecIdentityRef identity = originalNSURLCredential.identity)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity certificates:originalNSURLCredential.certificates persistence:toNSURLCredentialPersistence(persistence)]);
+    if (RetainPtr<NSString> user = originalNSURLCredential.get().user)
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user.get() password:originalNSURLCredential.get().password persistence:toNSURLCredentialPersistence(persistence)]);
+    else if (RetainPtr<SecIdentityRef> identity = originalNSURLCredential.get().identity)
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:originalNSURLCredential.get().certificates persistence:toNSURLCredentialPersistence(persistence)]);
     else {
         // It is not possible to set the persistence of server trust credentials.
         ASSERT_NOT_REACHED();
-        m_nsCredential = originalNSURLCredential;
+        m_nsCredential = WTFMove(originalNSURLCredential);
     }
 }
 

--- a/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
@@ -67,20 +67,20 @@ static Box<NetworkLoadMetrics> packageTimingData(MonotonicTime redirectStart, NS
 
 Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetrics, const NetworkLoadMetrics& metricsFromTask)
 {
-    NSArray<NSURLSessionTaskTransactionMetrics *> *transactionMetrics = incompleteMetrics.transactionMetrics;
-    NSURLSessionTaskTransactionMetrics *metrics = transactionMetrics.lastObject;
+    RetainPtr<NSArray<NSURLSessionTaskTransactionMetrics *>> transactionMetrics = incompleteMetrics.transactionMetrics;
+    RetainPtr<NSURLSessionTaskTransactionMetrics> metrics = transactionMetrics.get().lastObject;
     return packageTimingData(
-        dateToMonotonicTime(transactionMetrics.firstObject.fetchStartDate),
-        metrics.fetchStartDate,
-        metrics.domainLookupStartDate,
-        metrics.domainLookupEndDate,
-        metrics.connectStartDate,
-        metrics.secureConnectionStartDate,
-        metrics.connectEndDate,
-        metrics.requestStartDate,
-        metrics.responseStartDate,
-        metrics.reusedConnection,
-        metrics.response.URL.scheme,
+        dateToMonotonicTime(transactionMetrics.get().firstObject.fetchStartDate),
+        metrics.get().fetchStartDate,
+        metrics.get().domainLookupStartDate,
+        metrics.get().domainLookupEndDate,
+        metrics.get().connectStartDate,
+        metrics.get().secureConnectionStartDate,
+        metrics.get().connectEndDate,
+        metrics.get().requestStartDate,
+        metrics.get().responseStartDate,
+        metrics.get().reusedConnection,
+        metrics.get().response.URL.scheme,
         incompleteMetrics.redirectCount,
         metricsFromTask.failsTAOCheck,
         metricsFromTask.hasCrossOriginRedirect
@@ -89,11 +89,11 @@ Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetric
 
 Box<NetworkLoadMetrics> copyTimingData(NSURLConnection *connection, const ResourceHandle& handle)
 {
-    NSDictionary *timingData = [connection _timingData];
+    RetainPtr<NSDictionary> timingData = [connection _timingData];
 
     auto timingValue = [&](NSString *key) -> RetainPtr<NSDate> {
-        if (NSNumber *number = [timingData objectForKey:key]) {
-            if (double doubleValue = number.doubleValue)
+        if (RetainPtr<NSNumber> number = [timingData objectForKey:key]) {
+            if (double doubleValue = number.get().doubleValue)
                 return adoptNS([[NSDate alloc] initWithTimeIntervalSinceReferenceDate:doubleValue]);
         }
         return { };

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -58,17 +58,17 @@ void ResourceResponse::initNSURLResponse() const
         else
             expectedContentLength = static_cast<NSInteger>(m_expectedContentLength);
 
-        NSString* encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
-        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString]);
+        RetainPtr encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
+        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
         return;
     }
 
     // FIXME: We lose the status text and the HTTP version here.
-    NSMutableDictionary* headerDictionary = [NSMutableDictionary dictionary];
+    RetainPtr headerDictionary = adoptNS([[NSMutableDictionary alloc] init]);
     for (auto& header : m_httpHeaderFields)
         [headerDictionary setObject:(NSString *)header.value forKey:(NSString *)header.key];
 
-    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary]);
+    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary.get()]);
 
     // Mime type sniffing doesn't work with a synthesized response.
     [m_nsResponse _setMIMEType:(NSString *)m_mimeType];
@@ -85,31 +85,31 @@ CertificateInfo ResourceResponse::platformCertificateInfo(std::span<const std::b
     if (!cfResponse)
         return { };
 
-    CFDictionaryRef context = _CFURLResponseGetSSLCertificateContext(cfResponse);
+    RetainPtr context = _CFURLResponseGetSSLCertificateContext(cfResponse);
     if (!context)
         return { };
 
-    auto trustValue = CFDictionaryGetValue(context, kCFStreamPropertySSLPeerTrust);
+    auto trustValue = CFDictionaryGetValue(context.get(), kCFStreamPropertySSLPeerTrust);
     if (!trustValue)
         return { };
-    auto trust = checked_cf_cast<SecTrustRef>(trustValue);
+    RetainPtr trust = checked_cf_cast<SecTrustRef>(trustValue);
 
     if (trust && auditToken.size()) {
         auto data = adoptCF(CFDataCreate(nullptr, byteCast<uint8_t>(auditToken.data()), auditToken.size()));
-        SecTrustSetClientAuditToken(trust, data.get());
+        SecTrustSetClientAuditToken(trust.get(), data.get());
     }
 
     SecTrustResultType trustResultType;
-    OSStatus result = SecTrustGetTrustResult(trust, &trustResultType);
+    OSStatus result = SecTrustGetTrustResult(trust.get(), &trustResultType);
     if (result != errSecSuccess)
         return { };
 
     if (trustResultType == kSecTrustResultInvalid) {
-        if (!SecTrustEvaluateWithError(trust, nullptr))
+        if (!SecTrustEvaluateWithError(trust.get(), nullptr))
             return { };
     }
 
-    return CertificateInfo(trust);
+    return CertificateInfo(trust.get());
 }
 
 NSURLResponse *ResourceResponse::nsURLResponse() const

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -454,7 +454,7 @@ NS_ASSUME_NONNULL_END
     }
 
     [self addDelegateOperation:[strongSelf = retainPtr(self)] {
-        auto delegate = strongSelf.get().delegate;
+        RetainPtr<id<NSURLSessionDelegate> _Nullable> delegate = strongSelf.get().delegate;
         if ([delegate respondsToSelector:@selector(URLSession:didBecomeInvalidWithError:)])
             [delegate URLSession:(NSURLSession *)strongSelf.get() didBecomeInvalidWithError:nil];
     }];
@@ -751,14 +751,12 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     _resumeSessionID = 0;
 
     // CoreMedia will explicitly add a user agent header. Remove if present.
-    RetainPtr<NSMutableURLRequest> mutableRequest;
     if ([request valueForHTTPHeaderField:@"User-Agent"]) {
-        mutableRequest = adoptNS([request mutableCopy]);
+        RetainPtr mutableRequest = adoptNS([request mutableCopy]);
         [mutableRequest setValue:nil forHTTPHeaderField:@"User-Agent"];
-        request = mutableRequest.get();
-    }
-
-    self->_originalRequest = self->_currentRequest = request;
+        self->_originalRequest = self->_currentRequest = mutableRequest;
+    } else
+        self->_originalRequest = self->_currentRequest = request;
 
     return self;
 }
@@ -969,7 +967,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     [strongSession addDelegateOperation:[strongSelf, strongResponse, completionHandler = WTFMove(completionHandler), targetDispatcher = _targetDispatcher] () mutable {
         strongSelf->_response = strongResponse.get();
 
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if (![dataDelegate respondsToSelector:@selector(URLSession:dataTask:didReceiveResponse:completionHandler:)]) {
             targetDispatcher->dispatch([strongSelf, completionHandler = WTFMove(completionHandler)] () mutable {
                 completionHandler(ShouldContinuePolicyCheck::Yes);
@@ -1006,7 +1004,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     RetainPtr<WebCoreNSURLSession> strongSession { self.session };
     [strongSession addDelegateOperation:[strongSelf = RetainPtr { self }, data = WTFMove(data)] {
         strongSelf.get().countOfBytesReceived += [data length];
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if ([dataDelegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)])
             [dataDelegate URLSession:(NSURLSession *)strongSelf.get().session dataTask:(NSURLSessionDataTask *)strongSelf.get() didReceiveData:data.get()];
     }];
@@ -1027,7 +1025,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
             return;
         }
 
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if ([dataDelegate respondsToSelector:@selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
             auto completionHandlerBlock = makeBlockPtr([completionHandler = WTFMove(completionHandler), targetDispatcher = WTFMove(targetDispatcher)](NSURLRequest *newRequest) mutable {
                 targetDispatcher->dispatch([request = ResourceRequest { newRequest }, completionHandler = WTFMove(completionHandler)] () mutable {
@@ -1056,7 +1054,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     RetainPtr<NSError> strongError { error };
     auto taskMetrics = adoptNS([[WebCoreNSURLSessionTaskMetrics alloc] _initWithMetrics:metrics.isolatedCopy() onTarget:_targetDispatcher.get()]);
     [strongSession addDelegateOperation:[strongSelf, strongSession, strongError, taskMetrics = WTFMove(taskMetrics), targetDispatcher = _targetDispatcher] () mutable {
-        id<NSURLSessionTaskDelegate> delegate = (id<NSURLSessionTaskDelegate>)strongSession.get().delegate;
+        RetainPtr<id<NSURLSessionTaskDelegate>> delegate = (id<NSURLSessionTaskDelegate>)strongSession.get().delegate;
 
         if ([delegate respondsToSelector:@selector(URLSession:task:didFinishCollectingMetrics:)])
             [delegate URLSession:(NSURLSession *)strongSession.get() task:(NSURLSessionDataTask *)strongSelf.get() didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)taskMetrics.get()];

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1248,7 +1248,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             UTI = UTIFromMIMEType(attachmentType);
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-        [documentInteractionController setUTI:static_cast<NSString *>(UTI)];
+        [documentInteractionController setUTI:UTI.createNSString().get()];
 #endif
     }
 

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -59,14 +59,14 @@ bool GPUConnectionToWebProcess::setCaptureAttributionString()
     if (!auditToken)
         return false;
 
-    auto *visibleName = applicationVisibleNameFromOrigin(m_captureOrigin->data());
+    RetainPtr visibleName = applicationVisibleNameFromOrigin(m_captureOrigin->data());
     if (!visibleName)
         visibleName = gpuProcess().applicationVisibleName();
 
     if ([PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)])
-        [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionWebsiteString:visibleName auditToken:auditToken.value()];
+        [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionWebsiteString:visibleName.get() auditToken:auditToken.value()];
     else {
-        RetainPtr<NSString> formatString = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ in %%@", "The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only)."), visibleName];
+        RetainPtr<NSString> formatString = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ in %%@", "The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only)."), visibleName.get()];
         [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionStringWithFormat:formatString.get() auditToken:auditToken.value()];
     }
 #endif

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -54,7 +54,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
     RetainPtr nsData = toNSData(resumeData);
 
     RetainPtr dictionary = [NSPropertyListSerialization propertyListWithData:nsData.get() options:NSPropertyListMutableContainersAndLeaves format:0 error:nullptr];
-    [dictionary setObject:static_cast<NSString*>(path) forKey:@"NSURLSessionResumeInfoLocalPath"];
+    [dictionary setObject:path.createNSString().get() forKey:@"NSURLSessionResumeInfoLocalPath"];
     RetainPtr updatedData = [NSPropertyListSerialization dataWithPropertyList:dictionary.get() format:NSPropertyListXMLFormat_v1_0 options:0 error:nullptr];
 
     // FIXME: Use nsData instead of updatedData once we've migrated from _WKDownload to WKDownload

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -891,7 +891,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
         String name = String::fromUTF8(nw_interface_get_name(interface));
         [interfaces addObject:@{
             @"type" : description(nw_interface_get_type(interface)),
-            @"name" : static_cast<NSString *>(name) ?: @"",
+            @"name" : name.createNSString().get() ?: @"",
         }];
         return true;
     });
@@ -900,9 +900,9 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
     String provider = String::fromUTF8(nw_resolution_report_get_provider_name(report));
     String extraText = String::fromUTF8(nw_resolution_report_get_extended_dns_error_extra_text(report));
     return @{
-        @"provider" : static_cast<NSString *>(provider) ?: @"",
+        @"provider" : provider.createNSString().get() ?: @"",
         @"dnsFailureReason" : description(nw_resolution_report_get_dns_failure_reason(report)),
-        @"extendedDNSErrorExtraText" : static_cast<NSString *>(extraText) ?: @"",
+        @"extendedDNSErrorExtraText" : extraText.createNSString().get() ?: @"",
         @"interfaces" : interfaces.get(),
     };
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -99,7 +99,7 @@ static RetainPtr<NSArray<NSHTTPCookie *>> cookiesByCappingExpiry(NSArray<NSHTTPC
 {
     RetainPtr cappedCookies = [NSMutableArray arrayWithCapacity:cookies.count];
     for (NSHTTPCookie *cookie in cookies)
-        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap)];
+        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap).get()];
     return cappedCookies;
 }
 
@@ -342,8 +342,7 @@ void NetworkTaskCocoa::updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionTa
     if (request.isSameSiteUnspecified())
         return;
 #if HAVE(FOUNDATION_WITH_SAME_SITE_COOKIE_SUPPORT)
-    static NeverDestroyed<RetainPtr<NSURL>> emptyURL = adoptNS([[NSURL alloc] initWithString:@""]);
-    task._siteForCookies = request.isSameSite() ? task.currentRequest.URL : emptyURL.get().get();
+    task._siteForCookies = request.isSameSite() ? task.currentRequest.URL : URL::emptyNSURL();
     task._isTopLevelNavigation = request.isTopSite();
 #else
     UNUSED_PARAM(task);

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -472,7 +472,7 @@ NSSet *toAPI(const HashSet<URL>& set)
 {
     NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
     for (auto& element : set)
-        [result addObject:static_cast<NSURL *>(element)];
+        [result addObject:element.createNSURL().get()];
     return [result copy];
 }
 
@@ -480,7 +480,7 @@ NSSet *toAPI(const HashSet<String>& set)
 {
     NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
     for (auto& element : set)
-        [result addObject:static_cast<NSString *>(element)];
+        [result addObject:element.createNSString().get()];
     return [result copy];
 }
 
@@ -488,7 +488,7 @@ NSArray *toAPIArray(const HashSet<String>& set)
 {
     NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:set.size()];
     for (auto& element : set)
-        [result addObject:static_cast<NSString *>(element)];
+        [result addObject:element.createNSString().get()];
     return [result copy];
 }
 

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -204,7 +204,7 @@
     }
 
     if (!m_wrappedURL)
-        m_wrappedURL = adoptNS([[NSURL alloc] initWithString:@""]);
+        m_wrappedURL = URL::emptyNSURL();
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -899,7 +899,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 #if ENABLE(PAGE_LOAD_OBSERVER)
     URL url { _page->currentURL() };
     if (url.isValid() && url.protocolIsInHTTPFamily()) {
-        _pendingPageLoadObserverHost = static_cast<NSString *>(url.hostAndPort());
+        _pendingPageLoadObserverHost = url.hostAndPort().createNSString();
         [self _updatePageLoadObserverState];
     }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -110,13 +110,13 @@ bool checkUsageDescriptionStringForSpeechRecognition()
     return dynamic_objc_cast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSSpeechRecognitionUsageDescription"]).length > 0;
 }
 
-static NSString* visibleDomain(const String& host)
+static RetainPtr<NSString> visibleDomain(const String& host)
 {
     auto domain = WTF::URLHelpers::userVisibleURL(host.utf8());
-    return startsWithLettersIgnoringASCIICase(domain, "www."_s) ? StringView(domain).substring(4).createNSString().autorelease() : static_cast<NSString *>(domain);
+    return startsWithLettersIgnoringASCIICase(domain, "www."_s) ? StringView(domain).substring(4).createNSString() : domain.createNSString();
 }
 
-NSString *applicationVisibleNameFromOrigin(const WebCore::SecurityOriginData& origin)
+RetainPtr<NSString> applicationVisibleNameFromOrigin(const WebCore::SecurityOriginData& origin)
 {
     if (origin.protocol() != "http"_s && origin.protocol() != "https"_s)
         return nil;
@@ -134,25 +134,25 @@ NSString *applicationVisibleName()
 
 static NSString *alertMessageText(MediaPermissionReason reason, const WebCore::SecurityOriginData& origin)
 {
-    NSString *visibleOrigin = applicationVisibleNameFromOrigin(origin);
+    RetainPtr visibleOrigin = applicationVisibleNameFromOrigin(origin);
     if (!visibleOrigin)
         visibleOrigin = applicationVisibleName();
 
     switch (reason) {
     case MediaPermissionReason::Camera:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera?", @"Message for user camera access prompt"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera?", @"Message for user camera access prompt"), visibleOrigin.get()];
     case MediaPermissionReason::CameraAndMicrophone:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera and microphone?", @"Message for user media prompt"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera and microphone?", @"Message for user media prompt"), visibleOrigin.get()];
     case MediaPermissionReason::Microphone:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your microphone?", @"Message for user microphone access prompt"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your microphone?", @"Message for user microphone access prompt"), visibleOrigin.get()];
     case MediaPermissionReason::ScreenCapture:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe your screen?", @"Message for screen sharing prompt"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe your screen?", @"Message for screen sharing prompt"), visibleOrigin.get()];
     case MediaPermissionReason::DeviceOrientation:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"“%@” Would Like to Access Motion and Orientation", @"Message for requesting access to the device motion and orientation"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"“%@” Would Like to Access Motion and Orientation", @"Message for requesting access to the device motion and orientation"), visibleOrigin.get()];
     case MediaPermissionReason::Geolocation:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your current location?", @"Message for geolocation prompt"), visibleOrigin];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your current location?", @"Message for geolocation prompt"), visibleOrigin.get()];
     case MediaPermissionReason::SpeechRecognition:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to capture your audio and use it for speech recognition?", @"Message for spechrecognition prompt"), visibleDomain(origin.host())];
+        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to capture your audio and use it for speech recognition?", @"Message for spechrecognition prompt"), visibleDomain(origin.host()).get()];
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -481,8 +481,8 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         return;
     }
 
-    RetainPtr<NSURL> requesterTopOriginURL = static_cast<NSURL *>(action->data().requesterTopOrigin.toURL());
-    RetainPtr<NSURL> url = static_cast<NSURL *>(action->request().url());
+    RetainPtr requesterTopOriginURL = action->data().requesterTopOrigin.toURL().createNSURL();
+    RetainPtr url = action->request().url().createNSURL();
 
     if (!requesterTopOriginURL || !url) {
         RELEASE_LOG_ERROR(Loading, "NavigationState: can't handle MarketplaceKit navigation with requesterTopOriginURL: %d url: %d", static_cast<bool>(requesterTopOriginURL), static_cast<bool>(url));

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -88,7 +88,7 @@ inline static RetainPtr<WKTextExtractionTextItem> createWKTextItem(const TextExt
         if (UNLIKELY(range.location + range.length > data.content.length()))
             return { };
 
-        RetainPtr nsURL = static_cast<NSURL *>(url);
+        RetainPtr nsURL = url.createNSURL();
         if (!nsURL)
             return { };
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -93,7 +93,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
 
                 [tabs addObject:tab->delegate()];
             } else if (tabParameters.url)
-                [urls addObject:static_cast<NSURL *>(tabParameters.url.value())];
+                [urls addObject:tabParameters.url.value().createNSURL().get()];
         }
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3446,7 +3446,7 @@ WKWebView *WebExtensionContext::relatedWebView()
 NSString *WebExtensionContext::processDisplayName()
 {
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    return [NSString localizedStringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), static_cast<NSString *>(protectedExtension()->displayShortName())];
+    return [NSString localizedStringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), protectedExtension()->displayShortName().createNSString().get()];
 ALLOW_NONLITERAL_FORMAT_END
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -523,7 +523,7 @@ bool WebExtensionController::isFeatureEnabled(const String& featureName) const
 {
     WKPreferences *preferences = protectedConfiguration()->webViewConfiguration().preferences;
 
-    NSString *cocoaFeatureName = static_cast<NSString *>(featureName);
+    auto *cocoaFeatureName = featureName.createNSString().get();
     for (_WKFeature *feature in WKPreferences._features) {
         if ([feature.key isEqualToString:cocoaFeatureName])
             return [preferences _isEnabledForFeature:feature];

--- a/Source/WebKit/UIProcess/MediaPermissionUtilities.h
+++ b/Source/WebKit/UIProcess/MediaPermissionUtilities.h
@@ -67,7 +67,7 @@ bool checkSandboxRequirementForType(MediaPermissionType);
 bool checkUsageDescriptionStringForType(MediaPermissionType);
 bool checkUsageDescriptionStringForSpeechRecognition();
 
-NSString *applicationVisibleNameFromOrigin(const WebCore::SecurityOriginData&);
+RetainPtr<NSString> applicationVisibleNameFromOrigin(const WebCore::SecurityOriginData&);
 NSString *applicationVisibleName();
 void alertForPermission(WebPageProxy&, MediaPermissionReason, const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&);
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -100,7 +100,7 @@ static std::atomic<bool> managedKeyExists = false;
 
 static std::optional<bool> optionalExperimentalFeatureEnabled(const String& key, std::optional<bool> defaultValue = false)
 {
-    auto defaultsKey = adoptNS([[NSString alloc] initWithFormat:@"WebKitExperimental%@", static_cast<NSString *>(key)]);
+    auto defaultsKey = adoptNS([[NSString alloc] initWithFormat:@"WebKitExperimental%@", key.createNSString().get()]);
     if ([[NSUserDefaults standardUserDefaults] objectForKey:defaultsKey.get()] != nil)
         return [[NSUserDefaults standardUserDefaults] boolForKey:defaultsKey.get()];
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10020,7 +10020,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         context.get()[PAL::get_DataDetectorsUI_kDataDetectorsTrailingText()] = positionInformation.textAfter;
 
     auto canShowPreview = ^{
-        if (!static_cast<NSURL *>(positionInformation.url).iTunesStoreURL)
+        if (!positionInformation.url.createNSURL().get().iTunesStoreURL)
             return YES;
         if (!_page->websiteDataStore().isPersistent())
             return NO;

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -60,11 +60,11 @@ void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, c
         return;
     }
 
-    NSString *visibleOrigin = applicationVisibleNameFromOrigin(origin);
+    RetainPtr visibleOrigin = applicationVisibleNameFromOrigin(origin);
     if (!visibleOrigin)
         visibleOrigin = applicationVisibleName();
 
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe one of your windows or screens?", "Message for window and screen sharing prompt"), visibleOrigin];
+    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe one of your windows or screens?", "Message for window and screen sharing prompt"), visibleOrigin.get()];
     auto *allowWindowButtonString = WEB_UI_NSSTRING(@"Allow to Share Window", "Allow window button title in window and screen sharing prompt");
     auto *allowScreenButtonString = WEB_UI_NSSTRING(@"Allow to Share Screen", "Allow screen button title in window and screen sharing prompt");
     auto *doNotAllowButtonString = WEB_UI_NSSTRING_KEY(@"Don’t Allow", @"Don’t Allow (window and screen sharing)", "Disallow button title in window and screen sharing prompt");

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -520,7 +520,7 @@ static NSString *pathToPDFOnDisk(const String& suggestedFilename)
 
     // The NSFileManager expects a path string, while NSWorkspace uses file URLs, and will decode any percent encoding
     // in its passed URLs before loading from disk. Create the files using decoded file paths so they match up.
-    NSString *path = [[pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename.protectedNSString().get()] stringByRemovingPercentEncoding];
+    NSString *path = [[pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename.createNSString().get()] stringByRemovingPercentEncoding];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path]) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -58,7 +58,7 @@ static inline NSDictionary *toWebAPI(const WebExtensionAlarmParameters& alarm)
 {
     NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:3];
 
-    result[nameKey] = static_cast<NSString *>(alarm.name);
+    result[nameKey] = alarm.name.createNSString().get();
     result[scheduledTimeKey] = @(floor(alarm.nextScheduledTime.approximateWallTime().secondsSinceEpoch().milliseconds()));
 
     if (alarm.repeatInterval)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -183,16 +183,16 @@ static NSString *toWebAPI(const WebCore::FormData& formData, const String& conte
                 auto dataString = String::fromUTF8(data->span());
 
                 for (auto& pair : URLParser::parseURLEncodedForm(dataString)) {
-                    auto *key = static_cast<NSString *>(pair.key);
-                    auto *value = static_cast<NSString *>(pair.value);
+                    RetainPtr key = pair.key.createNSString();
+                    RetainPtr value = pair.value.createNSString();
 
-                    NSMutableArray *array = formDataDictionary[key];
+                    NSMutableArray *array = formDataDictionary[key.get()];
                     if (!array) {
                         array = [NSMutableArray array];
-                        formDataDictionary[key] = array;
+                        formDataDictionary[key.get()] = array;
                     }
 
-                    [array addObject:value ?: @""];
+                    [array addObject:value.get() ?: @""];
                 }
             } else {
                 auto typedArray = JSObjectMakeTypedArray(context, kJSTypedArrayTypeUint8Array, data->size(), nullptr);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
@@ -40,10 +40,9 @@ namespace WebKit {
 
 static RetainPtr<NSDictionary> policyProperties(const WebCore::SameSiteInfo& sameSiteInfo, const URL& url)
 {
-    static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
     NSURL *nsURL = url;
     NSDictionary *policyProperties = @{
-        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? nsURL : emptyURL,
+        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? nsURL : URL::emptyNSURL(),
         @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation": [NSNumber numberWithBool:sameSiteInfo.isTopSite],
     };
     return policyProperties;

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -404,7 +404,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 
     _private = static_cast<void*>(new WebDataSourcePrivate(WTFMove(loader)));
         
-    LOG(Loading, "creating datasource for %@", static_cast<NSURL *>(toPrivate(_private)->loader->request().url()));
+    LOG(Loading, "creating datasource for %@", toPrivate(_private)->loader->request().url().createNSURL().get());
 
     if ((toPrivate(_private)->includedInWebKitStatistics = [[self webFrame] _isIncludedInWebKitStatistics]))
         ++WebDataSourceCount;

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -387,7 +387,7 @@ TEST(RETAIN_PTR_TEST_NAME, URLBridgeCast)
     RetainPtr<NSURL> nsURL;
     uintptr_t nsURLPtr;
     @autoreleasepool {
-        URL url(""_str);
+        URL url("https://www.webkit.org"_str);
         nsURL = static_cast<NSURL *>(url);
         nsURLPtr = reinterpret_cast<uintptr_t>(nsURL.get());
     }


### PR DESCRIPTION
#### 8b6bee932bfd57c53cbe234e87cb820d8328cff5
<pre>
Address safer CPP failures in platform/network/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=290642">https://bugs.webkit.org/show_bug.cgi?id=290642</a>

Reviewed by Timothy Hatcher, Geoffrey Garen, and Darin Adler.

* Source/WTF/wtf/RetainPtr.h:
(WTF::lazyInitialize):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::portVectorFromList):
(WebCore::portStringFromVector):
(WebCore::cookieCreated):
(WebCore::cookieExpiry):
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const):
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
* Source/WebCore/platform/network/cocoa/CredentialCocoa.h:
(WebCore::Credential::encodingRequiresPlatformData const):
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::Credential):
* Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm:
(WebCore::copyTimingData):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setAllCookiesToSameSiteStrict):
(WebCore::policyProperties):
(WebCore::NetworkStorageSession::capExpiryOfPersistentCookie):
(WebCore::NetworkStorageSession::cookiesForSessionAsVector const):
(WebCore::adjustScriptWrittenCookie):
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::deleteCookie const):
(WebCore::NetworkStorageSession::getHostnamesWithCookies):
(WebCore::NetworkStorageSession::deleteAllCookies):
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::type):
(WebCore::scheme):
(WebCore::ProtectionSpace::ProtectionSpace):
(WebCore::ProtectionSpace::nsSpace const):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::Data::shutdownResource):
(WebCore::RangeResponseGenerator::removeTask):
(WebCore::RangeResponseGenerator::willSynthesizeRangeResponses):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::siteForCookies):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::initNSURLResponse const):
(WebCore::ResourceResponse::platformCertificateInfo const):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession finishTasksAndInvalidate]):
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:targetDispatcher:]):
(-[WebCoreNSURLSessionDataTask resource:receivedResponse:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:receivedData:]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
(-[WebCoreNSURLSessionDataTask _resource:loadFinishedWithError:metrics:]):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::cookiesByCappingExpiry):

Canonical link: <a href="https://commits.webkit.org/292902@main">https://commits.webkit.org/292902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b1354d6026837a381cb3bb635a597b6e9ea04a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97390 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74195 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47361 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90066 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104497 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96012 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82661 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18017 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15734 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29599 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119638 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24253 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33584 "Found 4 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default, microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js.no-llint, wasm.yaml/wasm/stress/spilled-constant-block-argument.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/spilled-constant-block-result.js.wasm-bbq-no-consts (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->