### PR TITLE
Crash under DocumentLoader::removePlugInStreamLoader()

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -368,10 +368,18 @@ inline CFHashCode safeCFHash(CFTypeRef a)
     return a ? CFHash(a) : 0;
 }
 
+template<typename T, typename U>
+ALWAYS_INLINE void lazyInitialize(const RetainPtr<T>& ptr, RetainPtr<U>&& obj)
+{
+    RELEASE_ASSERT(!ptr);
+    const_cast<RetainPtr<T>&>(ptr) = std::move(obj);
+}
+
 } // namespace WTF
 
 using WTF::RetainPtr;
 using WTF::adoptCF;
+using WTF::lazyInitialize;
 using WTF::retainPtr;
 using WTF::safeCFEqual;
 using WTF::safeCFHash;

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -192,7 +192,8 @@ void NetscapePlugInStreamLoader::notifyDone()
     if (!m_isInitialized)
         return;
 
-    protectedDocumentLoader()->removePlugInStreamLoader(*this);
+    if (RefPtr documentLoader = this->documentLoader())
+        documentLoader->removePlugInStreamLoader(*this);
 }
 
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -252,7 +252,7 @@ public:
     WEBCORE_EXPORT static String cookiePartitionIdentifier(const ResourceRequest&);
     static String cookiePartitionIdentifier(const URL&);
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT static NSHTTPCookie *capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
+    WEBCORE_EXPORT static RetainPtr<NSHTTPCookie> capExpiryOfPersistentCookie(NSHTTPCookie *, Seconds cap);
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
     WEBCORE_EXPORT static NSHTTPCookie *setCookiePartition(NSHTTPCookie *, NSString*);
 #endif

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -36,17 +36,16 @@ namespace WebCore {
 static Vector<uint16_t> portVectorFromList(NSArray<NSNumber *> *portList)
 {
     return Vector<uint16_t>(portList.count, [portList](size_t i) {
-        NSNumber *port = portList[i];
-        return port.unsignedShortValue;
+        return portList[i].unsignedShortValue;
     });
 }
 
-static NSString * _Nullable portStringFromVector(const Vector<uint16_t>& ports)
+static RetainPtr<NSString> portStringFromVector(const Vector<uint16_t>& ports)
 {
     if (ports.isEmpty())
         return nil;
 
-    auto *string = [NSMutableString stringWithCapacity:ports.size() * 5];
+    RetainPtr string = adoptNS([[NSMutableString alloc] initWithCapacity:ports.size() * 5]);
 
     for (size_t i = 0; i < ports.size() - 1; ++i)
         [string appendFormat:@"%" PRIu16 ", ", ports[i]];
@@ -58,24 +57,24 @@ static NSString * _Nullable portStringFromVector(const Vector<uint16_t>& ports)
 
 static double cookieCreated(NSHTTPCookie *cookie)
 {
-    id value = cookie.properties[@"Created"];
+    RetainPtr<id> value = cookie.properties[@"Created"];
 
     auto toCanonicalFormat = [](double referenceFormat) {
         return 1000.0 * (referenceFormat + NSTimeIntervalSince1970);
     };
 
-    if (auto *number = dynamic_objc_cast<NSNumber>(value))
-        return toCanonicalFormat(number.doubleValue);
+    if (RetainPtr number = dynamic_objc_cast<NSNumber>(value.get()))
+        return toCanonicalFormat(number.get().doubleValue);
 
-    if (auto *string = dynamic_objc_cast<NSString>(value))
-        return toCanonicalFormat(string.doubleValue);
+    if (RetainPtr string = dynamic_objc_cast<NSString>(value.get()))
+        return toCanonicalFormat(string.get().doubleValue);
 
     return 0;
 }
 
 static std::optional<double> cookieExpiry(NSHTTPCookie *cookie)
 {
-    NSDate *expiryDate = cookie.expiresDate;
+    RetainPtr<NSDate> expiryDate = cookie.expiresDate;
     if (!expiryDate)
         return std::nullopt;
     return [expiryDate timeIntervalSince1970] * 1000.0;
@@ -132,7 +131,7 @@ Cookie::operator NSHTTPCookie * _Nullable () const
     if (isNull())
         return nil;
 
-    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:14];
+    RetainPtr properties = adoptNS([[NSMutableDictionary alloc] initWithCapacity:14]);
 
     if (!comment.isNull())
         [properties setObject:(NSString *)comment forKey:NSHTTPCookieComment];
@@ -156,15 +155,15 @@ Cookie::operator NSHTTPCookie * _Nullable () const
         [properties setObject:(NSString *)value forKey:NSHTTPCookieValue];
 
     if (expires) {
-        NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:*expires / 1000.0];
-        [properties setObject:expirationDate forKey:NSHTTPCookieExpires];
+        RetainPtr expirationDate = [NSDate dateWithTimeIntervalSince1970:*expires / 1000.0];
+        [properties setObject:expirationDate.get() forKey:NSHTTPCookieExpires];
     }
 
     [properties setObject:@(created / 1000.0 - NSTimeIntervalSince1970) forKey:@"Created"];
 
-    auto* portString = portStringFromVector(ports);
+    RetainPtr portString = portStringFromVector(ports);
     if (portString)
-        [properties setObject:portString forKey:NSHTTPCookiePort];
+        [properties setObject:portString.get() forKey:NSHTTPCookiePort];
 
     if (secure)
         [properties setObject:@YES forKey:NSHTTPCookieSecure];
@@ -175,12 +174,12 @@ Cookie::operator NSHTTPCookie * _Nullable () const
     if (httpOnly)
         [properties setObject:@YES forKey:@"HttpOnly"];
 
-    if (auto* sameSitePolicy = nsSameSitePolicy(sameSite))
-        [properties setObject:sameSitePolicy forKey:@"SameSite"];
+    if (RetainPtr sameSitePolicy = nsSameSitePolicy(sameSite))
+        [properties setObject:sameSitePolicy.get() forKey:@"SameSite"];
 
     [properties setObject:@"1" forKey:NSHTTPCookieVersion];
 
-    return [NSHTTPCookie cookieWithProperties:properties];
+    return [NSHTTPCookie cookieWithProperties:properties.get()];
 }
     
 bool Cookie::operator==(const Cookie& other) const

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -107,7 +107,7 @@ void CookieStorageObserver::startObserving(WTF::Function<void()>&& callback)
 
     if (!m_hasRegisteredInternalsForNotifications) {
         if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
-            auto internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
+            RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
             [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
         }
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
@@ -51,7 +51,7 @@ public:
 
     WEBCORE_EXPORT bool isEmpty() const;
 
-    bool encodingRequiresPlatformData() const { return m_nsCredential && encodingRequiresPlatformData(m_nsCredential.get()); }
+    bool encodingRequiresPlatformData() const { return m_nsCredential && encodingRequiresPlatformData(RetainPtr { m_nsCredential }.get()); }
 
     WEBCORE_EXPORT NSURLCredential *nsCredential() const;
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -62,18 +62,18 @@ static CredentialPersistence toCredentialPersistence(NSURLCredentialPersistence 
 Credential::Credential(const Credential& original, CredentialPersistence persistence)
     : CredentialBase(original, persistence)
 {
-    NSURLCredential *originalNSURLCredential = original.m_nsCredential.get();
+    RetainPtr originalNSURLCredential = original.m_nsCredential;
     if (!originalNSURLCredential)
         return;
 
-    if (NSString *user = originalNSURLCredential.user)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user password:originalNSURLCredential.password persistence:toNSURLCredentialPersistence(persistence)]);
-    else if (SecIdentityRef identity = originalNSURLCredential.identity)
-        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity certificates:originalNSURLCredential.certificates persistence:toNSURLCredentialPersistence(persistence)]);
+    if (RetainPtr<NSString> user = originalNSURLCredential.get().user)
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithUser:user.get() password:originalNSURLCredential.get().password persistence:toNSURLCredentialPersistence(persistence)]);
+    else if (RetainPtr<SecIdentityRef> identity = originalNSURLCredential.get().identity)
+        m_nsCredential = adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:originalNSURLCredential.get().certificates persistence:toNSURLCredentialPersistence(persistence)]);
     else {
         // It is not possible to set the persistence of server trust credentials.
         ASSERT_NOT_REACHED();
-        m_nsCredential = originalNSURLCredential;
+        m_nsCredential = WTFMove(originalNSURLCredential);
     }
 }
 

--- a/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm
@@ -67,20 +67,20 @@ static Box<NetworkLoadMetrics> packageTimingData(MonotonicTime redirectStart, NS
 
 Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetrics, const NetworkLoadMetrics& metricsFromTask)
 {
-    NSArray<NSURLSessionTaskTransactionMetrics *> *transactionMetrics = incompleteMetrics.transactionMetrics;
-    NSURLSessionTaskTransactionMetrics *metrics = transactionMetrics.lastObject;
+    RetainPtr<NSArray<NSURLSessionTaskTransactionMetrics *>> transactionMetrics = incompleteMetrics.transactionMetrics;
+    RetainPtr<NSURLSessionTaskTransactionMetrics> metrics = transactionMetrics.get().lastObject;
     return packageTimingData(
-        dateToMonotonicTime(transactionMetrics.firstObject.fetchStartDate),
-        metrics.fetchStartDate,
-        metrics.domainLookupStartDate,
-        metrics.domainLookupEndDate,
-        metrics.connectStartDate,
-        metrics.secureConnectionStartDate,
-        metrics.connectEndDate,
-        metrics.requestStartDate,
-        metrics.responseStartDate,
-        metrics.reusedConnection,
-        metrics.response.URL.scheme,
+        dateToMonotonicTime(transactionMetrics.get().firstObject.fetchStartDate),
+        metrics.get().fetchStartDate,
+        metrics.get().domainLookupStartDate,
+        metrics.get().domainLookupEndDate,
+        metrics.get().connectStartDate,
+        metrics.get().secureConnectionStartDate,
+        metrics.get().connectEndDate,
+        metrics.get().requestStartDate,
+        metrics.get().responseStartDate,
+        metrics.get().reusedConnection,
+        metrics.get().response.URL.scheme,
         incompleteMetrics.redirectCount,
         metricsFromTask.failsTAOCheck,
         metricsFromTask.hasCrossOriginRedirect
@@ -89,11 +89,11 @@ Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetric
 
 Box<NetworkLoadMetrics> copyTimingData(NSURLConnection *connection, const ResourceHandle& handle)
 {
-    NSDictionary *timingData = [connection _timingData];
+    RetainPtr<NSDictionary> timingData = [connection _timingData];
 
     auto timingValue = [&](NSString *key) -> RetainPtr<NSDate> {
-        if (NSNumber *number = [timingData objectForKey:key]) {
-            if (double doubleValue = number.doubleValue)
+        if (RetainPtr<NSNumber> number = [timingData objectForKey:key]) {
+            if (double doubleValue = number.get().doubleValue)
                 return adoptNS([[NSDate alloc] initWithTimeIntervalSinceReferenceDate:doubleValue]);
         }
         return { };

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -153,8 +153,8 @@ void NetworkStorageSession::setAllCookiesToSameSiteStrict(const RegistrableDomai
             [oldCookiesToDelete addObject:nsCookie];
             RetainPtr<NSMutableDictionary<NSHTTPCookiePropertyKey, id>> mutableProperties = adoptNS([[nsCookie properties] mutableCopy]);
             mutableProperties.get()[NSHTTPCookieSameSitePolicy] = NSHTTPCookieSameSiteStrict;
-            NSHTTPCookie *strictCookie = [NSHTTPCookie cookieWithProperties:mutableProperties.get()];
-            [newCookiesToAdd addObject:strictCookie];
+            RetainPtr strictCookie = adoptNS([[NSHTTPCookie alloc] initWithProperties:mutableProperties.get()]);
+            [newCookiesToAdd addObject:strictCookie.get()];
         }
     }
 
@@ -267,9 +267,9 @@ void NetworkStorageSession::deleteHTTPCookie(CFHTTPCookieStorageRef cookieStorag
 
 static RetainPtr<NSDictionary> policyProperties(const SameSiteInfo& sameSiteInfo, NSURL *url)
 {
-    static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
+    static NeverDestroyed<RetainPtr<NSURL>> emptyURL = adoptNS([[NSURL alloc] initWithString:@""]);
     NSDictionary *policyProperties = @{
-        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? url : emptyURL,
+        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? url : emptyURL.get().get(),
         @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation": [NSNumber numberWithBool:sameSiteInfo.isTopSite],
     };
     return policyProperties;
@@ -337,7 +337,7 @@ RetainPtr<NSArray> NetworkStorageSession::httpCookiesForURL(CFHTTPCookieStorageR
     return cookiesForURLFromStorage(nsCookieStorage.get(), url, firstParty, sameSiteInfo, thirdPartyCookieBlockingDecision, partitionKey);
 }
 
-NSHTTPCookie *NetworkStorageSession::capExpiryOfPersistentCookie(NSHTTPCookie *cookie, Seconds cap)
+RetainPtr<NSHTTPCookie> NetworkStorageSession::capExpiryOfPersistentCookie(NSHTTPCookie *cookie, Seconds cap)
 {
     if ([cookie isSessionOnly])
         return cookie;
@@ -346,7 +346,7 @@ NSHTTPCookie *NetworkStorageSession::capExpiryOfPersistentCookie(NSHTTPCookie *c
         auto properties = adoptNS([[cookie properties] mutableCopy]);
         auto date = adoptNS([[NSDate alloc] initWithTimeIntervalSinceNow:cap.seconds()]);
         [properties setObject:date.get() forKey:NSHTTPCookieExpires];
-        cookie = [NSHTTPCookie cookieWithProperties:properties.get()];
+        return adoptNS([[NSHTTPCookie alloc] initWithProperties:properties.get()]);
     }
     return cookie;
 }
@@ -420,7 +420,7 @@ std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForSessionAsVector(c
         return Vector<Cookie> { };
 
     Vector<Cookie> cookiesVector;
-    NSString *name = options.name;
+    RetainPtr<NSString> name = static_cast<NSString *>(options.name);
     for (NSHTTPCookie *cookie in cookies.get()) {
         if (![[cookie name] length])
             continue;
@@ -428,7 +428,7 @@ std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForSessionAsVector(c
             continue;
         if ([cookie isSecure] && includeSecureCookies == IncludeSecureCookies::No)
             continue;
-        if (!options.name.isNull() && ![[cookie name] isEqualToString:name])
+        if (!options.name.isNull() && ![[cookie name] isEqualToString:name.get()])
             continue;
 
         cookiesVector.append(Cookie(cookie));
@@ -459,17 +459,17 @@ std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(con
     return cookiesForSession(headerFieldProxy.firstParty, headerFieldProxy.sameSiteInfo, headerFieldProxy.url, headerFieldProxy.frameID, headerFieldProxy.pageID, IncludeHTTPOnly, headerFieldProxy.includeSecureCookies, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No);
 }
 
-static NSHTTPCookie *adjustScriptWrittenCookie(NSHTTPCookie *initialCookie, std::optional<Seconds> cappedLifetime)
+static RetainPtr<NSHTTPCookie> adjustScriptWrittenCookie(NSHTTPCookie *initialCookie, std::optional<Seconds> cappedLifetime)
 {
     if (!initialCookie)
         return nil;
 
 #if ENABLE(JS_COOKIE_CHECKING)
-    auto mutableProperties = adoptNS([[initialCookie properties] mutableCopy]);
+    RetainPtr mutableProperties = adoptNS([[initialCookie properties] mutableCopy]);
     [mutableProperties.get() setValue:@1 forKey:@"SetInJavaScript"];
-    NSHTTPCookie* cookie = [NSHTTPCookie cookieWithProperties:mutableProperties.get()];
+    RetainPtr cookie = adoptNS([[NSHTTPCookie alloc] initWithProperties:mutableProperties.get()]);
 #else
-    NSHTTPCookie* cookie = initialCookie;
+    RetainPtr cookie = initialCookie;
 #endif
 
     // <rdar://problem/5632883> On 10.5, NSHTTPCookieStorage would store an empty cookie,
@@ -484,12 +484,12 @@ static NSHTTPCookie *adjustScriptWrittenCookie(NSHTTPCookie *initialCookie, std:
 
     // Cap lifetime of persistent, client-side cookies.
     if (cappedLifetime)
-        return NetworkStorageSession::capExpiryOfPersistentCookie(cookie, *cappedLifetime);
+        return NetworkStorageSession::capExpiryOfPersistentCookie(cookie.get(), *cappedLifetime);
 
     return cookie;
 }
 
-static NSHTTPCookie *parseDOMCookie(String cookieString, NSURL* cookieURL, std::optional<Seconds> cappedLifetime, const String& partition)
+static RetainPtr<NSHTTPCookie> parseDOMCookie(String cookieString, NSURL* cookieURL, std::optional<Seconds> cappedLifetime, const String& partition)
 {
     // <rdar://problem/5632883> On 10.5, NSHTTPCookieStorage would store an empty cookie,
     // which would be sent as "Cookie: =".
@@ -512,7 +512,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     if (applyTrackingPrevention == ApplyTrackingPrevention::Yes && shouldBlockCookies(firstParty, url, frameID, pageID, shouldRelaxThirdPartyCookieBlocking))
         return;
 
-    NSURL *cookieURL = url;
+    RetainPtr<NSURL> cookieURL = static_cast<NSURL *>(url);
 
     auto cookieCap = clientSideCookieCap(RegistrableDomain { firstParty }, requiresScriptTelemetry, pageID);
 
@@ -522,11 +522,11 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     String partitionKey;
 #endif
 
-    NSHTTPCookie *cookie = parseDOMCookie(cookieString, cookieURL, cookieCap, partitionKey);
+    RetainPtr cookie = parseDOMCookie(cookieString, cookieURL.get(), cookieCap, partitionKey);
     if (!cookie)
         return;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[cookie], cookieURL, firstParty, sameSiteInfo);
+    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty, sameSiteInfo);
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -597,13 +597,13 @@ void NetworkStorageSession::deleteCookie(const URL& firstParty, const URL& url, 
     RetainPtr<CFHTTPCookieStorageRef> cookieStorage = this->cookieStorage();
     RetainPtr<NSArray> cookies = httpCookiesForURL(cookieStorage.get(), firstParty, std::nullopt, url, ThirdPartyCookieBlockingDecision::None);
 
-    NSString *cookieNameString = cookieName;
+    RetainPtr<NSString> cookieNameString = static_cast<NSString *>(cookieName);
 
     NSUInteger count = [cookies count];
     for (NSUInteger i = 0; i < count; ++i) {
-        NSHTTPCookie *cookie = (NSHTTPCookie *)[cookies objectAtIndex:i];
-        if ([[cookie name] isEqualToString:cookieNameString])
-            deleteHTTPCookie(cookieStorage.get(), cookie, [aggregator] { });
+        RetainPtr<NSHTTPCookie> cookie = [cookies objectAtIndex:i];
+        if ([[cookie name] isEqualToString:cookieNameString.get()])
+            deleteHTTPCookie(cookieStorage.get(), cookie.get(), [aggregator] { });
     }
 
     END_BLOCK_OBJC_EXCEPTIONS
@@ -616,8 +616,8 @@ void NetworkStorageSession::getHostnamesWithCookies(HashSet<String>& hostnames)
     RetainPtr<NSArray> cookies = httpCookies(cookieStorage().get());
     
     for (NSHTTPCookie* cookie in cookies.get()) {
-        if (NSString *domain = [cookie domain])
-            hostnames.add(domain);
+        if (RetainPtr<NSString> domain = [cookie domain])
+            hostnames.add(domain.get());
         else
             ASSERT_NOT_REACHED();
     }
@@ -631,9 +631,8 @@ void NetworkStorageSession::deleteAllCookies(CompletionHandler<void()>&& complet
 
     auto work = [completionHandler = WTFMove(completionHandler), cookieStorage = RetainPtr { cookieStorage() }] () mutable {
         if (!cookieStorage) {
-            NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-            NSArray *cookies = [cookieStorage cookies];
-            for (NSHTTPCookie *cookie in cookies)
+            RetainPtr cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+            for (NSHTTPCookie *cookie in [cookieStorage cookies])
                 [cookieStorage deleteCookie:cookie];
         } else
             CFHTTPCookieStorageDeleteAllCookies(cookieStorage.get());
@@ -734,8 +733,8 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
     auto host = firstParty.host().toString();
 
     // _getCookiesForDomain only returned unpartitioned (i.e., nil partition) cookies
-    NSArray *unpartitionedCookies = [nsCookieStorage() _getCookiesForDomain:(NSString *)host];
-    NSMutableArray *nsCookies = [NSMutableArray arrayWithArray:unpartitionedCookies];
+    RetainPtr<NSArray> unpartitionedCookies = [nsCookieStorage() _getCookiesForDomain:(NSString *)host];
+    RetainPtr nsCookies = adoptNS([[NSMutableArray alloc] initWithArray:unpartitionedCookies.get()]);
 
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
     if (isOptInCookiePartitioningEnabled()) {
@@ -770,7 +769,7 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
     }
 #endif
 
-    return nsCookiesToCookieVector(nsCookies, [](NSHTTPCookie *cookie) { return !cookie.HTTPOnly; });
+    return nsCookiesToCookieVector(nsCookies.get(), [](NSHTTPCookie *cookie) { return !cookie.HTTPOnly; });
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -184,8 +184,8 @@ void ResourceRequest::doUpdateResourceRequest()
 
     m_requestData.m_isTopSite = static_cast<NSNumber*>([m_nsRequest _propertyForKey:@"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation"]).boolValue;
 
-    if (NSString* method = [m_nsRequest HTTPMethod])
-        m_requestData.m_httpMethod = method;
+    if (RetainPtr method = [m_nsRequest HTTPMethod])
+        m_requestData.m_httpMethod = method.get();
     m_requestData.m_allowCookies = [m_nsRequest HTTPShouldHandleCookies];
 
     if (resourcePrioritiesEnabled())
@@ -197,7 +197,7 @@ void ResourceRequest::doUpdateResourceRequest()
     }];
 
     m_requestData.m_responseContentDispositionEncodingFallbackArray.clear();
-    NSArray *encodingFallbacks = [m_nsRequest contentDispositionEncodingFallbackArray];
+    RetainPtr<NSArray> encodingFallbacks = [m_nsRequest contentDispositionEncodingFallbackArray];
     m_requestData.m_responseContentDispositionEncodingFallbackArray.reserveCapacity([encodingFallbacks count]);
     for (NSNumber *encodingFallback in [m_nsRequest contentDispositionEncodingFallbackArray]) {
         CFStringEncoding encoding = CFStringConvertNSStringEncodingToEncoding([encodingFallback unsignedLongValue]);
@@ -206,9 +206,9 @@ void ResourceRequest::doUpdateResourceRequest()
     }
 
     if (m_nsRequest) {
-        NSString* cachePartition = [NSURLProtocol propertyForKey:(NSString *)_kCFURLCachePartitionKey inRequest:m_nsRequest.get()];
+        RetainPtr<NSString> cachePartition = [NSURLProtocol propertyForKey:(NSString *)_kCFURLCachePartitionKey inRequest:m_nsRequest.get()];
         if (cachePartition)
-            m_cachePartition = cachePartition;
+            m_cachePartition = cachePartition.get();
     }
 }
 
@@ -234,8 +234,8 @@ static NSURL *siteForCookies(ResourceRequest::SameSiteDisposition disposition, N
     case ResourceRequest::SameSiteDisposition::SameSite:
         return url;
     case ResourceRequest::SameSiteDisposition::CrossSite:
-        static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
-        return emptyURL;
+        static NeverDestroyed<RetainPtr<NSURL>> emptyURL = adoptNS([[NSURL alloc] initWithString:@""]);
+        return emptyURL.get().get();
     }
 }
 
@@ -325,8 +325,8 @@ void ResourceRequest::doUpdatePlatformRequest()
 
     String partition = cachePartition();
     if (!partition.isNull() && !partition.isEmpty()) {
-        NSString *partitionValue = [NSString stringWithUTF8String:partition.utf8().data()];
-        [NSURLProtocol setProperty:partitionValue forKey:(NSString *)_kCFURLCachePartitionKey inRequest:nsRequest.get()];
+        RetainPtr partitionValue = adoptNS([[NSString alloc] initWithUTF8String:partition.utf8().data()]);
+        [NSURLProtocol setProperty:partitionValue.get() forKey:(NSString *)_kCFURLCachePartitionKey inRequest:nsRequest.get()];
     }
 
 #if PLATFORM(MAC)
@@ -363,14 +363,14 @@ void ResourceRequest::doUpdatePlatformHTTPBody()
     if (formData && !formData->isEmpty())
         WebCore::setHTTPBody(nsRequest.get(), WTFMove(formData));
 
-    if (NSInputStream *bodyStream = [nsRequest HTTPBodyStream]) {
+    if (RetainPtr bodyStream = [nsRequest HTTPBodyStream]) {
         // For streams, provide a Content-Length to avoid using chunked encoding, and to get accurate total length in callbacks.
-        NSString *lengthString = [bodyStream propertyForKey:(__bridge NSString *)formDataStreamLengthPropertyName()];
+        RetainPtr<NSString> lengthString = [bodyStream propertyForKey:(__bridge NSString *)formDataStreamLengthPropertyName()];
         if (lengthString) {
-            [nsRequest setValue:lengthString forHTTPHeaderField:@"Content-Length"];
+            [nsRequest setValue:lengthString.get() forHTTPHeaderField:@"Content-Length"];
             // Since resource request is already marked updated, we need to keep it up to date too.
             ASSERT(m_resourceRequestUpdated);
-            m_requestData.m_httpHeaderFields.set(HTTPHeaderName::ContentLength, lengthString);
+            m_requestData.m_httpHeaderFields.set(HTTPHeaderName::ContentLength, lengthString.get());
         }
     }
 

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -58,17 +58,17 @@ void ResourceResponse::initNSURLResponse() const
         else
             expectedContentLength = static_cast<NSInteger>(m_expectedContentLength);
 
-        NSString* encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
-        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString]);
+        RetainPtr encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
+        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
         return;
     }
 
     // FIXME: We lose the status text and the HTTP version here.
-    NSMutableDictionary* headerDictionary = [NSMutableDictionary dictionary];
+    RetainPtr headerDictionary = adoptNS([[NSMutableDictionary alloc] init]);
     for (auto& header : m_httpHeaderFields)
         [headerDictionary setObject:(NSString *)header.value forKey:(NSString *)header.key];
 
-    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary]);
+    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary.get()]);
 
     // Mime type sniffing doesn't work with a synthesized response.
     [m_nsResponse _setMIMEType:(NSString *)m_mimeType];
@@ -85,31 +85,31 @@ CertificateInfo ResourceResponse::platformCertificateInfo(std::span<const std::b
     if (!cfResponse)
         return { };
 
-    CFDictionaryRef context = _CFURLResponseGetSSLCertificateContext(cfResponse);
+    RetainPtr context = _CFURLResponseGetSSLCertificateContext(cfResponse);
     if (!context)
         return { };
 
-    auto trustValue = CFDictionaryGetValue(context, kCFStreamPropertySSLPeerTrust);
+    auto trustValue = CFDictionaryGetValue(context.get(), kCFStreamPropertySSLPeerTrust);
     if (!trustValue)
         return { };
-    auto trust = checked_cf_cast<SecTrustRef>(trustValue);
+    RetainPtr trust = checked_cf_cast<SecTrustRef>(trustValue);
 
     if (trust && auditToken.size()) {
         auto data = adoptCF(CFDataCreate(nullptr, byteCast<uint8_t>(auditToken.data()), auditToken.size()));
-        SecTrustSetClientAuditToken(trust, data.get());
+        SecTrustSetClientAuditToken(trust.get(), data.get());
     }
 
     SecTrustResultType trustResultType;
-    OSStatus result = SecTrustGetTrustResult(trust, &trustResultType);
+    OSStatus result = SecTrustGetTrustResult(trust.get(), &trustResultType);
     if (result != errSecSuccess)
         return { };
 
     if (trustResultType == kSecTrustResultInvalid) {
-        if (!SecTrustEvaluateWithError(trust, nullptr))
+        if (!SecTrustEvaluateWithError(trust.get(), nullptr))
             return { };
     }
 
-    return CertificateInfo(trust);
+    return CertificateInfo(trust.get());
 }
 
 NSURLResponse *ResourceResponse::nsURLResponse() const

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -454,7 +454,7 @@ NS_ASSUME_NONNULL_END
     }
 
     [self addDelegateOperation:[strongSelf = retainPtr(self)] {
-        auto delegate = strongSelf.get().delegate;
+        RetainPtr<id<NSURLSessionDelegate> _Nullable> delegate = strongSelf.get().delegate;
         if ([delegate respondsToSelector:@selector(URLSession:didBecomeInvalidWithError:)])
             [delegate URLSession:(NSURLSession *)strongSelf.get() didBecomeInvalidWithError:nil];
     }];
@@ -751,14 +751,12 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     _resumeSessionID = 0;
 
     // CoreMedia will explicitly add a user agent header. Remove if present.
-    RetainPtr<NSMutableURLRequest> mutableRequest;
     if ([request valueForHTTPHeaderField:@"User-Agent"]) {
-        mutableRequest = adoptNS([request mutableCopy]);
+        RetainPtr mutableRequest = adoptNS([request mutableCopy]);
         [mutableRequest setValue:nil forHTTPHeaderField:@"User-Agent"];
-        request = mutableRequest.get();
-    }
-
-    self->_originalRequest = self->_currentRequest = request;
+        self->_originalRequest = self->_currentRequest = mutableRequest;
+    } else
+        self->_originalRequest = self->_currentRequest = request;
 
     return self;
 }
@@ -969,7 +967,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     [strongSession addDelegateOperation:[strongSelf, strongResponse, completionHandler = WTFMove(completionHandler), targetDispatcher = _targetDispatcher] () mutable {
         strongSelf->_response = strongResponse.get();
 
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if (![dataDelegate respondsToSelector:@selector(URLSession:dataTask:didReceiveResponse:completionHandler:)]) {
             targetDispatcher->dispatch([strongSelf, completionHandler = WTFMove(completionHandler)] () mutable {
                 completionHandler(ShouldContinuePolicyCheck::Yes);
@@ -1006,7 +1004,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     RetainPtr<WebCoreNSURLSession> strongSession { self.session };
     [strongSession addDelegateOperation:[strongSelf = RetainPtr { self }, data = WTFMove(data)] {
         strongSelf.get().countOfBytesReceived += [data length];
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if ([dataDelegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)])
             [dataDelegate URLSession:(NSURLSession *)strongSelf.get().session dataTask:(NSURLSessionDataTask *)strongSelf.get() didReceiveData:data.get()];
     }];
@@ -1027,7 +1025,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
             return;
         }
 
-        id<NSURLSessionDataDelegate> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
+        RetainPtr<id<NSURLSessionDataDelegate>> dataDelegate = (id<NSURLSessionDataDelegate>)strongSelf.get().session.delegate;
         if ([dataDelegate respondsToSelector:@selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
             auto completionHandlerBlock = makeBlockPtr([completionHandler = WTFMove(completionHandler), targetDispatcher = WTFMove(targetDispatcher)](NSURLRequest *newRequest) mutable {
                 targetDispatcher->dispatch([request = ResourceRequest { newRequest }, completionHandler = WTFMove(completionHandler)] () mutable {
@@ -1056,7 +1054,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     RetainPtr<NSError> strongError { error };
     auto taskMetrics = adoptNS([[WebCoreNSURLSessionTaskMetrics alloc] _initWithMetrics:metrics.isolatedCopy() onTarget:_targetDispatcher.get()]);
     [strongSession addDelegateOperation:[strongSelf, strongSession, strongError, taskMetrics = WTFMove(taskMetrics), targetDispatcher = _targetDispatcher] () mutable {
-        id<NSURLSessionTaskDelegate> delegate = (id<NSURLSessionTaskDelegate>)strongSession.get().delegate;
+        RetainPtr<id<NSURLSessionTaskDelegate>> delegate = (id<NSURLSessionTaskDelegate>)strongSession.get().delegate;
 
         if ([delegate respondsToSelector:@selector(URLSession:task:didFinishCollectingMetrics:)])
             [delegate URLSession:(NSURLSession *)strongSession.get() task:(NSURLSessionDataTask *)strongSelf.get() didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)taskMetrics.get()];

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -99,7 +99,7 @@ static RetainPtr<NSArray<NSHTTPCookie *>> cookiesByCappingExpiry(NSArray<NSHTTPC
 {
     RetainPtr cappedCookies = [NSMutableArray arrayWithCapacity:cookies.count];
     for (NSHTTPCookie *cookie in cookies)
-        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap)];
+        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap).get()];
     return cappedCookies;
 }
 


### PR DESCRIPTION
#### 3a3539a12205c6b946362fa44a53215be9a09d9b
<pre>
Crash under DocumentLoader::removePlugInStreamLoader()
<a href="https://bugs.webkit.org/show_bug.cgi?id=290649">https://bugs.webkit.org/show_bug.cgi?id=290649</a>

Reviewed by NOBODY (OOPS!).

Null check the DocumentLoader before calling `removePlugInStreamLoader()`
on it, as it appears it can be null.

* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::notifyDone):
</pre>
----------------------------------------------------------------------
#### 535d9318f1f363cba4dc12f9fa7219705f431e1c
<pre>
Address safer CPP failures in platform/network/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=290642">https://bugs.webkit.org/show_bug.cgi?id=290642</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/RetainPtr.h:
(WTF::lazyInitialize):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::portVectorFromList):
(WebCore::portStringFromVector):
(WebCore::cookieCreated):
(WebCore::cookieExpiry):
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const):
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
* Source/WebCore/platform/network/cocoa/CredentialCocoa.h:
(WebCore::Credential::encodingRequiresPlatformData const):
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::Credential):
* Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm:
(WebCore::copyTimingData):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setAllCookiesToSameSiteStrict):
(WebCore::policyProperties):
(WebCore::NetworkStorageSession::capExpiryOfPersistentCookie):
(WebCore::NetworkStorageSession::cookiesForSessionAsVector const):
(WebCore::adjustScriptWrittenCookie):
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::deleteCookie const):
(WebCore::NetworkStorageSession::getHostnamesWithCookies):
(WebCore::NetworkStorageSession::deleteAllCookies):
(WebCore::NetworkStorageSession::domCookiesForHost):
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::type):
(WebCore::scheme):
(WebCore::ProtectionSpace::ProtectionSpace):
(WebCore::ProtectionSpace::nsSpace const):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::Data::shutdownResource):
(WebCore::RangeResponseGenerator::removeTask):
(WebCore::RangeResponseGenerator::willSynthesizeRangeResponses):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::siteForCookies):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::initNSURLResponse const):
(WebCore::ResourceResponse::platformCertificateInfo const):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession finishTasksAndInvalidate]):
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:targetDispatcher:]):
(-[WebCoreNSURLSessionDataTask resource:receivedResponse:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:receivedData:]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
(-[WebCoreNSURLSessionDataTask _resource:loadFinishedWithError:metrics:]):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::cookiesByCappingExpiry):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3539a12205c6b946362fa44a53215be9a09d9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97295 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/16920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7134 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/47823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/99340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/17213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/25369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/102381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/47823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/100298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/17213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/87993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/17213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/5872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/89971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/17213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/5955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/95917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/25369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/104401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/24745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/104401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/4821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/17918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/119543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/119543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/25732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->