### PR TITLE
AX: AXProperty::RolePlatformString is unnecessarily cached for every single object

### DIFF
--- a/LayoutTests/accessibility/display-contents/element-roles-expected.txt
+++ b/LayoutTests/accessibility/display-contents/element-roles-expected.txt
@@ -92,7 +92,7 @@ This test ensures elements with CSS display: contents have the correct role.
     AXSubrole: AXInsertStyleGroup
 
 <label class="testcase" id="label"></label>
-    AXRole: AXGroup
+    AXRole: AXStaticText
 
 <main class="testcase" id="main"></main>
     AXRole: AXGroup

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,5 +1,5 @@
 PAL/pal/spi/mac/NSGraphicsSPI.h
-accessibility/mac/AccessibilityObjectMac.mm
+accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 page/EventHandler.h
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1056,6 +1056,8 @@ public:
     void appendRadioButtonDescendants(AXCoreObject&, AccessibilityChildrenVector&) const;
     virtual AccessibilityChildrenVector radioButtonGroup() const = 0;
 
+    virtual bool containsOnlyStaticText() const;
+
     bool hasPopup() const;
     bool selfOrAncestorLinkHasPopup() const;
     virtual String explicitPopupValue() const = 0;
@@ -1171,10 +1173,14 @@ public:
     virtual SRGBA<uint8_t> colorValue() const = 0;
 
     AccessibilityRole roleValue() const { return m_role; }
+#if PLATFORM(MAC)
     // Non-localized string associated with the object role.
-    virtual String rolePlatformString() const = 0;
+    String rolePlatformString();
+#else
+    String rolePlatformString() { return { }; }
+#endif // PLATFORM(MAC)
     // Localized string that describes the object's role.
-    virtual String roleDescription() const = 0;
+    virtual String roleDescription() = 0;
     // Localized string that describes ARIA landmark roles.
     String ariaLandmarkRoleDescription() const;
     // Non-localized string associated with the object's subrole.
@@ -1420,6 +1426,7 @@ public:
     virtual bool isMathTableCell() const = 0;
     virtual bool isMathMultiscript() const = 0;
     virtual bool isMathToken() const = 0;
+    virtual bool isAnonymousMathOperator() const = 0;
 
     // Root components.
     virtual std::optional<AccessibilityChildrenVector> mathRadicand() = 0;
@@ -1505,7 +1512,7 @@ public:
     virtual Vector<RetainPtr<id>> modelElementChildren() = 0;
 #endif
 
-    String infoStringForTesting() const;
+    String infoStringForTesting();
 
 protected:
     AXCoreObject() = delete;
@@ -1863,6 +1870,12 @@ template<typename T, typename U> inline T retrieveAutoreleasedValueFromMainThrea
 #endif
 
 bool inRenderTreeOrStyleUpdate(const Document&);
+
+using PlatformRoleMap = UncheckedKeyHashMap<AccessibilityRole, String, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
+
+void initializeRoleMap();
+PlatformRoleMap createPlatformRoleMap();
+String roleToPlatformString(AccessibilityRole);
 
 } // namespace Accessibility
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -843,6 +843,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::IsARIATreeGridRow:
         stream << "IsARIATreeGridRow";
         break;
+    case AXProperty::IsAnonymousMathOperator:
+        stream << "IsAnonymousMathOperator";
+        break;
     case AXProperty::IsAttachment:
         stream << "IsAttachment";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -792,7 +792,7 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
 
     bool isAnonymous = false;
 #if USE(ATSPI)
-    // This branch is only necessary because ATSPI walks the render tree rather than the DOM to build the accessiblity tree.
+    // This branch is only necessary because ATSPI walks the render tree rather than the DOM to build the accessibility tree.
     // FIXME: Consider removing this with https://bugs.webkit.org/show_bug.cgi?id=282117.
     isAnonymous = renderer.isAnonymous();
 #endif

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -71,7 +71,7 @@ HTMLAttachmentElement* AccessibilityAttachment::attachmentElement() const
     return dynamicDowncast<HTMLAttachmentElement>(node());
 }
     
-String AccessibilityAttachment::roleDescription() const
+String AccessibilityAttachment::roleDescription()
 {
     return AXAttachmentRoleText();
 }

--- a/Source/WebCore/accessibility/AccessibilityAttachment.h
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.h
@@ -48,7 +48,7 @@ private:
 
     bool isAttachmentElement() const final { return true; }
 
-    String roleDescription() const final;
+    String roleDescription() final;
     float valueForRange() const final;
     bool computeIsIgnored() const final;
     void accessibilityText(Vector<AccessibilityText>&) const final;

--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -37,7 +37,7 @@ public:
     static Ref<AccessibilityLabel> create(AXID, RenderObject&);
     virtual ~AccessibilityLabel();
 
-    bool containsOnlyStaticText() const;
+    bool containsOnlyStaticText() const final;
 private:
     explicit AccessibilityLabel(AXID, RenderObject&);
     bool computeIsIgnored() const final { return isIgnoredByDefault(); }

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -165,11 +165,6 @@ bool AccessibilityMathMLElement::isMathOperator() const
     return m_renderer && m_renderer->isRenderMathMLOperator();
 }
 
-bool AccessibilityMathMLElement::isAnonymousMathOperator() const
-{
-    return m_isAnonymousOperator;
-}
-
 bool AccessibilityMathMLElement::isMathFenceOperator() const
 {
     auto* mathMLOperator = dynamicDowncast<RenderMathMLOperator>(renderer());

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -100,7 +100,7 @@ private:
     String mathFencedOpenString() const final;
     String mathFencedCloseString() const final;
     int mathLineThickness() const final;
-    bool isAnonymousMathOperator() const final;
+    bool isAnonymousMathOperator() const final { return m_isAnonymousOperator; }
 
     // Multiscripts components.
     void mathPrescripts(AccessibilityMathMultiscriptPairs&) final;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -703,13 +703,10 @@ bool AccessibilityNodeObject::computeIsIgnored() const
     return role == AccessibilityRole::Ignored || role == AccessibilityRole::Unknown;
 }
 
-bool AccessibilityNodeObject::canvasHasFallbackContent() const
+bool AccessibilityNodeObject::hasElementDescendant() const
 {
-    RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(node());
-    // If it has any children that are elements, we'll assume it might be fallback
-    // content. If it has no children or its only children are not elements
-    // (e.g. just text nodes), it doesn't have fallback content.
-    return canvasElement && childrenOfType<Element>(*canvasElement).first();
+    RefPtr element = dynamicDowncast<Element>(node());
+    return element && childrenOfType<Element>(*element).first();
 }
 
 bool AccessibilityNodeObject::isNativeTextControl() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -46,7 +46,7 @@ public:
 
     void init() override;
 
-    bool canvasHasFallbackContent() const final;
+    bool hasElementDescendant() const final;
 
     bool isBusy() const final;
     bool isDetached() const override { return !m_node; }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2790,12 +2790,7 @@ SRGBA<uint8_t> AccessibilityObject::colorValue() const
 }
 
 #if !PLATFORM(MAC)
-String AccessibilityObject::rolePlatformString() const
-{
-    return Accessibility::roleToPlatformString(roleValue());
-}
-
-String AccessibilityObject::rolePlatformDescription() const
+String AccessibilityObject::rolePlatformDescription()
 {
     // FIXME: implement in other platforms.
     return String();
@@ -2828,7 +2823,7 @@ bool AccessibilityObject::supportsARIARoleDescription() const
     }
 }
 
-String AccessibilityObject::roleDescription() const
+String AccessibilityObject::roleDescription()
 {
     // aria-roledescription takes precedence over any other rule.
     if (supportsARIARoleDescription()) {
@@ -4220,20 +4215,5 @@ AccessibilityObject* AccessibilityObject::containingWebArea() const
     RefPtr root = cache ? dynamicDowncast<AccessibilityScrollView>(cache->getOrCreate(frameView.get())) : nullptr;
     return root ? root->webAreaObject() : nullptr;
 }
-
-namespace Accessibility {
-
-#if !PLATFORM(MAC) && !USE(ATSPI)
-// FIXME: implement in other platforms.
-PlatformRoleMap createPlatformRoleMap() { return PlatformRoleMap(); }
-#endif
-
-String roleToPlatformString(AccessibilityRole role)
-{
-    static NeverDestroyed<PlatformRoleMap> roleMap = createPlatformRoleMap();
-    return roleMap->get(enumToUnderlyingType(role));
-}
-
-} // namespace Accessibility
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -286,7 +286,7 @@ public:
     bool supportsChecked() const final;
     bool supportsRowCountChange() const;
     AccessibilitySortDirection sortDirection() const final;
-    virtual bool canvasHasFallbackContent() const { return false; }
+    virtual bool hasElementDescendant() const { return false; }
     String identifierAttribute() const final;
     String linkRelValue() const final;
     Vector<String> classList() const final;
@@ -432,8 +432,7 @@ public:
     SRGBA<uint8_t> colorValue() const override;
 
     virtual AccessibilityRole determineAccessibilityRole() = 0;
-    String rolePlatformString() const final;
-    String roleDescription() const override;
+    String roleDescription() override;
     String subrolePlatformString() const final;
 
     AXObjectCache* axObjectCache() const override;
@@ -711,7 +710,7 @@ public:
     String mathFencedOpenString() const override { return String(); }
     String mathFencedCloseString() const override { return String(); }
     int mathLineThickness() const override { return 0; }
-    virtual bool isAnonymousMathOperator() const { return false; }
+    bool isAnonymousMathOperator() const override { return false; }
 
     // Multiscripts components.
     void mathPrescripts(AccessibilityMathMultiscriptPairs&) override { }
@@ -900,7 +899,7 @@ protected:
 
     virtual bool shouldIgnoreAttributeRole() const { return false; }
     virtual AccessibilityRole buttonRoleType() const;
-    String rolePlatformDescription() const;
+    String rolePlatformDescription();
     bool dispatchTouchEvent();
 
     static bool isARIAInput(AccessibilityRole);
@@ -995,11 +994,6 @@ inline bool AccessibilityObject::hasAttributedText() const
 AccessibilityObject* firstAccessibleObjectFromNode(const Node*, NOESCAPE const Function<bool(const AccessibilityObject&)>& isAccessible);
 
 namespace Accessibility {
-
-using PlatformRoleMap = UncheckedKeyHashMap<AccessibilityRole, String, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
-
-PlatformRoleMap createPlatformRoleMap();
-String roleToPlatformString(AccessibilityRole);
 
 #if PLATFORM(IOS_FAMILY)
 WEBCORE_EXPORT RetainPtr<NSData> newAccessibilityRemoteToken(NSString *);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1279,8 +1279,13 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         return !blockFlow->hasLines() && !clickableSelfOrAncestor();
 
     if (isCanvas()) {
-        if (canvasHasFallbackContent())
+        if (hasElementDescendant()) {
+            // Don't ignore canvases with potential fallback content, indicated by
+            // having at least one element descendant. If it has no children or its
+            // only children are not elements (e.g. just text nodes), it doesn't have
+            // fallback content.
             return false;
+        }
 
         if (WeakPtr canvasBox = dynamicDowncast<RenderBox>(*m_renderer)) {
             if (canvasBox->height() <= 1 || canvasBox->width() <= 1)

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -290,6 +290,34 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
+String AXCoreObject::rolePlatformString()
+{
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    if (isAttachment())
+        return [[wrapper() attachmentView] accessibilityAttributeValue:NSAccessibilityRoleAttribute];
+
+    if (isRemoteFrame())
+        return [remoteFramePlatformElement().get() accessibilityAttributeValue:NSAccessibilityRoleAttribute];
+ALLOW_DEPRECATED_DECLARATIONS_END
+
+    auto role = roleValue();
+    if (role == AccessibilityRole::Label) {
+        // Labels that only contain static text should just be mapped to static text.
+        if (containsOnlyStaticText())
+            role = AccessibilityRole::StaticText;
+    } else if (isAnonymousMathOperator()) {
+        // The mfenced element creates anonymous RenderMathMLOperators with no RenderText
+        // descendants. These anonymous renderers are the only accessible objects
+        // containing the operator.
+        role = AccessibilityRole::StaticText;
+    } else if (role == AccessibilityRole::Canvas && firstUnignoredChild() && !containsOnlyStaticText()) {
+        // If this is a canvas with fallback content (one or more non-text thing), re-map to group.
+        role = AccessibilityRole::Group;
+    }
+
+    return Accessibility::roleToPlatformString(role);
+}
+
 bool AXCoreObject::isEmptyGroup()
 {
 #if ENABLE(MODEL_ELEMENT)
@@ -319,6 +347,155 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::sortedDescendants(size_t
     }
     return results;
 }
+
+namespace Accessibility {
+
+PlatformRoleMap createPlatformRoleMap()
+{
+    struct RoleEntry {
+        AccessibilityRole value;
+        NSString *string;
+    };
+    static const RoleEntry roles[] = {
+        { AccessibilityRole::Unknown, NSAccessibilityUnknownRole },
+        { AccessibilityRole::Button, NSAccessibilityButtonRole },
+        { AccessibilityRole::RadioButton, NSAccessibilityRadioButtonRole },
+        { AccessibilityRole::Checkbox, NSAccessibilityCheckBoxRole },
+        { AccessibilityRole::Slider, NSAccessibilitySliderRole },
+        { AccessibilityRole::TabGroup, NSAccessibilityTabGroupRole },
+        { AccessibilityRole::TextField, NSAccessibilityTextFieldRole },
+        { AccessibilityRole::StaticText, NSAccessibilityStaticTextRole },
+        { AccessibilityRole::TextArea, NSAccessibilityTextAreaRole },
+        { AccessibilityRole::ScrollArea, NSAccessibilityScrollAreaRole },
+        { AccessibilityRole::PopUpButton, NSAccessibilityPopUpButtonRole },
+        { AccessibilityRole::Table, NSAccessibilityTableRole },
+        { AccessibilityRole::Application, NSAccessibilityApplicationRole },
+        { AccessibilityRole::Group, NSAccessibilityGroupRole },
+        { AccessibilityRole::TextGroup, NSAccessibilityGroupRole },
+        { AccessibilityRole::RadioGroup, NSAccessibilityRadioGroupRole },
+        { AccessibilityRole::List, NSAccessibilityListRole },
+        { AccessibilityRole::Directory, NSAccessibilityListRole },
+        { AccessibilityRole::ScrollBar, NSAccessibilityScrollBarRole },
+        { AccessibilityRole::Image, NSAccessibilityImageRole },
+        { AccessibilityRole::MenuBar, NSAccessibilityMenuBarRole },
+        { AccessibilityRole::Menu, NSAccessibilityMenuRole },
+        { AccessibilityRole::MenuItem, NSAccessibilityMenuItemRole },
+        { AccessibilityRole::MenuItemCheckbox, NSAccessibilityMenuItemRole },
+        { AccessibilityRole::MenuItemRadio, NSAccessibilityMenuItemRole },
+        { AccessibilityRole::Column, NSAccessibilityColumnRole },
+        { AccessibilityRole::Row, NSAccessibilityRowRole },
+        { AccessibilityRole::Toolbar, NSAccessibilityToolbarRole },
+        { AccessibilityRole::ProgressIndicator, NSAccessibilityProgressIndicatorRole },
+        { AccessibilityRole::Meter, NSAccessibilityLevelIndicatorRole },
+        { AccessibilityRole::ComboBox, NSAccessibilityComboBoxRole },
+        { AccessibilityRole::DateTime, NSAccessibilityDateTimeAreaRole },
+        { AccessibilityRole::Splitter, NSAccessibilitySplitterRole },
+        { AccessibilityRole::Code, NSAccessibilityGroupRole },
+        { AccessibilityRole::ColorWell, NSAccessibilityColorWellRole },
+        { AccessibilityRole::Link, NSAccessibilityLinkRole },
+        { AccessibilityRole::Grid, NSAccessibilityTableRole },
+        { AccessibilityRole::TreeGrid, NSAccessibilityTableRole },
+        { AccessibilityRole::WebCoreLink, NSAccessibilityLinkRole },
+        { AccessibilityRole::ImageMapLink, NSAccessibilityLinkRole },
+        { AccessibilityRole::ImageMap, NSAccessibilityImageMapRole },
+        { AccessibilityRole::ListMarker, NSAccessibilityListMarkerRole },
+        { AccessibilityRole::WebArea, NSAccessibilityWebAreaRole },
+        { AccessibilityRole::Heading, NSAccessibilityHeadingRole },
+        { AccessibilityRole::ListBox, NSAccessibilityListRole },
+        { AccessibilityRole::ListBoxOption, NSAccessibilityStaticTextRole },
+        { AccessibilityRole::Cell, NSAccessibilityCellRole },
+        { AccessibilityRole::GridCell, NSAccessibilityCellRole },
+        { AccessibilityRole::TableHeaderContainer, NSAccessibilityGroupRole },
+        { AccessibilityRole::ColumnHeader, NSAccessibilityCellRole },
+        { AccessibilityRole::RowHeader, NSAccessibilityCellRole },
+        { AccessibilityRole::Definition, NSAccessibilityGroupRole },
+        { AccessibilityRole::DescriptionListDetail, NSAccessibilityGroupRole },
+        { AccessibilityRole::DescriptionListTerm, NSAccessibilityGroupRole },
+        { AccessibilityRole::Term, NSAccessibilityGroupRole },
+        { AccessibilityRole::DescriptionList, NSAccessibilityListRole },
+        { AccessibilityRole::SliderThumb, NSAccessibilityValueIndicatorRole },
+        { AccessibilityRole::WebApplication, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkBanner, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkComplementary, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkDocRegion, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkContentInfo, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkMain, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkNavigation, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkRegion, NSAccessibilityGroupRole },
+        { AccessibilityRole::LandmarkSearch, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationAlert, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationAlertDialog, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationDialog, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationLog, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationMarquee, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationStatus, NSAccessibilityGroupRole },
+        { AccessibilityRole::ApplicationTimer, NSAccessibilityGroupRole },
+        { AccessibilityRole::Document, NSAccessibilityGroupRole },
+        { AccessibilityRole::DocumentArticle, NSAccessibilityGroupRole },
+        { AccessibilityRole::DocumentMath, NSAccessibilityGroupRole },
+        { AccessibilityRole::DocumentNote, NSAccessibilityGroupRole },
+        { AccessibilityRole::Emphasis, NSAccessibilityGroupRole },
+        { AccessibilityRole::UserInterfaceTooltip, NSAccessibilityGroupRole },
+        { AccessibilityRole::Tab, NSAccessibilityRadioButtonRole },
+        { AccessibilityRole::TabList, NSAccessibilityTabGroupRole },
+        { AccessibilityRole::TabPanel, NSAccessibilityGroupRole },
+        { AccessibilityRole::Tree, NSAccessibilityOutlineRole },
+        { AccessibilityRole::TreeItem, NSAccessibilityRowRole },
+        { AccessibilityRole::ListItem, NSAccessibilityGroupRole },
+        { AccessibilityRole::Paragraph, NSAccessibilityGroupRole },
+        { AccessibilityRole::Label, NSAccessibilityGroupRole },
+        { AccessibilityRole::Form, NSAccessibilityGroupRole },
+        { AccessibilityRole::Generic, NSAccessibilityGroupRole },
+        { AccessibilityRole::SpinButton, NSAccessibilityIncrementorRole },
+        { AccessibilityRole::SpinButtonPart, NSAccessibilityIncrementorArrowRole },
+        { AccessibilityRole::Footer, NSAccessibilityGroupRole },
+        { AccessibilityRole::ToggleButton, NSAccessibilityCheckBoxRole },
+        { AccessibilityRole::Canvas, NSAccessibilityImageRole },
+        { AccessibilityRole::SVGRoot, NSAccessibilityGroupRole },
+        { AccessibilityRole::Legend, NSAccessibilityGroupRole },
+        { AccessibilityRole::MathElement, NSAccessibilityGroupRole },
+        { AccessibilityRole::Audio, NSAccessibilityGroupRole },
+        { AccessibilityRole::Video, NSAccessibilityGroupRole },
+        { AccessibilityRole::HorizontalRule, NSAccessibilitySplitterRole },
+        { AccessibilityRole::Blockquote, NSAccessibilityGroupRole },
+        { AccessibilityRole::Switch, NSAccessibilityCheckBoxRole },
+        { AccessibilityRole::SearchField, NSAccessibilityTextFieldRole },
+        { AccessibilityRole::Pre, NSAccessibilityGroupRole },
+        { AccessibilityRole::RubyInline, NSAccessibilityGroupRole },
+        { AccessibilityRole::RubyText, NSAccessibilityGroupRole },
+        { AccessibilityRole::Details, NSAccessibilityGroupRole },
+        { AccessibilityRole::Summary, NSAccessibilityDisclosureTriangleRole },
+        { AccessibilityRole::SVGTextPath, NSAccessibilityGroupRole },
+        { AccessibilityRole::SVGText, NSAccessibilityGroupRole },
+        { AccessibilityRole::SVGTSpan, NSAccessibilityGroupRole },
+        { AccessibilityRole::Inline, NSAccessibilityGroupRole },
+        { AccessibilityRole::Mark, NSAccessibilityGroupRole },
+        { AccessibilityRole::Time, NSAccessibilityGroupRole },
+        { AccessibilityRole::Feed, NSAccessibilityGroupRole },
+        { AccessibilityRole::Figure, NSAccessibilityGroupRole },
+        { AccessibilityRole::Footnote, NSAccessibilityGroupRole },
+        { AccessibilityRole::GraphicsDocument, NSAccessibilityGroupRole },
+        { AccessibilityRole::GraphicsObject, NSAccessibilityGroupRole },
+        { AccessibilityRole::GraphicsSymbol, NSAccessibilityImageRole },
+        { AccessibilityRole::Caption, NSAccessibilityGroupRole },
+        { AccessibilityRole::Deletion, NSAccessibilityGroupRole },
+        { AccessibilityRole::Insertion, NSAccessibilityGroupRole },
+        { AccessibilityRole::Strong, NSAccessibilityGroupRole },
+        { AccessibilityRole::Subscript, NSAccessibilityGroupRole },
+        { AccessibilityRole::Superscript, NSAccessibilityGroupRole },
+        { AccessibilityRole::Model, NSAccessibilityGroupRole },
+        { AccessibilityRole::Suggestion, NSAccessibilityGroupRole },
+        { AccessibilityRole::RemoteFrame, NSAccessibilityGroupRole },
+    };
+    PlatformRoleMap roleMap;
+    for (auto& role : roles)
+        roleMap.add(static_cast<unsigned>(role.value), role.string);
+    return roleMap;
+}
+
+} // namespace Accessibility
+
+
 #endif // PLATFORM(MAC)
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -183,7 +183,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::InsideLink, object.insideLink());
     setProperty(AXProperty::IsValueAutofillAvailable, object.isValueAutofillAvailable());
     setProperty(AXProperty::RoleDescription, object.roleDescription().isolatedCopy());
-    setProperty(AXProperty::RolePlatformString, object.rolePlatformString().isolatedCopy());
     setProperty(AXProperty::SubrolePlatformString, object.subrolePlatformString().isolatedCopy());
     setProperty(AXProperty::CanSetFocusAttribute, object.canSetFocusAttribute());
     setProperty(AXProperty::CanSetValueAttribute, object.canSetValueAttribute());
@@ -383,6 +382,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::MathFencedOpenString, object.mathFencedOpenString().isolatedCopy());
         setProperty(AXProperty::MathFencedCloseString, object.mathFencedCloseString().isolatedCopy());
         setProperty(AXProperty::MathLineThickness, object.mathLineThickness());
+        setProperty(AXProperty::IsAnonymousMathOperator, object.isAnonymousMathOperator());
 
         bool isMathRoot = object.isMathRoot();
         setProperty(AXProperty::IsMathRoot, isMathRoot);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -290,8 +290,7 @@ private:
     String expandedTextValue() const final { return stringAttributeValue(AXProperty::ExpandedTextValue); }
     bool supportsExpandedTextValue() const final { return boolAttributeValue(AXProperty::SupportsExpandedTextValue); }
     SRGBA<uint8_t> colorValue() const final;
-    String rolePlatformString() const final { return stringAttributeValue(AXProperty::RolePlatformString); }
-    String roleDescription() const final { return stringAttributeValue(AXProperty::RoleDescription); }
+    String roleDescription() final { return stringAttributeValue(AXProperty::RoleDescription); }
     String subrolePlatformString() const final { return stringAttributeValue(AXProperty::SubrolePlatformString); }
     LayoutRect elementRect() const final;
     IntPoint clickPoint() final;
@@ -322,6 +321,7 @@ private:
     bool isMathTableCell() const final { return boolAttributeValue(AXProperty::IsMathTableCell); }
     bool isMathMultiscript() const final { return boolAttributeValue(AXProperty::IsMathMultiscript); }
     bool isMathToken() const final { return boolAttributeValue(AXProperty::IsMathToken); }
+    bool isAnonymousMathOperator() const final { return boolAttributeValue(AXProperty::IsAnonymousMathOperator); }
     std::optional<AccessibilityChildrenVector> mathRadicand() final;
     AXIsolatedObject* mathRootIndexObject() final { return objectAttributeValue(AXProperty::MathRootIndexObject); }
     AXIsolatedObject* mathUnderObject() final { return objectAttributeValue(AXProperty::MathUnderObject); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -160,6 +160,7 @@ enum class AXProperty : uint16_t {
     InsideLink,
     IsGrabbed,
     IsARIATreeGridRow,
+    IsAnonymousMathOperator,
     IsAttachment,
     IsBusy,
     IsChecked,

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -718,6 +718,11 @@ void AXObjectCache::initializeAXThreadIfNeeded()
         return;
 
     if (_AXSIsolatedTreeModeFunctionIsAvailable() && _AXSIsolatedTreeMode_Soft() == AXSIsolatedTreeModeSecondaryThread) {
+        // Initialize the role map before the accessibility thread starts so that it's safe for both threads
+        // to use (the only thing that needs to be thread-safe about it is initialization since it's not modified
+        // after creation and is never destroyed).
+        initializeRoleMap();
+
         _AXUIElementUseSecondaryAXThread(true);
         axThreadInitialized = true;
     }


### PR DESCRIPTION
#### 6ef292c6821de1aefe4efc2d98e1f469e80a11e6
<pre>
AX: AXProperty::RolePlatformString is unnecessarily cached for every single object
<a href="https://bugs.webkit.org/show_bug.cgi?id=290661">https://bugs.webkit.org/show_bug.cgi?id=290661</a>
<a href="https://rdar.apple.com/148135147">rdar://148135147</a>

Reviewed by Chris Fleizach.

With this commit, we move computation of AXCoreObject::rolePlatformStrign() off the main-thread, allowing us to remove
AXProperty::RolePlatformString, which was cached for every single object. To accomplish this, we need to:

  - Cache a new, very rare, property: AXProperty::IsAnonymousMathOperator

  - Add methods to determine whether an object contains only static text, needed to determine the role platform string
    for canvases and labels

  - Make the PlatfomrRoleMap thread-safe by initializing it before the accessibility thread is started. This is the only
    thing that is required thread-safety wise, as the map is not modified after creation, and never destroyed.

Removing this property saves ~27mb of memory on <a href="http://html.spec.whatwg.org.">http://html.spec.whatwg.org.</a>

(567769 objects * 1 fewer property per object * 48 bytes (sizeof(AXPropertyValueVariant)))

* LayoutTests/accessibility/display-contents/element-roles-expected.txt:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::containsOnlyStaticText const):
(WebCore::AXCoreObject::infoStringForTesting):
(WebCore::Accessibility::createPlatformRoleMap):
(WebCore::Accessibility::initializeRoleMap):
(WebCore::Accessibility::roleToPlatformString):
(WebCore::AXCoreObject::infoStringForTesting const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::roleDescription):
(WebCore::AccessibilityAttachment::roleDescription const): Deleted.
* Source/WebCore/accessibility/AccessibilityAttachment.h:
* Source/WebCore/accessibility/AccessibilityLabel.h:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::isAnonymousMathOperator const): Deleted.
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::hasElementDescendant const):
(WebCore::AccessibilityNodeObject::canvasHasFallbackContent const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::rolePlatformString):
(WebCore::AccessibilityObject::rolePlatformDescription):
(WebCore::AccessibilityObject::roleDescription):
(WebCore::AccessibilityObject::rolePlatformString const): Deleted.
(WebCore::AccessibilityObject::rolePlatformDescription const): Deleted.
(WebCore::AccessibilityObject::roleDescription const): Deleted.
(WebCore::Accessibility::createPlatformRoleMap): Deleted.
(WebCore::Accessibility::roleToPlatformString): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::hasElementDescendant const):
(WebCore::AccessibilityObject::canvasHasFallbackContent const): Deleted.
(WebCore::AccessibilityObject::isAnonymousMathOperator const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::rolePlatformString):
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::initializeAXThreadIfNeeded):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::rolePlatformDescription):
(WebCore::AccessibilityObject::rolePlatformString const): Deleted.
(WebCore::AccessibilityObject::rolePlatformDescription const): Deleted.
(WebCore::Accessibility::createPlatformRoleMap): Deleted.

Canonical link: <a href="https://commits.webkit.org/292917@main">https://commits.webkit.org/292917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4af029793d651a4a52a8b20a520828415a3ffc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74207 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31390 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24481 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17849 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82674 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18029 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29611 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->