### PR TITLE
Support pointer-events="bounding-box" for svg containers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox-expected.txt
@@ -6,10 +6,10 @@ PASS circle1 contains point at (36, 60)
 PASS circle1 contains point at (42, 67)
 PASS circle1 does not contain point at (50, 50)
 PASS circle1 does not contain point at (50, 55)
-FAIL group1 contains point at (100, 100) assert_true: expected true got false
-FAIL group1 contains point at (137, 84) assert_true: expected true got false
-FAIL group1 contains point at (51, 156) assert_true: expected true got false
-FAIL group1 contains point at (70, 120) assert_true: expected true got false
+PASS group1 contains point at (100, 100)
+PASS group1 contains point at (137, 84)
+PASS group1 contains point at (51, 156)
+PASS group1 contains point at (70, 120)
 PASS circle2 contains point at (400, 150)
 PASS circle2 contains point at (432, 182)
 PASS circle2 contains point at (361, 122)

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -188,7 +188,15 @@ bool RenderSVGContainer::nodeAtPoint(const HitTestRequest& request, HitTestResul
             return true;
     }
 
-    // Spec: Only graphical elements can be targeted by the mouse, period.
+    // pointer-events=bounding-box makes it possible for containers to be direct targets.
+    if (style().pointerEvents() == PointerEvents::BoundingBox) {
+        if (!isObjectBoundingBoxValid())
+            return false;
+        if (objectBoundingBox().contains(localPoint)) {
+            updateHitTestResult(result, LayoutPoint(localPoint));
+            return true;
+        }
+    }
     // 16.4: "If there are no graphics elements whose relevant graphics content is under the pointer (i.e., there is no target element), the event is not dispatched."
     return false;
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -253,7 +253,15 @@ bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, H
             return true;
     }
     
-    // Spec: Only graphical elements can be targeted by the mouse, period.
+    // pointer-events=bounding-box makes it possible for containers to be direct targets.
+    if (style().pointerEvents() == PointerEvents::BoundingBox) {
+        if (!isObjectBoundingBoxValid())
+            return false;
+        if (objectBoundingBox().contains(localPoint)) {
+            updateHitTestResult(result, LayoutPoint(localPoint));
+            return true;
+        }
+    }
     // 16.4: "If there are no graphics elements whose relevant graphics content is under the pointer (i.e., there is no target element), the event is not dispatched."
     return false;
 }


### PR DESCRIPTION
#### f851f91c045d10ad74ccc4d97b9d37307517123e
<pre>
Support pointer-events=&quot;bounding-box&quot; for svg containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290721">https://bugs.webkit.org/show_bug.cgi?id=290721</a>
<a href="https://rdar.apple.com/148181592">rdar://148181592</a>

Reviewed by Abrar Rahman Protyasha and Said Abou-Hallawa.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/25803a9c71990a61b4bd5fa964bce09e62cde44d">https://chromium.googlesource.com/chromium/blink/+/25803a9c71990a61b4bd5fa964bce09e62cde44d</a>

The &apos;bounding-box&apos; keyword in &apos;pointer-events&apos; enables
svg authors to leave out certain invisible &apos;hit-area&apos;
elements, and instead get them generated based on the
bounding box. In case of &apos;groups&apos;, which are container
elements. These elements currently are not possible to
target directly, since they only get events through
bubbling from their children.

This patch makes container elements targetable if one
specifies &apos;pointer-events: bounding-box&apos; on them (either
as an svg presentation attribute or in css).

* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::nodeAtPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/293473@main">https://commits.webkit.org/293473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bf083c40b431cf348dd7699ec1c0f24e16126fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75285 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32420 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84249 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19718 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31135 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->