### PR TITLE
[Win] Improvements to run loop timer resolution

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -263,8 +263,10 @@ private:
 #if USE(WINDOWS_EVENT_LOOP)
     static LRESULT CALLBACK RunLoopWndProc(HWND, UINT, WPARAM, LPARAM);
     LRESULT wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+    DWORD msTillNextTimer();
+    void fireTimers();
     HWND m_runLoopMessageWindow;
-    UncheckedKeyHashSet<UINT_PTR> m_liveTimers;
+    Deque<TimerBase*> m_timers;
 
     Lock m_loopLock;
 #elif USE(COCOA_EVENT_LOOP)

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -32,7 +32,6 @@ namespace WTF {
 
 static const UINT PerformWorkMessage = WM_USER + 1;
 static const UINT SetTimerMessage = WM_USER + 2;
-static const UINT KillTimerMessage = WM_USER + 3;
 static const LPCWSTR kRunLoopMessageWindowClassName = L"RunLoopMessageWindow";
 
 LRESULT CALLBACK RunLoop::RunLoopWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -58,20 +57,6 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         performWork();
         return 0;
     case SetTimerMessage:
-        ::SetTimer(hWnd, wParam, lParam, nullptr);
-        return 0;
-    case KillTimerMessage:
-        ::KillTimer(hWnd, wParam);
-        return 0;
-    case WM_TIMER:
-        RunLoop::TimerBase* timer = nullptr;
-        {
-            Locker locker { m_loopLock };
-            if (m_liveTimers.contains(wParam))
-                timer = std::bit_cast<RunLoop::TimerBase*>(wParam);
-        }
-        if (timer != nullptr)
-            timer->timerFired();
         return 0;
     }
 
@@ -80,13 +65,57 @@ LRESULT RunLoop::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 void RunLoop::run()
 {
-    MSG message;
-    while (BOOL result = ::GetMessage(&message, nullptr, 0, 0)) {
-        if (result == -1)
-            break;
-        ::TranslateMessage(&message);
-        ::DispatchMessage(&message);
+    while (true) {
+        RunLoop::currentSingleton().fireTimers();
+        MSG message;
+        while (BOOL result = ::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+            if (result == -1)
+                break;
+            if (message.message == WM_QUIT)
+                return;
+            ::TranslateMessage(&message);
+            ::DispatchMessage(&message);
+        }
+
+        DWORD timeout = RunLoop::currentSingleton().msTillNextTimer();
+        if (timeout > 0)
+            ::MsgWaitForMultipleObjectsEx(0, nullptr, timeout, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
     }
+}
+
+DWORD RunLoop::msTillNextTimer()
+{
+    Locker locker { m_loopLock };
+    Seconds timeout = Seconds(3600);
+
+    if (!m_timers.isEmpty()) {
+        auto now = MonotonicTime::now();
+        auto firstTimer = m_timers.last();
+
+        timeout = std::max<Seconds>(firstTimer->m_nextFireDate - now, 0_s);
+    }
+    return timeout.milliseconds();
+}
+
+void RunLoop::fireTimers()
+{
+    Vector<TimerBase*> timers;
+    {
+        Locker locker { m_loopLock };
+
+        // Can bail here if there's no timers before we check the time
+        if (m_timers.isEmpty())
+            return;
+
+        // Fire any timers ready from the front of the queue
+        auto now = MonotonicTime::now();
+        while (!m_timers.isEmpty() && m_timers.last()->m_nextFireDate <= now) {
+            timers.append(m_timers.last());
+            m_timers.removeLast();
+        }
+    }
+    for (auto timer : timers)
+        timer->timerFired();
 }
 
 void RunLoop::setWakeUpCallback(WTF::Function<void()>&& function)
@@ -137,6 +166,7 @@ void RunLoop::wakeUp()
 
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
+    RunLoop::currentSingleton().fireTimers();
     MSG message;
     while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
         if (message.message == WM_QUIT)
@@ -160,9 +190,13 @@ void RunLoop::TimerBase::timerFired()
 
         if (!m_isRepeating) {
             m_isActive = false;
-            ::KillTimer(m_runLoop->m_runLoopMessageWindow, std::bit_cast<uintptr_t>(this));
-        } else
+            m_nextFireDate = MonotonicTime::infinity();
+        } else {
             m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
+            m_runLoop->m_timers.appendAndBubble(this, [&] (TimerBase* otherTimer) -> bool {
+                return m_nextFireDate > otherTimer->m_nextFireDate;
+            });
+        }
     }
 
     fired();
@@ -181,12 +215,23 @@ RunLoop::TimerBase::~TimerBase()
 void RunLoop::TimerBase::start(Seconds interval, bool repeat)
 {
     Locker locker { m_runLoop->m_loopLock };
+    if (isActiveWithLock()) {
+        // Rescheduling timer that's already started
+        m_runLoop->m_timers.removeFirstMatching([&] (TimerBase* t) -> bool {
+            return this == t;
+        });
+    }
+
     m_isRepeating = repeat;
     m_isActive = true;
     m_interval = interval;
     m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
-    m_runLoop->m_liveTimers.add(std::bit_cast<uintptr_t>(this));
-    ::PostMessage(m_runLoop->m_runLoopMessageWindow, SetTimerMessage, std::bit_cast<uintptr_t>(this), interval.millisecondsAs<UINT>());
+    m_runLoop->m_timers.appendAndBubble(this, [&] (TimerBase* otherTimer) -> bool {
+        return m_nextFireDate > otherTimer->m_nextFireDate;
+    });
+    // If this is the first timer now, we need to cycle the run loop so we don't sleep through it
+    if (m_runLoop->m_timers.last() == this)
+        ::PostMessage(m_runLoop->m_runLoopMessageWindow, SetTimerMessage, std::bit_cast<uintptr_t>(this), interval.millisecondsAs<UINT>());
 }
 
 void RunLoop::TimerBase::stop()
@@ -196,8 +241,11 @@ void RunLoop::TimerBase::stop()
         return;
 
     m_isActive = false;
-    m_runLoop->m_liveTimers.remove(std::bit_cast<uintptr_t>(this));
-    ::PostMessage(m_runLoop->m_runLoopMessageWindow, KillTimerMessage, std::bit_cast<uintptr_t>(this), 0LL);
+    m_nextFireDate = MonotonicTime::infinity();
+
+    m_runLoop->m_timers.removeFirstMatching([&] (TimerBase* t) -> bool {
+        return this == t;
+    });
 }
 
 bool RunLoop::TimerBase::isActiveWithLock() const


### PR DESCRIPTION
#### b376a535708e386590eeeb28fe63ec54c56723a1
<pre>
[Win] Improvements to run loop timer resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=284823">https://bugs.webkit.org/show_bug.cgi?id=284823</a>

Reviewed by Yusuke Suzuki.

WM_TIMER has a 10ms resolution, which means we can&apos;t hit 60fps on
requestAnimationFrame. By using MsgWaitForMultipleObjectsEx and
maintaining our own timer queue we can get better timer resolution.

* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::wndProc):
(WTF::RunLoop::run):
(WTF::RunLoop::msTillNextTimer):
(WTF::RunLoop::fireTimers):
(WTF::RunLoop::cycle):
(WTF::RunLoop::TimerBase::timerFired):
(WTF::RunLoop::TimerBase::start):
(WTF::RunLoop::TimerBase::stop):

Canonical link: <a href="https://commits.webkit.org/292977@main">https://commits.webkit.org/292977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c70aee9cb87b23caf1b3a055efc9ff83983376ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47904 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74184 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31368 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100379 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13081 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47347 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104483 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/95998 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24455 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17828 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83229 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82649 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18001 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29585 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119624 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24239 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33580 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->