### PR TITLE
New Test(285483@main): [ iOS ] editing/selection/ios/selection-moves-between-composited-layers.html is a constant failure.

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt
@@ -5,10 +5,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS rectsBeforeStyleChange.length is 1
 PASS rectsBeforeStyleChange.length is rectsAfterStyleChange.length
-PASS rectsBeforeStyleChange[0].top is rectsAfterStyleChange[0].top
-PASS rectsBeforeStyleChange[0].left is rectsAfterStyleChange[0].left
-PASS rectsBeforeStyleChange[0].width is rectsAfterStyleChange[0].width
-PASS rectsBeforeStyleChange[0].height is rectsAfterStyleChange[0].height
+PASS firstRectBeforeStyleChange.top is firstRectAfterStyleChange.top
+PASS firstRectBeforeStyleChange.left is firstRectAfterStyleChange.left
+PASS firstRectBeforeStyleChange.width is firstRectAfterStyleChange.width
+PASS firstRectBeforeStyleChange.height is firstRectAfterStyleChange.height
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html
+++ b/LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html
@@ -50,17 +50,19 @@ addEventListener("load", async () => {
     input.select();
     await UIHelper.ensurePresentationUpdate();
     rectsBeforeStyleChange = await UIHelper.waitForSelectionToAppear();
+    firstRectBeforeStyleChange = UIHelper.roundRectToDevicePixel(rectsBeforeStyleChange[0]);
 
     container.style.position = "static";
     await UIHelper.ensurePresentationUpdate();
     rectsAfterStyleChange = await UIHelper.getUISelectionViewRects();
+    firstRectAfterStyleChange = UIHelper.roundRectToDevicePixel(rectsAfterStyleChange[0]);
 
     shouldBe("rectsBeforeStyleChange.length", "1");
     shouldBe("rectsBeforeStyleChange.length", "rectsAfterStyleChange.length");
-    shouldBe("rectsBeforeStyleChange[0].top", "rectsAfterStyleChange[0].top");
-    shouldBe("rectsBeforeStyleChange[0].left", "rectsAfterStyleChange[0].left");
-    shouldBe("rectsBeforeStyleChange[0].width", "rectsAfterStyleChange[0].width");
-    shouldBe("rectsBeforeStyleChange[0].height", "rectsAfterStyleChange[0].height");
+    shouldBe("firstRectBeforeStyleChange.top", "firstRectAfterStyleChange.top");
+    shouldBe("firstRectBeforeStyleChange.left", "firstRectAfterStyleChange.left");
+    shouldBe("firstRectBeforeStyleChange.width", "firstRectAfterStyleChange.width");
+    shouldBe("firstRectBeforeStyleChange.height", "firstRectAfterStyleChange.height");
 
     input.blur();
     await UIHelper.waitForKeyboardToHide();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7795,5 +7795,3 @@ webkit.org/b/290666 imported/w3c/web-platform-tests/screen-orientation/fullscree
 webkit.org/b/290670 imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units.html [ Failure ]
 
 webkit.org/b/290546 [ Debug ] imported/w3c/web-platform-tests/workers/abrupt-completion.html [ Pass Crash ]
-
-webkit.org/b/290673 editing/selection/ios/selection-moves-between-composited-layers.html [ Failure ]


### PR DESCRIPTION
#### 11f26c5193ae91b7597f97c017ceb62465298977
<pre>
New Test(285483@main): [ iOS ] editing/selection/ios/selection-moves-between-composited-layers.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290673">https://bugs.webkit.org/show_bug.cgi?id=290673</a>
<a href="https://rdar.apple.com/148144078">rdar://148144078</a>

Reviewed by Abrar Rahman Protyasha.

Round selection rects to the nearest device pixel, to avoid test failures due to tiny floating point
arithmetic error when running tests on iPad (the selection rects before and after are still visually
identical).

* LayoutTests/editing/selection/ios/selection-moves-between-composited-layers-expected.txt:
* LayoutTests/editing/selection/ios/selection-moves-between-composited-layers.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/292907@main">https://commits.webkit.org/292907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc411eeabc281d0e3e8f4810e17933151d04e7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25482 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74211 "Found 1 new test failure: media/media-vp8-webm-seek-to-start.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13109 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83256 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82676 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4909 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24447 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->