### PR TITLE
Web Inspector: Elements: show a badge for `<slot>` to quickly jump to the assigned node

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled-expected.txt
@@ -1,0 +1,30 @@
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.SlotFilled
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotFilled.Named.Empty
+PASS: Should not be filled.
+Changing slot of child...
+PASS: Should be filled.
+Adding child with slot...
+PASS: Should be filled.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotFilled.Named.Filled
+PASS: Should be filled.
+Removing first assigned node...
+PASS: Should be filled.
+Removing last assigned node...
+PASS: Should not be filled.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotFilled.Manual.Empty
+PASS: Should not be filled.
+Adding second child as assigned node...
+PASS: Should be filled.
+Adding first child as assigned node...
+PASS: Should be filled.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotFilled.Manual.Filled
+PASS: Should be filled.
+Removing first assigned node...
+PASS: Should be filled.
+Removing last assigned node...
+PASS: Should not be filled.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+customElements.define("test-element", class TestElement extends HTMLElement {
+    connectedCallback() {
+        let shadowRoot = this.attachShadow({
+            mode: "open",
+            slotAssignment: this.id.substring(0, this.id.indexOf("-")),
+        });
+
+        this._slotElement = shadowRoot.appendChild(document.createElement("slot"));
+        this._slotElement.name = "test-slot";
+    }
+
+    assign(...nodes) {
+        this._slotElement.assign(...nodes);
+    }
+});
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.SlotFilled");
+
+    function addTestCase({name, selector, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+
+                let containerNodeId = await documentNode.querySelector(selector);
+                let containerNode = WI.domManager.nodeForId(containerNodeId);
+                InspectorTest.assert(containerNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let slotNodeId = await containerNode.shadowRoots()[0].querySelector("slot");
+                let slotNode = WI.domManager.nodeForId(slotNodeId);
+                InspectorTest.assert(slotNode, `Should find <slot> inside DOM Node for selector '${selector}'.`);
+
+                await domNodeHandler(slotNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotFilled.Named.Empty",
+        selector: "#named-empty",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should not be filled.");
+
+            InspectorTest.log("Changing slot of child...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#named-empty-1").slot = "test-slot"`),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            let listener = domNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+
+            InspectorTest.log("Adding child with slot...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-empty").appendChild(document.querySelector("#named-empty-2"))`);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotFilled.Named.Filled",
+        selector: "#named-filled",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            let listener = domNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+
+            InspectorTest.log("Removing first assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-filled-1").remove()`);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.log("Removing last assigned node...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#named-filled-2").slot = "invalid-slot"`),
+            ]);
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should not be filled.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotFilled.Manual.Empty",
+        selector: "#manual-empty",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should not be filled.");
+
+            InspectorTest.log("Adding second child as assigned node...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(document.querySelector("#manual-empty-2"))`),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            let listener = domNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+
+            InspectorTest.log("Adding first child as assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(...document.querySelectorAll("#manual-empty > span"))`);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotFilled.Manual.Filled",
+        selector: "#manual-filled",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            let listener = domNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+
+            InspectorTest.log("Removing first assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign(document.querySelector("#manual-filled-2"))`);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should be filled.");
+
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.log("Removing last assigned node...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign()`),
+            ]);
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotFilled), "Should not be filled.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <test-element id="named-empty">
+        <span slot="invalid-slot" id="named-empty-1"></span>
+    </test-element>
+    <span slot="test-slot" id="named-empty-2"></span>
+
+    <test-element id="named-filled">
+        <span slot="test-slot" id="named-filled-1"></span>
+        <span slot="test-slot" id="named-filled-2"></span>
+    </test-element>
+
+    <test-element id="manual-empty">
+        <span slot="test-slot" id="manual-empty-1"></span>
+        <span slot="test-slot" id="manual-empty-2"></span>
+    </test-element>
+
+    <test-element id="manual-filled">
+        <span slot="invalid-slot" id="manual-filled-1"></span>
+        <span slot="invalid-slot" id="manual-filled-2"></span>
+    </test-element>
+
+    <script>
+        document.querySelector("#manual-filled").assign(...document.querySelectorAll("#manual-filled > span"));
+    </script>
+</body>
+</html>

--- a/LayoutTests/inspector/dom/requestAssignedNodes-expected.txt
+++ b/LayoutTests/inspector/dom/requestAssignedNodes-expected.txt
@@ -1,0 +1,38 @@
+
+== Running test suite: DOM.requestAssignedNodes
+-- Running test case: DOM.requestAssignedNodes.Named.Empty
+PASS: Should have assigned nodes: [].
+Changing slot of child...
+PASS: Should have assigned nodes: ["named-empty-1"].
+Adding child with slot...
+PASS: Should have assigned nodes: ["named-empty-1","named-empty-2"].
+
+-- Running test case: DOM.requestAssignedNodes.Named.Filled
+PASS: Should have assigned nodes: ["named-filled-1","named-filled-2"].
+Removing first assigned node...
+PASS: Should have assigned nodes: ["named-filled-2"].
+Removing last assigned node...
+PASS: Should have assigned nodes: [].
+
+-- Running test case: DOM.requestAssignedNodes.Manual.Empty
+PASS: Should have assigned nodes: [].
+Adding second child as assigned node...
+PASS: Should have assigned nodes: ["manual-empty-2"].
+Adding first child as assigned nodes...
+PASS: Should have assigned nodes: ["manual-empty-1","manual-empty-2"].
+
+-- Running test case: DOM.requestAssignedNodes.Manual.Filled
+PASS: Should have assigned nodes: ["manual-filled-1","manual-filled-2"].
+Removing first assigned node...
+PASS: Should have assigned nodes: ["manual-filled-2"].
+Removing last assigned node...
+PASS: Should have assigned nodes: [].
+
+-- Running test case: DOM.requestAssignedNodes.MissingNode
+PASS: Should produce an exception.
+Error: Missing node for given nodeId
+
+-- Running test case: DOM.requestAssignedNodes.WrongNode
+PASS: Should produce an exception.
+Error: Node for given nodeId is not a slot element
+

--- a/LayoutTests/inspector/dom/requestAssignedNodes.html
+++ b/LayoutTests/inspector/dom/requestAssignedNodes.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+customElements.define("test-element", class TestElement extends HTMLElement {
+    connectedCallback() {
+        let shadowRoot = this.attachShadow({
+            mode: "open",
+            slotAssignment: this.id.substring(0, this.id.indexOf("-")),
+        });
+
+        this._slotElement = shadowRoot.appendChild(document.createElement("slot"));
+        this._slotElement.name = "test-slot";
+    }
+
+    assign(...nodes) {
+        this._slotElement.assign(...nodes);
+    }
+});
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("DOM.requestAssignedNodes");
+
+    async function checkAssignedNodes(slotNode, expectedIDs) {
+        let assignedNodes = await slotNode.requestAssignedNodes();
+
+        InspectorTest.expectShallowEqual(assignedNodes.map((assignedNode) => assignedNode.getAttribute("id")), expectedIDs, `Should have assigned nodes: ${JSON.stringify(expectedIDs)}.`);
+    }
+
+    function addTestCase({name, selector, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+
+                let containerNodeId = await documentNode.querySelector(selector);
+                let containerNode = WI.domManager.nodeForId(containerNodeId);
+                InspectorTest.assert(containerNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let slotNodeId = await containerNode.shadowRoots()[0].querySelector("slot");
+                let slotNode = WI.domManager.nodeForId(slotNodeId);
+                InspectorTest.assert(slotNode, `Should find <slot> inside DOM Node for selector '${selector}'.`);
+
+                await domNodeHandler(slotNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "DOM.requestAssignedNodes.Named.Empty",
+        selector: "#named-empty",
+        async domNodeHandler(domNode) {
+            await checkAssignedNodes(domNode, []);
+
+            InspectorTest.log("Changing slot of child...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-empty-1").slot = "test-slot"`);
+            await checkAssignedNodes(domNode, ["named-empty-1"]);
+
+            InspectorTest.log("Adding child with slot...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-empty").appendChild(document.querySelector("#named-empty-2"))`);
+            await checkAssignedNodes(domNode, ["named-empty-1", "named-empty-2"]);
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedNodes.Named.Filled",
+        selector: "#named-filled",
+        async domNodeHandler(domNode) {
+            await checkAssignedNodes(domNode, ["named-filled-1", "named-filled-2"]);
+
+            InspectorTest.log("Removing first assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-filled-1").remove()`);
+            await checkAssignedNodes(domNode, ["named-filled-2"]);
+
+            InspectorTest.log("Removing last assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-filled-2").slot = "invalid-slot"`);
+            await checkAssignedNodes(domNode, []);
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedNodes.Manual.Empty",
+        selector: "#manual-empty",
+        async domNodeHandler(domNode) {
+            await checkAssignedNodes(domNode, []);
+
+            InspectorTest.log("Adding second child as assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(document.querySelector("#manual-empty-2"))`);
+            await checkAssignedNodes(domNode, ["manual-empty-2"]);
+
+            InspectorTest.log("Adding first child as assigned nodes...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(...document.querySelectorAll("#manual-empty > span"))`);
+            await checkAssignedNodes(domNode, ["manual-empty-1", "manual-empty-2"]);
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedNodes.Manual.Filled",
+        selector: "#manual-filled",
+        async domNodeHandler(domNode) {
+            await checkAssignedNodes(domNode, ["manual-filled-1", "manual-filled-2"]);
+
+            InspectorTest.log("Removing first assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign(document.querySelector("#manual-filled-2"))`);
+            await checkAssignedNodes(domNode, ["manual-filled-2"]);
+
+            InspectorTest.log("Removing last assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign()`);
+            await checkAssignedNodes(domNode, []);
+        },
+    });
+
+    suite.addTestCase({
+        name: "DOM.requestAssignedNodes.MissingNode",
+        async test() {
+            await InspectorTest.expectException(() => DOMAgent.requestAssignedNodes(9999999));
+        },
+    });
+
+    suite.addTestCase({
+        name: "DOM.requestAssignedNodes.WrongNode",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            await InspectorTest.expectException(() => documentNode.requestAssignedNodes());
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <test-element id="named-empty">
+        <span slot="invalid-slot" id="named-empty-1"></span>
+    </test-element>
+    <span slot="test-slot" id="named-empty-2"></span>
+
+    <test-element id="named-filled">
+        <span slot="test-slot" id="named-filled-1"></span>
+        <span slot="test-slot" id="named-filled-2"></span>
+    </test-element>
+
+    <test-element id="manual-empty">
+        <span slot="test-slot" id="manual-empty-1"></span>
+        <span slot="test-slot" id="manual-empty-2"></span>
+    </test-element>
+
+    <test-element id="manual-filled">
+        <span slot="invalid-slot" id="manual-filled-1"></span>
+        <span slot="invalid-slot" id="manual-filled-2"></span>
+    </test-element>
+
+    <script>
+        document.querySelector("#manual-filled").assign(...document.querySelectorAll("#manual-filled > span"));
+    </script>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -289,7 +289,8 @@
                 "scrollable",
                 "flex",
                 "grid",
-                "event"
+                "event",
+                "slot-filled"
             ],
             "description": "Relevant layout information about the node. Things not in this list are not important to Web Inspector."
         },

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -287,6 +287,16 @@
             ]
         },
         {
+            "name": "requestAssignedNodes",
+            "description": "Requests the list of assigned nodes for the <code>HTMLSlotElement</code> with the given id.",
+            "parameters": [
+                { "name": "slotElementId", "$ref": "NodeId" }
+            ],
+            "returns": [
+                { "name": "assignedNodeIds", "type": "array", "items": { "$ref": "NodeId" } }
+            ]
+        },
+        {
             "name": "querySelector",
             "description": "Executes <code>querySelector</code> on a given node.",
             "targetTypes": ["page"],

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -31,6 +31,7 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "HTMLNames.h"
+#include "InspectorInstrumentation.h"
 #include "MutationObserver.h"
 #include "ShadowRoot.h"
 #include "SlotAssignment.h"
@@ -218,10 +219,12 @@ void HTMLSlotElement::removeManuallyAssignedNode(Node& node)
 void HTMLSlotElement::enqueueSlotChangeEvent()
 {
     // https://dom.spec.whatwg.org/#signal-a-slot-change
-    if (m_inSignalSlotList)
-        return;
-    m_inSignalSlotList = true;
-    MutationObserver::enqueueSlotChangeEvent(*this);
+    if (!m_inSignalSlotList) {
+        m_inSignalSlotList = true;
+        MutationObserver::enqueueSlotChangeEvent(*this);
+    }
+
+    InspectorInstrumentation::didChangeAssignedNodes(*this);
 }
 
 void HTMLSlotElement::dispatchSlotChangeEvent()

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -266,6 +266,12 @@ void InspectorInstrumentation::willPopShadowRootImpl(InstrumentingAgents& instru
         domAgent->willPopShadowRoot(host, root);
 }
 
+void InspectorInstrumentation::didChangeAssignedNodesImpl(InstrumentingAgents& instrumentingAgents, Element& slotElement)
+{
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->didChangeAssignedNodes(slotElement);
+}
+
 void InspectorInstrumentation::didChangeCustomElementStateImpl(InstrumentingAgents& instrumentingAgents, Element& element)
 {
     if (auto* domAgent = instrumentingAgents.persistentDOMAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -139,6 +139,7 @@ public:
     static void activeStyleSheetsUpdated(Document&);
     static void didPushShadowRoot(Element& host, ShadowRoot&);
     static void willPopShadowRoot(Element& host, ShadowRoot&);
+    static void didChangeAssignedNodes(Element& slotElement);
     static void didChangeCustomElementState(Element&);
     static void pseudoElementCreated(Page*, PseudoElement&);
     static void pseudoElementDestroyed(Page*, PseudoElement&);
@@ -365,6 +366,7 @@ private:
     static void activeStyleSheetsUpdatedImpl(InstrumentingAgents&, Document&);
     static void didPushShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
     static void willPopShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
+    static void didChangeAssignedNodesImpl(InstrumentingAgents&, Element& slotElement);
     static void didChangeCustomElementStateImpl(InstrumentingAgents&, Element&);
     static void pseudoElementCreatedImpl(InstrumentingAgents&, PseudoElement&);
     static void pseudoElementDestroyedImpl(InstrumentingAgents&, PseudoElement&);
@@ -699,6 +701,13 @@ inline void InspectorInstrumentation::willPopShadowRoot(Element& host, ShadowRoo
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(host.document()))
         willPopShadowRootImpl(*agents, host, root);
+}
+
+inline void InspectorInstrumentation::didChangeAssignedNodes(Element& slotElement)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(slotElement.document()))
+        didChangeAssignedNodesImpl(*agents, slotElement);
 }
 
 inline void InspectorInstrumentation::didChangeCustomElementState(Element& element)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -129,6 +129,7 @@ public:
     void didChangeRendererForDOMNode(Node&);
     void didAddEventListener(EventTarget&);
     void willRemoveEventListener(EventTarget&);
+    void didChangeAssignedNodes(Element& slotElement);
 
     // InspectorDOMAgent hooks
     void didRemoveDOMNode(Node&, Inspector::Protocol::DOM::NodeId);
@@ -140,6 +141,7 @@ public:
         Grid = 1 << 2,
         Event = 1 << 3,
         Scrollable = 1 << 4,
+        SlotFilled = 1 << 5,
     };
     OptionSet<LayoutFlag> layoutFlagsForNode(Node&);
     RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> protocolLayoutFlagsForNode(Node&);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -115,6 +115,7 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> querySelectorAll(Inspector::Protocol::DOM::NodeId, const String& selector);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Node>> getDocument();
     Inspector::Protocol::ErrorStringOr<void> requestChildNodes(Inspector::Protocol::DOM::NodeId, std::optional<int>&& depth);
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestAssignedNodes(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<void> setAttributeValue(Inspector::Protocol::DOM::NodeId, const String& name, const String& value);
     Inspector::Protocol::ErrorStringOr<void> setAttributesAsText(Inspector::Protocol::DOM::NodeId, const String& text, const String& name);
     Inspector::Protocol::ErrorStringOr<void> removeAttribute(Inspector::Protocol::DOM::NodeId, const String& name);

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -218,6 +218,8 @@ localizedStrings["Assertion Failed: %s"] = "Assertion Failed: %s";
 /* Break (pause) when console.assert() fails */
 localizedStrings["Assertion Failures @ JavaScript Breakpoint"] = "Assertion Failures";
 localizedStrings["Assertive"] = "Assertive";
+/* Title for a badge applied to HTMLSlotElement that have assigned nodes. */
+localizedStrings["Assigned"] = "Assigned";
 localizedStrings["Associated Data"] = "Associated Data";
 localizedStrings["Attribute"] = "Attribute";
 /* A submenu item of 'Break On' that breaks (pauses) before DOM attribute is modified */
@@ -1598,6 +1600,8 @@ localizedStrings["Sizes"] = "Sizes";
 localizedStrings["Skip Network @ Local Override Popover Options"] = "Skip Network";
 /* Property value for `font-variant-numeric: slashed-zero`. */
 localizedStrings["Slashed Zeros @ Font Details Sidebar Property Value"] = "Slashed Zeros";
+/* Title for a badge applied to HTMLSlotElement that have assigned nodes or nodes that are assigned to HTMLSlotElement. */
+localizedStrings["Slot"] = "Slot";
 /* Property value for `font-variant-capitals: small-caps`. */
 localizedStrings["Small Capitals @ Font Details Sidebar Property Value"] = "Small Capitals";
 localizedStrings["Snapshot Comparison (%d and %d)"] = "Snapshot Comparison (%d and %d)";

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -811,6 +811,21 @@ WI.DOMNode = class DOMNode extends WI.Object
         target.DOMAgent.requestChildNodes(this.id, depth, mycallback.bind(this));
     }
 
+    async requestAssignedNodes()
+    {
+        let target = WI.assumingMainTarget();
+        let {assignedNodeIds} = await target.DOMAgent.requestAssignedNodes(this.id);
+
+        let assignedNodes = [];
+        for (let assignedNodeId of assignedNodeIds) {
+            let assignedNode = WI.domManager.nodeForId(assignedNodeId);
+            console.assert(assignedNode, this, assignedNodeId);
+            if (assignedNode)
+                assignedNodes.push(assignedNode);
+        }
+        return assignedNodes;
+    }
+
     getOuterHTML(callback)
     {
         console.assert(!this._destroyed, this);
@@ -1374,6 +1389,7 @@ WI.DOMNode.LayoutFlag = {
     Rendered: "rendered",
     Event: "event",
     Scrollable: "scrollable",
+    SlotFilled: "slot-filled",
 
     // These are mutually exclusive.
     Flex: "flex",

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -541,6 +541,14 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
                 WI.settings.enabledDOMTreeBadgeTypes.save();
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Scrollable));
         }
+
+        // COMPATIBILITY (iOS X.Y, macOS X.Y): `SlotFilled` value for `CSS.LayoutFlag` did not exist yet.
+        if (InspectorBackend.Enum.CSS?.LayoutFlag?.SlotFilled) {
+            contextMenu.appendCheckboxItem(WI.UIString("Slot", "Title for a badge applied to HTMLSlotElement that have assigned nodes or nodes that are assigned to HTMLSlotElement."), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.SlotFilled);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.SlotFilled));
+        }
     }
 
     _domTreeElementAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
@@ -48,7 +48,7 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
     color: var(--text-color);
 }
 
-.event-badge-popover-content {
+.event-badge-popover-content, .slot-filled-badge-popover-content {
     overflow: hidden;
 }
 
@@ -60,6 +60,23 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
 
 .event-badge-popover-content > .details-section.event-listeners .details-section {
     border-inline: 1px solid var(--border-color);
+}
+
+.slot-filled-badge-popover-content > table {
+    border-collapse: collapse;
+}
+
+.slot-filled-badge-popover-content > table > tr + tr > td {
+    padding-top: 2px;
+}
+
+.slot-filled-badge-popover-content > table > tr > td:first-child {
+    font-family: -webkit-system-font, sans-serif;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+    vertical-align: top;
+    color: var(--console-secondary-text-color);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
#### 4f88ca91386d7fc52b79472a0f22fd6823ba41fe
<pre>
Web Inspector: Elements: show a badge for `&lt;slot&gt;` to quickly jump to the assigned node
<a href="https://bugs.webkit.org/show_bug.cgi?id=290679">https://bugs.webkit.org/show_bug.cgi?id=290679</a>

Reviewed by BJ Burg.

It&apos;s not always obvious where the assigned node is for a `&lt;slot&gt;` (assuming it&apos;s even nearby in the DOM).
Having a way to quickly see (and jump to) any assigned DOM nodes will help developers more easily understand the content they&apos;re debugging.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::isSlotElementWithAssignedNodes): Added.
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
(WebCore::toProtocol):
(WebCore::InspectorCSSAgent::didChangeAssignedNodes): Added.
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeAssignedNodes): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeAssignedNodesImpl): Added.
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::enqueueSlotChangeEvent):
Introduce a new `LayoutFlag.SlotFilled` in order to (re)use the existing DOM node badging system.
This has the added benefit of debouncing changes, which is ideal since the frontend doesn&apos;t actually need the list of assigned nodes until the developer clicks on the &quot;Assigned&quot; badge.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::requestAssignedNodes): Added.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.async requestAssignedNodes): Added.
Add a way for the frontend to request the list of assigned nodes for a given `&lt;slot&gt;`

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._createBadge):
(WI.DOMTreeElement.prototype._createBadges):
(WI.DOMTreeElement.prototype.async _handleSlotFilledBadgeClicked): Added.
(WI.DOMTreeElement.prototype.didDismissPopover):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css:
(.event-badge-popover-content, .slot-filled-badge-popover-content): Renamed from `.event-badge-popover-content`.
(.slot-filled-badge-popover-content &gt; table): Added.
(.slot-filled-badge-popover-content &gt; table &gt; tr + tr &gt; td): Added.
(.slot-filled-badge-popover-content &gt; table &gt; tr &gt; td:first-child): Added.
Show an &quot;Assigned&quot; badge for `&lt;slot&gt;` that have assigned nodes.
Clicking it will either select the (single) assigned DOM node or show a `WI.Popover` containing a list of all assigned DOM nodes (if there&apos;s more than one).

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled.html: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotFilled-expected.txt: Added.
* LayoutTests/inspector/dom/requestAssignedNodes.html: Added.
* LayoutTests/inspector/dom/requestAssignedNodes-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/292996@main">https://commits.webkit.org/292996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06a3bac7f7d0af8279db8a25d339e8e6c29c5ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7495 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/102759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31575 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100656 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47624 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/90329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96275 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24733 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82863 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27422 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24694 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119901 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24516 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->