### PR TITLE
Remove more antique (in-process) layer hosting code

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -77,10 +77,6 @@
 #endif
 
 #if PLATFORM(COCOA)
-#define HAVE_OUT_OF_PROCESS_LAYER_HOSTING 1
-#endif
-
-#if PLATFORM(COCOA)
 #define HAVE_REMAP_JIT 1
 #endif
 
@@ -233,10 +229,6 @@
 
 #if OS(DARWIN) && __has_include(<mach/memory_entry.h>)
 #define HAVE_MACH_MEMORY_ENTRY 1
-#endif
-
-#if PLATFORM(MAC)
-#define HAVE_HOSTED_CORE_ANIMATION 1
 #endif
 
 #if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || OS(HAIKU) || OS(NETBSD) || OS(OPENBSD) || OS(LINUX) || OS(HURD) || OS(QNX)) && (CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(RISCV64)))

--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -123,7 +123,6 @@ typedef struct _CARenderContext CARenderContext;
 #if PLATFORM(MAC)
 @property uint64_t GPURegistryID;
 @property uint32_t commitPriority;
-@property BOOL colorMatchUntaggedContent;
 #endif
 @property (readonly) uint32_t contextId;
 @property (strong) CALayer *layer;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -476,7 +476,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 void GPUConnectionToWebProcess::createVisibilityPropagationContextForPage(WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, bool canShowWhileLocked)
 {
-    auto contextForVisibilityPropagation = LayerHostingContext::createForExternalHostingProcess({ canShowWhileLocked });
+    auto contextForVisibilityPropagation = LayerHostingContext::create({ canShowWhileLocked });
     RELEASE_LOG(Process, "GPUConnectionToWebProcess::createVisibilityPropagationContextForPage: pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", contextID=%u", pageProxyID.toUInt64(), pageID.toUInt64(), contextForVisibilityPropagation->contextID());
     gpuProcess().send(Messages::GPUProcessProxy::DidCreateContextForVisibilityPropagation(pageProxyID, pageID, contextForVisibilityPropagation->contextID()));
     m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTFMove(contextForVisibilityPropagation));

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -82,7 +82,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 #if PLATFORM(IOS_FAMILY)
         contextOptions.canShowWhileLocked = m_configuration.canShowWhileLocked;
 #endif
-        m_inlineLayerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
+        m_inlineLayerHostingContext = LayerHostingContext::create(contextOptions);
         if (m_configuration.videoLayerSize.isEmpty())
             m_configuration.videoLayerSize = enclosingIntRect(WebCore::FloatRect(layer.get().frame)).size();
         auto& size = m_configuration.videoLayerSize;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -80,7 +80,7 @@ void RemoteSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size
         if (!protectedThis || !didSucceed)
             return callback({ });
 
-        protectedThis->m_layerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
+        protectedThis->m_layerHostingContext = LayerHostingContext::create(contextOptions);
         protectedThis->m_layerHostingContext->setRootLayer(protectedThis->protectedSampleBufferDisplayLayer()->rootLayer());
         callback(protectedThis->m_layerHostingContext->contextID());
     });

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -112,7 +112,7 @@ void ModelConnectionToWebProcess::didClose(IPC::Connection& connection)
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 void ModelConnectionToWebProcess::createVisibilityPropagationContextForPage(WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, bool canShowWhileLocked)
 {
-    auto contextForVisibilityPropagation = LayerHostingContext::createForExternalHostingProcess({ canShowWhileLocked });
+    auto contextForVisibilityPropagation = LayerHostingContext::create({ canShowWhileLocked });
     RELEASE_LOG(Process, "ModelConnectionToWebProcess::createVisibilityPropagationContextForPage: pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", contextID=%u", pageProxyID.toUInt64(), pageID.toUInt64(), contextForVisibilityPropagation->contextID());
     modelProcess().send(Messages::ModelProcessProxy::DidCreateContextForVisibilityPropagation(pageProxyID, pageID, contextForVisibilityPropagation->contextID()));
     m_visibilityPropagationContexts.add(std::make_pair(pageProxyID, pageID), WTFMove(contextForVisibilityPropagation));

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -303,7 +303,7 @@ void ModelProcessModelPlayerProxy::createLayer()
     [m_layer setPlayer:WeakPtr { this }];
 
     LayerHostingContextOptions contextOptions;
-    m_layerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
+    m_layerHostingContext = LayerHostingContext::create(contextOptions);
     m_layerHostingContext->setRootLayer(m_layer.get());
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy creating remote CA layer ctxID = %" PRIu64 " id=%" PRIu64, this, layerHostingContextIdentifier().value().toUInt64(), m_id.toUInt64());

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -53,7 +53,6 @@ constexpr auto machPortKey = "p";
 #endif
 
 using LayerHostingContextID = uint32_t;
-enum class LayerHostingMode : uint8_t;
 
 struct LayerHostingContextOptions {
 #if PLATFORM(IOS_FAMILY)
@@ -68,16 +67,11 @@ class LayerHostingContext {
     WTF_MAKE_TZONE_ALLOCATED(LayerHostingContext);
     WTF_MAKE_NONCOPYABLE(LayerHostingContext);
 public:
-    static std::unique_ptr<LayerHostingContext> createForPort(const WTF::MachSendRight& serverPort);
-    
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-    static std::unique_ptr<LayerHostingContext> createForExternalHostingProcess(const LayerHostingContextOptions& = { });
+    static std::unique_ptr<LayerHostingContext> create(const LayerHostingContextOptions& = { });
     
     static std::unique_ptr<LayerHostingContext> createTransportLayerForRemoteHosting(LayerHostingContextID);
 
     static RetainPtr<CALayer> createPlatformLayerForHostingContext(LayerHostingContextID);
-
-#endif // HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
 
     LayerHostingContext();
     ~LayerHostingContext();
@@ -88,26 +82,16 @@ public:
     LayerHostingContextID contextID() const;
     void invalidate();
 
-    LayerHostingMode layerHostingMode() { return m_layerHostingMode; }
-
     void setColorSpace(CGColorSpaceRef);
     CGColorSpaceRef colorSpace() const;
 
-#if PLATFORM(MAC)
-    void setColorMatchUntaggedContent(bool);
-    bool colorMatchUntaggedContent() const;
-#endif
-
-    // Fences only work on iOS and OS 10.10+.
     void setFencePort(mach_port_t);
 
     // createFencePort does not install the fence port on the LayerHostingContext's
     // CAContext; call setFencePort() with the newly created port if synchronization
     // with this context is desired.
     WTF::MachSendRight createFencePort();
-    
-    // Should be only be used inside webprocess
-    void updateCachedContextID(LayerHostingContextID);
+
     LayerHostingContextID cachedContextID();
 
 #if USE(EXTENSIONKIT)
@@ -119,7 +103,6 @@ public:
 #endif
 
 private:
-    LayerHostingMode m_layerHostingMode;
     // Denotes the contextID obtained from GPU process, should be returned
     // for all calls to context ID in web process when UI side compositing
     // is enabled. This is done to avoid making calls to CARenderServer from webprocess

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1214,7 +1214,6 @@ def headers_for_type(type):
         'WebKit::SnapshotOption': ['"ImageOptions.h"'],
         'WebKit::LastNavigationWasAppInitiated': ['"AppPrivacyReport.h"'],
         'WebKit::LayerHostingContextID': ['"LayerHostingContext.h"'],
-        'WebKit::LayerHostingMode': ['"LayerTreeContext.h"'],
         'WebKit::MediaTimeUpdateData': ['"MediaPlayerPrivateRemote.h"'],
         'WebKit::PageGroupIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::PaymentSetupConfiguration': ['"PaymentSetupConfigurationWebKit.h"'],

--- a/Source/WebKit/Shared/LayerTreeContext.h
+++ b/Source/WebKit/Shared/LayerTreeContext.h
@@ -29,13 +29,6 @@
 
 namespace WebKit {
 
-enum class LayerHostingMode : uint8_t {
-    InProcess,
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-    OutOfProcess
-#endif
-};
-
 class LayerTreeContext {
 public:
     LayerTreeContext() = default;

--- a/Source/WebKit/Shared/LayerTreeContext.serialization.in
+++ b/Source/WebKit/Shared/LayerTreeContext.serialization.in
@@ -22,13 +22,6 @@
 
 header: "LayerTreeContext.h"
 
-enum class WebKit::LayerHostingMode : uint8_t {
-    InProcess,
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-    OutOfProcess
-#endif
-}
-
 class WebKit::LayerTreeContext {
     uint64_t contextID;
 }

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -175,8 +175,6 @@ struct WebPageCreationParameters {
 
     bool backgroundExtendsBeyondPage { false };
 
-    LayerHostingMode layerHostingMode { LayerHostingMode::InProcess };
-
     bool hasResourceLoadClient { false };
 
     Vector<String> mimeTypesWithCustomContentProviders { };
@@ -225,9 +223,6 @@ struct WebPageCreationParameters {
 #endif
 #if HAVE(STATIC_FONT_REGISTRY)
     Vector<SandboxExtension::Handle> fontMachExtensionHandles { };
-#endif
-#if HAVE(HOSTED_CORE_ANIMATION)
-    WTF::MachSendRight acceleratedCompositingPort { };
 #endif
 #if HAVE(APP_ACCENT_COLORS)
     WebCore::Color accentColor { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -95,8 +95,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool backgroundExtendsBeyondPage;
 
-    WebKit::LayerHostingMode layerHostingMode;
-
     bool hasResourceLoadClient;
 
     Vector<String> mimeTypesWithCustomContentProviders;
@@ -145,9 +143,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #endif
 #if HAVE(STATIC_FONT_REGISTRY)
     Vector<WebKit::SandboxExtensionHandle> fontMachExtensionHandles;
-#endif
-#if HAVE(HOSTED_CORE_ANIMATION)
-    MachSendRight acceleratedCompositingPort;
 #endif
 #if HAVE(APP_ACCENT_COLORS)
     WebCore::Color accentColor;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1532,13 +1532,6 @@ bool WebPageProxy::tryToSendCommandToActiveControlledVideo(PlatformMediaSession:
 
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)
 
-#if HAVE(HOSTED_CORE_ANIMATION)
-WTF::MachSendRight WebPageProxy::createMachSendRightForRemoteLayerServer()
-{
-    return MachSendRight::create([CARemoteLayerServer sharedServer].serverPort);
-}
-#endif
-
 void WebPageProxy::getInformationFromImageData(Vector<uint8_t>&& data, CompletionHandler<void(Expected<std::pair<String, Vector<IntSize>>, WebCore::ImageDecodingError>&&)>&& completionHandler)
 {
     ensureProtectedRunningProcess()->sendWithAsyncReply(Messages::WebPage::GetInformationFromImageData(WTFMove(data)), [preventProcessShutdownScope = protectedLegacyMainFrameProcess()->shutdownPreventingScope(), completionHandler = WTFMove(completionHandler)] (auto result) mutable {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -282,9 +282,6 @@ public:
     // Return whether the view is visually idle.
     virtual bool isVisuallyIdle() { return !isViewVisible(); }
 
-    // Return the layer hosting mode for the view.
-    virtual LayerHostingMode viewLayerHostingMode() { return LayerHostingMode::InProcess; }
-
     virtual WindowKind windowKind() { return isViewInWindow() ? WindowKind::Normal : WindowKind::Unparented; }
 
     virtual void processDidExit() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1003,8 +1003,6 @@ public:
     void waitForDidUpdateActivityState(ActivityStateChangeID);
     void didUpdateActivityState() { m_waitingForDidUpdateActivityState = false; }
 
-    void layerHostingModeDidChange();
-
     WebCore::IntSize viewSize() const;
     bool isViewVisible() const;
     bool isViewFocused() const;
@@ -3350,10 +3348,6 @@ private:
     struct Internals;
     Internals& internals() { return m_internals; }
     const Internals& internals() const { return m_internals; }
-
-#if HAVE(HOSTED_CORE_ANIMATION)
-    static WTF::MachSendRight createMachSendRightForRemoteLayerServer();
-#endif
 
     void takeVisibleActivity();
     void takeAudibleActivity();

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -304,7 +304,6 @@ public:
     GeolocationPermissionRequestManagerProxy geolocationPermissionRequestManager;
     HiddenPageThrottlingAutoIncreasesCounter::Token hiddenPageDOMTimerThrottlingAutoIncreasesCount;
     Deque<NativeWebKeyboardEvent> keyEventQueue;
-    LayerHostingMode layerHostingMode { LayerHostingMode::InProcess };
     WebCore::RectEdges<bool> mainFramePinnedState { true, true, true, true };
     WebCore::LayoutPoint maxStableLayoutViewportOrigin;
     WebCore::FloatSize maximumUnobscuredSize;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -171,7 +171,6 @@ private:
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
     void setRemoteLayerTreeRootNode(RemoteLayerTreeNode*) override;
     CALayer* acceleratedCompositingRootLayer() const override;
-    LayerHostingMode viewLayerHostingMode() override { return LayerHostingMode::OutOfProcess; }
 
     void makeViewBlank(bool) final;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -84,7 +84,6 @@ private:
     bool isViewVisibleOrOccluded() override;
     bool isViewInWindow() override;
     bool isVisuallyIdle() override;
-    LayerHostingMode viewLayerHostingMode() override;
     WebCore::DestinationColorSpace colorSpace() override;
     void setRemoteLayerTreeRootNode(RemoteLayerTreeNode*) override;
     CALayer *acceleratedCompositingRootLayer() const override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -106,12 +106,6 @@ static NSString * const kAXLoadCompleteNotification = @"AXLoadComplete";
 - (NSCursor *)_cursorRectCursor;
 @end
 
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-@interface NSWindow (WebNSWindowLayerHostingDetails)
-- (BOOL)_hostsLayersInWindowServer;
-@end
-#endif
-
 namespace WebKit {
 
 using namespace WebCore;
@@ -237,15 +231,6 @@ bool PageClientImpl::isViewInWindow()
 bool PageClientImpl::isVisuallyIdle()
 {
     return WindowServerConnection::singleton().applicationWindowModificationsHaveStopped() || !isViewVisible();
-}
-
-LayerHostingMode PageClientImpl::viewLayerHostingMode()
-{
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-    if ([activeWindow() _hostsLayersInWindowServer])
-        return LayerHostingMode::OutOfProcess;
-#endif
-    return LayerHostingMode::InProcess;
 }
 
 void PageClientImpl::viewWillMoveToAnotherWindow()

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -323,7 +323,6 @@ public:
     void windowWillBeginSheet();
     void windowDidChangeBackingProperties(CGFloat oldBackingScaleFactor);
     void windowDidChangeScreen();
-    void windowDidChangeLayerHosting();
     void windowDidChangeOcclusionState();
     void windowWillClose();
     void screenDidChangeColorSpace();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -355,7 +355,6 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     [defaultNotificationCenter addObserver:self selector:@selector(_windowWillBeginSheet:) name:NSWindowWillBeginSheetNotification object:window];
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeBackingProperties:) name:NSWindowDidChangeBackingPropertiesNotification object:window];
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeScreen:) name:NSWindowDidChangeScreenNotification object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeLayerHosting:) name:_NSWindowDidChangeContentsHostedInLayerSurfaceNotification object:window];
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeOcclusionState:) name:NSWindowDidChangeOcclusionStateNotification object:window];
     [defaultNotificationCenter addObserver:self selector:@selector(_windowWillClose:) name:NSWindowWillCloseNotification object:window];
 
@@ -513,12 +512,6 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 {
     if (_impl)
         _impl->windowDidChangeScreen();
-}
-
-- (void)_windowDidChangeLayerHosting:(NSNotification *)notification
-{
-    if (_impl)
-        _impl->windowDidChangeLayerHosting();
 }
 
 - (void)_windowDidChangeOcclusionState:(NSNotification *)notification
@@ -2163,11 +2156,6 @@ void WebViewImpl::windowDidChangeScreen()
     m_page->windowScreenDidChange(displayID);
 }
 
-void WebViewImpl::windowDidChangeLayerHosting()
-{
-    m_page->layerHostingModeDidChange();
-}
-
 void WebViewImpl::windowDidChangeOcclusionState()
 {
     LOG(ActivityState, "WebViewImpl %p (page %llu) windowDidChangeOcclusionState", this, m_page->identifier().toUInt64());
@@ -2334,9 +2322,6 @@ void WebViewImpl::viewDidMoveToWindow()
         m_page->activityStateDidChange(activityStateChanges);
 
         updateWindowAndViewFrames();
-
-        // FIXME(135509) This call becomes unnecessary once 135509 is fixed; remove.
-        m_page->layerHostingModeDidChange();
 
         accessibilityRegisterUIProcessTokens();
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -146,7 +146,6 @@ public:
     virtual void dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void ()>&&);
 
     virtual void activityStateDidChange(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, CompletionHandler<void()>&& completionHandler) { completionHandler(); };
-    virtual void setLayerHostingMode(LayerHostingMode) { }
 
     virtual void tryMarkLayersVolatile(CompletionHandler<void(bool)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -244,8 +244,6 @@ void GraphicsLayerCARemote::setLayerContentsToImageBuffer(PlatformCALayer* layer
 
 GraphicsLayer::LayerMode GraphicsLayerCARemote::layerMode() const
 {
-    if (m_context && m_context->layerHostingMode() == LayerHostingMode::InProcess)
-        return GraphicsLayer::LayerMode::PlatformLayer;
     return GraphicsLayer::LayerMode::LayerHostingContextId;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -97,24 +97,11 @@ PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(WebCore::PlatformCALaye
 PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(LayerType layerType, PlatformLayer * customLayer, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
     : PlatformCALayerRemote(layerType, owner, context)
 {
-    switch (context.layerHostingMode()) {
-    case LayerHostingMode::InProcess:
-#if HAVE(HOSTED_CORE_ANIMATION)
-        m_layerHostingContext = LayerHostingContext::createForPort(WebProcess::singleton().compositingRenderServerPort());
-#else
-        RELEASE_ASSERT_NOT_REACHED();
-#endif
-        break;
-#if HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
-    case LayerHostingMode::OutOfProcess:
-        m_layerHostingContext = LayerHostingContext::createForExternalHostingProcess({
+    m_layerHostingContext = LayerHostingContext::create({
 #if PLATFORM(IOS_FAMILY)
-            context.canShowWhileLocked()
+        context.canShowWhileLocked()
 #endif
-        });
-        break;
-#endif
-    }
+    });
 
     m_layerHostingContext->setRootLayer(customLayer);
     [customLayer setValue:[NSValue valueWithPointer:this] forKey:platformCALayerPointer];

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -70,8 +70,6 @@ public:
     WebCore::LayerPool& layerPool() { return m_layerPool; }
 
     float deviceScaleFactor() const;
-
-    LayerHostingMode layerHostingMode() const;
     
     std::optional<WebCore::DestinationColorSpace> displayColorSpace() const;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -80,11 +80,6 @@ float RemoteLayerTreeContext::deviceScaleFactor() const
     return m_webPage->deviceScaleFactor();
 }
 
-LayerHostingMode RemoteLayerTreeContext::layerHostingMode() const
-{
-    return m_webPage->layerHostingMode();
-}
-
 std::optional<DrawingAreaIdentifier> RemoteLayerTreeContext::drawingAreaIdentifier() const
 {
     if (!m_webPage->drawingArea())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -438,7 +438,6 @@ enum class DragControllerAction : uint8_t;
 enum class DrawingAreaType : uint8_t;
 enum class FindOptions : uint16_t;
 enum class FindDecorationStyle : uint8_t;
-enum class LayerHostingMode : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
 enum class MediaPlaybackState : uint8_t;
 enum class SnapshotOption : uint16_t;
@@ -866,9 +865,6 @@ public:
 
     OptionSet<WebCore::ActivityState> activityState() const { return m_activityState; }
     bool isThrottleable() const;
-
-    LayerHostingMode layerHostingMode() const { return m_layerHostingMode; }
-    void setLayerHostingMode(LayerHostingMode);
 
 #if PLATFORM(COCOA)
     void updatePluginsActiveAndFocusedState();
@@ -2538,7 +2534,6 @@ private:
     RefPtr<WebCore::Page> m_page;
 
     WebCore::IntSize m_viewSize;
-    LayerHostingMode m_layerHostingMode;
     RefPtr<DrawingArea> m_drawingArea;
 
     RefPtr<WebPageTesting> m_webPageTesting;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -27,7 +27,6 @@
 messages -> WebPage WantsAsyncDispatchMessage {
     SetInitialFocus(bool forward, bool isKeyboardEventValid, std::optional<WebKit::WebKeyboardEvent> event) -> ()
     SetActivityState(OptionSet<WebCore::ActivityState> activityState, WebKit::ActivityStateChangeID activityStateChangeID) -> ()
-    SetLayerHostingMode(enum:uint8_t WebKit::LayerHostingMode layerHostingMode)
 
     SetBackgroundColor(std::optional<WebCore::Color> color)
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -110,7 +110,6 @@ private:
     void setDeviceScaleFactor(float, CompletionHandler<void()>&&) override;
     void suspendPainting();
     void resumePainting();
-    void setLayerHostingMode(LayerHostingMode) override;
     void setColorSpace(std::optional<WebCore::DestinationColorSpace>) override;
     std::optional<WebCore::DestinationColorSpace> displayColorSpace() const override;
     void addFence(const WTF::MachSendRight&) override;

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -226,11 +226,6 @@ public:
 
     WebCore::ThirdPartyCookieBlockingMode thirdPartyCookieBlockingMode() const { return m_thirdPartyCookieBlockingMode; }
 
-#if HAVE(HOSTED_CORE_ANIMATION)
-    const WTF::MachSendRight& compositingRenderServerPort() const { return m_compositingRenderServerPort; }
-    void setCompositingRenderServerPort(WTF::MachSendRight&& port) { m_compositingRenderServerPort = WTFMove(port); }
-#endif
-
     bool fullKeyboardAccessEnabled() const { return m_fullKeyboardAccessEnabled; }
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
@@ -742,10 +737,6 @@ private:
 
     bool m_hasSetCacheModel { false };
     CacheModel m_cacheModel { CacheModel::DocumentViewer };
-
-#if HAVE(HOSTED_CORE_ANIMATION)
-    WTF::MachSendRight m_compositingRenderServerPort;
-#endif
 
     bool m_fullKeyboardAccessEnabled { false };
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -203,7 +203,7 @@ VideoPresentationManager::ModelInterfaceTuple VideoPresentationManager::createMo
     m_playbackSessionManager->addClientForContext(contextId);
 
     if (createlayerHostingContext)
-        interface->setLayerHostingContext(LayerHostingContext::createForExternalHostingProcess());
+        interface->setLayerHostingContext(LayerHostingContext::create());
 
     model->addClient(interface.get());
 


### PR DESCRIPTION
#### bac63ddba73ca0273c384c7643c8f30c91ecb7c4
<pre>
Remove more antique (in-process) layer hosting code
<a href="https://bugs.webkit.org/show_bug.cgi?id=290683">https://bugs.webkit.org/show_bug.cgi?id=290683</a>
<a href="https://rdar.apple.com/148153948">rdar://148153948</a>

Reviewed by Sam Weinig.

Windows on macOS are always hosted in the window server in all versions of the OS
that we ship to. Remove code that existed only to support in-process hosting,
dynamic switching of hosting modes, etc.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::createVisibilityPropagationContextForPage):
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::initialize):
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::createVisibilityPropagationContextForPage):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::createLayer):
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
(WebKit::LayerHostingContext::create):
(WebKit::LayerHostingContext::createForExternalHostingProcess): Deleted.
(WebKit::LayerHostingContext::layerHostingMode): Deleted.
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::create):
(WebKit::LayerHostingContext::createTransportLayerForRemoteHosting):
(WebKit::LayerHostingContext::createForPort): Deleted.
(WebKit::LayerHostingContext::createForExternalHostingProcess): Deleted.
(WebKit::LayerHostingContext::setColorMatchUntaggedContent): Deleted.
(WebKit::LayerHostingContext::colorMatchUntaggedContent const): Deleted.
(WebKit::LayerHostingContext::updateCachedContextID): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/LayerTreeContext.h:
* Source/WebKit/Shared/LayerTreeContext.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::createMachSendRightForRemoteLayerServer): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::viewLayerHostingMode): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::viewDidEnterWindow):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::layerHostingModeDidChange): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::viewLayerHostingMode): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(WebKit::WebViewImpl::viewDidMoveToWindow):
(-[WKWindowVisibilityObserver _windowDidChangeLayerHosting:]): Deleted.
(WebKit::WebViewImpl::windowDidChangeLayerHosting): Deleted.
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::activityStateDidChange):
(WebKit::DrawingArea::setLayerHostingMode): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::layerMode const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerHostingMode const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):
(WebKit::m_textAnimationController):
(WebKit::WebPage::reinitializeWebPage):
(WebKit::WebPage::setLayerHostingMode): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateLayerHostingContext):
(WebKit::TiledCoreAnimationDrawingArea::setLayerHostingMode): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::createModelAndInterface):

Canonical link: <a href="https://commits.webkit.org/292905@main">https://commits.webkit.org/292905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06dce48fc1e3d5ea2ba642e4ad3b70b3964f9535

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74174 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31361 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54517 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/96851 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47335 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90040 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104471 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95986 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24443 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17820 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83218 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82639 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17987 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24405 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29573 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24227 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33573 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->