### PR TITLE
Add collect-pgo-profiles script to support collection on iOS.

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -59,14 +59,6 @@ if [[ ! -d "$BASE" ]] ; then
     mkdir -p "$BASE"
 fi
 
-rm -rf "$BASE/*"
-
-mkdir -p "$BASE/speedometer2"
-mkdir -p "$BASE/speedometer3"
-mkdir -p "$BASE/jetstream"
-mkdir -p "$BASE/motionmark"
-mkdir -p "$BASE/output"
-mkdir -p "$BASE/Internal/WebKit/WebKitAdditions/Profiling/"
 
 if [[ -z $APP ]] ; then
     cd Internal
@@ -83,63 +75,20 @@ else
     echo "Using .app: $APP"
 fi
 
-jsargs=(
-    --plan jetstream2
-    --diagnose-directory="$BASE/jetstream"
-    --generate-pgo-profiles
-    --http-server-type builtin
-    --count 1
-)
-
-sp3args=(
-    --plan speedometer3
-    --diagnose-directory="$BASE/speedometer3"
-    --generate-pgo-profiles
-    --http-server-type builtin
-    --count 1
-)
-
-mmargs=(
-    --plan motionmark
-    --diagnose-directory="$BASE/motionmark"
-    --generate-pgo-profiles
-    --http-server-type builtin
-    --count 1
-)
+benchmarks=(jetstream2 speedometer3 motionmark)
 
 if [[ -n $APP ]] ; then
-   jsargs+=(--browser-path "$APP")
-   sp3args+=(--browser-path "$APP")
-   mmargs+=(--browser-path "$APP")
+   run_benchmark_args=(--browser-path "$APP")
    deployment_target=$(vtool -show-build "$APP"/Contents/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
 else
-   jsargs+=(--build-directory $BUILD)
-   sp3args+=(--build-directory $BUILD)
-   mmargs+=(--build-directory $BUILD)
+   run_benchmark_args=(--build-directory $BUILD)
    deployment_target=$(vtool -show-build "$BUILD"/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
 fi
 
 # The reported target triple is based on an arbitrary binary (JavaScriptCore)
 # and this machine's architecture.
 target_triple=$(machine)-apple-macos${deployment_target}
+COMPRESSED_PROFILE_SUB_PATH="Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
 
 SPTH='OpenSource/Tools/Scripts'
-
-$SPTH/run-benchmark "${jsargs[@]}"
-$SPTH/pgo-profile merge "$BASE/jetstream"
-
-$SPTH/run-benchmark "${sp3args[@]}"
-$SPTH/pgo-profile merge "$BASE/speedometer3"
-
-$SPTH/run-benchmark "${mmargs[@]}"
-$SPTH/pgo-profile merge "$BASE/motionmark"
-
-rm *.result
-
-$SPTH/pgo-profile combine --jetstream "$BASE/jetstream" --speedometer3 "$BASE/speedometer3" --motionmark "$BASE/motionmark" --output "$BASE/output"
-
-mkdir -p "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
-$SPTH/pgo-profile compress --input "$BASE/output" --output "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
-
-echo "Done! Find your profiles in $BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
-echo "To check these in, do: 'cp -r $BASE/Internal/ ../Internal/'"
+$SPTH/collect-pgo-profiles --benchmarks ${benchmarks[@]} --output-directory $BASE --compressed-profile-sub-path $COMPRESSED_PROFILE_SUB_PATH ${run_benchmark_args[@]}

--- a/Tools/Scripts/collect-pgo-profiles
+++ b/Tools/Scripts/collect-pgo-profiles
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import shutil
+import shlex
+import subprocess
+import sys
+import tempfile
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+
+SCRIPT_DIR = os.path.dirname(__file__)
+DEFAULT_RUN_BENCHMARK = os.path.join(SCRIPT_DIR, 'run-benchmark')
+PGO_PROFILE = os.path.join(SCRIPT_DIR, 'pgo-profile')
+
+
+def check_or_create_empty_directory(path):
+    if not os.path.exists(path):
+        os.makedirs(path, exist_ok=False)
+        return
+
+    assert os.path.isdir(path) and len(os.listdir(path)) == 0, f'{path} is not empty or is not a directory'
+
+
+def collect_pgo_profiles(harness, benchmark, output_directory, run_benchmark_args, verbose):
+    benchmark_profile_directory = os.path.join(output_directory, benchmark)
+    os.makedirs(benchmark_profile_directory)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_file = os.path.join(temp_dir, f'{benchmark}.json')
+        command = [sys.executable, harness, '--plan', benchmark, '--diagnose-directory', benchmark_profile_directory,
+                   '--generate-pgo-profiles', '--http-server-type', 'twisted', '--count', '1',
+                   '--output-file', output_file, *run_benchmark_args]
+        if verbose:
+            command.append('--debug')
+        logger.info(f'Running {benchmark} with {shlex.join(command)}')
+        subprocess.run(command, check=True)
+
+    merge_command = [sys.executable, PGO_PROFILE, 'merge', benchmark_profile_directory]
+    if verbose:
+        merge_command.append('--verbose')
+    subprocess.run(merge_command, check=True)
+
+    return benchmark_profile_directory
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='collect-pgo-profiles',
+                                     allow_abbrev=False,
+                                     description='PGO profile collection script, '
+                                                 'unknown arguments will be passed to run-benchmark harness.')
+    parser.add_argument('-r', '--run-benchmark-harness', required=False, default=DEFAULT_RUN_BENCHMARK,
+                        help=f'Location for run-benchmark harness, defaults to {DEFAULT_RUN_BENCHMARK}')
+    parser.add_argument('-b', '--benchmarks', nargs='+', required=True,
+                        help='Benchmarks to run for PGO profile collection.')
+    parser.add_argument('-o', '--output-directory', required=True,
+                        help='PGO profile output directory.')
+    parser.add_argument('-p', '--compressed-profile-sub-path', required=True,
+                        help='Sub path under output directory for compressed PGO profiles.')
+    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+                        help='Turn on debug logging')
+    args, run_benchmark_args = parser.parse_known_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    check_or_create_empty_directory(args.output_directory)
+
+    combine_command = [sys.executable, PGO_PROFILE, 'combine']
+    for benchmark in args.benchmarks:
+        profile_directory = collect_pgo_profiles(args.run_benchmark_harness, benchmark, args.output_directory,
+                                                 run_benchmark_args, args.verbose)
+        combine_command.extend([f'--{benchmark}', profile_directory])
+
+    combined_profile_directory = os.path.join(args.output_directory, 'output')
+    os.makedirs(combined_profile_directory)
+    combine_command.extend(['--output', combined_profile_directory])
+    subprocess.run(combine_command, check=True)
+
+    compressed_profile_directory = os.path.join(args.output_directory, args.compressed_profile_sub_path)
+    os.makedirs(compressed_profile_directory)
+    subprocess.run([sys.executable, PGO_PROFILE, 'compress', '--input', combined_profile_directory,
+                    '--output', compressed_profile_directory], check=True)
+
+    logger.info(f'Compressed profile is located at {compressed_profile_directory}')
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -1,42 +1,46 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
-import math
-import subprocess
+import logging
 import os
+import subprocess
 
-PROFILED_DYLIBS = ["JavaScriptCore", "WebCore", "WebKit"]
-BENCHMARK_GROUP_WEIGHTS = [("speedometer3", 0.6), ("jetstream", 0.2), ("motionmark", 0.2)]
+from webkitpy.llvm_profile_utils import (LLVMProfileData, simplify_profile_weights,
+                                         merge_raw_profiles_in_directory_by_prefixes)
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger()
+
+
+PROFILED_DYLIBS = ['JavaScriptCore', 'WebCore', 'WebKit']
+BENCHMARK_GROUP_WEIGHTS = [('speedometer3', 0.6), ('jetstream2', 0.2), ('motionmark', 0.2)]
 
 
 def pad(string, max_length):
     if len(string) > max_length:
-        return string[:max_length - 1] + u"…"
+        return string[:max_length - 1] + u'…'
     return string.ljust(max_length)
 
 
-def shell(command):
-    return subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip()
-
-
 def shortened(name):
-    return name if len(name) < 200 else name[0:99] + u"…" + name[-98:]
+    return name if len(name) < 200 else name[0:99] + u'…' + name[-98:]
 
 
 def assert_directory(directory_path):
-    assert os.path.isdir(directory_path), f"No directory at {directory_path}"
+    assert os.path.isdir(directory_path), f'No directory at {directory_path}'
     return directory_path
 
 
 def assert_file(file_path):
-    assert os.path.isfile(file_path), f"No file at {file_path}"
+    assert os.path.isfile(file_path), f'No file at {file_path}'
     return file_path
 
 
-def summarize_parser(subparsers):
-    parser = subparsers.add_parser("summarize", help="Dumps function names in a given .profraw file, sorted in descending order by function count")
-    parser.add_argument("file", help="Path to the .profraw file")
+def summarize_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('summarize', parents=[parent_parser],
+                                   help='Dumps function names in a given .profraw file, '
+                                        'sorted in descending order by function count')
+    parser.add_argument('file', help='Path to the .profraw file')
     parser.set_defaults(func=summarize)
     return parser
 
@@ -44,13 +48,16 @@ def summarize_parser(subparsers):
 def summarize(args):
     file = assert_file(args.file)
 
-    lines = shell(f"xcrun -sdk macosx llvm-profdata show --all-functions --value-cutoff=10 \"{file}\" | c++filt -n").decode("utf-8").splitlines()
+    show_process = LLVMProfileData.show(file)
+    show_process.check_returncode()
+
+    lines = show_process.stdout.splitlines()
 
     counts_and_functions = []
 
     for line_number in range(len(lines)):
         line = lines[line_number].strip()
-        if line.startswith("Function count: "):
+        if line.startswith('Function count: '):
             count = int(line.split()[-1])
             symbol = lines[line_number - 3].strip()[:-1]
             counts_and_functions.append((count, symbol))
@@ -60,80 +67,67 @@ def summarize(args):
         print(pad(str(count), 15), shortened(name))
 
 
-def merge_parser(subparsers):
-    parser = subparsers.add_parser("merge", help="Merge a pile of *.profraw files into the *.profdata files we can build with.")
-    parser.add_argument("directory", help="Path to the directory containing the *.profraw files")
+def merge_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('merge', parents=[parent_parser],
+                                   help='Merge a pile of *.profraw files into the *.profdata files we can build with.')
+    parser.add_argument('directory', help='Path to the directory containing the *.profraw files')
     parser.set_defaults(func=merge)
     return parser
 
 
 def merge(args):
-    path = assert_directory(args.directory)
-
-    for lib in PROFILED_DYLIBS:
-        print("Merging", lib)
-        inputs = glob.glob(os.path.join(path, lib) + "*.profraw")
-        inputs = [f"\"{i}\"" for i in inputs]
-        inputs = " ".join(inputs)
-        output_file = os.path.join(path, lib + '.profdata')
-        print(shell(f"xcrun -sdk macosx.internal llvm-profdata merge --sparse {inputs} -output=\"{output_file}\""))
+    directory = assert_directory(args.directory)
+    merge_raw_profiles_in_directory_by_prefixes(PROFILED_DYLIBS, directory)
 
 
-def combine_parser(subparsers):
-    parser = subparsers.add_parser("combine", help="Combine directories containing *.profdata files from different platforms together.")
+def combine_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('combine', parents=[parent_parser],
+                                   help='Combine directories containing *.profdata files from different platforms together.')
     for i in range(0, len(BENCHMARK_GROUP_WEIGHTS)):
         group, _ = BENCHMARK_GROUP_WEIGHTS[i]
-        parser.add_argument(f"--{group}", default=None, help=f"Path to the directory containing the *.profdata files from a {group} run.")
-    parser.add_argument("--output", help="Path to the directory where the output will be placed.")
+        parser.add_argument(f'--{group}', default=None,
+                            help=f'Path to the directory containing the *.profdata files from a {group} run.')
+    parser.add_argument('--output', help='Path to the directory where the output will be placed.')
     parser.set_defaults(func=combine)
     return parser
 
 
 def combine(args):
-    assert args.output, "Must specify output directory."
+    assert args.output, 'Must specify output directory.'
+
     out = assert_directory(args.output)
     args = vars(args)
-    group_paths = []
+    profile_weight_pairs = []
 
     for i in range(0, len(BENCHMARK_GROUP_WEIGHTS)):
         group, weight = BENCHMARK_GROUP_WEIGHTS[i]
         if args[group]:
-            path = assert_directory(args[group])
-            group_paths.append((path, weight))
-    
-    assert len(group_paths) > 0, "Must specify at least one group."
-    
-    sum = 0
-    max = 0
-    # We need to turn percentages into weights > 1, but we don't want crazy high multipliers.
-    # For example, if we have weights 0.35 and 0.65, we don't need a 7:13 ratio when 5:9 is good enough.
-    max_multiplier = 15
-    for group, weight in group_paths:
-        sum = sum + weight
-        if weight > max:
-            max = weight
+            profile_group = assert_directory(args[group])
+            profile_weight_pairs.append((profile_group, weight))
 
-    gcd = int(max * max_multiplier)
-    for group, weight in group_paths:
-        gcd = math.gcd(gcd, int((weight / sum) * max_multiplier))
-    for i in range(0, len(group_paths)):
-        group, weight = group_paths[i]
-        group_paths[i] = (group, int((weight / sum) * max_multiplier) // gcd)
-    
-    print("Simplified group weights: ", group_paths)
+    assert len(profile_weight_pairs) > 0, 'Must specify at least one group.'
+
+    profile_weight_pairs = simplify_profile_weights(profile_weight_pairs)
+    logger.info(f'Simplified group weights: {profile_weight_pairs}')
 
     for lib in PROFILED_DYLIBS:
-        print("Merging", lib)
-        group_input = ["--weighted-input={},\"{}\"".format(weight, os.path.join(path, lib + ".profdata")) for path, weight in group_paths]
-        group_input = " ".join(group_input)
-        output_file = os.path.join(out, lib + '.profdata')
-        print(shell(f"xcrun -sdk macosx.internal llvm-profdata merge --sparse {group_input} -output=\"{output_file}\""))
+        logger.info(f'Merging {lib}')
+        weighted_profiles = [(os.path.join(path, f'{lib}.profdata'), weight)
+                             for path, weight in profile_weight_pairs]
+
+        output_file = os.path.join(out, f'{lib}.profdata')
+        merge_process = LLVMProfileData.merge(output_file, weighted_profiles=weighted_profiles)
+        logger.info(f'stdout: {merge_process.stdout}')
+        logger.info(f'stderr: {merge_process.stderr}')
+        merge_process.check_returncode()
+        logger.info(f'{lib} is successfully merged')
 
 
-def compress_parser(subparsers):
-    parser = subparsers.add_parser("compress", help="Compress *.profdata files so that they can be checked in.")
-    parser.add_argument("--input", help="Path to the directory containing the input *.profdata files.")
-    parser.add_argument("--output", help="Path to the directory where the output will be placed.")
+def compress_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('compress', parents=[parent_parser],
+                                   help='Compress *.profdata files so that they can be checked in.')
+    parser.add_argument('--input', help='Path to the directory containing the input *.profdata files.')
+    parser.add_argument('--output', help='Path to the directory where the output will be placed.')
     parser.set_defaults(func=compress)
     return parser
 
@@ -143,23 +137,32 @@ def compress(args):
     input_directory = assert_directory(args.input)
 
     for lib in PROFILED_DYLIBS:
-        print("Compressing", lib)
-        input_file = os.path.join(input_directory, lib + ".profdata")
-        output_file = os.path.join(out, lib + ".profdata.compressed")
-        print(shell(f"compression_tool -encode -i \"{input_file}\" -o \"{output_file}\" -a lzfse"))
+        logger.info(f'Compressing {lib}')
+        input_file = os.path.join(input_directory, f'{lib}.profdata')
+        output_file = os.path.join(out, f'{lib}.profdata.compressed')
+
+        compress_process = LLVMProfileData.compress(input_file, output_file)
+        logger.info(f'stdout: {compress_process.stdout}')
+        logger.info(f'stderr: {compress_process.stderr}')
+        compress_process.check_returncode()
+        logger.info(f'{lib} is successfully compressed')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='pgo-profile')
+    verbose_parser = argparse.ArgumentParser(add_help=False)
+    verbose_parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Turn on debug logging')
     subparsers = parser.add_subparsers(help='valid sub-commands', required=True, dest='sub command')
-    merge_parser(subparsers)
-    summarize_parser(subparsers)
-    combine_parser(subparsers)
-    compress_parser(subparsers)
+    merge_parser(subparsers, verbose_parser)
+    summarize_parser(subparsers, verbose_parser)
+    combine_parser(subparsers, verbose_parser)
+    compress_parser(subparsers, verbose_parser)
 
     args = parser.parse_args()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
     try:
         args.func(args)
     except subprocess.CalledProcessError as e:
-        print(e.stdout)
+        logger.error(e.stdout)
         raise e

--- a/Tools/Scripts/webkitpy/llvm_profile_utils.py
+++ b/Tools/Scripts/webkitpy/llvm_profile_utils.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import glob
+import logging
+import math
+import os
+import shlex
+import shutil
+import subprocess
+
+from functools import cache
+
+logger = logging.getLogger(__name__)
+
+
+def locate_binary_xcrun(sdk, binary_name):
+    completed_process = subprocess.run(['/usr/bin/xcrun', '-sdk', sdk, '--find', binary_name],
+                                       check=False, text=True, capture_output=True)
+    if completed_process.returncode:
+        return None
+    return completed_process.stdout.strip()
+
+
+def simplify_profile_weights(profile_weights):
+    simplified_profile_weights = []
+
+    weight_sum = 0
+    max_weight = 0
+    # We need to turn percentages into weights > 1, but we don't want crazy high multipliers.
+    # For example, if we have weights 0.35 and 0.65, we don't need a 7:13 ratio when 5:9 is good enough.
+    max_multiplier = 15
+    for group, weight in profile_weights:
+        weight_sum = weight_sum + weight
+        if weight > max_weight:
+            max_weight = weight
+
+    gcd = int(max_weight * max_multiplier)
+    for group, weight in profile_weights:
+        gcd = math.gcd(gcd, int((weight / weight_sum) * max_multiplier))
+
+    for i in range(0, len(profile_weights)):
+        group, weight = profile_weights[i]
+        simplified_profile_weights.append((group, int((weight / weight_sum) * max_multiplier) // gcd))
+
+    return simplified_profile_weights
+
+
+class ExecutablesFromEnvAndXcode:
+    PREFERRED_EXECUTABLE_INDEX = 0
+    EXECUTABLE_NAME = None
+
+    @classmethod
+    @cache
+    def detect_binaries(cls):
+        llvm_profdata_binaries = []
+        process = shutil.which(cls.EXECUTABLE_NAME)
+        if not process.returncode:
+            llvm_profdata_binaries.append(process.stdout.strip())
+
+        for sdk_name in ('macosx.internal', 'iphoneos.internal', 'macosx', 'iphoneos'):
+            binary_path = locate_binary_xcrun(sdk_name, cls.EXECUTABLE_NAME)
+            if not binary_path:
+                continue
+            if binary_path in llvm_profdata_binaries:
+                continue
+            llvm_profdata_binaries.append(binary_path)
+
+        logger.debug(f'Available {cls.EXECUTABLE_NAME} from {llvm_profdata_binaries}')
+
+        return llvm_profdata_binaries
+
+    @classmethod
+    def preference_ordered_paths(cls):
+        count = len(cls.detect_binaries())
+        for _ in range(count):
+            cls.PREFERRED_EXECUTABLE_INDEX = (cls.PREFERRED_EXECUTABLE_INDEX + 1) % count
+            yield cls.detect_binaries()[cls.PREFERRED_EXECUTABLE_INDEX]
+
+    @classmethod
+    def run(cls, command, *args, check=False, stdout=None, stderr=None, capture_output=False,
+            **kwargs) -> subprocess.CompletedProcess:
+        kwarg_capture_output = capture_output or (stdout is None and stderr is None)
+
+        completed_process = None
+        for binary_path in cls.preference_ordered_paths():
+            logger.debug(f'Running {shlex.join([binary_path, *command])}')
+            completed_process = subprocess.run([binary_path, *command], *args,
+                                               check=False, capture_output=kwarg_capture_output,
+                                               stdout=stdout, stderr=stderr, **kwargs)
+            if not completed_process.returncode:
+                break
+
+            logger.debug(f'Failed to {command} with binary {binary_path}\n'
+                         f'return_code: {completed_process.returncode}\n'
+                         f'stdout: {completed_process.stdout}\n'
+                         f'stderr: {completed_process.stderr}\n')
+
+        if check:
+            completed_process.check_returncode()
+
+        return completed_process
+
+
+class LLVMProfDataExecutable(ExecutablesFromEnvAndXcode):
+    EXECUTABLE_NAME = 'llvm-profdata'
+
+
+class LLVMProfileData:
+    @classmethod
+    def show(cls, profile_path):
+        list_functions_process = LLVMProfDataExecutable.run(['show', '--all-functions', '--value-cutoff=10',
+                                                             profile_path], stdout=subprocess.PIPE, text=True)
+
+        return subprocess.run(['/usr/bin/c++filt', '-n'], input=list_functions_process.stdout,
+                              capture_output=True, text=True, check=True)
+
+    @classmethod
+    def merge(cls, output_file, unweighted_profiles=(), weighted_profiles=()):
+        command = ['merge', '--sparse', *unweighted_profiles]
+        for profile_path, weight in weighted_profiles:
+            lib_profile_path = profile_path
+            command.extend(['--weighted-input', f'{weight},{lib_profile_path}'])
+
+        command.extend(['--output', output_file])
+
+        return LLVMProfDataExecutable.run(command, capture_output=True, text=True)
+
+    @classmethod
+    def compress(cls, input_profile, output_file):
+        return subprocess.run(['/usr/bin/compression_tool', '-encode', '-i', input_profile, '-o', output_file,
+                               '-a', 'lzfse'], capture_output=True, check=True, text=True)
+
+
+def merge_raw_profiles_in_directory_by_prefixes(prefix_list, input_directory, output_directory=None,
+                                                input_suffix='.profraw', output_suffix='.profdata'):
+    output_files = []
+    for prefix in prefix_list:
+        logger.info(f'Merging {prefix}')
+        pattern = f'{prefix}*{input_suffix}'
+        input_profiles = glob.glob(os.path.join(input_directory, pattern))
+        output_file = os.path.join(output_directory or input_directory, f'{prefix}{output_suffix}')
+        merge_process = LLVMProfileData.merge(output_file, unweighted_profiles=input_profiles)
+        logger.info(f'stdout: {merge_process.stdout}')
+        logger.info(f'stderr: {merge_process.stderr}')
+        merge_process.check_returncode()
+        output_files.append(output_file)
+        logger.info(f'{prefix} is successfully merged')
+
+    return output_files


### PR DESCRIPTION
#### 6137efe4895017b2236d516299e70acab922e54a
<pre>
Add collect-pgo-profiles script to support collection on iOS.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290715">https://bugs.webkit.org/show_bug.cgi?id=290715</a>
<a href="https://rdar.apple.com/148177797">rdar://148177797</a>

Reviewed by Stephanie Lewis.

Move PGO profile collection to a standalone script from &apos;build-and-collect-pgo-profiles&apos;.
Move &apos;llvm-profdata&apos; operations from &apos;pgo-profile&apos; into a separate module and make it be
able to try different `llvm-profdata` binaries.

* Tools/Scripts/build-and-collect-pgo-profiles: Moved collect pgo profile logic into
collect-pgo-profiles script.
* Tools/Scripts/collect-pgo-profiles: This script supports passing additional arguments
to run-benchmark and specifying a custom run-benchmark script.
(check_or_create_empty_directory):
(collect_pgo_profiles):
(main):
* Tools/Scripts/pgo-profile: Move llvm-profdata operations to &apos;llvm_profile_utils&apos;.
(pad):
(shortened):
(assert_directory):
(assert_file):
(summarize_parser):
(summarize):
(merge_parser):
(merge):
(combine_parser):
(combine):
(compress):
(shell): Deleted.
* Tools/Scripts/webkitpy/llvm_profile_utils.py: Modules for llvm-profdata operations.
(locate_xcrun_binary):
(simplify_profile_weights):
(ExecutablesFromEnvAndXcode):
(ExecutablesFromEnvAndXcode.detect_binaries):
(ExecutablesFromEnvAndXcode.preference_ordered_paths):
(ExecutablesFromEnvAndXcode.run):
(LLVMProfDataExecutable):
(LLVMProfileData):
(LLVMProfileData.show):
(LLVMProfileData.merge):
(LLVMProfileData.compress):
(merge_raw_profiles_in_directory_by_prefixes):

Canonical link: <a href="https://commits.webkit.org/293342@main">https://commits.webkit.org/293342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/651d0108fa69771ad8b5ec9e09df33750bc58bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89076 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55441 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98117 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83816 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106128 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25722 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83541 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28185 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19414 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25498 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->