### PR TITLE
[macOS][GPUP] Enforce IOKit restrictions on user client AudioAUUC

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -813,6 +813,7 @@
         (iokit-user-client-class "IOAudioEngineUserClient")))
 #endif
 
+#if !ENABLE(GPU_PROCESS_IOKIT_RESTRICTIONS)
 ;; Following is needed due to <rdar://problem/10427451> && <rdar://problem/10808817>
 (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
     (allow IOKIT_OPEN_USER_CLIENT (with report) (with telemetry)
@@ -825,6 +826,7 @@
     ;; else
     (allow IOKIT_OPEN_USER_CLIENT
         (iokit-user-client-class "AudioAUUC")))
+#endif
 
 #if HAVE(APPLE_CAMERA_USER_CLIENT)
 ;; Following is needed due to <rdar://problem/108282689>


### PR DESCRIPTION
#### ce7c65a74174dc158e0cddc48d26bd8fbec1c67b
<pre>
[macOS][GPUP] Enforce IOKit restrictions on user client AudioAUUC
<a href="https://bugs.webkit.org/show_bug.cgi?id=290711">https://bugs.webkit.org/show_bug.cgi?id=290711</a>
<a href="https://rdar.apple.com/148177186">rdar://148177186</a>

Reviewed by Sihui Liu.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/293072@main">https://commits.webkit.org/293072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0dbc8ee970f45cd796178f888bf7beee935d868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74218 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100419 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13114 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88093 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12878 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24495 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17860 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/Worker-timeout-cancel-order.html imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83270 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82690 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18043 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15839 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29625 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->