### PR TITLE
AppSSO should not hang the main thread

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
@@ -34,6 +34,14 @@ DECLARE_SYSTEM_HEADER
 #import <AppSSO/AppSSO.h>
 #import <AppSSOCore/AppSSOCore.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SOAuthorization (Staging_rdar_148133727)
++ (void)canPerformAuthorizationWithURL:(NSURL *)url responseCode:(NSInteger)responseCode callerBundleIdentifier:(NSString * _Nullable)callerBundleIdentifier useInternalExtensions:(BOOL)useInternalExtensions completion:(void (^)(BOOL))completion;
+@end
+
+NS_ASSUME_NONNULL_END
+
 #else
 
 #if __has_include(<UIKit/UIKit.h>)
@@ -101,6 +109,7 @@ typedef NS_ENUM(NSInteger, SOAuthorizationInitiatingAction) {
 - (void)getAuthorizationHintsWithURL:(NSURL *)url responseCode:(NSInteger)responseCode completion:(void (^)(SOAuthorizationHints * _Nullable authorizationHints, NSError * _Nullable error))completion;
 + (BOOL)canPerformAuthorizationWithURL:(NSURL *)url responseCode:(NSInteger)responseCode;
 + (BOOL)canPerformAuthorizationWithURL:(NSURL *)url responseCode:(NSInteger)responseCode useInternalExtensions:(BOOL)useInternalExtensions;
++ (void)canPerformAuthorizationWithURL:(NSURL *)url responseCode:(NSInteger)responseCode callerBundleIdentifier:(NSString * _Nullable)callerBundleIdentifier useInternalExtensions:(BOOL)useInternalExtensions completion:(void (^)(BOOL))completion;
 - (void)beginAuthorizationWithURL:(NSURL *)url httpHeaders:(NSDictionary <NSString *, NSString *> *)httpHeaders httpBody:(NSData *)httpBody;
 - (void)beginAuthorizationWithOperation:(nullable SOAuthorizationOperation)operation url:(NSURL *)url httpHeaders:(NSDictionary <NSString *, NSString *> *)httpHeaders httpBody:(NSData *)httpBody;
 - (void)beginAuthorizationWithParameters:(SOAuthorizationParameters *)parameters;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
@@ -63,7 +63,7 @@ public:
     void tryAuthorize(Ref<API::PageConfiguration>&&, Ref<API::NavigationAction>&&, WebPageProxy&, NewPageCallback&&, UIClientCallback&&);
 
 private:
-    bool canAuthorize(const URL&) const;
+    void canAuthorize(const URL&, CompletionHandler<void(bool)>&&);
 
     RetainPtr<WKSOAuthorizationDelegate> m_soAuthorizationDelegate;
     bool m_hasAppSSO { false };


### PR DESCRIPTION
#### 1730f65980c9f1e1f31ecc0a17f667258f4dd066
<pre>
AppSSO should not hang the main thread
<a href="https://rdar.apple.com/133093114">rdar://133093114</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290656">https://bugs.webkit.org/show_bug.cgi?id=290656</a>

Reviewed by Charlie Wolfe and Ben Nham.

AppSSO currently performs a sync call that ends up hanging the main thread.
We have been provided equivalent SPI that does not hang the main thread, this
patch moves to using that.

Updated API test infrastructure and all existing tests pass.

* Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::canAuthorize):
(WebKit::SOAuthorizationCoordinator::tryAuthorize):
(WebKit::SOAuthorizationCoordinator::canAuthorize const): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(overrideCanPerformAuthorizationWithURL):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionError)):

Canonical link: <a href="https://commits.webkit.org/293270@main">https://commits.webkit.org/293270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a544028d5c7fc01232fea0e86ec3250f9c50e4c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48888 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6796 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48330 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19094 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25405 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->