### PR TITLE
Navigation to a different text fragment on a page leaves the first highlighted.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<style>
+  span {
+    background-color: rgb(255, 238, 190);
+  }
+</style>
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div>First</div>
+<div><span id="highlight">Second</span></div>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive is cleared when a second one is navigated to.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1100" />
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div>First</div>
+<div><span>Second</span></div>
+
+<script>
+  location.href = "#:~:text=First";
+  setTimeout(function () {
+        location.href = "#:~:text=Second";
+    }, 1);
+</script>
+</html>

--- a/LayoutTests/platform/gtk/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
+++ b/LayoutTests/platform/gtk/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div>First</div>
+<div><span id="highlight">Second</span></div>

--- a/LayoutTests/platform/mac-wk1/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
+++ b/LayoutTests/platform/mac-wk1/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<style>
+  span {
+    background-color: rgb(255, 238, 190);
+  }
+</style>
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div><span id="highlight">First</span></div>
+<div>Second</div>

--- a/LayoutTests/platform/win/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
+++ b/LayoutTests/platform/win/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div>First</div>
+<div><span id="highlight">Second</span></div>

--- a/LayoutTests/platform/wpe/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
+++ b/LayoutTests/platform/wpe/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - second navigation clears first highlight</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if only the 2nd word has a yellow background.</p>
+<div>First</div>
+<div><span id="highlight">Second</span></div>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2403,7 +2403,9 @@ bool LocalFrameView::scrollToFragment(const URL& url)
 {
     ASSERT(m_frame->document());
     Ref document = *m_frame->document();
-    
+
+    document->fragmentHighlightRegistry().clear();
+
     auto fragmentIdentifier = url.fragmentIdentifier();
     auto fragmentDirective = document->fragmentDirective();
     
@@ -2430,6 +2432,7 @@ bool LocalFrameView::scrollToFragment(const URL& url)
                 TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
                 if (m_frame->settings().scrollToTextFragmentIndicatorEnabled() && !m_frame->page()->isControlledByAutomation())
                     m_delayedTextFragmentIndicatorTimer.startOneShot(100_ms);
+
                 maintainScrollPositionAtScrollToTextFragmentRange(range);
                 return true;
             }


### PR DESCRIPTION
#### ed02d083824ec2e28478fb820124bcafa9e08997
<pre>
Navigation to a different text fragment on a page leaves the first highlighted.
<a href="https://rdar.apple.com/142968610">rdar://142968610</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290664">https://bugs.webkit.org/show_bug.cgi?id=290664</a>

Reviewed by Aditya Keerthi and BJ Burg.

The storage for the fragment highlights is never cleared.
This normally isn&apos;t an issue because it&apos;s not common
for pages to navigate internally using fragments, but if
they do, the highlights will never be cleared. Clear
the registry before filling it with the recently parsed
and located ranges.

* LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation.html: Added.
* LayoutTests/platform/gtk/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html: Added.
* LayoutTests/platform/mac-wk1/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html: Added.
* LayoutTests/platform/win/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html: Added.
* LayoutTests/platform/wpe/http/tests/scroll-to-text-fragment/clear-on-new-fragment-navigation-expected.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragment):

Canonical link: <a href="https://commits.webkit.org/293110@main">https://commits.webkit.org/293110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6552b8280e33040485c1dfec6dcf32b8f19c7d40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74510 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13462 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88441 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82960 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18554 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->