### PR TITLE
REGRESSION (291444@main): UserMessageHandler.postMessage of unserializable types should result in WKScriptMessage.body of NSNull

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -60,6 +60,11 @@ JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef contex
     , m_wireBytes(m_valueFromJS ? m_valueFromJS->wireBytes().span() : std::span<const uint8_t>())
 {
 }
+
+std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
+{
+    return JavaScriptEvaluationResult { context, value };
+}
 #endif
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JavaScriptEvaluationResult&&) = default;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -64,14 +64,14 @@ public:
     using Variant = std::variant<NullType, bool, CoreIPCNumber, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>>;
 
     JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, Variant>&&);
-    static Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> extract(JSGlobalContextRef, JSValueRef);
     static std::optional<JavaScriptEvaluationResult> extract(id);
 #else
     JavaScriptEvaluationResult(std::span<const uint8_t> wireBytes)
         : m_wireBytes(wireBytes) { }
 #endif
 
-    JavaScriptEvaluationResult(JSGlobalContextRef, JSValueRef);
+    static std::optional<JavaScriptEvaluationResult> extract(JSGlobalContextRef, JSValueRef);
+
     JavaScriptEvaluationResult(JavaScriptEvaluationResult&&);
     JavaScriptEvaluationResult& operator=(JavaScriptEvaluationResult&&);
     ~JavaScriptEvaluationResult();
@@ -91,6 +91,8 @@ public:
     JSValueRef toJS(JSGlobalContextRef);
 
 private:
+    JavaScriptEvaluationResult(JSGlobalContextRef, JSValueRef);
+
 #if PLATFORM(COCOA)
     JavaScriptEvaluationResult(id);
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -218,13 +218,13 @@ static std::optional<JSValueRef> roundTripThroughSerializedScriptValue(JSGlobalC
     return std::nullopt;
 }
 
-Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
+std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
 {
     JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
 
     auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
     if (!result)
-        return makeUnexpected(std::nullopt);
+        return std::nullopt;
     return { JavaScriptEvaluationResult { deserializationContext.get(), *result } };
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -146,14 +146,15 @@ public:
     {
     }
 
-    void didPostMessage(WebKit::WebPageProxy& page, WebKit::FrameInfoData&& frameInfoData, API::ContentWorld& world, WebKit::JavaScriptEvaluationResult&& jsMessage) final
+    void didPostMessage(WebKit::WebPageProxy& page, WebKit::FrameInfoData&& frameInfoData, API::ContentWorld& world, std::optional<WebKit::JavaScriptEvaluationResult>&& jsMessage) final
     {
         @autoreleasepool {
             RetainPtr webView = page.cocoaView();
             if (!webView)
                 return;
+            RetainPtr body = jsMessage ? jsMessage->toID() : NSNull.null;
             RetainPtr<WKFrameInfo> frameInfo = wrapper(API::FrameInfo::create(WTFMove(frameInfoData), &page));
-            auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:jsMessage.toID().get() webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
+            auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:body.get() webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
             [(id<WKScriptMessageHandler>)m_handler.get() userContentController:m_controller.get() didReceiveScriptMessage:message.get()];
         }
     }
@@ -163,7 +164,7 @@ public:
         return m_supportsAsyncReply;
     }
 
-    void didPostMessageWithAsyncReply(WebKit::WebPageProxy& page, WebKit::FrameInfoData&& frameInfoData, API::ContentWorld& world, WebKit::JavaScriptEvaluationResult&& jsMessage, Function<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& replyHandler) final
+    void didPostMessageWithAsyncReply(WebKit::WebPageProxy& page, WebKit::FrameInfoData&& frameInfoData, API::ContentWorld& world, std::optional<WebKit::JavaScriptEvaluationResult>&& jsMessage, Function<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& replyHandler) final
     {
         ASSERT(m_supportsAsyncReply);
 
@@ -177,8 +178,9 @@ public:
         __block auto handler = CompletionHandlerWithFinalizer<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>(WTFMove(replyHandler), WTFMove(finalizer));
 
         @autoreleasepool {
+            RetainPtr body = jsMessage ? jsMessage->toID() : NSNull.null;
             RetainPtr<WKFrameInfo> frameInfo = wrapper(API::FrameInfo::create(WTFMove(frameInfoData), &page));
-            auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:jsMessage.toID().get() webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
+            auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:body.get() webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
 
             [(id<WKScriptMessageHandlerWithReply>)m_handler.get() userContentController:m_controller.get() didReceiveScriptMessage:message.get() replyHandler:^(id result, NSString *errorMessage) {
                 if (!handler)

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -405,14 +405,16 @@ public:
     {
     }
 
-    void didPostMessage(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&& jsMessage) override
+    void didPostMessage(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&& jsMessage) override
     {
-        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage.wireBytes());
         if (!m_manager) {
             g_critical("Script message %s received after the WebKitUserContentManager has been destroyed. You must unregister the message handler!", g_quark_to_string(m_handlerName));
             return;
         }
+        if (!jsMessage)
+            return;
 
+        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage->wireBytes());
 #if ENABLE(2022_GLIB_API)
         GRefPtr<JSCValue> value = API::SerializedScriptValue::deserialize(serializedScriptValue->internalRepresentation());
         g_signal_emit(m_manager.get(), signals[SCRIPT_MESSAGE_RECEIVED], m_handlerName, value.get());
@@ -428,15 +430,17 @@ public:
         return m_supportsAsyncReply;
     }
 
-    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&& jsMessage, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&& completionHandler) override
+    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&& jsMessage, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&& completionHandler) override
     {
         if (!m_manager) {
             g_critical("Script message %s received after the WebKitUserContentManager has been destroyed. You must unregister the message handler!", g_quark_to_string(m_handlerName));
             return;
         }
+        if (!jsMessage)
+            return;
 
         WebKitScriptMessageReply* message = webKitScriptMessageReplyCreate(WTFMove(completionHandler));
-        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage.wireBytes());
+        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage->wireBytes());
         GRefPtr<JSCValue> value = API::SerializedScriptValue::deserialize(serializedScriptValue->internalRepresentation());
         gboolean returnValue;
         g_signal_emit(m_manager.get(), signals[SCRIPT_MESSAGE_WITH_REPLY_RECEIVED], m_handlerName, value.get(), message, &returnValue);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
@@ -48,9 +48,9 @@ public:
     {
     }
 
-    void didPostMessage(WebPageProxy& page, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&& jsMessage) override
+    void didPostMessage(WebPageProxy& page, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&& jsMessage) override
     {
-        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage.wireBytes());
+        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage->wireBytes());
         String message = serializedScriptValue->internalRepresentation().toString();
         Vector<String> tokens = message.split(':');
         if (tokens.size() != 3)
@@ -65,7 +65,7 @@ public:
         return false;
     }
     
-    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) override
+    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) override
     {
     }
 

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -61,9 +61,9 @@ public:
 
     ~ScriptMessageClient() { }
 
-    void didPostMessage(WebPageProxy& page, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&& jsMessage) override
+    void didPostMessage(WebPageProxy& page, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&& jsMessage) override
     {
-        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage.wireBytes());
+        Ref serializedScriptValue = API::SerializedScriptValue::createFromWireBytes(jsMessage->wireBytes());
         auto valueAsString = serializedScriptValue->internalRepresentation().toString();
         auto tokens = StringView { valueAsString }.split(':');
         uint32_t connectionID = 0;
@@ -93,7 +93,7 @@ public:
         return false;
     }
     
-    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) override
+    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) override
     {
     }
 

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -55,9 +55,9 @@ public:
     class Client {
     public:
         virtual ~Client() { }
-        virtual void didPostMessage(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&&) = 0;
+        virtual void didPostMessage(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&&) = 0;
         virtual bool supportsAsyncReply() = 0;
-        virtual void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, JavaScriptEvaluationResult&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) = 0;
+        virtual void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, std::optional<JavaScriptEvaluationResult>&&, WTF::Function<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) = 0;
     };
 
     static Ref<WebScriptMessageHandler> create(std::unique_ptr<Client>, const String& name, API::ContentWorld&);

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -399,7 +399,7 @@ void WebUserContentControllerProxy::removeAllUserMessageHandlers()
     m_scriptMessageHandlers.clear();
 }
 
-void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& reply)
+void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, std::optional<JavaScriptEvaluationResult>&& message, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& reply)
 {
     auto page = WebProcessProxy::webPage(pageProxyID);
     if (!page)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -146,7 +146,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
+    void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, std::optional<JavaScriptEvaluationResult>&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
 
     void addContentWorld(API::ContentWorld&);
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
@@ -29,5 +29,5 @@
     DispatchedTo=UI
 ]
 messages -> WebUserContentControllerProxy {
-    DidPostMessage(WebKit::WebPageProxyIdentifier pageID, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply)
+    DidPostMessage(WebKit::WebPageProxyIdentifier pageID, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, std::optional<WebKit::JavaScriptEvaluationResult> message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply)
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -283,7 +283,10 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
 
         JSC::JSValue resultPayload = objectResult->get(frontendGlobalObject, JSC::Identifier::fromString(frontendGlobalObject->vm(), "result"_s));
 
-        completionHandler(JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)), std::nullopt);
+        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)))
+            completionHandler(WTFMove(*extracted), std::nullopt);
+        else
+            completionHandler(makeUnexpected(std::nullopt), std::nullopt);
     });
 }
 
@@ -462,7 +465,10 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
 
         JSC::JSValue resultPayload = objectResult->get(frontendGlobalObject, JSC::Identifier::fromString(frontendGlobalObject->vm(), "result"_s));
 
-        completionHandler(JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)), std::nullopt);
+        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)))
+            completionHandler(WTFMove(*extracted), std::nullopt);
+        else
+            completionHandler(makeUnexpected(std::nullopt), std::nullopt);
     });
 }
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -304,7 +304,7 @@ private:
             return;
 
         JSRetainPtr context { JSContextGetGlobalContext(toRef(&globalObject)) };
-        WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::WebUserContentControllerProxy::DidPostMessage(webPage->webPageProxyIdentifier(), webFrame->info(), m_identifier, JavaScriptEvaluationResult { context.get(), toRef(&globalObject, message) }), [completionHandler = WTFMove(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
+        WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::WebUserContentControllerProxy::DidPostMessage(webPage->webPageProxyIdentifier(), webFrame->info(), m_identifier, JavaScriptEvaluationResult::extract(context.get(), toRef(&globalObject, message))), [completionHandler = WTFMove(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
             if (!result)
                 return completionHandler(JSC::jsUndefined(), result.error());
             completionHandler(toJS(toJS(context.get()), result->toJS(context.get())), { });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4453,15 +4453,15 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         JSGlobalContextRef context = frame->jsContextForWorld(world.ptr());
         JSValueRef jsValue = toRef(coreFrame->script().globalObject(Ref { world->coreWorld() }), result.value());
 #if PLATFORM(COCOA)
-        completionHandler(JavaScriptEvaluationResult::extract(context, jsValue));
+        if (auto result = JavaScriptEvaluationResult::extract(context, jsValue))
+            return completionHandler(WTFMove(*result));
 #else
         if (RefPtr serializedResultValue = SerializedScriptValue::create(context, jsValue, nullptr)) {
             if (auto wireBytes = serializedResultValue->wireBytes(); !wireBytes.isEmpty())
                 return completionHandler(JavaScriptEvaluationResult { wireBytes });
-            return completionHandler(makeUnexpected(std::nullopt));
         }
-        return completionHandler(makeUnexpected(std::nullopt));
 #endif
+        return completionHandler(makeUnexpected(std::nullopt));
     };
 
     auto mapArguments = [] (auto&& vector) -> std::optional<HashMap<String, Function<JSC::JSValue(JSC::JSGlobalObject&)>>> {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -31,6 +31,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestScriptMessageHandler.h"
 #import "TestURLSchemeHandler.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
@@ -91,6 +92,12 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
 
     isDone = false;
     TestWebKitAPI::Util::run(&isDone);
+
+    auto handler = adoptNS([TestScriptMessageHandler new]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[webView configuration].userContentController addScriptMessageHandler:handler.get() name:@"testHandler"];
+    [webView evaluateJavaScript:@"window.webkit.messageHandlers.testHandler.postMessage(document.body)" completionHandler:nil];
+    EXPECT_EQ([handler waitForMessage].body, NSNull.null);
 
     [webView evaluateJavaScript:@"document.body.insertBefore(document, document)" completionHandler:^(id result, NSError *error) {
         EXPECT_NULL(result);


### PR DESCRIPTION
#### 869c1b5dd5fb0db47a4fd9cc580e9d3f47900b5a
<pre>
REGRESSION (291444@main): UserMessageHandler.postMessage of unserializable types should result in WKScriptMessage.body of NSNull
<a href="https://bugs.webkit.org/show_bug.cgi?id=290646">https://bugs.webkit.org/show_bug.cgi?id=290646</a>
<a href="https://rdar.apple.com/146688485">rdar://146688485</a>

Reviewed by Abrar Rahman Protyasha and Sihui Liu.

When sending a non-serializable JS type from the web content process to become an ObjC type in the UI process,
it becomes WKErrorJavaScriptResultTypeIsUnsupported if it is the result of something with an error parameter
like the completion handler of WKWebView.evaluateJavaScript.  Before 291444@main if such a type were sent via
UserMessageHandler.postMessage it would arrive in the UI process as NSNull.null, but that change made it skip
the SerializedScriptValue filtering in the web content process and arrive as an NSDictionary, which broke
compatibility with some apps.  This restores the prior behavior and makes the JavaScriptEvaluationResult
constructor private to make it harder to forget the call to JavaScriptEvaluationResult::extract.

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::extract):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::extract):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::didPostMessage):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionController::evaluateScriptInExtensionTab):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptErrorCases)):

Canonical link: <a href="https://commits.webkit.org/292881@main">https://commits.webkit.org/292881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fd7429e30338b7340f7d8d4ffcefe789d2d284e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47299 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24405 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82607 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4834 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->