### PR TITLE
[WebIDL] Rename handleEvent[...]() functions used by callbacks to invoke[...]()

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -332,7 +332,7 @@ private:
 
     bool hasCallback() const final { return true; }
 
-    CallbackResult<void> handleEvent(double, const VideoFrameMetadata&) override
+    CallbackResult<void> invoke(double, const VideoFrameMetadata&) override
     {
         if (!m_videoElement)
             return { };
@@ -346,9 +346,9 @@ private:
         return { };
     }
 
-    CallbackResult<void> handleEventRethrowingException(double now, const VideoFrameMetadata& metadata) override
+    CallbackResult<void> invokeRethrowingException(double now, const VideoFrameMetadata& metadata) override
     {
-        return handleEvent(now, metadata);
+        return invoke(now, metadata);
     }
 
     Ref<GPUExternalTexture> m_externalTexture;

--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.cpp
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 void ErrorCallback::scheduleCallback(ScriptExecutionContext& context, Ref<DOMException>&& exception)
 {
     context.postTask([protectedThis = Ref { *this }, exception = WTFMove(exception)] (ScriptExecutionContext&) {
-        protectedThis->handleEvent(exception);
+        protectedThis->invoke(exception);
     });
 }
 

--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.h
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.h
@@ -38,8 +38,8 @@ class ErrorCallback : public RefCounted<ErrorCallback>, public ActiveDOMCallback
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(DOMException&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(DOMException&) = 0;
+    virtual CallbackResult<void> invoke(DOMException&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 
     // Helper to post callback task.
     void scheduleCallback(ScriptExecutionContext&, Ref<DOMException>&&);

--- a/Source/WebCore/Modules/entriesapi/FileCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileCallback.h
@@ -38,8 +38,8 @@ class FileCallback : public RefCounted<FileCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(File&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(File&) = 0;
+    virtual CallbackResult<void> invoke(File&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(File&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
@@ -65,7 +65,7 @@ void FileSystemDirectoryEntry::getEntry(ScriptExecutionContext& context, const S
         if (result.hasException()) {
             if (errorCallback && document) {
                 document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), exception = result.releaseException(), pendingActivity = WTFMove(pendingActivity)]() mutable {
-                    errorCallback->handleEvent(DOMException::create(WTFMove(exception)));
+                    errorCallback->invoke(DOMException::create(WTFMove(exception)));
                 });
             }
             return;
@@ -74,14 +74,14 @@ void FileSystemDirectoryEntry::getEntry(ScriptExecutionContext& context, const S
         if (!matches(entry)) {
             if (errorCallback && document) {
                 document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)]() mutable {
-                    errorCallback->handleEvent(DOMException::create(Exception { ExceptionCode::TypeMismatchError, "Entry at given path does not match expected type"_s }));
+                    errorCallback->invoke(DOMException::create(Exception { ExceptionCode::TypeMismatchError, "Entry at given path does not match expected type"_s }));
                 });
             }
             return;
         }
         if (successCallback && document) {
             document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), entry = WTFMove(entry), pendingActivity = WTFMove(pendingActivity)]() mutable {
-                successCallback->handleEvent(WTFMove(entry));
+                successCallback->invoke(WTFMove(entry));
             });
         }
     });

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -91,7 +91,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
                 m_error = result.releaseException();
                 if (errorCallback && document) {
                     document->eventLoop().queueTask(TaskSource::Networking, [this, errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)]() mutable {
-                        errorCallback->handleEvent(DOMException::create(*m_error));
+                        errorCallback->invoke(DOMException::create(*m_error));
                     });
                 }
                 return;
@@ -99,7 +99,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
             m_isDone = true;
             if (document) {
                 document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), pendingActivity = WTFMove(pendingActivity), result = result.releaseReturnValue()]() mutable {
-                    successCallback->handleEvent(WTFMove(result));
+                    successCallback->invoke(WTFMove(result));
                 });
             }
         });

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 void FileSystemEntriesCallback::scheduleCallback(ScriptExecutionContext& context, const Vector<Ref<FileSystemEntry>>& entries)
 {
     context.postTask([protectedThis = Ref { *this }, entries] (ScriptExecutionContext&) {
-        protectedThis->handleEvent(entries);
+        protectedThis->invoke(entries);
     });
 }
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
@@ -38,8 +38,8 @@ class FileSystemEntriesCallback : public RefCounted<FileSystemEntriesCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(const Vector<Ref<FileSystemEntry>>&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(const Vector<Ref<FileSystemEntry>>&) = 0;
+    virtual CallbackResult<void> invoke(const Vector<Ref<FileSystemEntry>>&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<FileSystemEntry>>&) = 0;
 
     // Helper to post callback task.
     void scheduleCallback(ScriptExecutionContext&, const Vector<Ref<FileSystemEntry>>&);

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -74,11 +74,11 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
         document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = std::forward<Result>(result), pendingActivity = WTFMove(pendingActivity)] () mutable {
             if (result.hasException()) {
                 if (errorCallback)
-                    errorCallback->handleEvent(DOMException::create(result.releaseException()));
+                    errorCallback->invoke(DOMException::create(result.releaseException()));
                 return;
             }
             if (successCallback)
-                successCallback->handleEvent(result.releaseReturnValue());
+                successCallback->invoke(result.releaseReturnValue());
         });
     });
 }

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
@@ -38,8 +38,8 @@ class FileSystemEntryCallback : public RefCounted<FileSystemEntryCallback>, publ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(FileSystemEntry&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(FileSystemEntry&) = 0;
+    virtual CallbackResult<void> invoke(FileSystemEntry&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(FileSystemEntry&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
@@ -58,10 +58,10 @@ void FileSystemFileEntry::file(ScriptExecutionContext& context, Ref<FileCallback
         document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = WTFMove(result), pendingActivity = WTFMove(pendingActivity)]() mutable {
             if (result.hasException()) {
                 if (errorCallback)
-                    errorCallback->handleEvent(DOMException::create(result.releaseException()));
+                    errorCallback->invoke(DOMException::create(result.releaseException()));
                 return;
             }
-            successCallback->handleEvent(result.releaseReturnValue());
+            successCallback->invoke(result.releaseReturnValue());
         });
     });
 }

--- a/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
@@ -76,13 +76,13 @@ void GeoNotifier::runSuccessCallback(GeolocationPosition* position)
     if (!m_geolocation->isAllowed())
         CRASH();
 
-    protectedSuccessCallback()->handleEvent(position);
+    protectedSuccessCallback()->invoke(position);
 }
 
 void GeoNotifier::runErrorCallback(GeolocationPositionError& error)
 {
     if (RefPtr errorCallback = m_errorCallback)
-        errorCallback->handleEvent(error);
+        errorCallback->invoke(error);
 }
 
 void GeoNotifier::startTimerIfNeeded()
@@ -119,7 +119,7 @@ void GeoNotifier::timerFired()
     
     if (m_errorCallback) {
         auto error = GeolocationPositionError::create(GeolocationPositionError::TIMEOUT, "Timeout expired"_s);
-        m_errorCallback->handleEvent(error);
+        m_errorCallback->invoke(error);
     }
     geolocation->requestTimedOut(this);
 }

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -306,7 +306,7 @@ void Geolocation::getCurrentPosition(Ref<PositionCallback>&& successCallback, Re
     if (!document || !document->isFullyActive()) {
         if (errorCallback && errorCallback->scriptExecutionContext()) {
             errorCallback->scriptExecutionContext()->eventLoop().queueTask(TaskSource::Geolocation, [errorCallback] {
-                errorCallback->handleEvent(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
+                errorCallback->invoke(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
             });
         }
         return;
@@ -324,7 +324,7 @@ int Geolocation::watchPosition(Ref<PositionCallback>&& successCallback, RefPtr<P
     if (!document || !document->isFullyActive()) {
         if (errorCallback && errorCallback->scriptExecutionContext()) {
             errorCallback->scriptExecutionContext()->eventLoop().queueTask(TaskSource::Geolocation, [errorCallback] {
-                errorCallback->handleEvent(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
+                errorCallback->invoke(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
             });
         }
         return 0;

--- a/Source/WebCore/Modules/geolocation/PositionCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.h
@@ -37,8 +37,8 @@ class PositionCallback : public RefCounted<PositionCallback>, public ActiveDOMCa
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(GeolocationPosition*) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(GeolocationPosition*) = 0;
+    virtual CallbackResult<void> invoke(GeolocationPosition*) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(GeolocationPosition*) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
@@ -37,8 +37,8 @@ class PositionErrorCallback : public RefCounted<PositionErrorCallback>, public A
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(GeolocationPositionError&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(GeolocationPositionError&) = 0;
+    virtual CallbackResult<void> invoke(GeolocationPositionError&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(GeolocationPositionError&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -114,7 +114,7 @@ MediaControlsHost::~MediaControlsHost()
 {
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     if (auto showMediaControlsContextMenuCallback = std::exchange(m_showMediaControlsContextMenuCallback, nullptr))
-        showMediaControlsContextMenuCallback->handleEvent();
+        showMediaControlsContextMenuCallback->invoke();
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 }
 
@@ -717,7 +717,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
         auto invokeCallbackAtScopeExit = makeScopeExit([protectedThis] {
             if (auto showMediaControlsContextMenuCallback = std::exchange(protectedThis->m_showMediaControlsContextMenuCallback, nullptr))
-                showMediaControlsContextMenuCallback->handleEvent();
+                showMediaControlsContextMenuCallback->invoke();
         });
 
         if (selectedItemID == invalidMenuItemIdentifier)

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -331,7 +331,7 @@ bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
         std::optional<UserGestureIndicator> maybeGestureIndicator;
         if (triggerGestureIndicator == TriggerGestureIndicator::Yes)
             maybeGestureIndicator.emplace(IsProcessingUserGesture::Yes, document());
-        handler->handleEvent(actionDetails);
+        handler->invoke(actionDetails);
         return true;
     }
     auto element = activeMediaElement();

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
@@ -39,8 +39,8 @@ class MediaSessionActionHandler : public RefCounted<MediaSessionActionHandler>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(const MediaSessionActionDetails&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(const MediaSessionActionDetails&) = 0;
+    virtual CallbackResult<void> invoke(const MediaSessionActionDetails&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(const MediaSessionActionDetails&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -399,7 +399,7 @@ void Notification::requestPermission(Document& document, RefPtr<NotificationPerm
     auto resolvePromiseAndCallback = [document = Ref { document }, callback = WTFMove(callback), promise = WTFMove(promise)](Permission permission) mutable {
         document->eventLoop().queueTask(TaskSource::DOMManipulation, [callback = WTFMove(callback), promise = WTFMove(promise), permission]() mutable {
             if (callback)
-                callback->handleEvent(permission);
+                callback->invoke(permission);
             promise->resolve<IDLEnumeration<NotificationPermission>>(permission);
         });
     };

--- a/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
+++ b/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
@@ -39,8 +39,8 @@ class NotificationPermissionCallback : public RefCounted<NotificationPermissionC
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(Notification::Permission) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(Notification::Permission) = 0;
+    virtual CallbackResult<void> invoke(Notification::Permission) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(Notification::Permission) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -122,7 +122,7 @@ void RemotePlayback::watchAvailability(Ref<RemotePlaybackAvailabilityCallback>&&
                 if (foundCallback == playback.m_callbackMap.end())
                     return;
 
-                foundCallback->value->handleEvent(available);
+                foundCallback->value->invoke(available);
             });
 
             // 8.2 Run the algorithm to monitor the list of available remote playback devices.
@@ -433,7 +433,7 @@ void RemotePlayback::availabilityChanged(bool available)
 
         // Protect m_callbackMap against mutation while it's being iterated over.
         for (auto& callback : copyToVector(playback.m_callbackMap.values()))
-            callback->handleEvent(available);
+            callback->invoke(available);
     });
 }
 

--- a/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
@@ -38,8 +38,8 @@ class RemotePlaybackAvailabilityCallback : public RefCounted<RemotePlaybackAvail
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<bool> handleEvent(bool) = 0;
-    virtual CallbackResult<bool> handleEventRethrowingException(bool) = 0;
+    virtual CallbackResult<bool> invoke(bool) = 0;
+    virtual CallbackResult<bool> invokeRethrowingException(bool) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -145,7 +145,7 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
         auto reports = observer.takeRecords();
 
         InspectorInstrumentation::willFireObserverCallback(*context, "ReportingObserver"_s);
-        protectedCallback->handleEvent(reports, observer);
+        protectedCallback->invoke(reports, observer);
         InspectorInstrumentation::didFireObserverCallback(*context);
     });
 }

--- a/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
@@ -39,8 +39,8 @@ class ReportingObserverCallback : public RefCounted<ReportingObserverCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
+    virtual CallbackResult<void> invoke(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
 
     virtual bool hasCallback() const = 0;
 };

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -39,7 +39,7 @@ class WebLockGrantedCallback : public RefCounted<WebLockGrantedCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<RefPtr<DOMPromise>> handleEvent(WebLock*) = 0;
+    virtual CallbackResult<RefPtr<DOMPromise>> invoke(WebLock*) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -261,7 +261,7 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
             }
 
             Ref lock = WebLock::create(*request.lockIdentifier, request.name, request.mode);
-            auto result = request.grantedCallback->handleEvent(lock.ptr());
+            auto result = request.grantedCallback->invoke(lock.ptr());
             RefPtr<DOMPromise> waitingPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
             if (!waitingPromise || waitingPromise->isSuspended()) {
                 manager.m_mainThreadBridge->releaseLock(*request.lockIdentifier, request.name);
@@ -277,7 +277,7 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
                 protectedThis->settleReleasePromise(lockIdentifier, static_cast<JSC::JSValue>(waitingPromise->promise()));
             });
         } else {
-            auto result = request.grantedCallback->handleEvent(nullptr);
+            auto result = request.grantedCallback->invoke(nullptr);
             RefPtr<DOMPromise> waitingPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
             if (!waitingPromise || waitingPromise->isSuspended()) {
                 manager.settleReleasePromise(*request.lockIdentifier, Exception { ExceptionCode::ExistingExceptionError });

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
@@ -38,8 +38,8 @@ class AudioBufferCallback : public RefCounted<AudioBufferCallback>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(AudioBuffer*) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(AudioBuffer*) = 0;
+    virtual CallbackResult<void> invoke(AudioBuffer*) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(AudioBuffer*) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
@@ -43,8 +43,8 @@ class AudioWorkletProcessorConstructor : public RefCounted<AudioWorkletProcessor
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> handleEvent(JSC::Strong<JSC::JSObject> options) = 0;
-    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> handleEventRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
+    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invoke(JSC::Strong<JSC::JSObject> options) = 0;
+    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invokeRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -320,13 +320,13 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
             if (!result) {
                 promise->reject(WTFMove(result.error()));
                 if (errorCallback)
-                    errorCallback->handleEvent(nullptr);
+                    errorCallback->invoke(nullptr);
                 return;
             }
             auto audioBuffer = WTFMove(result.value());
             promise->resolve<IDLInterface<AudioBuffer>>(audioBuffer.get());
             if (successCallback)
-                successCallback->handleEvent(audioBuffer.ptr());
+                successCallback->invoke(audioBuffer.ptr());
         });
     });
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
@@ -41,8 +41,8 @@ class WebCodecsAudioDataOutputCallback : public RefCounted<WebCodecsAudioDataOut
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(WebCodecsAudioData&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(WebCodecsAudioData&) = 0;
+    virtual CallbackResult<void> invoke(WebCodecsAudioData&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(WebCodecsAudioData&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -147,7 +147,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebC
 
                 auto decodedResult = WTFMove(result).value();
                 auto audioData = WebCodecsAudioData::create(*decoder.scriptExecutionContext(), WTFMove(decodedResult.data));
-                decoder.m_output->handleEvent(WTFMove(audioData));
+                decoder.m_output->invoke(WTFMove(audioData));
             });
         });
 
@@ -253,7 +253,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::closeDecoder(Exception&& exception)
     setState(WebCodecsCodecState::Closed);
     m_internalDecoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
-        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+        m_error->invoke(DOMException::create(WTFMove(exception)));
 
     return { };
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -231,7 +231,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
                     result.duration,
                     BufferSource { WTFMove(buffer) }
                 });
-                encoder.m_output->handleEvent(WTFMove(chunk), encoder.createEncodedChunkMetadata());
+                encoder.m_output->invoke(WTFMove(chunk), encoder.createEncodedChunkMetadata());
             });
         });
 
@@ -384,7 +384,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::closeEncoder(Exception&& exception)
     setState(WebCodecsCodecState::Closed);
     m_internalEncoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
-        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+        m_error->invoke(DOMException::create(WTFMove(exception)));
 
     return { };
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
@@ -42,8 +42,8 @@ class WebCodecsEncodedAudioChunkOutputCallback : public RefCounted<WebCodecsEnco
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
+    virtual CallbackResult<void> invoke(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
@@ -41,8 +41,8 @@ class WebCodecsEncodedVideoChunkOutputCallback : public RefCounted<WebCodecsEnco
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
+    virtual CallbackResult<void> invoke(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
@@ -40,8 +40,8 @@ class WebCodecsErrorCallback : public RefCounted<WebCodecsErrorCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(DOMException&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(DOMException&) = 0;
+    virtual CallbackResult<void> invoke(DOMException&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -182,7 +182,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
                 };
 
                 auto videoFrame = WebCodecsVideoFrame::create(*decoder.scriptExecutionContext(), WTFMove(decodedResult.frame), WTFMove(init));
-                decoder.m_output->handleEvent(WTFMove(videoFrame));
+                decoder.m_output->invoke(WTFMove(videoFrame));
             });
         });
 
@@ -288,7 +288,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)
     setState(WebCodecsCodecState::Closed);
     m_internalDecoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
-        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+        m_error->invoke(DOMException::create(WTFMove(exception)));
 
     return { };
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -214,7 +214,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
                     result.duration,
                     BufferSource { WTFMove(buffer) }
                 });
-                encoder.m_output->handleEvent(WTFMove(chunk), encoder.createEncodedChunkMetadata(result.temporalIndex));
+                encoder.m_output->invoke(WTFMove(chunk), encoder.createEncodedChunkMetadata(result.temporalIndex));
             });
         });
 
@@ -364,7 +364,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::closeEncoder(Exception&& exception)
     setState(WebCodecsCodecState::Closed);
     m_internalEncoder = nullptr;
     if (exception.code() != ExceptionCode::AbortError)
-        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+        m_error->invoke(DOMException::create(WTFMove(exception)));
 
     return { };
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
@@ -40,8 +40,8 @@ class WebCodecsVideoFrameOutputCallback : public RefCounted<WebCodecsVideoFrameO
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(WebCodecsVideoFrame&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(WebCodecsVideoFrame&) = 0;
+    virtual CallbackResult<void> invoke(WebCodecsVideoFrame&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(WebCodecsVideoFrame&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -684,7 +684,7 @@ void Database::runTransaction(RefPtr<SQLTransactionCallback>&& callback, RefPtr<
     if (!m_isTransactionQueueEnabled) {
         if (errorCallback) {
             m_document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = Ref { *errorCallback }]() {
-                errorCallback->handleEvent(SQLError::create(SQLError::UNKNOWN_ERR, "database has been closed"_s));
+                errorCallback->invoke(SQLError::create(SQLError::UNKNOWN_ERR, "database has been closed"_s));
             });
         }
         return;

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
@@ -42,8 +42,8 @@ class DatabaseCallback : public ThreadSafeRefCounted<DatabaseCallback>, public A
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(Database&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(Database&) = 0;
+    virtual CallbackResult<void> invoke(Database&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(Database&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -216,7 +216,7 @@ ExceptionOr<Ref<Database>> DatabaseManager::openDatabase(Document& document, con
         LOG(StorageAPI, "Scheduling DatabaseCreationCallbackTask for database %p\n", database.get());
         database->setHasPendingCreationEvent(true);
         database->m_document->eventLoop().queueTask(TaskSource::Networking, [creationCallback, database]() {
-            creationCallback->handleEvent(*database);
+            creationCallback->invoke(*database);
             database->setHasPendingCreationEvent(false);
         });
     }

--- a/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
@@ -206,7 +206,7 @@ bool SQLStatement::performCallback(SQLTransaction& transaction)
 
     if (m_error) {
         if (auto errorCallback = m_statementErrorCallbackWrapper.unwrap()) {
-            auto result = errorCallback->handleEvent(transaction, *m_error);
+            auto result = errorCallback->invoke(transaction, *m_error);
 
             // The spec says:
             // "If the error callback returns false, then move on to the next statement..."
@@ -227,7 +227,7 @@ bool SQLStatement::performCallback(SQLTransaction& transaction)
     if (auto callback = m_statementCallbackWrapper.unwrap()) {
         ASSERT(m_resultSet);
 
-        auto result = callback->handleEvent(transaction, *m_resultSet);
+        auto result = callback->invoke(transaction, *m_resultSet);
         return result.type() == CallbackResultType::ExceptionThrown;
     }
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
@@ -41,8 +41,8 @@ class SQLStatementCallback : public ThreadSafeRefCounted<SQLStatementCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(SQLTransaction&, SQLResultSet&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(SQLTransaction&, SQLResultSet&) = 0;
+    virtual CallbackResult<void> invoke(SQLTransaction&, SQLResultSet&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&, SQLResultSet&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
@@ -41,8 +41,8 @@ class SQLStatementErrorCallback : public ThreadSafeRefCounted<SQLStatementErrorC
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<bool> handleEvent(SQLTransaction&, SQLError&) = 0;
-    virtual CallbackResult<bool> handleEventRethrowingException(SQLTransaction&, SQLError&) = 0;
+    virtual CallbackResult<bool> invoke(SQLTransaction&, SQLError&) = 0;
+    virtual CallbackResult<bool> invokeRethrowingException(SQLTransaction&, SQLError&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -137,7 +137,7 @@ void SQLTransaction::callErrorCallbackDueToInterruption()
         return;
 
     m_database->document().eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback)]() mutable {
-        errorCallback->handleEvent(SQLError::create(SQLError::DATABASE_ERR, "the database was closed"_s));
+        errorCallback->invoke(SQLError::create(SQLError::DATABASE_ERR, "the database was closed"_s));
     });
 }
 
@@ -387,7 +387,7 @@ void SQLTransaction::deliverTransactionCallback()
     if (callback) {
         m_executeSqlAllowed = true;
 
-        auto result = callback->handleEvent(*this);
+        auto result = callback->invoke(*this);
         shouldDeliverErrorCallback = result.type() == CallbackResultType::ExceptionThrown;
 
         m_executeSqlAllowed = false;
@@ -411,7 +411,7 @@ void SQLTransaction::deliverTransactionErrorCallback()
     RefPtr<SQLTransactionErrorCallback> errorCallback = m_errorCallbackWrapper.unwrap();
     if (errorCallback) {
         m_database->document().eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), transactionError = m_transactionError]() mutable {
-            errorCallback->handleEvent(*transactionError);
+            errorCallback->invoke(*transactionError);
         });
     }
 
@@ -462,7 +462,7 @@ void SQLTransaction::deliverSuccessCallback()
     RefPtr<VoidCallback> successCallback = m_successCallbackWrapper.unwrap();
     if (successCallback) {
         m_database->document().eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback)]() mutable {
-            successCallback->handleEvent();
+            successCallback->invoke();
         });
     }
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
@@ -40,8 +40,8 @@ class SQLTransactionCallback : public ThreadSafeRefCounted<SQLTransactionCallbac
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(SQLTransaction&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(SQLTransaction&) = 0;
+    virtual CallbackResult<void> invoke(SQLTransaction&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
@@ -40,8 +40,8 @@ class SQLTransactionErrorCallback : public ThreadSafeRefCounted<SQLTransactionEr
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(SQLError&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(SQLError&) = 0;
+    virtual CallbackResult<void> invoke(SQLError&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(SQLError&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -677,7 +677,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
                     continue;
                 callback->setFiredOrCancelled();
                 //  6.7.Invoke the Web IDL callback function for entry, passing now and frame as the arguments
-                callback->handleEvent(now, frame.get());
+                callback->invoke(now, frame.get());
 
                 //  6.8.If an exception is thrown, report the exception.
             }

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -634,15 +634,15 @@ private:
     {
     }
 
-    CallbackResult<void> handleEvent(double) final
+    CallbackResult<void> invoke(double) final
     {
         m_callback();
         return { };
     }
 
-    CallbackResult<void> handleEventRethrowingException(double now) final
+    CallbackResult<void> invokeRethrowingException(double now) final
     {
-        return handleEvent(now);
+        return invoke(now);
     }
 
     Function<void()> m_callback;

--- a/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
+++ b/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
@@ -39,8 +39,8 @@ class XRFrameRequestCallback : public RefCounted<XRFrameRequestCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(double highResTimeMs, WebXRFrame&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(double highResTimeMs, WebXRFrame&) = 0;
+    virtual CallbackResult<void> invoke(double highResTimeMs, WebXRFrame&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs, WebXRFrame&) = 0;
 
     unsigned callbackId() { ASSERT(m_id); return m_id; }
     void setCallbackId(unsigned id) { ASSERT(!m_id); m_id = id; }

--- a/Source/WebCore/animation/CustomEffect.cpp
+++ b/Source/WebCore/animation/CustomEffect.cpp
@@ -83,7 +83,7 @@ void CustomEffect::animationDidTick()
     if (!computedTiming.progress)
         return;
 
-    m_callback->handleEvent(*computedTiming.progress);
+    m_callback->invoke(*computedTiming.progress);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CustomEffectCallback.h
+++ b/Source/WebCore/animation/CustomEffectCallback.h
@@ -36,8 +36,8 @@ class CustomEffectCallback : public RefCounted<CustomEffectCallback>, public Act
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(double progress) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(double progress) = 0;
+    virtual CallbackResult<void> invoke(double progress) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(double progress) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6776,8 +6776,7 @@ sub GenerateCallbackHeaderContent
 
             my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::CallbackReturnType>";
             
-            # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
-            my $functionName = $operation->extendedAttributes->{ImplementedAs} || $operation->name || "handleEvent";
+            my $functionName = $operation->extendedAttributes->{ImplementedAs} || $operation->name || "invoke";
             push(@$contentRef, "    ${nativeReturnType} ${functionName}(" . join(", ", @arguments) . ") override;\n");
 
             # Unless the callback function returns a promise, also generate a version that rethrows any exception it might encounter.
@@ -6823,8 +6822,7 @@ sub GenerateCallbackImplementationOperationBody
 
     my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::CallbackReturnType>";
 
-    # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
-    my $functionName = $operation->name || "handleEvent";
+    my $functionName = $operation->name || "invoke";
 
     my $functionImplementationName = $operation->extendedAttributes->{ImplementedAs} || $functionName;
     $functionImplementationName .= "RethrowingException" if $isForRethrowingHandler;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -52,7 +52,7 @@ JSTestCallbackFunction::~JSTestCallbackFunction()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction::handleEvent(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction::invoke(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -84,7 +84,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction::handleEventRethrowingException(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction::invokeRethrowingException(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -40,8 +40,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLLong::ParameterType argument) override;
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEventRethrowingException(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invoke(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invokeRethrowingException(typename IDLLong::ParameterType argument) override;
 
 private:
     JSTestCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -52,7 +52,7 @@ JSTestCallbackFunctionGenerateIsReachable::~JSTestCallbackFunctionGenerateIsReac
 #endif
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionGenerateIsReachable::handleEvent(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionGenerateIsReachable::invoke(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -84,7 +84,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionGenerateIsReachable::handleEventRethrowingException(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionGenerateIsReachable::invokeRethrowingException(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -41,8 +41,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLLong::ParameterType argument) override;
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEventRethrowingException(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invoke(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invokeRethrowingException(typename IDLLong::ParameterType argument) override;
 
 private:
     JSTestCallbackFunctionGenerateIsReachable(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -56,7 +56,7 @@ JSTestCallbackFunctionWithThisObject::~JSTestCallbackFunctionWithThisObject()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithThisObject::handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithThisObject::invoke(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -84,7 +84,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     return { };
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithThisObject::handleEventRethrowingException(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithThisObject::invokeRethrowingException(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -40,8 +40,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEventRethrowingException(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invoke(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invokeRethrowingException(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
 
 private:
     JSTestCallbackFunctionWithThisObject(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -56,7 +56,7 @@ JSTestCallbackFunctionWithTypedefs::~JSTestCallbackFunctionWithTypedefs()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithTypedefs::handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithTypedefs::invoke(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -85,7 +85,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     return { };
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithTypedefs::handleEventRethrowingException(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithTypedefs::invokeRethrowingException(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -40,8 +40,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEventRethrowingException(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invoke(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invokeRethrowingException(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
 
 private:
     JSTestCallbackFunctionWithTypedefs(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -51,7 +51,7 @@ JSTestCallbackFunctionWithVariadic::~JSTestCallbackFunctionWithVariadic()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionWithVariadic::handleEvent(VariadicArguments<IDLAny>&& arguments)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionWithVariadic::invoke(VariadicArguments<IDLAny>&& arguments)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -85,7 +85,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionWithVariadic::handleEventRethrowingException(VariadicArguments<IDLAny>&& arguments)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionWithVariadic::invokeRethrowingException(VariadicArguments<IDLAny>&& arguments)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -42,8 +42,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(VariadicArguments<IDLAny>&& arguments) override;
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEventRethrowingException(VariadicArguments<IDLAny>&& arguments) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invoke(VariadicArguments<IDLAny>&& arguments) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> invokeRethrowingException(VariadicArguments<IDLAny>&& arguments) override;
 
 private:
     JSTestCallbackFunctionWithVariadic(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -58,7 +58,7 @@ JSTestCallbackWithFunctionOrDict::~JSTestCallbackWithFunctionOrDict()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunctionOrDict::handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunctionOrDict::invoke(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -86,7 +86,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunc
     return { };
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunctionOrDict::handleEventRethrowingException(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunctionOrDict::invokeRethrowingException(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -40,8 +40,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEventRethrowingException(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invoke(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invokeRethrowingException(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
 
 private:
     JSTestCallbackWithFunctionOrDict(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -64,7 +64,7 @@ JSTestVoidCallbackFunction::~JSTestVoidCallbackFunction()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunction::handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunction::invoke(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -97,7 +97,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunc
     return { };
 }
 
-CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunction::handleEventRethrowingException(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunction::invokeRethrowingException(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -42,8 +42,8 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
-    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEventRethrowingException(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invoke(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> invokeRethrowingException(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
 
 private:
     JSTestVoidCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/css/CSSPaintCallback.h
+++ b/Source/WebCore/css/CSSPaintCallback.h
@@ -43,8 +43,8 @@ class CSSPaintCallback : public RefCountedAndCanMakeWeakPtr<CSSPaintCallback>, p
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
+    virtual CallbackResult<void> invoke(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
 
     virtual ~CSSPaintCallback()
     {

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -39,8 +39,8 @@ class AbortAlgorithm : public ThreadSafeRefCounted<AbortAlgorithm>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -210,11 +210,11 @@ void AbortSignal::eventListenersDidChange()
 uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAlgorithm>&& algorithm)
 {
     if (signal.aborted()) {
-        algorithm->handleEvent(signal.m_reason.getValue());
+        algorithm->invoke(signal.m_reason.getValue());
         return 0;
     }
     return signal.addAlgorithm([algorithm = WTFMove(algorithm)](JSC::JSValue value) mutable {
-        algorithm->handleEvent(value);
+        algorithm->invoke(value);
     });
 }
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -62,7 +62,7 @@ private:
 
     bool hasCallback() const final { return true; }
 
-    CallbackResult<void> handleEvent(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {
         ASSERT(!entries.isEmpty());
 
@@ -73,9 +73,9 @@ private:
         return { };
     }
 
-    CallbackResult<void> handleEventRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
     {
-        return handleEvent(thisObserver, entries, observer);
+        return invoke(thisObserver, entries, observer);
     }
 };
 

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -38,8 +38,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
-    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -38,8 +38,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
-    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -38,8 +38,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
-    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -127,7 +127,7 @@ bool IdleCallbackController::invokeIdleCallbacks()
 
     auto request = m_runnableIdleCallbacks.takeFirst();
     auto idleDeadline = IdleDeadline::create(request.timeout && *request.timeout < now ? IdleDeadline::DidTimeout::Yes : IdleDeadline::DidTimeout::No);
-    request.callback->handleEvent(idleDeadline.get());
+    request.callback->invoke(idleDeadline.get());
 
     return !m_runnableIdleCallbacks.isEmpty();
 }
@@ -148,7 +148,7 @@ void IdleCallbackController::invokeIdleCallbackTimeout(unsigned identifier)
     auto idleDeadline = IdleDeadline::create(IdleDeadline::DidTimeout::Yes);
     auto callback = WTFMove(it->callback);
     m_idleRequestCallbacks.remove(it);
-    callback->handleEvent(idleDeadline.get());
+    callback->invoke(idleDeadline.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/IdleRequestCallback.h
+++ b/Source/WebCore/dom/IdleRequestCallback.h
@@ -37,8 +37,8 @@ class IdleRequestCallback : public RefCounted<IdleRequestCallback>, public Activ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(IdleDeadline&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(IdleDeadline&) = 0;
+    virtual CallbackResult<void> invoke(IdleDeadline&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(IdleDeadline&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -52,7 +52,7 @@ public:
             return adoptRef(*new InternalObserverDrop::SubscriberCallbackDrop(context, source, amount));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> invoke(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -68,9 +68,9 @@ public:
             return { };
         }
 
-        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final
         {
-            return handleEvent(subscriber);
+            return invoke(subscriber);
         }
 
     private:

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -65,7 +65,7 @@ private:
             // abort signal and promise rejection.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
+            auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -53,7 +53,7 @@ public:
             return adoptRef(*new InternalObserverFilter::SubscriberCallbackFilter(context, source, predicate));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> invoke(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -69,9 +69,9 @@ public:
             return { };
         }
 
-        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final
         {
-            return handleEvent(subscriber);
+            return invoke(subscriber);
         }
 
     private:
@@ -104,7 +104,7 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            auto result = protectedPredicate()->handleEventRethrowingException(value, m_idx);
+            auto result = protectedPredicate()->invokeRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -66,7 +66,7 @@ private:
             // abort signal and promise rejection.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
+            auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -63,7 +63,7 @@ private:
             // abort signal and promise rejection.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            protectedCallback()->handleEventRethrowingException(value, m_idx++);
+            protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -49,13 +49,13 @@ Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecuti
 void InternalObserverFromScript::next(JSC::JSValue value)
 {
     if (RefPtr next = m_next)
-        next->handleEvent(value);
+        next->invoke(value);
 }
 
 void InternalObserverFromScript::error(JSC::JSValue value)
 {
     if (RefPtr error = m_error) {
-        error->handleEvent(value);
+        error->invoke(value);
         return;
     }
 
@@ -65,7 +65,7 @@ void InternalObserverFromScript::error(JSC::JSValue value)
 void InternalObserverFromScript::complete()
 {
     if (RefPtr complete = m_complete)
-        complete->handleEvent();
+        complete->invoke();
 
     m_active = false;
 }

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -54,7 +54,7 @@ public:
             return adoptRef(*new SubscriberCallbackInspect(context, WTFMove(source), WTFMove(inspector)));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> invoke(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -72,7 +72,7 @@ public:
                 JSC::JSLockHolder lock(vm);
                 auto scope = DECLARE_CATCH_SCOPE(vm);
 
-                subscribe->handleEventRethrowingException();
+                subscribe->invokeRethrowingException();
 
                 JSC::Exception* exception = scope.exception();
                 if (UNLIKELY(exception)) {
@@ -88,9 +88,9 @@ public:
             return { };
         }
 
-        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final
         {
-            return handleEvent(subscriber);
+            return invoke(subscriber);
         }
 
     private:
@@ -114,7 +114,7 @@ private:
             JSC::JSLockHolder lock(vm);
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            next->handleEventRethrowingException(value);
+            next->invokeRethrowingException(value);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {
@@ -136,7 +136,7 @@ private:
             JSC::JSLockHolder lock(vm);
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            error->handleEventRethrowingException(value);
+            error->invokeRethrowingException(value);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {
@@ -160,7 +160,7 @@ private:
             JSC::JSLockHolder lock(vm);
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            complete->handleEventRethrowingException();
+            complete->invokeRethrowingException();
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {
@@ -217,7 +217,7 @@ private:
         if (RefPtr abort = m_inspector.abort) {
             Ref signal = protectedSubscriber()->signal();
             m_abortAlgorithmHandler = signal->addAlgorithm([abort = WTFMove(abort)](JSC::JSValue reason) {
-                abort->handleEvent(reason);
+                abort->invoke(reason);
             });
         }
     }

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -53,7 +53,7 @@ public:
             return adoptRef(*new InternalObserverMap::SubscriberCallbackMap(context, source, mapper));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> invoke(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -69,9 +69,9 @@ public:
             return { };
         }
 
-        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final
         {
-            return handleEvent(subscriber);
+            return invoke(subscriber);
         }
 
     private:
@@ -102,7 +102,7 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            auto result = protectedMapper()->handleEventRethrowingException(value, m_idx);
+            auto result = protectedMapper()->invokeRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -68,7 +68,7 @@ private:
         JSC::JSLockHolder lock(vm);
         auto scope = DECLARE_CATCH_SCOPE(vm);
 
-        auto result = protectedCallback()->handleEventRethrowingException(m_accumulator.getValue(), value, m_index++);
+        auto result = protectedCallback()->invokeRethrowingException(m_accumulator.getValue(), value, m_index++);
 
         JSC::Exception* exception = scope.exception();
         if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -66,7 +66,7 @@ private:
             // abort signal and promise rejection.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
+            auto result = protectedCallback()->invokeRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -52,7 +52,7 @@ public:
             return adoptRef(*new InternalObserverTake::SubscriberCallbackTake(context, source, amount));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> invoke(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -68,9 +68,9 @@ public:
             return { };
         }
 
-        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
+        CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final
         {
-            return handleEvent(subscriber);
+            return invoke(subscriber);
         }
 
     private:

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -35,8 +35,8 @@ class MapperCallback : public RefCounted<MapperCallback>, public ActiveDOMCallba
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<JSC::JSValue> handleEvent(JSC::JSValue, uint64_t) = 0;
-    virtual CallbackResult<JSC::JSValue> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/MutationCallback.h
+++ b/Source/WebCore/dom/MutationCallback.h
@@ -47,8 +47,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<void> handleEvent(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
+    virtual CallbackResult<void> invoke(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -218,7 +218,7 @@ void MutationObserver::deliver()
             return;
 
         InspectorInstrumentation::willFireObserverCallback(*context, "MutationObserver"_s);
-        protectedCallback()->handleEvent(*this, records, *this);
+        protectedCallback()->invoke(*this, records, *this);
         InspectorInstrumentation::didFireObserverCallback(*context);
     }
 }

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -97,7 +97,7 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
     JSC::Exception* previousException = nullptr;
     {
         auto catchScope = DECLARE_CATCH_SCOPE(vm);
-        m_subscriberCallback->handleEventRethrowingException(subscriber);
+        m_subscriberCallback->invokeRethrowingException(subscriber);
         previousException = catchScope.exception();
         if (previousException) {
             catchScope.clearException();

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.h
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.h
@@ -35,8 +35,8 @@ class ObservableInspectorAbortCallback : public RefCounted<ObservableInspectorAb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -35,8 +35,8 @@ class PredicateCallback : public RefCounted<PredicateCallback>, public ActiveDOM
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<bool> handleEvent(JSC::JSValue, uint64_t) = 0;
-    virtual CallbackResult<bool> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<bool> invoke(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<bool> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/ReducerCallback.h
+++ b/Source/WebCore/dom/ReducerCallback.h
@@ -35,8 +35,8 @@ class ReducerCallback : public RefCounted<ReducerCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<JSC::JSValue> handleEvent(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
-    virtual CallbackResult<JSC::JSValue> handleEventRethrowingException(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/RequestAnimationFrameCallback.h
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.h
@@ -42,8 +42,8 @@ class RequestAnimationFrameCallback : public RefCounted<RequestAnimationFrameCal
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(double highResTimeMs) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(double highResTimeMs) = 0;
+    virtual CallbackResult<void> invoke(double highResTimeMs) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs) = 0;
 
     int m_id;
     bool m_firedOrCancelled;

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -171,7 +171,7 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
 
         auto identifier = callback->m_id;
         InspectorInstrumentation::willFireAnimationFrame(document, identifier);
-        Ref { callback }->handleEvent(highResNowMs);
+        Ref { callback }->invoke(highResNowMs);
         InspectorInstrumentation::didFireAnimationFrame(document, identifier);
     }
 

--- a/Source/WebCore/dom/StringCallback.cpp
+++ b/Source/WebCore/dom/StringCallback.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 void StringCallback::scheduleCallback(ScriptExecutionContext& context, const String& data)
 {
     context.postTask([protectedThis = Ref { *this }, data] (ScriptExecutionContext&) {
-        protectedThis->handleEvent(data);
+        protectedThis->invoke(data);
     });
 }
 

--- a/Source/WebCore/dom/StringCallback.h
+++ b/Source/WebCore/dom/StringCallback.h
@@ -43,8 +43,8 @@ class StringCallback : public RefCounted<StringCallback>, public ActiveDOMCallba
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(const String& data) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(const String& data) = 0;
+    virtual CallbackResult<void> invoke(const String& data) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(const String& data) = 0;
 
     // Helper to post callback task.
     WEBCORE_EXPORT void scheduleCallback(ScriptExecutionContext&, const String& data);

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -94,7 +94,7 @@ void Subscriber::addTeardown(Ref<VoidCallback> callback)
         Locker locker { m_teardownsLock };
         m_teardowns.append(callback);
     } else
-        callback->handleEvent();
+        callback->invoke();
 }
 
 void Subscriber::followSignal(AbortSignal& signal)
@@ -122,7 +122,7 @@ void Subscriber::close(JSC::JSValue reason)
         for (auto teardown = m_teardowns.rbegin(); teardown != m_teardowns.rend(); ++teardown) {
             if (isInactiveDocument())
                 return;
-            (*teardown)->handleEvent();
+            (*teardown)->invoke();
         }
     }
 

--- a/Source/WebCore/dom/SubscriberCallback.h
+++ b/Source/WebCore/dom/SubscriberCallback.h
@@ -37,8 +37,8 @@ class SubscriberCallback : public RefCounted<SubscriberCallback>, public ActiveD
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(Subscriber&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(Subscriber&) = 0;
+    virtual CallbackResult<void> invoke(Subscriber&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(Subscriber&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/SubscriptionObserverCallback.h
+++ b/Source/WebCore/dom/SubscriptionObserverCallback.h
@@ -35,8 +35,8 @@ class SubscriptionObserverCallback : public RefCounted<SubscriptionObserverCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -90,7 +90,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateHTML = m_options.createHTML;
         }
         if (protectedCreateHTML && protectedCreateHTML->hasCallback())
-            policyValue = protectedCreateHTML->handleEventRethrowingException(input, WTFMove(arguments));
+            policyValue = protectedCreateHTML->invokeRethrowingException(input, WTFMove(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScript) {
         RefPtr<CreateScriptCallback> protectedCreateScript;
         {
@@ -98,7 +98,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateScript = m_options.createScript;
         }
         if (protectedCreateScript && protectedCreateScript->hasCallback())
-            policyValue = protectedCreateScript->handleEventRethrowingException(input, WTFMove(arguments));
+            policyValue = protectedCreateScript->invokeRethrowingException(input, WTFMove(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScriptURL) {
         RefPtr<CreateScriptURLCallback> protectedCreateScriptURL;
         {
@@ -106,7 +106,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateScriptURL = m_options.createScriptURL;
         }
         if (protectedCreateScriptURL && protectedCreateScriptURL->hasCallback())
-            policyValue = protectedCreateScriptURL->handleEventRethrowingException(input, WTFMove(arguments));
+            policyValue = protectedCreateScriptURL->invokeRethrowingException(input, WTFMove(arguments));
     } else {
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::TypeError };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -256,7 +256,7 @@ void ViewTransition::callUpdateCallback()
         Ref { promiseAndWrapper.second }->resolve();
         callbackPromise = WTFMove(promiseAndWrapper.first);
     } else {
-        auto result = RefPtr { m_updateCallback }->handleEvent();
+        auto result = RefPtr { m_updateCallback }->invoke();
         callbackPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
         if (!callbackPromise || callbackPromise->isSuspended()) {
             auto promiseAndWrapper = createPromiseAndWrapper(document);

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.h
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.h
@@ -38,7 +38,7 @@ class ViewTransitionUpdateCallback : public RefCounted<ViewTransitionUpdateCallb
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<RefPtr<DOMPromise>> handleEvent() = 0;
+    virtual CallbackResult<RefPtr<DOMPromise>> invoke() = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -35,8 +35,8 @@ class VisitorCallback : public RefCounted<VisitorCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue, uint64_t) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<void> invoke(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/editing/CustomUndoStep.cpp
+++ b/Source/WebCore/editing/CustomUndoStep.cpp
@@ -47,7 +47,7 @@ void CustomUndoStep::unapply()
     // edit commands. Should the page be allowed to specify a target in the DOM for undo and redo?
     Ref<UndoItem> protectedUndoItem(*m_undoItem);
     protectedUndoItem->protectedDocument()->updateLayoutIgnorePendingStylesheets();
-    protectedUndoItem->undoHandler().handleEvent();
+    protectedUndoItem->undoHandler().invoke();
 }
 
 void CustomUndoStep::reapply()
@@ -57,7 +57,7 @@ void CustomUndoStep::reapply()
 
     Ref<UndoItem> protectedUndoItem(*m_undoItem);
     protectedUndoItem->protectedDocument()->updateLayoutIgnorePendingStylesheets();
-    protectedUndoItem->redoHandler().handleEvent();
+    protectedUndoItem->redoHandler().invoke();
 }
 
 bool CustomUndoStep::isValid() const

--- a/Source/WebCore/fileapi/BlobCallback.cpp
+++ b/Source/WebCore/fileapi/BlobCallback.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 void BlobCallback::scheduleCallback(ScriptExecutionContext& context, RefPtr<Blob>&& blob)
 {
     context.postTask([this, protectedThis = Ref { *this }, blob = WTFMove(blob)](ScriptExecutionContext&) {
-        handleEvent(blob.get());
+        invoke(blob.get());
     });
 }
 

--- a/Source/WebCore/fileapi/BlobCallback.h
+++ b/Source/WebCore/fileapi/BlobCallback.h
@@ -39,8 +39,8 @@ class BlobCallback : public RefCounted<BlobCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(Blob*) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(Blob*) = 0;
+    virtual CallbackResult<void> invoke(Blob*) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(Blob*) = 0;
 
     void scheduleCallback(ScriptExecutionContext&, RefPtr<Blob>&&);
 

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -118,7 +118,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
         return ImageDrawResult::DidNothing;
     }
 
-    auto result = callback->handleEvent(WTFMove(thisObject), *context, size, propertyMap, m_arguments);
+    auto result = callback->invoke(WTFMove(thisObject), *context, size, propertyMap, m_arguments);
     if (result.type() != CallbackResultType::Success)
         return ImageDrawResult::DidNothing;
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -749,7 +749,7 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
     m_videoFrameRequests.swap(m_servicedVideoFrameRequests);
     for (auto& request : m_servicedVideoFrameRequests) {
         if (RefPtr callback = std::exchange(request->callback, { }))
-            callback->handleEvent(std::round(now.milliseconds()), *videoFrameMetadata);
+            callback->invoke(std::round(now.milliseconds()), *videoFrameMetadata);
     }
     m_servicedVideoFrameRequests.clear();
 

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -55,7 +55,7 @@ private:
 
     bool hasCallback() const final { return true; }
 
-    CallbackResult<void> handleEvent(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {
         ASSERT(!entries.isEmpty());
 
@@ -70,9 +70,9 @@ private:
         return { };
     }
 
-    CallbackResult<void> handleEventRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
     {
-        return handleEvent(thisObserver, entries, observer);
+        return invoke(thisObserver, entries, observer);
     }
 };
 

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -53,7 +53,7 @@ private:
 
     bool hasCallback() const final { return true; }
 
-    CallbackResult<void> handleEvent(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {
         ASSERT(!entries.isEmpty());
 
@@ -68,9 +68,9 @@ private:
         return { };
     }
 
-    CallbackResult<void> handleEventRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
     {
-        return handleEvent(thisObserver, entries, observer);
+        return invoke(thisObserver, entries, observer);
     }
 };
 

--- a/Source/WebCore/html/VideoFrameRequestCallback.h
+++ b/Source/WebCore/html/VideoFrameRequestCallback.h
@@ -40,8 +40,8 @@ class VideoFrameRequestCallback : public RefCounted<VideoFrameRequestCallback>, 
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(double, const VideoFrameMetadata&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(double, const VideoFrameMetadata&) = 0;
+    virtual CallbackResult<void> invoke(double, const VideoFrameMetadata&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(double, const VideoFrameMetadata&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/html/VoidCallback.h
+++ b/Source/WebCore/html/VoidCallback.h
@@ -36,8 +36,8 @@ class VoidCallback : public RefCounted<VoidCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent() = 0;
-    virtual CallbackResult<void> handleEventRethrowingException() = 0;
+    virtual CallbackResult<void> invoke() = 0;
+    virtual CallbackResult<void> invokeRethrowingException() = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -160,7 +160,7 @@ void CommandLineAPIHost::gatherRTCLogs(JSGlobalObject& globalObject, RefPtr<RTCL
         ASSERT(!logType.isNull());
         ASSERT(!logMessage.isNull());
 
-        callback->handleEvent({ WTFMove(logType), WTFMove(logMessage), WTFMove(logLevel), WTFMove(connection) });
+        callback->invoke({ WTFMove(logType), WTFMove(logMessage), WTFMove(logLevel), WTFMove(connection) });
     });
 }
 #endif

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
@@ -74,7 +74,7 @@ ExceptionOr<void> InspectorAuditDOMObject::simulateUserInteraction(Document& doc
     ERROR_IF_NO_ACTIVE_AUDIT();
 
     UserGestureEmulationScope userGestureScope(m_auditAgent.inspectedPage(), true, &document);
-    callback->handleEvent();
+    callback->invoke();
 
     return { };
 }

--- a/Source/WebCore/inspector/RTCLogsCallback.h
+++ b/Source/WebCore/inspector/RTCLogsCallback.h
@@ -43,8 +43,8 @@ public:
         RefPtr<RTCPeerConnection> connection;
     };
 
-    virtual CallbackResult<void> handleEvent(const Logs&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(const Logs&) = 0;
+    virtual CallbackResult<void> invoke(const Logs&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(const Logs&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -577,7 +577,7 @@ void IntersectionObserver::notify()
 #endif
 
     InspectorInstrumentation::willFireObserverCallback(*context, "IntersectionObserver"_s);
-    m_callback->handleEvent(*this, WTFMove(takenRecords.records), *this);
+    m_callback->invoke(*this, WTFMove(takenRecords.records), *this);
     InspectorInstrumentation::didFireObserverCallback(*context);
 }
 

--- a/Source/WebCore/page/IntersectionObserverCallback.h
+++ b/Source/WebCore/page/IntersectionObserverCallback.h
@@ -41,8 +41,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<void> handleEvent(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;
+    virtual CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -966,7 +966,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         Vector<RefPtr<DOMPromise>> promiseList;
 
         for (auto& handler : event->handlers()) {
-            auto callbackResult = handler->handleEvent();
+            auto callbackResult = handler->invoke();
             if (callbackResult.type() == CallbackResultType::Success)
                 promiseList.append(callbackResult.releaseReturnValue());
             else if (callbackResult.type() == CallbackResultType::ExceptionThrown) {

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -35,7 +35,7 @@ class NavigationInterceptHandler : public ThreadSafeRefCounted<NavigationInterce
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<WTF::RefPtr<DOMPromise>> handleEvent() = 0;
+    virtual CallbackResult<WTF::RefPtr<DOMPromise>> invoke() = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -144,7 +144,7 @@ void PerformanceObserver::deliver()
     auto list = PerformanceObserverEntryList::create(WTFMove(entries));
 
     InspectorInstrumentation::willFireObserverCallback(*context, "PerformanceObserver"_s);
-    m_callback->handleEvent(*this, list, *this);
+    m_callback->invoke(*this, list, *this);
     InspectorInstrumentation::didFireObserverCallback(*context);
 }
 

--- a/Source/WebCore/page/PerformanceObserverCallback.h
+++ b/Source/WebCore/page/PerformanceObserverCallback.h
@@ -40,8 +40,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<void> handleEvent(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;
+    virtual CallbackResult<void> invoke(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -182,7 +182,7 @@ void ResizeObserver::deliverObservations()
         return;
 
     InspectorInstrumentation::willFireObserverCallback(*context, "ResizeObserver"_s);
-    jsCallback->handleEvent(*this, entries, *this);
+    jsCallback->invoke(*this, entries, *this);
     InspectorInstrumentation::didFireObserverCallback(*context);
 }
 

--- a/Source/WebCore/page/ResizeObserverCallback.h
+++ b/Source/WebCore/page/ResizeObserverCallback.h
@@ -40,8 +40,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<void> handleEvent(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;
+    virtual CallbackResult<void> invoke(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5828,13 +5828,13 @@ bool Internals::isProcessingUserGesture()
 void Internals::withUserGesture(Ref<VoidCallback>&& callback)
 {
     UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, contextDocument());
-    callback->handleEvent();
+    callback->invoke();
 }
 
 void Internals::withoutUserGesture(Ref<VoidCallback>&& callback)
 {
     UserGestureIndicator gestureIndicator(IsProcessingUserGesture::No, contextDocument());
-    callback->handleEvent();
+    callback->invoke();
 }
 
 bool Internals::userIsInteracting()
@@ -6031,12 +6031,12 @@ void Internals::postTask(Ref<VoidCallback>&& callback)
 {
     auto* document = contextDocument();
     if (!document) {
-        callback->handleEvent();
+        callback->invoke();
         return;
     }
 
     document->postTask([callback = WTFMove(callback)](ScriptExecutionContext&) {
-        callback->handleEvent();
+        callback->invoke();
     });
 }
 
@@ -6054,7 +6054,7 @@ ExceptionOr<void> Internals::queueTask(ScriptExecutionContext& context, const St
         return Exception { ExceptionCode::NotSupportedError };
 
     context.eventLoop().queueTask(*source, [callback = WTFMove(callback)] {
-        callback->handleEvent();
+        callback->invoke();
     });
 
     return { };
@@ -6070,7 +6070,7 @@ ExceptionOr<void> Internals::queueTaskToQueueMicrotask(Document& document, const
     context.eventLoop().queueTask(*source, [movedCallback = WTFMove(callback), protectedDocument = Ref { document }]() mutable {
         ScriptExecutionContext& context = protectedDocument.get();
         context.eventLoop().queueMicrotask([callback = WTFMove(movedCallback)] {
-            callback->handleEvent();
+            callback->invoke();
         });
     });
 
@@ -6649,10 +6649,10 @@ void Internals::requestTextRecognition(Element& element, Ref<VoidCallback>&& cal
 {
     auto page = contextDocument()->page();
     if (!page)
-        callback->handleEvent();
+        callback->invoke();
 
     page->chrome().client().requestTextRecognition(element, { }, [callback = WTFMove(callback)] (auto&&) {
-        callback->handleEvent();
+        callback->invoke();
     });
 }
 

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -116,7 +116,7 @@ void WebXRTest::simulateUserActivation(Document& document, XRSimulateUserActivat
     // https://immersive-web.github.io/webxr-test-api/#dom-xrtest-simulateuseractivation
     // Invoke function as if it had transient activation.
     UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &document);
-    function.handleEvent();
+    function.invoke();
 }
 
 void WebXRTest::disconnectAllDevices(DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/testing/XRSimulateUserActivationFunction.h
+++ b/Source/WebCore/testing/XRSimulateUserActivationFunction.h
@@ -39,8 +39,8 @@ class XRSimulateUserActivationFunction : public RefCounted<XRSimulateUserActivat
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(void) = 0;
-    virtual CallbackResult<void> handleEventRethrowingException(void) = 0;
+    virtual CallbackResult<void> invoke(void) = 0;
+    virtual CallbackResult<void> invokeRethrowingException(void) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -141,7 +141,7 @@ void WorkerAnimationController::serviceRequestAnimationFrameCallbacks(DOMHighRes
             continue;
         callback->m_firedOrCancelled = true;
         InspectorInstrumentation::willFireAnimationFrame(m_workerGlobalScope, callback->m_id);
-        callback->handleEvent(timestamp);
+        callback->invoke(timestamp);
         InspectorInstrumentation::didFireAnimationFrame(m_workerGlobalScope, callback->m_id);
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -634,7 +634,7 @@ void PDFPlugin::installPDFDocument()
 
     auto handlePDFTestCallback = makeScopeExit([testCallback = WTFMove(m_pdfTestCallback)] {
         if (testCallback)
-            testCallback->handleEvent();
+            testCallback->invoke();
     });
 
 #if HAVE(INCREMENTAL_PDF_APIS)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1388,7 +1388,7 @@ void PDFPluginBase::registerPDFTest(RefPtr<WebCore::VoidCallback>&& callback)
     ASSERT(!m_pdfTestCallback);
 
     if (m_pdfDocument && callback)
-        callback->handleEvent();
+        callback->invoke();
     else
         m_pdfTestCallback = WTFMove(callback);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -313,7 +313,7 @@ void UnifiedPDFPlugin::installPDFDocument()
 
     auto handlePDFTestCallback = makeScopeExit([testCallback = WTFMove(m_pdfTestCallback)] {
         if (testCallback)
-            testCallback->handleEvent();
+            testCallback->invoke();
     });
 
     m_documentLayout.setPDFDocument(m_pdfDocument.get());


### PR DESCRIPTION
#### 64bf598508221043400d29d549c8aa0316ab0fec
<pre>
[WebIDL] Rename handleEvent[...]() functions used by callbacks to invoke[...]()
<a href="https://bugs.webkit.org/show_bug.cgi?id=283231">https://bugs.webkit.org/show_bug.cgi?id=283231</a>
<a href="https://rdar.apple.com/140525030">rdar://140525030</a>

Reviewed by Darin Adler.

Fix an ancient FIXME by renaming the handleEvent[...]() functions used by callbacks to invoke[...]().

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/entriesapi/ErrorCallback.cpp:
* Source/WebCore/Modules/entriesapi/ErrorCallback.h:
* Source/WebCore/Modules/entriesapi/FileCallback.h:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
* Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.cpp:
* Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h:
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
* Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h:
* Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp:
* Source/WebCore/Modules/geolocation/GeoNotifier.cpp:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
* Source/WebCore/Modules/geolocation/PositionCallback.h:
* Source/WebCore/Modules/geolocation/PositionErrorCallback.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h:
* Source/WebCore/Modules/notifications/Notification.cpp:
* Source/WebCore/Modules/notifications/NotificationPermissionCallback.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
* Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h:
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
* Source/WebCore/Modules/reporting/ReportingObserverCallback.h:
* Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/Modules/webaudio/AudioBufferCallback.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h:
* Source/WebCore/Modules/webdatabase/Database.cpp:
* Source/WebCore/Modules/webdatabase/DatabaseCallback.h:
* Source/WebCore/Modules/webdatabase/DatabaseManager.cpp:
* Source/WebCore/Modules/webdatabase/SQLStatement.cpp:
* Source/WebCore/Modules/webdatabase/SQLStatementCallback.h:
* Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h:
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
* Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h:
* Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
* Source/WebCore/Modules/webxr/XRFrameRequestCallback.h:
* Source/WebCore/animation/CustomEffect.cpp:
* Source/WebCore/animation/CustomEffectCallback.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
* Source/WebCore/css/CSSPaintCallback.h:
* Source/WebCore/dom/AbortAlgorithm.h:
* Source/WebCore/dom/AbortSignal.cpp:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.h:
* Source/WebCore/dom/IdleCallbackController.cpp:
* Source/WebCore/dom/IdleRequestCallback.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverFromScript.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/MapperCallback.h:
* Source/WebCore/dom/MutationCallback.h:
* Source/WebCore/dom/MutationObserver.cpp:
* Source/WebCore/dom/Observable.cpp:
* Source/WebCore/dom/ObservableInspectorAbortCallback.h:
* Source/WebCore/dom/PredicateCallback.h:
* Source/WebCore/dom/ReducerCallback.h:
* Source/WebCore/dom/RequestAnimationFrameCallback.h:
* Source/WebCore/dom/ScriptedAnimationController.cpp:
* Source/WebCore/dom/StringCallback.cpp:
* Source/WebCore/dom/StringCallback.h:
* Source/WebCore/dom/Subscriber.cpp:
* Source/WebCore/dom/SubscriberCallback.h:
* Source/WebCore/dom/SubscriptionObserverCallback.h:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/dom/ViewTransitionUpdateCallback.h:
* Source/WebCore/dom/VisitorCallback.h:
* Source/WebCore/editing/CustomUndoStep.cpp:
* Source/WebCore/fileapi/BlobCallback.cpp:
* Source/WebCore/fileapi/BlobCallback.h:
* Source/WebCore/html/CustomPaintImage.cpp:
* Source/WebCore/html/HTMLVideoElement.cpp:
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
* Source/WebCore/html/VideoFrameRequestCallback.h:
* Source/WebCore/html/VoidCallback.h:
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
* Source/WebCore/inspector/InspectorAuditDOMObject.cpp:
* Source/WebCore/inspector/RTCLogsCallback.h:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/IntersectionObserverCallback.h:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/NavigationInterceptHandler.h:
* Source/WebCore/page/PerformanceObserver.cpp:
* Source/WebCore/page/PerformanceObserverCallback.h:
* Source/WebCore/page/ResizeObserver.cpp:
* Source/WebCore/page/ResizeObserverCallback.h:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/XRSimulateUserActivationFunction.h:
* Source/WebCore/workers/WorkerAnimationController.cpp:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:

Canonical link: <a href="https://commits.webkit.org/292916@main">https://commits.webkit.org/292916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3151f1da3c92d01c024b9accbc4aaddd10dfabef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74198 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31382 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5955 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104499 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17880 "Found 2 new test failures: imported/w3c/web-platform-tests/IndexedDB/key-conversion-exceptions.htm imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18019 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29601 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24255 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->