### PR TITLE
[macOS][GPUP] Address telemetry for IOKit user client AppleParavirtDeviceUserClient

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -181,6 +181,11 @@
                 (with-filter (iokit-registry-entry-class "AGXDeviceUserClient")
                     (allow iokit-external-method
                         (iokit-method-number 21 22 23 24 259 260 262 270)))
+                (with-filter (iokit-registry-entry-class "AppleParavirtDeviceUserClient")
+                    (allow iokit-external-trap
+                        (iokit-method-number 257 260 261))
+                    (allow iokit-external-method
+                        (iokit-method-number 257 259 260 262 265 266)))
                 (allow iokit-external-trap
                     (iokit-trap-number 0 1 3))
                 (allow iokit-async-external-method


### PR DESCRIPTION
#### fdb0616b2d3314187c61a417ce6e40a32fda8aba
<pre>
[macOS][GPUP] Address telemetry for IOKit user client AppleParavirtDeviceUserClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=290672">https://bugs.webkit.org/show_bug.cgi?id=290672</a>
<a href="https://rdar.apple.com/148143836">rdar://148143836</a>

Reviewed by Sihui Liu.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/292972@main">https://commits.webkit.org/292972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c6a7ecb0197f291682369f5d7da0eb6b546d60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74188 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31369 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13084 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88061 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54531 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12848 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-007.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-012.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-022.html imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-019.html imported/w3c/web-platform-tests/encoding/streams/backpressure.any.serviceworker.html imported/w3c/web-platform-tests/encoding/streams/backpressure.any.sharedworker.html imported/w3c/web-platform-tests/encoding/streams/decode-attributes.any.serviceworker.html imported/w3c/web-platform-tests/encoding/streams/decode-attributes.any.sharedworker.html imported/w3c/web-platform-tests/encoding/streams/decode-bad-chunks.any.serviceworker.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104488 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24460 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17831 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83232 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82652 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18008 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29590 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->