### PR TITLE
Storage Access API should only automatically grant storage access if all ancestors are same-origin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 PASS [ABA] document.hasStorageAccess() should exist on the document interface
-FAIL [ABA] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe. assert_false: Access should not be granted in secure same-origin iframe that is in a third-party context by default. expected false got true
+PASS [ABA] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
 FAIL [ABA] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -320,7 +320,6 @@ void WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated(Vector<Resour
 
 void WebResourceLoadStatisticsStore::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, std::optional<FrameIdentifier> frameID, PageIdentifier pageID, CompletionHandler<void(bool)>&& completionHandler)
 {
-    ASSERT(subFrameDomain != topFrameDomain);
     ASSERT(RunLoop::isMain());
 
     if (isEphemeral())


### PR DESCRIPTION
#### a580892a1c4ca2dd450f2df60296676c0c6cd3b4
<pre>
Storage Access API should only automatically grant storage access if all ancestors are same-origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=290643">https://bugs.webkit.org/show_bug.cgi?id=290643</a>
<a href="https://rdar.apple.com/148117515">rdar://148117515</a>

Reviewed by Pascoe.

This aligns WebKit with Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::hasSameOrigin):
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccess):

Canonical link: <a href="https://commits.webkit.org/292862@main">https://commits.webkit.org/292862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72a38043622b7218b8181fe3eb171f9b09f874b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74121 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104383 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83163 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82574 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4805 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15707 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->