### PR TITLE
[JSC] Make generator body arrow function

### DIFF
--- a/Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js
@@ -49,7 +49,7 @@ function asyncFunctionResume(generator, sentValue, resumeMode)
 
     try {
         @putGeneratorInternalField(generator, @generatorFieldState, @GeneratorStateExecuting);
-        var value = @getGeneratorInternalField(generator, @generatorFieldNext).@call(@getGeneratorInternalField(generator, @generatorFieldThis), generator, state, sentValue, resumeMode, @getGeneratorInternalField(generator, @generatorFieldFrame));
+        var value = @getGeneratorInternalField(generator, @generatorFieldNext).@call(generator, state, sentValue, resumeMode, @getGeneratorInternalField(generator, @generatorFieldFrame));
         if (@getGeneratorInternalField(generator, @generatorFieldState) === @GeneratorStateExecuting)
             return @resolvePromiseWithFirstResolvingFunctionCallCheck(@getGeneratorInternalField(generator, @generatorFieldContext), value);
     } catch (error) {

--- a/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
@@ -187,7 +187,7 @@ function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
     @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonNone);
 
     try {
-        value = @getAsyncGeneratorInternalField(generator, @generatorFieldNext).@call(@getAsyncGeneratorInternalField(generator, @generatorFieldThis), generator, state, resumeValue, resumeMode, @getAsyncGeneratorInternalField(generator, @generatorFieldFrame));
+        value = @getAsyncGeneratorInternalField(generator, @generatorFieldNext).@call(generator, state, resumeValue, resumeMode, @getAsyncGeneratorInternalField(generator, @generatorFieldFrame));
         state = @getAsyncGeneratorInternalField(generator, @generatorFieldState);
         if (state === @AsyncGeneratorStateExecuting) {
             @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);

--- a/Source/JavaScriptCore/builtins/GeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/GeneratorPrototype.js
@@ -39,7 +39,7 @@ function generatorResume(generator, state, value, resumeMode)
     @putGeneratorInternalField(generator, @generatorFieldState, @GeneratorStateExecuting);
 
     try {
-        var value = @getGeneratorInternalField(generator, @generatorFieldNext).@call(@getGeneratorInternalField(generator, @generatorFieldThis), generator, state, value, resumeMode, @getGeneratorInternalField(generator, @generatorFieldFrame));
+        var value = @getGeneratorInternalField(generator, @generatorFieldNext).@call(generator, state, value, resumeMode, @getGeneratorInternalField(generator, @generatorFieldFrame));
     } catch (error) {
         @putGeneratorInternalField(generator, @generatorFieldState, @GeneratorStateCompleted);
         throw error;

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -93,7 +93,6 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_promiseFieldReactionsOrResult.set(m_vm, jsNumber(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)));
     m_generatorFieldState.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::State)));
     m_generatorFieldNext.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Next)));
-    m_generatorFieldThis.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::This)));
     m_generatorFieldFrame.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Frame)));
     m_generatorFieldContext.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Context)));
     m_GeneratorResumeModeNormal.set(m_vm, jsNumber(static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode)));

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -152,7 +152,6 @@ enum class LinkTimeConstant : int32_t;
     macro(proxyFieldHandler) \
     macro(generatorFieldState) \
     macro(generatorFieldNext) \
-    macro(generatorFieldThis) \
     macro(generatorFieldFrame) \
     macro(generatorFieldContext) \
     macro(GeneratorResumeModeNormal) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -482,8 +482,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
         //    function *gen(a, b = hello())
         //    {
         //        return {
-        //            @generatorNext: function (@generator, @generatorState, @generatorValue, @generatorResumeMode, @generatorFrame)
-        //            {
+        //            @generatorNext: (@generatorState, @generatorValue, @generatorResumeMode, @generatorFrame) => {
         //                arguments;  // This `arguments` should reference to the gen's arguments.
         //                ...
         //            }
@@ -523,8 +522,12 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
 
     emitEnter();
 
-    if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode))
-        m_generatorRegister = &m_parameters[static_cast<unsigned>(JSGenerator::Argument::Generator)];
+    if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode)) {
+        m_generatorRegister = addVar();
+        auto virtualRegister = m_thisRegister.virtualRegister();
+        m_thisRegister.setIndex(m_generatorRegister->virtualRegister());
+        m_generatorRegister->setIndex(virtualRegister);
+    }
 
     allocateScope();
 
@@ -725,7 +728,13 @@ IGNORE_GCC_WARNINGS_END
         }
 
         bool shouldCreateArgumensVariable = !haveParameterNamedArguments
-            && !SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode, SourceParseMode::ClassFieldInitializerMode).contains(m_codeBlock->parseMode());
+            && !SourceParseModeSet(
+                SourceParseMode::ArrowFunctionMode,
+                SourceParseMode::AsyncArrowFunctionMode,
+                SourceParseMode::GeneratorBodyMode,
+                SourceParseMode::AsyncFunctionBodyMode,
+                SourceParseMode::AsyncGeneratorBodyMode,
+                SourceParseMode::ClassFieldInitializerMode).contains(m_codeBlock->parseMode());
         shouldCreateArgumentsVariableInParameterScope = shouldCreateArgumensVariable && !isSimpleParameterList;
         // Do not create arguments variable in case of Arrow function. Value will be loaded from parent scope
         if (shouldCreateArgumensVariable && !shouldCreateArgumentsVariableInParameterScope) {
@@ -762,11 +771,6 @@ IGNORE_GCC_WARNINGS_END
     case SourceParseMode::AsyncGeneratorWrapperMethodMode:
     case SourceParseMode::AsyncGeneratorWrapperFunctionMode: {
         m_generatorRegister = addVar();
-
-        // FIXME: Emit to_this only when Generator uses it.
-        // https://bugs.webkit.org/show_bug.cgi?id=151586
-        emitToThis();
-
         break;
     }
 
@@ -777,12 +781,6 @@ IGNORE_GCC_WARNINGS_END
         ASSERT(constructorKind() == ConstructorKind::None);
         m_generatorRegister = addVar();
         m_promiseRegister = addVar();
-
-        if (parseMode != SourceParseMode::AsyncArrowFunctionMode) {
-            // FIXME: Emit to_this only when AsyncFunctionBody uses it.
-            // https://bugs.webkit.org/show_bug.cgi?id=151586
-            emitToThis();
-        }
 
         emitNewGenerator(m_generatorRegister);
         bool isInternalPromise = false;
@@ -796,12 +794,8 @@ IGNORE_GCC_WARNINGS_END
     case SourceParseMode::AsyncGeneratorBodyMode:
     case SourceParseMode::AsyncFunctionBodyMode:
     case SourceParseMode::AsyncArrowFunctionBodyMode:
-    case SourceParseMode::GeneratorBodyMode: {
-        // |this| is already filled correctly before here.
-        if (m_newTargetRegister)
-            emitLoad(m_newTargetRegister, jsUndefined());
+    case SourceParseMode::GeneratorBodyMode:
         break;
-    }
 
     case SourceParseMode::ArrowFunctionMode:
         break;
@@ -864,7 +858,7 @@ IGNORE_GCC_WARNINGS_END
 
     // We need load |super| & |this| for arrow function before initializeDefaultParameterValuesAndSetupFunctionScopeStack
     // if we have default parameter expression. Because |super| & |this| values can be used there
-    if ((SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(parseMode) && !isSimpleParameterList) || parseMode == SourceParseMode::AsyncArrowFunctionBodyMode) {
+    if (isArrowFunctionParseMode(parseMode) && !isSimpleParameterList) {
         if (functionNode->usesThis() || functionNode->usesSuperProperty())
             emitLoadThisFromArrowFunctionLexicalEnvironment();
 
@@ -892,7 +886,7 @@ IGNORE_GCC_WARNINGS_END
     // If we don't have  default parameter expression, then loading |this| inside an arrow function must be done
     // after initializeDefaultParameterValuesAndSetupFunctionScopeStack() because that function sets up the
     // SymbolTable stack and emitLoadThisFromArrowFunctionLexicalEnvironment() consults the SymbolTable stack
-    if (SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(parseMode) && isSimpleParameterList) {
+    if (isArrowFunctionParseMode(parseMode) && isSimpleParameterList) {
         if (functionNode->usesThis() || functionNode->usesSuperProperty())
             emitLoadThisFromArrowFunctionLexicalEnvironment();
     
@@ -2847,19 +2841,12 @@ void BytecodeGenerator::emitPutSetterByVal(RegisterID* base, RegisterID* propert
 void BytecodeGenerator::emitPutGeneratorFields(RegisterID* nextFunction)
 {
     emitPutInternalField(m_generatorRegister, static_cast<unsigned>(JSGenerator::Field::Next), nextFunction);
-
-    // We do not store 'this' in arrow function within constructor,
-    // because it might be not initialized, if super is called later.
-    if (!(isDerivedConstructorContext() && m_codeBlock->parseMode() == SourceParseMode::AsyncArrowFunctionMode))
-        emitPutInternalField(m_generatorRegister, static_cast<unsigned>(JSGenerator::Field::This), &m_thisRegister);
 }
 
 void BytecodeGenerator::emitPutAsyncGeneratorFields(RegisterID* nextFunction)
 {
     ASSERT(isAsyncGeneratorWrapperParseMode(parseMode()));
-
     emitPutInternalField(m_generatorRegister, static_cast<unsigned>(JSAsyncGenerator::Field::Next), nextFunction);
-    emitPutInternalField(m_generatorRegister, static_cast<unsigned>(JSAsyncGenerator::Field::This), &m_thisRegister);
 }
 
 RegisterID* BytecodeGenerator::emitDeleteById(RegisterID* dst, RegisterID* base, const Identifier& property)
@@ -3470,7 +3457,7 @@ RegisterID* BytecodeGenerator::emitNewFunctionExpression(RegisterID* dst, FuncEx
 
 RegisterID* BytecodeGenerator::emitNewArrowFunctionExpression(RegisterID* dst, ArrowFuncExprNode* func)
 {
-    ASSERT(SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(func->metadata()->parseMode()));
+    ASSERT(isArrowFunctionParseMode(func->metadata()->parseMode()));
     emitNewFunctionExpressionCommon(dst, func->metadata());
     return dst;
 }

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1557,8 +1557,6 @@ static JSGenerator::Field generatorInternalFieldIndex(BytecodeIntrinsicNode* nod
         return JSGenerator::Field::State;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldNext)
         return JSGenerator::Field::Next;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldThis)
-        return JSGenerator::Field::This;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldFrame)
         return JSGenerator::Field::Frame;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldContext)
@@ -1585,8 +1583,6 @@ static JSAsyncGenerator::Field asyncGeneratorInternalFieldIndex(BytecodeIntrinsi
         return JSAsyncGenerator::Field::State;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldNext)
         return JSAsyncGenerator::Field::Next;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldThis)
-        return JSAsyncGenerator::Field::This;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_generatorFieldFrame)
         return JSAsyncGenerator::Field::Frame;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_asyncGeneratorFieldSuspendReason)
@@ -5309,11 +5305,8 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         ASSERT(singleStatement->isExprStatement());
         ExprStatementNode* exprStatement = static_cast<ExprStatementNode*>(singleStatement);
         ExpressionNode* expr = exprStatement->expr();
-        ASSERT(expr->isFuncExprNode());
-        FuncExprNode* funcExpr = static_cast<FuncExprNode*>(expr);
-
         RefPtr<RegisterID> next = generator.newTemporary();
-        generator.emitNode(next.get(), funcExpr);
+        generator.emitNode(next.get(), expr);
 
         if (generator.superBinding() == SuperBinding::Needed) {
             RefPtr<RegisterID> homeObject = emitHomeObjectForCallee(generator);
@@ -5340,11 +5333,8 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
         ASSERT(singleStatement->isExprStatement());
         ExprStatementNode* exprStatement = static_cast<ExprStatementNode*>(singleStatement);
         ExpressionNode* expr = exprStatement->expr();
-        ASSERT(expr->isFuncExprNode());
-        FuncExprNode* funcExpr = static_cast<FuncExprNode*>(expr);
-
         RefPtr<RegisterID> next = generator.newTemporary();
-        generator.emitNode(next.get(), funcExpr);
+        generator.emitNode(next.get(), expr);
 
         if (generator.superBinding() == SuperBinding::Needed || (generator.parseMode() == SourceParseMode::AsyncArrowFunctionMode && generator.isSuperUsedInInnerArrowFunction())) {
             RefPtr<RegisterID> homeObject = emitHomeObjectForCallee(generator);

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1648,7 +1648,6 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
 
     ProtoCallFrame protoCallFrame;
     EncodedJSValue args[numberOfArguments] = {
-        JSValue::encode(record),
         JSValue::encode(record->internalField(JSModuleRecord::Field::State).get()),
         JSValue::encode(sentValue),
         JSValue::encode(resumeMode),
@@ -1674,7 +1673,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
             // The |this| of the module is always `undefined`.
             // http://www.ecma-international.org/ecma-262/6.0/#sec-module-environment-records-hasthisbinding
             // http://www.ecma-international.org/ecma-262/6.0/#sec-module-environment-records-getthisbinding
-            protoCallFrame.init(codeBlock, globalObject, callee, jsUndefined(), numberOfArguments + 1, args);
+            protoCallFrame.init(codeBlock, globalObject, callee, record, numberOfArguments + 1, args);
         }
 
         record->internalField(JSModuleRecord::Field::State).set(vm, record, jsNumber(static_cast<int>(JSModuleRecord::State::Executing)));

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1560,7 +1560,6 @@ void JIT::emit_op_to_this(const JSInstruction* currentInstruction)
 
     emitJumpSlowCaseIfNotJSCell(jsRegT10, srcDst);
 
-    addSlowCase(branchIfNotType(jsRegT10.payloadGPR(), FinalObjectType));
     load32FromMetadata(bytecode, OpToThis::Metadata::offsetOfCachedStructureID(), regT2);
     addSlowCase(branch32(NotEqual, Address(jsRegT10.payloadGPR(), JSCell::structureIDOffset()), regT2));
 }

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -868,7 +868,6 @@ llintOpWithMetadata(op_to_this, OpToThis, macro (size, get, dispatch, metadata, 
     get(m_srcDst, t0)
     bineq TagOffset[cfr, t0, 8], CellTag, .opToThisSlow
     loadi PayloadOffset[cfr, t0, 8], t0
-    bbneq JSCell::m_type[t0], FinalObjectType, .opToThisSlow
     metadata(t2, t3)
     loadi OpToThis::Metadata::m_cachedStructureID[t2], t2
     bineq JSCell::m_structureID[t0], t2, .opToThisSlow

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -879,7 +879,6 @@ llintOpWithMetadata(op_to_this, OpToThis, macro (size, get, dispatch, metadata, 
     get(m_srcDst, t0)
     loadq [cfr, t0, 8], t0
     btqnz t0, notCellMask, .opToThisSlow
-    bbneq JSCell::m_type[t0], FinalObjectType, .opToThisSlow
     loadi JSCell::m_structureID[t0], t1
     metadata(t2, t3)
     loadi OpToThis::Metadata::m_cachedStructureID[t2], t2

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -438,7 +438,7 @@ public:
 
     ExpressionNode* createGeneratorFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, const Identifier& name)
     {
-        FuncExprNode* result = static_cast<FuncExprNode*>(createFunctionExpr(location, functionInfo));
+        auto* result = static_cast<ArrowFuncExprNode*>(createArrowFunctionExpr(location, functionInfo));
         if (!name.isNull())
             result->metadata()->setEcmaName(name);
         return result;
@@ -447,12 +447,13 @@ public:
     ExpressionNode* createAsyncFunctionBody(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo, SourceParseMode parseMode)
     {
         if (parseMode == SourceParseMode::AsyncArrowFunctionBodyMode) {
+            usesArrowFunction();
             SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-            FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body, source);
+            auto* result = new (m_parserArena) ArrowFuncExprNode(location, *functionInfo.name, functionInfo.body, source);
             functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
             return result;
         }
-        return createFunctionExpr(location, functionInfo);
+        return createArrowFunctionExpr(location, functionInfo);
     }
 
     ExpressionNode* createMethodDefinition(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2404,8 +2404,6 @@ template <class TreeBuilder> typename TreeBuilder::FormalParameterList Parser<Le
         ++parameterCount;
     };
 
-    // @generator
-    addParameter(m_vm.propertyNames->generatorPrivateName);
     // @generatorState
     addParameter(m_vm.propertyNames->generatorStatePrivateName);
     // @generatorValue
@@ -4295,7 +4293,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseYieldExpress
     //     yield [no LineTerminator here] * AssignmentExpression[?In, Yield]
 
     // http://ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions
-    failIfFalse(currentScope()->isGeneratorFunction() && !currentScope()->isArrowFunctionBoundary(), "Cannot use yield expression out of generator");
+    failIfFalse(currentScope()->isGeneratorFunction(), "Cannot use yield expression out of generator");
 
     // http://ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions-static-semantics-early-errors
     failIfTrue(m_parserState.functionParsePhase == FunctionParsePhase::Parameters, "Cannot use yield expression within parameters");

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -212,6 +212,7 @@ public:
         case SourceParseMode::AsyncGeneratorBodyMode:
             setIsAsyncGeneratorFunctionBody();
             break;
+
         case SourceParseMode::AsyncArrowFunctionBodyMode:
             setIsAsyncArrowFunctionBody();
             break;
@@ -883,7 +884,7 @@ private:
 
     void setIsGeneratorFunctionBody()
     {
-        setIsFunction();
+        setIsArrowFunction();
         m_hasArguments = false;
         m_isGeneratorFunction = true;
         m_isGeneratorFunctionBoundary = true;
@@ -917,7 +918,7 @@ private:
 
     void setIsAsyncGeneratorFunctionBody()
     {
-        setIsFunction();
+        setIsArrowFunction();
         m_hasArguments = false;
         m_isGeneratorFunction = true;
         m_isGeneratorFunctionBoundary = true;
@@ -927,7 +928,7 @@ private:
 
     void setIsAsyncFunctionBody()
     {
-        setIsFunction();
+        setIsArrowFunction();
         m_hasArguments = false;
         m_isAsyncFunction = true;
         m_isAsyncFunctionBoundary = true;

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -269,7 +269,10 @@ ALWAYS_INLINE bool isArrowFunctionParseMode(SourceParseMode parseMode)
     return SourceParseModeSet(
         SourceParseMode::ArrowFunctionMode,
         SourceParseMode::AsyncArrowFunctionMode,
-        SourceParseMode::AsyncArrowFunctionBodyMode).contains(parseMode);
+        SourceParseMode::AsyncArrowFunctionBodyMode,
+        SourceParseMode::GeneratorBodyMode,
+        SourceParseMode::AsyncFunctionBodyMode,
+        SourceParseMode::AsyncGeneratorBodyMode).contains(parseMode);
 }
 
 ALWAYS_INLINE bool isModuleParseMode(SourceParseMode parseMode) 

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -30,9 +30,9 @@
 
 namespace JSC {
 
-class JSAsyncGenerator final : public JSInternalFieldObjectImpl<8> {
+class JSAsyncGenerator final : public JSInternalFieldObjectImpl<7> {
 public:
-    using Base = JSInternalFieldObjectImpl<8>;
+    using Base = JSInternalFieldObjectImpl<7>;
 
     // JSAsyncGenerator has one inline storage slot, which is pointing internalField(0).
     static size_t allocationSize(Checked<size_t> inlineCapacity)
@@ -69,19 +69,17 @@ public:
         PolyProto = 0,
         State,
         Next,
-        This,
         Frame,
         SuspendReason,
         QueueFirst,
         QueueLast,
     };
-    static_assert(numberOfInternalFields == 8);
+    static_assert(numberOfInternalFields == 7);
     static std::array<JSValue, numberOfInternalFields> initialValues()
     {
         return { {
             jsNull(),
             jsNumber(static_cast<int32_t>(AsyncGeneratorState::SuspendedStart)),
-            jsUndefined(),
             jsUndefined(),
             jsUndefined(),
             jsNumber(static_cast<int32_t>(AsyncGeneratorSuspendReason::None)),

--- a/Source/JavaScriptCore/runtime/JSGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSGenerator.h
@@ -29,9 +29,9 @@
 
 namespace JSC {
 
-class JSGenerator final : public JSInternalFieldObjectImpl<6> {
+class JSGenerator final : public JSInternalFieldObjectImpl<5> {
 public:
-    using Base = JSInternalFieldObjectImpl<6>;
+    using Base = JSInternalFieldObjectImpl<5>;
 
     // JSGenerator has one inline storage slot, which is pointing internalField(0).
     static size_t allocationSize(Checked<size_t> inlineCapacity)
@@ -58,14 +58,13 @@ public:
         Init = 0,
     };
 
-    // [this], @generator, @generatorState, @generatorValue, @generatorResumeMode, @generatorFrame.
+    // [this(@generator)], @generatorState, @generatorValue, @generatorResumeMode, @generatorFrame.
     enum class Argument : int32_t {
-        ThisValue = 0,
-        Generator = 1,
-        State = 2,
-        Value = 3,
-        ResumeMode = 4,
-        Frame = 5,
+        Generator = 0,
+        State = 1,
+        Value = 2,
+        ResumeMode = 3,
+        Frame = 4,
         NumberOfArguments = Frame,
     };
 
@@ -75,17 +74,15 @@ public:
         PolyProto = 0,
         State,
         Next,
-        This,
         Frame,
         Context,
     };
-    static_assert(numberOfInternalFields == 6);
+    static_assert(numberOfInternalFields == 5);
     static std::array<JSValue, numberOfInternalFields> initialValues()
     {
         return { {
             jsNull(),
             jsNumber(static_cast<int32_t>(State::Init)),
-            jsUndefined(),
             jsUndefined(),
             jsUndefined(),
             jsUndefined(),


### PR DESCRIPTION
#### 3d9ee53e26fbb04f587dac6d969af16795ed510b
<pre>
[JSC] Make generator body arrow function
<a href="https://bugs.webkit.org/show_bug.cgi?id=290722">https://bugs.webkit.org/show_bug.cgi?id=290722</a>
<a href="https://rdar.apple.com/148181640">rdar://148181640</a>

Reviewed by NOBODY (OOPS!).

This patch makes generator body function simplified by using arrow
function. So we do not need to manually propagate |this| to the body.
Arrow function will automatically handles them by looking into the upper
scope.

* Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js:
(linkTimeConstant.asyncFunctionResume):
* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
(linkTimeConstant.doAsyncGeneratorBodyCall):
* Source/JavaScriptCore/builtins/GeneratorPrototype.js:
(linkTimeConstant.generatorResume):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::emitPutGeneratorFields):
(JSC::BytecodeGenerator::emitPutAsyncGeneratorFields):
(JSC::BytecodeGenerator::emitNewArrowFunctionExpression):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::generatorInternalFieldIndex):
(JSC::asyncGeneratorInternalFieldIndex):
(JSC::FunctionNode::emitBytecode):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_to_this):
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createGeneratorFunctionBody):
(JSC::ASTBuilder::createAsyncFunctionBody):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::createGeneratorParameters):
(JSC::Parser&lt;LexerType&gt;::parseYieldExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::setSourceParseMode):
(JSC::Scope::setIsGeneratorFunctionBody):
(JSC::Scope::setIsAsyncGeneratorFunctionBody):
(JSC::Scope::setIsAsyncFunctionBody):
* Source/JavaScriptCore/parser/ParserModes.h:
(JSC::isArrowFunctionParseMode):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSGenerator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d9ee53e26fbb04f587dac6d969af16795ed510b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25514 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74242 "Found 27 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31424 "Found 26 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100441 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13135 "Found 24 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54586 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12901 "Found 8 new test failures: imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-002.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-vs-script-1.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/module-vs-script-2.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/nomodule-attribute.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/single-evaluation-1.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/single-evaluation-2.html imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/016.html imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6000 "Found 33 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47409 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90114 "Found 284 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/SourceToString.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/mru.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck5.js.default, ChakraCore.yaml/ChakraCore/test/strict/22.callerCalleeArguments.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout-dfg-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82933 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6081 "Found 33 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104545 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96060 "Found 288 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/SourceToString.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/mru.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck5.js.default, ChakraCore.yaml/ChakraCore/test/strict/22.callerCalleeArguments.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout-dfg-eager-no-cjit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24517 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17878 "Found 34 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83288 "Found 33 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27251 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4938 "Found 33 new test failures: fast/css-grid-layout/grid-item-column-row-get-set.html fast/css-grid-layout/grid-item-end-after-get-set.html fast/css-grid-layout/grid-item-start-before-get-set.html fast/events/constructors/composition-event-constructor.html fast/events/constructors/focus-event-constructor.html fast/events/constructors/keyboard-event-constructor.html fast/events/constructors/message-event-constructor.html fast/events/constructors/mouse-event-constructor.html fast/events/constructors/ui-event-constructor.html fast/events/constructors/wheel-event-constructor.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29647 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119686 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24301 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33592 "Found 157 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Regex/BolEol.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/SourceToString.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/mru.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck5.js.default, ChakraCore.yaml/ChakraCore/test/strict/22.callerCalleeArguments.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords.js.default, ChakraCore.yaml/ChakraCore/test/strict/23.reservedWords_sm.js.default, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout, jsc-layout-tests.yaml/js/script-tests/dfg-convert-this-dom-window.js.layout-dfg-eager-no-cjit ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->