### PR TITLE
Address Safer CPP failure about CALayer forward declaration in RemoteSampleBufferDisplayLayer.cpp

### DIFF
--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -23,20 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RemoteSampleBufferDisplayLayer.h"
+#import "config.h"
+#import "RemoteSampleBufferDisplayLayer.h"
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
-#include "GPUConnectionToWebProcess.h"
-#include "IPCUtilities.h"
-#include "MessageSenderInlines.h"
-#include "RemoteVideoFrameObjectHeap.h"
-#include "SampleBufferDisplayLayerMessages.h"
-#include "SharedPreferencesForWebProcess.h"
-#include <WebCore/ImageTransferSessionVT.h>
-#include <WebCore/LocalSampleBufferDisplayLayer.h>
-#include <wtf/TZoneMallocInlines.h>
+#import "GPUConnectionToWebProcess.h"
+#import "IPCUtilities.h"
+#import "MessageSenderInlines.h"
+#import "RemoteVideoFrameObjectHeap.h"
+#import "SampleBufferDisplayLayerMessages.h"
+#import "SharedPreferencesForWebProcess.h"
+#import <QuartzCore/CALayer.h>
+#import <WebCore/ImageTransferSessionVT.h>
+#import <WebCore/LocalSampleBufferDisplayLayer.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,4 +1,3 @@
-GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/IPC/Connection.h
 Platform/IPC/Encoder.h

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -91,7 +91,6 @@ GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
 GPUProcess/media/RemoteSourceBufferProxy.cpp
 GPUProcess/media/RemoteTextTrackProxy.cpp
 GPUProcess/media/RemoteVideoTrackProxy.cpp
-GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
 
 ModelProcess/ModelProcess.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -83,6 +83,7 @@ GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
 GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
 GPUProcess/webrtc/LibWebRTCCodecsProxy.mm @no-unify
 GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
 
 ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
 ModelProcess/cocoa/ModelProcessCocoa.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5377,7 +5377,7 @@
 		41FBE824206DA79C000F0741 /* NetworkContentRuleListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkContentRuleListManager.cpp; sourceTree = "<group>"; };
 		41FCD6B323CDC60400C62567 /* SampleBufferDisplayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SampleBufferDisplayLayer.h; sourceTree = "<group>"; };
 		41FCD6B423CDCAC200C62567 /* RemoteSampleBufferDisplayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteSampleBufferDisplayLayer.h; sourceTree = "<group>"; };
-		41FCD6B523CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteSampleBufferDisplayLayer.cpp; sourceTree = "<group>"; };
+		41FCD6B523CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteSampleBufferDisplayLayer.mm; sourceTree = "<group>"; };
 		41FCD6B623CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteSampleBufferDisplayLayer.messages.in; sourceTree = "<group>"; };
 		41FCD6B723CDE53D00C62567 /* SampleBufferDisplayLayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SampleBufferDisplayLayer.cpp; sourceTree = "<group>"; };
 		41FCD6B823CDE53E00C62567 /* SampleBufferDisplayLayer.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SampleBufferDisplayLayer.messages.in; sourceTree = "<group>"; };
@@ -12497,9 +12497,9 @@
 				41C3B89126493B7B004ED4DE /* RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp */,
 				41C3B89026493B7B004ED4DE /* RemoteAudioMediaStreamTrackRendererInternalUnitManager.h */,
 				41C3B89426493B7C004ED4DE /* RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in */,
-				41FCD6B523CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.cpp */,
 				41FCD6B423CDCAC200C62567 /* RemoteSampleBufferDisplayLayer.h */,
 				41FCD6B623CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.messages.in */,
+				41FCD6B523CDE1C600C62567 /* RemoteSampleBufferDisplayLayer.mm */,
 				41FCD6BE23CE044000C62567 /* RemoteSampleBufferDisplayLayerManager.cpp */,
 				41FCD6BF23CE044000C62567 /* RemoteSampleBufferDisplayLayerManager.h */,
 				41FCD6BD23CE043F00C62567 /* RemoteSampleBufferDisplayLayerManager.messages.in */,


### PR DESCRIPTION
#### 75eb2a38d6ce4e59682773ff8aaa4118019647a5
<pre>
Address Safer CPP failure about CALayer forward declaration in RemoteSampleBufferDisplayLayer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290676">https://bugs.webkit.org/show_bug.cgi?id=290676</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm: Renamed from Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp.
(WebKit::RemoteSampleBufferDisplayLayer::create):
(WebKit::RemoteSampleBufferDisplayLayer::RemoteSampleBufferDisplayLayer):
(WebKit::m_remoteSampleBufferDisplayLayerManager):
(WebKit::RemoteSampleBufferDisplayLayer::protectedSampleBufferDisplayLayer const):
(WebKit::RemoteSampleBufferDisplayLayer::initialize):
(WebKit::RemoteSampleBufferDisplayLayer::setLogIdentifier):
(WebKit::RemoteSampleBufferDisplayLayer::~RemoteSampleBufferDisplayLayer):
(WebKit::RemoteSampleBufferDisplayLayer::bounds const):
(WebKit::RemoteSampleBufferDisplayLayer::updateDisplayMode):
(WebKit::RemoteSampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::RemoteSampleBufferDisplayLayer::flush):
(WebKit::RemoteSampleBufferDisplayLayer::flushAndRemoveImage):
(WebKit::RemoteSampleBufferDisplayLayer::play):
(WebKit::RemoteSampleBufferDisplayLayer::pause):
(WebKit::RemoteSampleBufferDisplayLayer::enqueueVideoFrame):
(WebKit::RemoteSampleBufferDisplayLayer::clearVideoFrames):
(WebKit::RemoteSampleBufferDisplayLayer::messageSenderConnection const):
(WebKit::RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail):
(WebKit::RemoteSampleBufferDisplayLayer::setSharedVideoFrameSemaphore):
(WebKit::RemoteSampleBufferDisplayLayer::setSharedVideoFrameMemory):
(WebKit::RemoteSampleBufferDisplayLayer::setShouldMaintainAspectRatio):
(WebKit::RemoteSampleBufferDisplayLayer::sharedPreferencesForWebProcess const):
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/292893@main">https://commits.webkit.org/292893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced407e1bfddbe0152654765978d65520bc2f402

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47884 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74164 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31351 "Found 1 new test failure: workers/worker-to-worker.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12825 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104463 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24434 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17812 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83209 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17979 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15730 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->