### PR TITLE
Minor cleanup in ProtectionSpace::nsSpace

### DIFF
--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
@@ -180,10 +180,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     default:
         ASSERT_NOT_REACHED();
     }
-    
-    lazyInitialize(m_nsSpace, adoptNS(proxyType
-        ? [[NSURLProtectionSpace alloc] initWithProxyHost:host() port:port() type:proxyType.get() realm:realm() authenticationMethod:method]
-        : [[NSURLProtectionSpace alloc] initWithHost:host() port:port() protocol:protocol.get() realm:realm() authenticationMethod:method]));
+
+    if (proxyType)
+        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithProxyHost:host() port:port() type:proxyType.get() realm:realm() authenticationMethod:method]));
+    else
+        lazyInitialize(m_nsSpace, adoptNS([[NSURLProtectionSpace alloc] initWithHost:host() port:port() protocol:protocol.get() realm:realm() authenticationMethod:method]));
 
     return m_nsSpace.get();
 }


### PR DESCRIPTION
#### 9ae9bdf0b0df02046a483485ac92ab40c571ddf4
<pre>
Minor cleanup in ProtectionSpace::nsSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=290714">https://bugs.webkit.org/show_bug.cgi?id=290714</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Use if statement instead of ternary expression, which confuses static analyzer.

* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::ProtectionSpace::nsSpace const):

Canonical link: <a href="https://commits.webkit.org/292920@main">https://commits.webkit.org/292920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a508faae61584007c0cc2bc913c634e250c0e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25497 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74224 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31407 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24500 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17862 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/semantics/navigation/001.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83269 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82689 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18048 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15743 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29630 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->