### PR TITLE
AX: accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html needs to have async waits to pass in ITM

### DIFF
--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html
@@ -85,51 +85,51 @@ customElements.define(
 <script>
 description("This tests the basic interaction between referenceTarget and aria-activedescendant.");
 
+var realInput;
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     let output = "aria-activedescendant targeting a custom element with shadowrootreferencetarget.\n"
     var combobox1 = accessibilityController.accessibleElementById("combobox1");
     output += expect("combobox1.selectedChildrenCount", "1");
-    output += expect("combobox1.selectedChildAtIndex(0).title", "'AXTitle: Option 2'");
-    output += "\n";
+    output += `${expect("combobox1.selectedChildAtIndex(0).title", "'AXTitle: Option 2'")}\n`;
 
     output += "ShadowRoot.referenceTarget property works on an imperatively defined custom element.\n";
     var combobox2 = accessibilityController.accessibleElementById("combobox2");
     output += expect("combobox2.selectedChildrenCount", "1");
-    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
-    output += "\n";
+    output += `${expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option C'")}\n`;
 
     output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object.\n";
     const listboxElement = document.getElementById("x-listbox2");
     listboxElement.setReferenceTarget("option-a");
-    output += expect("combobox2.selectedChildrenCount", "1");
-    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option A'");
-    output += "\n";
+    setTimeout(async function() {
+        output += await expectAsync("combobox2.selectedChildrenCount", "1");
+        output += `${expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option A'")}\n`;
 
-    output += "Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.\n";
-    let referenceTargetElement = listboxElement.referenceTargetElement();
-    referenceTargetElement.id = "option-d";
-    output += expect("combobox2.selectedChildrenCount", "0");
-    referenceTargetElement.nextElementSibling.id = "option-a";
-    output += expect("combobox2.selectedChildrenCount", "1");
-    output += expect("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
-    output += "\n";
+        output += "Modifying a ShadowRoot's referenceTarget's ID also updates the accessibility object.\n";
+        let referenceTargetElement = listboxElement.referenceTargetElement();
+        referenceTargetElement.id = "option-d";
+        output += await expectAsync("combobox2.selectedChildrenCount", "0");
+        referenceTargetElement.nextElementSibling.id = "option-a";
+        output += await expectAsync("combobox2.selectedChildrenCount", "1");
+        output += await expectAsync("combobox2.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+        output += "\n";
 
-    output += "aria-activedescendant works when the linkage is created across two sibling shadow trees.\n";
-    var realInput = accessibilityController.accessibleElementById("real-input");
-    output += expect("realInput.selectedChildrenCount", "1");
-    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
-    output += "\n";
+        output += "aria-activedescendant works when the linkage is created across two sibling shadow trees.\n";
+        realInput = accessibilityController.accessibleElementById("real-input");
+        output += expect("realInput.selectedChildrenCount", "1");
+        output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option C'");
+        output += "\n";
 
-    output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.\n";
-    const fancyListboxElement = document.getElementById("fancy-listbox");
-    fancyListboxElement.setReferenceTarget("option-b");
-    output += expect("realInput.selectedChildrenCount", "1");
-    output += expect("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
+        output += "Modifying a ShadowRoot's referenceTarget also updates the accessibility object when the linkage is created across two sibling shadow trees.\n";
+        const fancyListboxElement = document.getElementById("fancy-listbox");
+        fancyListboxElement.setReferenceTarget("option-b");
+        output += await expectAsync("realInput.selectedChildrenCount", "1");
+        output += await expectAsync("realInput.selectedChildAtIndex(0).title", "'AXTitle: Option B'");
 
-    debug(output);
-    finishJSTest();
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>


### PR DESCRIPTION
#### 4717614512a305bfcd427b5f3f8ad09a65e14601
<pre>
AX: accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html needs to have async waits to pass in ITM
<a href="https://bugs.webkit.org/show_bug.cgi?id=290701">https://bugs.webkit.org/show_bug.cgi?id=290701</a>
<a href="https://rdar.apple.com/148172679">rdar://148172679</a>

Reviewed by Chris Fleizach.

In ITM, we need to wait for DOM changes to be synced to the accessibility thread, so change test to do that.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-activedescendant.html:

Canonical link: <a href="https://commits.webkit.org/292933@main">https://commits.webkit.org/292933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/303792f89e45c7ca2117af431822fa9d6f876e8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74208 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100407 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13106 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88082 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5967 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24483 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17851 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83255 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->