### PR TITLE
Storage Access API should reject the promise if the document is not fully active

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 PASS [ABA] document.hasStorageAccess() should exist on the document interface
 PASS [ABA] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [ABA] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [ABA] document.hasStorageAccess() should reject in a document that isn't fully active.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window-expected.txt
@@ -5,11 +5,11 @@ Harness Error (TIMEOUT), message = null
 
 PASS [top-level-context] document.hasStorageAccess() should be supported on the document interface
 FAIL [top-level-context] document.hasStorageAccess() should be disallowed in insecure contexts assert_false: Access should be disallowed in insecure contexts expected false got true
-FAIL [top-level-context] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [top-level-context] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [same-origin-frame] document.hasStorageAccess() should be supported on the document interface
 FAIL [same-origin-frame] document.hasStorageAccess() should be disallowed in insecure contexts assert_false: Access should be disallowed in insecure contexts expected false got true
-FAIL [same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [nested-same-origin-frame] document.hasStorageAccess() should be supported on the document interface
 FAIL [nested-same-origin-frame] document.hasStorageAccess() should be disallowed in insecure contexts assert_false: Access should be disallowed in insecure contexts expected false got true
-FAIL [nested-same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [nested-same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt
@@ -1,17 +1,17 @@
 
 PASS [top-level-context] document.hasStorageAccess() should exist on the document interface
 PASS [top-level-context] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [top-level-context] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [top-level-context] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [same-origin-frame] document.hasStorageAccess() should exist on the document interface
 PASS [same-origin-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [cross-site-frame] document.hasStorageAccess() should exist on the document interface
 PASS [cross-site-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [nested-same-origin-frame] document.hasStorageAccess() should exist on the document interface
 PASS [nested-same-origin-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [nested-same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [nested-same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [nested-cross-site-frame] document.hasStorageAccess() should exist on the document interface
 PASS [nested-cross-site-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-FAIL [nested-cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active. assert_unreached: Should have rejected: Promise should reject when called on a generated document not part of the DOM. Reached unreachable code
+PASS [nested-cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window-expected.txt
@@ -5,8 +5,8 @@ Harness Error (TIMEOUT), message = null
 
 PASS [top-level-context] document.requestStorageAccess() should exist on the document interface
 FAIL [top-level-context] document.requestStorageAccess() should be rejected in insecure context assert_unreached: Should have rejected: document.requestStorageAccess() call without user gesture Reached unreachable code
-FAIL [non-fully-active] document.requestStorageAccess() should reject when run in a detached frame promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'e.name')"
-FAIL [non-fully-active] document.requestStorageAccess() should reject when run in a detached DOMParser document promise_rejects_dom: document.requestStorageAccess() in a detached DOMParser result function "function() { throw e }" threw undefined with type "undefined", not an object
+PASS [non-fully-active] document.requestStorageAccess() should reject when run in a detached frame
+PASS [non-fully-active] document.requestStorageAccess() should reject when run in a detached DOMParser document
 TIMEOUT [top-level-context] document.requestStorageAccess() should be rejected when called with a user gesture in insecure context Test timed out
 PASS [same-origin-frame] document.requestStorageAccess() should exist on the document interface
 FAIL [same-origin-frame] document.requestStorageAccess() should be rejected in insecure context assert_unreached: Should have rejected: document.requestStorageAccess() call without user gesture Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-non-fully-active.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-non-fully-active.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL [non-fully-active] document.requestStorageAccess() should not resolve when run in a detached frame promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'e.name')"
-FAIL [non-fully-active] document.requestStorageAccess() should not resolve when run in a detached DOMParser document promise_rejects_dom: document.requestStorageAccess() in a detached DOMParser result function "function() { throw e }" threw undefined with type "undefined", not an object
+PASS [non-fully-active] document.requestStorageAccess() should not resolve when run in a detached frame
+PASS [non-fully-active] document.requestStorageAccess() should not resolve when run in a detached DOMParser document
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -114,6 +114,10 @@ std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
 void DocumentStorageAccess::hasStorageAccess(Ref<DeferredPromise>&& promise)
 {
     Ref document = m_document.get();
+    if (!document->isFullyActive()) {
+        promise->reject(ExceptionCode::InvalidStateError);
+        return;
+    }
 
     auto quickCheckResult = hasStorageAccessQuickCheck();
     if (quickCheckResult) {
@@ -186,6 +190,10 @@ std::optional<StorageAccessQuickResult> DocumentStorageAccess::requestStorageAcc
 void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
 {
     Ref document = m_document.get();
+    if (!document->isFullyActive()) {
+        promise->reject(ExceptionCode::InvalidStateError);
+        return;
+    }
 
     auto quickCheckResult = requestStorageAccessQuickCheck();
     if (quickCheckResult) {


### PR DESCRIPTION
#### aab1be805a4f263dac298821217f87d225b76a66
<pre>
Storage Access API should reject the promise if the document is not fully active
<a href="https://bugs.webkit.org/show_bug.cgi?id=290647">https://bugs.webkit.org/show_bug.cgi?id=290647</a>
<a href="https://rdar.apple.com/148119672">rdar://148119672</a>

Reviewed by Pascoe.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-ABA.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-non-fully-active.sub.https.window-expected.txt:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccess):

Canonical link: <a href="https://commits.webkit.org/292863@main">https://commits.webkit.org/292863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59c6cf8ca05223b9b3f54df17836bfa8ca9e3f33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7178 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99384 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/17257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25413 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/102426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100342 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/17257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/17257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/5903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/17257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104445 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/82617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15708 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/25776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->