### PR TITLE
[Page Color Sampler] Avoid detection/sampling unless fixed-position layers have been repainted or repositioned

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -402,6 +402,8 @@ public:
     virtual bool shouldPaintEntireContents() const { return false; }
     virtual bool hasStablePageScaleFactor() const { return true; }
 
+    virtual void setNeedsFixedContainerEdgesUpdate() { }
+
     // Allows ports to customize the type of graphics layers created by this page.
     virtual GraphicsLayerFactory* graphicsLayerFactory() const { return nullptr; }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1065,6 +1065,9 @@ void LocalFrameView::obscuredContentInsetsDidChange(const FloatBoxExtent& newObs
         tiledBacking->setObscuredContentInsets(newObscuredContentInsets);
 
     setCurrentScrollType(oldScrollType);
+
+    if (RefPtr page = m_frame->page())
+        page->chrome().client().setNeedsFixedContainerEdgesUpdate();
 }
 
 void LocalFrameView::topContentDirectionDidChange()

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5198,6 +5198,15 @@ void Page::setSceneIdentifier(String&& sceneIdentifier)
         document.sceneIdentifierDidChange();
     });
 }
+
+void Page::setObscuredInsets(const FloatBoxExtent& insets)
+{
+    if (m_obscuredInsets == insets)
+        return;
+
+    m_obscuredInsets = insets;
+    m_chrome->client().setNeedsFixedContainerEdgesUpdate();
+}
 #endif
 
 void Page::setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -635,7 +635,7 @@ public:
     void setEnclosedInScrollableAncestorView(bool f) { m_enclosedInScrollableAncestorView = f; }
 
     const FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
-    void setObscuredInsets(const FloatBoxExtent& insets) { m_obscuredInsets = insets; }
+    WEBCORE_EXPORT void setObscuredInsets(const FloatBoxExtent&);
 #endif
 
     const FloatBoxExtent& obscuredContentInsets() const { return m_obscuredContentInsets; }

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -603,6 +603,8 @@ public:
     bool rendererHasHDRContent() const;
 #endif
 
+    bool isViewportConstrained() const { return renderer().isFixedPositioned() || renderer().isStickilyPositioned(); }
+
     // FIXME: We should ASSERT(!m_hasSelfPaintingLayerDescendantDirty); here but we hit the same bugs as visible content above.
     // Part of the issue is with subtree relayout: we don't check if our ancestors have some descendant flags dirty, missing some updates.
     bool hasSelfPaintingLayerDescendant() const { return m_hasSelfPaintingLayerDescendant; }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1555,6 +1555,8 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
         primaryLayerPosition = { };
     }
 
+    setNeedsFixedContainerEdgesUpdateIfNeeded();
+
     if (m_contentsContainmentLayer) {
         m_contentsContainmentLayer->setPreserves3D(preserves3D);
         m_contentsContainmentLayer->setPosition(primaryLayerPosition);
@@ -3621,6 +3623,8 @@ void RenderLayerBacking::setContentsNeedDisplay(GraphicsLayer::ShouldClipToLayer
 
     if (m_scrolledContentsLayer && m_scrolledContentsLayer->drawsContent())
         m_scrolledContentsLayer->setNeedsDisplay();
+
+    setNeedsFixedContainerEdgesUpdateIfNeeded();
 }
 
 // r is in the coordinate space of the layer's render object
@@ -3672,6 +3676,8 @@ void RenderLayerBacking::setContentsNeedDisplayInRect(const LayoutRect& r, Graph
         layerDirtyRect.move(-m_scrolledContentsLayer->offsetFromRenderer() + toLayoutSize(scrollOffset) - m_subpixelOffsetFromRenderer);
         m_scrolledContentsLayer->setNeedsDisplayInRect(layerDirtyRect, shouldClip);
     }
+
+    setNeedsFixedContainerEdgesUpdateIfNeeded();
 }
 
 void RenderLayerBacking::paintIntoLayer(const GraphicsLayer* graphicsLayer, GraphicsContext& context,
@@ -4627,6 +4633,14 @@ void RenderLayerBacking::dumpProperties(const GraphicsLayer* layer, TextStream& 
         ts << remoteFrame->client().layerTreeAsText(ts.indent() + 1, options);
         ts << indent << ")\n"_s;
     }
+}
+
+void RenderLayerBacking::setNeedsFixedContainerEdgesUpdateIfNeeded()
+{
+    if (!m_owningLayer.isViewportConstrained())
+        return;
+
+    renderer().page().chrome().client().setNeedsFixedContainerEdgesUpdate();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -427,6 +427,8 @@ private:
 
     bool shouldSetContentsDisplayDelegate() const;
 
+    void setNeedsFixedContainerEdgesUpdateIfNeeded();
+
     RenderLayer& m_owningLayer;
     
     // A list other layers that paint into this backing store, later than m_owningLayer in paint order.

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -137,7 +137,7 @@ header: "RemoteLayerBackingStore.h"
     WebCore::Color m_themeColor;
     WebCore::Color m_pageExtendedBackgroundColor;
     WebCore::Color m_sampledPageTopColor;
-    WebCore::FixedContainerEdges m_fixedContainerEdges;
+    std::optional<WebCore::FixedContainerEdges> m_fixedContainerEdges;
 
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -258,8 +258,8 @@ public:
     void setAcceleratedTimelineTimeOrigin(Seconds timeOrigin) { m_acceleratedTimelineTimeOrigin = timeOrigin; }
 #endif
 
-    const WebCore::FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdges; }
-    void setFixedContainerEdges(WebCore::FixedContainerEdges&& edges) { m_fixedContainerEdges = WTFMove(edges); }
+    const std::optional<WebCore::FixedContainerEdges>& fixedContainerEdges() const { return m_fixedContainerEdges; }
+    void setFixedContainerEdges(WebCore::FixedContainerEdges&& edges) { m_fixedContainerEdges = { WTFMove(edges) }; }
 
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
@@ -288,7 +288,7 @@ private:
     WebCore::Color m_themeColor;
     WebCore::Color m_pageExtendedBackgroundColor;
     WebCore::Color m_sampledPageTopColor;
-    WebCore::FixedContainerEdges m_fixedContainerEdges;
+    std::optional<WebCore::FixedContainerEdges> m_fixedContainerEdges;
 
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID; // Only used for non-delegated scaling.

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -435,7 +435,8 @@ void PageClientImplCocoa::setFullScreenClientForTesting(std::unique_ptr<WebFullS
 
 void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction)
 {
-    [webView() _updateFixedContainerEdges:transaction.fixedContainerEdges()];
+    if (auto& edges = transaction.fixedContainerEdges())
+        [webView() _updateFixedContainerEdges:*edges];
     [webView() _updateScrollGeometryWithContentOffset:transaction.scrollPosition() contentSize:transaction.contentsSize()];
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2049,4 +2049,9 @@ WebCore::FrameDamageHistory* WebChromeClient::damageHistoryForTesting() const
 }
 #endif
 
+void WebChromeClient::setNeedsFixedContainerEdgesUpdate()
+{
+    m_page->setNeedsFixedContainerEdgesUpdate();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -568,6 +568,8 @@ private:
     WebCore::FrameDamageHistory* damageHistoryForTesting() const final;
 #endif
 
+    void setNeedsFixedContainerEdgesUpdate() final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5003,8 +5003,8 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setThemeColor(page->themeColor());
     layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
     layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
-    if (auto sides = sidesRequiringFixedContainerEdges())
-        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges(sides));
+    if (std::exchange(m_needsFixedContainerEdgesUpdate, false))
+        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges(sidesRequiringFixedContainerEdges()));
 
     layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());
     layerTransaction.setMinStableLayoutViewportOrigin(frameView->minStableLayoutViewportOrigin());
@@ -7961,6 +7961,8 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_hasActiveContextMenuInteraction = false;
 #endif
 
+    m_needsFixedContainerEdgesUpdate = true;
+
     flushDeferredDidReceiveMouseEvent();
 }
 
@@ -10129,6 +10131,8 @@ void WebPage::updateLastNodeBeforeWritingSuggestions(const KeyboardEvent& event)
 
 void WebPage::didAddOrRemoveViewportConstrainedObjects()
 {
+    m_needsFixedContainerEdgesUpdate = true;
+
 #if PLATFORM(IOS_FAMILY)
     scheduleLayoutViewportHeightExpansionUpdate();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1978,6 +1978,8 @@ public:
 
     bool shouldSendConsoleLogsToUIProcessForTesting() const { return m_shouldSendConsoleLogsToUIProcessForTesting; }
 
+    void setNeedsFixedContainerEdgesUpdate() { m_needsFixedContainerEdgesUpdate = true; }
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2946,6 +2948,7 @@ private:
     bool m_isSuspended { false };
     bool m_needsFontAttributes { false };
     bool m_firstFlushAfterCommit { false };
+    bool m_needsFixedContainerEdgesUpdate { true };
 #if PLATFORM(COCOA)
     WeakPtr<WebRemoteObjectRegistry> m_remoteObjectRegistry;
 #endif


### PR DESCRIPTION
#### 14b4507e839436794cc013d109cb22c0297528c6
<pre>
[Page Color Sampler] Avoid detection/sampling unless fixed-position layers have been repainted or repositioned
<a href="https://bugs.webkit.org/show_bug.cgi?id=290662">https://bugs.webkit.org/show_bug.cgi?id=290662</a>
<a href="https://rdar.apple.com/148135149">rdar://148135149</a>

Reviewed by Abrar Rahman Protyasha.

Refactor how fixed edge container detection/sampling works, such that it only engages after painting
or repositioning viewport-constrained layers. See below for more details.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::setNeedsFixedContainerEdgesUpdate):

Add a new chrome client hook to call out into `WebPage`, to set the new flag.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::obscuredContentInsetsDidChange):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setObscuredInsets):
* Source/WebCore/page/Page.h:
(WebCore::Page::setObscuredInsets): Deleted.

Set the `m_needsFixedContainerEdgesUpdate` flag when insets change.

* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::setContentsNeedDisplay):
(WebCore::RenderLayerBacking::setContentsNeedDisplayInRect):
(WebCore::RenderLayerBacking::setNeedsFixedContainerEdgesUpdateIfNeeded):

Compute and send `FixedContainerEdges` after the next layer tree commit, if geometry of any
fixed/sticky layers changes or the layer needs to be repainted.

* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:

Change `m_fixedContainerEdges` to be a `std::optional`; this allows us to only update the cached
UI-side `_fixedContainerEdges` in the case where the transaction contains something other than
`std::nullopt`.

(WebKit::RemoteLayerTreeTransaction::fixedContainerEdges const):
(WebKit::RemoteLayerTreeTransaction::setFixedContainerEdges):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didCommitLayerTree):

Only update `WKWebView` if the transaction contains `FixedContainerEdges`.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setNeedsFixedContainerEdgesUpdate):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Change this to only compute and send `FixedContainerEdges` if `m_needsFixedContainerEdgesUpdate` is
set.

(WebKit::WebPage::didCommitLoad):

Reset `m_needsFixedContainerEdgesUpdate` to its initial state.

(WebKit::WebPage::didAddOrRemoveViewportConstrainedObjects):

Set `m_needsFixedContainerEdgesUpdate` whenever the viewport-constrained objects set changes.

* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/292931@main">https://commits.webkit.org/292931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7305c997bd581fad54aac46405fb15a1d43c0da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74258 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13153 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88136 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6019 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24536 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17893 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83302 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->