### PR TITLE
[JSC] Fix tc39 a test case for Date.prototype.setUTCFullYear

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1350,8 +1350,6 @@ test/language/statements/with/set-mutable-binding-idref-compound-assign-with-pro
   default: 'Test262Error: Actual [has:p, get:Symbol(Symbol.unscopables), get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] and expected [has:p, get:Symbol(Symbol.unscopables), has:p, get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] should have the same contents. '
 test/staging/sm/ArrayBuffer/slice-species.js:
   default: 'Test262Error: Expected SameValue(«function ArrayBuffer() {'
-test/staging/sm/Date/makeday-year-month-is-infinity.js:
-  default: 'Test262Error: Expected SameValue(«-62167219200000», «NaN») to be true'
 test/staging/sm/Date/non-iso.js:
   default: 'Test262Error: Expected SameValue(«NaN», «857811661010») to be true'
 test/staging/sm/Date/to-temporal-instant.js:

--- a/LayoutTests/js/date-timeClip-large-values-expected.txt
+++ b/LayoutTests/js/date-timeClip-large-values-expected.txt
@@ -58,8 +58,8 @@ PASS new Date(8.64e15).setYear(new Date(8.64e15).getFullYear()).valueOf() is 8.6
 PASS new Date(8.64e15).setYear(new Date(8.64e15).getFullYear() + 1).valueOf() is NaN
 Testing setFullYear()
 PASS new Date(0).setFullYear(Infinity).valueOf() is NaN
-FAIL new Date(0).setFullYear(1.79769e+308).valueOf() should be NaN. Was -62135597222000.
-FAIL new Date(0).setFullYear(-1.79769e+308).valueOf() should be NaN. Was -62135597222000.
+PASS new Date(0).setFullYear(1.79769e+308).valueOf() is NaN
+PASS new Date(0).setFullYear(-1.79769e+308).valueOf() is NaN
 PASS new Date(8.64e15).setFullYear(new Date(8.64e15).getFullYear()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setFullYear(new Date(8.64e15).getFullYear() + 1).valueOf() is NaN
 Testing setUTCMilliseconds()
@@ -101,8 +101,8 @@ PASS new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth()).valueOf() is
 PASS new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth() + 1).valueOf() is NaN
 Testing setUTCFullYear()
 PASS new Date(0).setUTCFullYear(Infinity).valueOf() is NaN
-FAIL new Date(0).setUTCFullYear(1.79769e+308).valueOf() should be NaN. Was -62167219200000.
-FAIL new Date(0).setUTCFullYear(-1.79769e+308).valueOf() should be NaN. Was -62167219200000.
+PASS new Date(0).setUTCFullYear(1.79769e+308).valueOf() is NaN
+PASS new Date(0).setUTCFullYear(-1.79769e+308).valueOf() is NaN
 PASS new Date(8.64e15).setUTCFullYear(new Date(8.64e15).getUTCFullYear()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setUTCFullYear(new Date(8.64e15).getUTCFullYear() + 1).valueOf() is NaN
 PASS successfullyParsed is true

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -194,7 +194,11 @@ static bool fillStructuresUsingDateArgs(JSGlobalObject* globalObject, CallFrame*
     if (maxArgs >= 3 && idx < numArgs) {
         double years = callFrame->uncheckedArgument(idx++).toIntegerPreserveNaN(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        ok = ok && std::isfinite(years);
+
+        // The GregorianDateTime class represents `years` as `int`.
+        // Therefore, if the `years` exceeds the maximum representable `int`, date calculations may produce incorrect results.
+        // The condidtion, `std::abs(years) <= msToYear(WTF::maxECMAScriptTime)`, is used as a safeguard before `timeClip(double)`.
+        ok = ok && std::isfinite(years) && std::abs(years) <= msToYear(WTF::maxECMAScriptTime);
         t->setYear(toInt32(years));
     }
     // months


### PR DESCRIPTION
#### 7160fd30c3a9a3b3c438193a539096dd10314332
<pre>
[JSC] Fix tc39 a test case for Date.prototype.setUTCFullYear
<a href="https://bugs.webkit.org/show_bug.cgi?id=290724">https://bugs.webkit.org/show_bug.cgi?id=290724</a>

Reviewed by Sosuke Suzuki.

TimeClip[1] function, as referenced in Date.prototype.setUTCFullYear[2],
mentions that absolute value of time must not exceed 8.64E15 in milliseconds,
otherwise returns NaN. However, the current GregorianDateTime class represents
years member variable as int.
Therefore, if the years exceeds the maximum representable int,
date calculations may produce incorrect results.
This patch adds a safeguard to ensure that such overflows are prevented
to align the behavior with the TC39 spec.

[1]: <a href="https://tc39.es/ecma262/#sec-timeclip">https://tc39.es/ecma262/#sec-timeclip</a>
[2]: <a href="https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear">https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear</a>

* JSTests/test262/expectations.yaml:
* LayoutTests/js/date-timeClip-large-values-expected.txt:
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::fillStructuresUsingDateArgs):

Canonical link: <a href="https://commits.webkit.org/295562@main">https://commits.webkit.org/295562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44d6b95a0f844d663c1c937b3f7e59e6682e2064

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55839 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79888 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55224 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97849 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112940 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103786 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88587 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22599 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11273 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27748 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17103 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37880 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128092 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32044 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35026 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->