### PR TITLE
PDF HUD should not offer save/open-in-preview options in recoveryOS

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/mac/NSImageSPI.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/spi/darwin/OSVariantSPI.h>
 
 //  The HUD items should have the following spacing:
 //  -------------------------------------------------
@@ -70,15 +71,19 @@ static const CGFloat layerFadeInTimeInterval = 0.25;
 static const CGFloat layerFadeOutTimeInterval = 0.5;
 static const CGFloat initialHideTimeInterval = 3.0;
 
+static bool isInRecoveryOS()
+{
+    return os_variant_is_basesystem("WebKit");
+}
+
 static NSArray<NSString *> *controlArray()
 {
-    return @[
-        PDFHUDZoomOutControl,
-        PDFHUDZoomInControl,
-        PDFHUDSeparatorControl,
-        PDFHUDLaunchPreviewControl,
-        PDFHUDSavePDFControl
-    ];
+    NSArray<NSString *> *controls = @[ PDFHUDZoomOutControl, PDFHUDZoomInControl ];
+
+    if (isInRecoveryOS())
+        return controls;
+
+    return [controls arrayByAddingObjectsFromArray:@[ PDFHUDSeparatorControl, PDFHUDLaunchPreviewControl, PDFHUDSavePDFControl ]];
 }
 
 @implementation WKPDFHUDView {


### PR DESCRIPTION
#### 827ee7e5be102ae2943daad9a05ab22d2061e892
<pre>
PDF HUD should not offer save/open-in-preview options in recoveryOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=290659">https://bugs.webkit.org/show_bug.cgi?id=290659</a>
<a href="https://rdar.apple.com/148129854">rdar://148129854</a>

Reviewed by Tim Horton.

Preview.app is not available in recoveryOS, and saving a PDF file does
not make a lot of sense in that environment either. As such, this patch
conditionalizes inclusion of those controls behind a check that we are
not in recoveryOS.

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(isInRecoveryOS):

Canonical link: <a href="https://commits.webkit.org/292908@main">https://commits.webkit.org/292908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3c8d1bdc9f04f0813a59bce06ce4f90e4b2a74c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74144 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31332 "Found 1 new test failure: workers/worker-to-worker.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54484 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12795 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24401 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17788 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/abrupt-completion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83187 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82604 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17947 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29532 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->