### PR TITLE
[GStreamer][MediaStream] video capture source for Camera portal

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -126,6 +126,7 @@ platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cp
 platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
 platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
 
+platform/mediastream/gstreamer/DesktopPortal.cpp
 platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
 platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
 platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -143,6 +144,7 @@ platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
 platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
 platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
 platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
 platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
 platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
 platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
@@ -528,6 +528,28 @@ void derefGPtr<GstDeviceMonitor>(GstDeviceMonitor* ptr)
 }
 
 template<>
+GRefPtr<GstDeviceProvider> adoptGRef(GstDeviceProvider* ptr)
+{
+    return GRefPtr<GstDeviceProvider>(ptr, GRefPtrAdopt);
+}
+
+template<>
+GstDeviceProvider* refGPtr<GstDeviceProvider>(GstDeviceProvider* ptr)
+{
+    if (ptr)
+        gst_object_ref(GST_OBJECT_CAST(ptr));
+
+    return ptr;
+}
+
+template<>
+void derefGPtr<GstDeviceProvider>(GstDeviceProvider* ptr)
+{
+    if (ptr)
+        gst_object_unref(ptr);
+}
+
+template<>
 GRefPtr<GstDevice> adoptGRef(GstDevice* ptr)
 {
     return GRefPtr<GstDevice>(ptr, GRefPtrAdopt);

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -169,6 +169,10 @@ template<> GRefPtr<GstDeviceMonitor> adoptGRef(GstDeviceMonitor*);
 template<> GstDeviceMonitor* refGPtr<GstDeviceMonitor>(GstDeviceMonitor*);
 template<> void derefGPtr<GstDeviceMonitor>(GstDeviceMonitor*);
 
+template<> GRefPtr<GstDeviceProvider> adoptGRef(GstDeviceProvider*);
+template<> GstDeviceProvider* refGPtr<GstDeviceProvider>(GstDeviceProvider*);
+template<> void derefGPtr<GstDeviceProvider>(GstDeviceProvider*);
+
 template<> GRefPtr<GstDevice> adoptGRef(GstDevice*);
 template<> GstDevice* refGPtr<GstDevice>(GstDevice*);
 template<> void derefGPtr<GstDevice>(GstDevice*);

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "DesktopPortal.h"
+
+#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
+
+#include "GRefPtrGStreamer.h"
+#include <gio/gunixfdlist.h>
+#include <gst/video/video-format.h>
+#include <optional>
+#include <unistd.h>
+#include <wtf/Scope.h>
+#include <wtf/UUID.h>
+#include <wtf/WeakRandomNumber.h>
+#include <wtf/glib/GUniquePtr.h>
+
+#if GST_CHECK_VERSION(1, 24, 0)
+#include <gst/video/video-info-dma.h>
+#endif
+
+namespace WebCore {
+
+static const Seconds s_dbusCallTimeout = 10_ms;
+
+static GRefPtr<GDBusProxy> createDBusProxy(ASCIILiteral interfaceName)
+{
+    GUniqueOutPtr<GError> error;
+    auto proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+        static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
+        "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", interfaceName.characters(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Unable to connect to the Deskop portal: %s", error->message);
+        return nullptr;
+    }
+    return proxy;
+}
+
+RefPtr<DesktopPortalCamera> DesktopPortalCamera::create()
+{
+    auto interfaceName = "org.freedesktop.portal.Camera"_s;
+    auto proxy = createDBusProxy(interfaceName);
+    if (!proxy)
+        return nullptr;
+    return adoptRef(*new DesktopPortalCamera(interfaceName, WTFMove(proxy)));
+}
+
+DesktopPortalCamera::DesktopPortalCamera(ASCIILiteral interfaceName, GRefPtr<GDBusProxy>&& proxy)
+    : DesktopPortal(interfaceName, WTFMove(proxy))
+{
+}
+
+RefPtr<DesktopPortalScreenCast> DesktopPortalScreenCast::create()
+{
+    auto interfaceName = "org.freedesktop.portal.ScreenCast"_s;
+    auto proxy = createDBusProxy(interfaceName);
+    if (!proxy)
+        return nullptr;
+    return adoptRef(*new DesktopPortalScreenCast(interfaceName, WTFMove(proxy)));
+}
+
+DesktopPortalScreenCast::DesktopPortalScreenCast(ASCIILiteral interfaceName, GRefPtr<GDBusProxy>&& proxy)
+    : DesktopPortal(interfaceName, WTFMove(proxy))
+{
+}
+
+DesktopPortal::DesktopPortal(ASCIILiteral interfaceName, GRefPtr<GDBusProxy>&& proxy)
+    : m_interfaceName(interfaceName)
+    , m_proxy(WTFMove(proxy))
+{
+}
+
+GRefPtr<GVariant> DesktopPortal::getProperty(ASCIILiteral name)
+{
+    auto propertiesResult = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "org.freedesktop.DBus.Properties.Get",
+        g_variant_new("(ss)", m_interfaceName.characters(), name.characters()), G_DBUS_CALL_FLAGS_NONE,
+        s_dbusCallTimeout.millisecondsAs<int>(), nullptr, nullptr));
+    if (propertiesResult) {
+        GRefPtr<GVariant> property;
+        g_variant_get(propertiesResult.get(), "(v)", &property.outPtr());
+        return property;
+    }
+    return nullptr;
+}
+
+void DesktopPortal::waitResponseSignal(ASCIILiteral objectPath, ResponseCallback&& callback)
+{
+    RELEASE_ASSERT(!m_currentResponseCallback);
+    m_currentResponseCallback = WTFMove(callback);
+    auto* connection = g_dbus_proxy_get_connection(m_proxy.get());
+    auto signalId = g_dbus_connection_signal_subscribe(connection, "org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request",
+        "Response", objectPath.characters(), nullptr, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE, reinterpret_cast<GDBusSignalCallback>(+[](GDBusConnection*, const char* /* senderName */, const char* /* objectPath */, const char* /* interfaceName */, const char* /* signalName */, GVariant* parameters, gpointer userData) {
+            auto& self = *reinterpret_cast<DesktopPortal*>(userData);
+            self.notifyResponse(parameters);
+        }), this, nullptr);
+
+    while (m_currentResponseCallback)
+        g_main_context_iteration(nullptr, false);
+
+    g_dbus_connection_signal_unsubscribe(connection, signalId);
+}
+
+bool DesktopPortalCamera::isCameraPresent()
+{
+    auto isCameraPresent = getProperty("IsCameraPresent"_s);
+    if (!isCameraPresent)
+        return false;
+
+    return g_variant_get_boolean(isCameraPresent.get());
+}
+
+bool DesktopPortalCamera::accessCamera()
+{
+    auto token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    GVariantBuilder options;
+    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.utf8().data()));
+
+    auto connection = g_dbus_proxy_get_connection(m_proxy.get());
+    auto connectionString = StringView::fromLatin1(g_dbus_connection_get_unique_name(connection));
+    auto sender = makeStringByReplacingAll(connectionString.substring(1), '.', '_');
+    auto objectPath = makeString("/org/freedesktop/portal/desktop/request/"_s, sender, '/', token);
+    m_cameraAccessResults.add(objectPath, std::nullopt);
+
+    m_currentResponseCallback = [&](auto* variant) mutable {
+        if (!variant) {
+            m_cameraAccessResults.get(objectPath) = false;
+            return;
+        }
+
+        uint32_t response;
+        g_variant_get(variant, "(u@a{sv})", &response, nullptr);
+        // 0 response value means the user allowed device access.
+        m_cameraAccessResults.set(objectPath, !response);
+    };
+
+    auto signalId = g_dbus_connection_signal_subscribe(connection, "org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request",
+        "Response", objectPath.utf8().data(), nullptr, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE, reinterpret_cast<GDBusSignalCallback>(+[](GDBusConnection*, const char* /* senderName */, const char* /* objectPath */, const char* /* interfaceName */, const char* /* signalName */, GVariant* parameters, gpointer userData) {
+            auto& self = *reinterpret_cast<DesktopPortal*>(userData);
+            self.notifyResponse(parameters);
+        }),
+        this, nullptr);
+
+    g_dbus_proxy_call(m_proxy.get(), "AccessCamera", g_variant_new("(a{sv})", &options), G_DBUS_CALL_FLAGS_NONE, -1, nullptr, reinterpret_cast<GAsyncReadyCallback>(+[](GDBusProxy* proxy, GAsyncResult* result, gpointer) {
+        auto finalResult = adoptGRef(g_dbus_proxy_call_finish(proxy, result, nullptr));
+    }), nullptr);
+
+    while (m_currentResponseCallback)
+        g_main_context_iteration(nullptr, false);
+
+    g_dbus_connection_signal_unsubscribe(connection, signalId);
+    auto result = m_cameraAccessResults.take(objectPath);
+    return *result;
+}
+
+std::optional<int> DesktopPortalCamera::openCameraPipewireRemote()
+{
+    GRefPtr<GUnixFDList> fdList;
+    int fd = -1;
+    GVariantBuilder options;
+    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+    GUniqueOutPtr<GError> error;
+    auto result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
+        g_variant_new("(a{sv})", &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);
+        return { };
+    }
+
+    int index;
+    g_variant_get(result.get(), "(h)", &index);
+    fd = g_unix_fd_list_get(fdList.get(), index, &error.outPtr());
+    if (fd == -1) {
+        gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);
+        return { };
+    }
+    return fd;
+}
+
+std::optional<DesktopPortalScreenCast::ScreencastSession> DesktopPortalScreenCast::createScreencastSession()
+{
+    auto token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    auto sessionToken = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    GVariantBuilder options;
+    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
+    g_variant_builder_add(&options, "{sv}", "session_handle_token", g_variant_new_string(sessionToken.ascii().data()));
+
+    GUniqueOutPtr<GError> error;
+    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "CreateSession", g_variant_new("(a{sv})", &options),
+        G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Unable to create a Deskop portal session: %s", error->message);
+        return { };
+    }
+
+    GUniqueOutPtr<char> objectPath;
+    g_variant_get(result.get(), "(o)", &objectPath.outPtr());
+    waitResponseSignal(ASCIILiteral::fromLiteralUnsafe(objectPath.get()));
+
+    auto requestPath = StringView::fromLatin1(objectPath.get());
+    auto sessionPath = makeStringByReplacingAll(requestPath.toStringWithoutCopying(), "/request/"_s, "/session/"_s);
+    sessionPath = makeStringByReplacingAll(sessionPath, token, sessionToken);
+    return { ScreencastSession { WTFMove(sessionPath), m_proxy } };
+}
+
+void DesktopPortalScreenCast::closeSession(const String& path)
+{
+    GUniqueOutPtr<GError> error;
+    auto proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+        static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
+        "org.freedesktop.portal.Desktop", path.ascii().data(), "org.freedesktop.portal.Session", nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Unable to connect to the Desktop portal: %s", error->message);
+        return;
+    }
+    auto dbusCallTimeout = 100_ms;
+    auto result = adoptGRef(g_dbus_proxy_call_sync(proxy.get(), "Close", nullptr, G_DBUS_CALL_FLAGS_NONE,
+        dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
+    if (error)
+        gst_printerrln("Portal session could not be closed: %s", error->message);
+}
+
+GRefPtr<GVariant> DesktopPortalScreenCast::ScreencastSession::selectSources(GVariantBuilder& options)
+{
+    auto token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
+
+    GUniqueOutPtr<GError> error;
+    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "SelectSources",
+        g_variant_new("(oa{sv})", m_path.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("SelectSources error: %s", error->message);
+        return nullptr;
+    }
+
+    return result;
+}
+
+GRefPtr<GVariant> DesktopPortalScreenCast::ScreencastSession::start()
+{
+    auto token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    GVariantBuilder options;
+    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
+
+    GUniqueOutPtr<GError> error;
+    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "Start",
+        g_variant_new("(osa{sv})", m_path.ascii().data(), "", &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Start error: %s", error->message);
+        return nullptr;
+    }
+    return result;
+}
+
+std::optional<PipeWireNodeData> DesktopPortalScreenCast::ScreencastSession::openPipewireRemote()
+{
+    GRefPtr<GUnixFDList> fdList;
+    GVariantBuilder options;
+    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+    GUniqueOutPtr<GError> error;
+    auto result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
+        g_variant_new("(oa{sv})", m_path.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
+    if (error) {
+        gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);
+        return { };
+    }
+
+    int index;
+    g_variant_get(result.get(), "(h)", &index);
+    int fd = g_unix_fd_list_get(fdList.get(), index, &error.outPtr());
+    if (fd == -1) {
+        gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);
+        return { };
+    }
+
+    auto nodeData = PipeWireNodeData(0);
+    nodeData.fd = fd;
+    nodeData.path = path();
+    nodeData.caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
+    gst_caps_set_features_simple(nodeData.caps.get(), gst_caps_features_new("memory:DMABuf", nullptr));
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    auto fourcc = gst_video_dma_drm_fourcc_from_format(GST_VIDEO_FORMAT_BGRA);
+    GUniquePtr<char> drmFormat(gst_video_dma_drm_fourcc_to_string(fourcc, 0));
+    gst_caps_set_simple(nodeData.caps.get(), "format", G_TYPE_STRING, "DMA_DRM", "drm-format", G_TYPE_STRING, drmFormat.get(), nullptr);
+#endif
+    return nodeData;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
+
+#include "PipeWireNodeData.h"
+#include <gio/gio.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class DesktopPortal : public RefCounted<DesktopPortal> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    DesktopPortal(ASCIILiteral, GRefPtr<GDBusProxy>&&);
+
+    GRefPtr<GVariant> getProperty(ASCIILiteral name);
+
+    using ResponseCallback = CompletionHandler<void(GVariant*)>;
+    void waitResponseSignal(ASCIILiteral objectPath, ResponseCallback&& = [](auto*) { });
+
+    void notifyResponse(GVariant* parameters) { m_currentResponseCallback(parameters); }
+
+protected:
+    ASCIILiteral m_interfaceName;
+    GRefPtr<GDBusProxy> m_proxy;
+    ResponseCallback m_currentResponseCallback;
+};
+
+class DesktopPortalCamera : public DesktopPortal {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static RefPtr<DesktopPortalCamera> create();
+
+    bool isCameraPresent();
+    bool accessCamera();
+    std::optional<int> openCameraPipewireRemote();
+
+private:
+    DesktopPortalCamera(ASCIILiteral, GRefPtr<GDBusProxy>&&);
+    HashMap<String, std::optional<bool>> m_cameraAccessResults;
+};
+
+class DesktopPortalScreenCast : public DesktopPortal {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static RefPtr<DesktopPortalScreenCast> create();
+
+    class ScreencastSession {
+    public:
+        ScreencastSession(String&& path, const GRefPtr<GDBusProxy>& proxy)
+            : m_path(WTFMove(path))
+            , m_proxy(proxy)
+        {
+        }
+        const String& path() const { return m_path; }
+        GRefPtr<GVariant> selectSources(GVariantBuilder&);
+        GRefPtr<GVariant> start();
+        std::optional<PipeWireNodeData> openPipewireRemote();
+
+    private:
+        String m_path;
+        const GRefPtr<GDBusProxy>& m_proxy;
+    };
+
+    std::optional<ScreencastSession> createScreencastSession();
+    void closeSession(const String& path);
+
+private:
+    DesktopPortalScreenCast(ASCIILiteral, GRefPtr<GDBusProxy>&&);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -29,8 +29,6 @@
 #include "GStreamerAudioStreamDescription.h"
 #include "GStreamerCaptureDeviceManager.h"
 
-#include <gst/app/gstappsink.h>
-#include <gst/gst.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
 
@@ -49,6 +47,9 @@ class GStreamerAudioCaptureSourceFactory : public AudioCaptureFactory {
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier>) final
     {
+        // Here, like in GStreamerVideoCaptureSource, we could rely on the DesktopPortal and
+        // PipeWireCaptureDeviceManager, but there is no audio desktop portal yet. See
+        // https://github.com/flatpak/xdg-desktop-portal/discussions/1142.
         return GStreamerAudioCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints);
     }
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -46,8 +46,8 @@ GStreamerAudioCapturer::GStreamerAudioCapturer(GStreamerCaptureDevice&& device)
     initializeAudioCapturerDebugCategory();
 }
 
-GStreamerAudioCapturer::GStreamerAudioCapturer()
-    : GStreamerCapturer("appsrc", adoptGRef(gst_caps_new_empty_simple("audio/x-raw")), CaptureDevice::DeviceType::Microphone)
+GStreamerAudioCapturer::GStreamerAudioCapturer(const PipeWireCaptureDevice& device)
+    : GStreamerCapturer(device)
 {
     initializeAudioCapturerDebugCategory();
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -244,7 +244,7 @@ void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
     if (!gstCaptureDevice)
         return;
 
-    GST_INFO("Registering %sdefault device %s", gstCaptureDevice->isDefault() ? "" : "non-", gstCaptureDevice->label().utf8().data());
+    GST_INFO_OBJECT(gstCaptureDevice->device(), "Registering %sdefault device %s", gstCaptureDevice->isDefault() ? "" : "non-", gstCaptureDevice->label().utf8().data());
     const auto type = gstCaptureDevice->type();
     m_gstreamerDevices.append(WTFMove(*gstCaptureDevice));
     if (type == CaptureDevice::DeviceType::Speaker)
@@ -362,7 +362,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
             gst_message_parse_device_added(message, &device.outPtr());
 #ifndef GST_DISABLE_GST_DEBUG
             name.reset(gst_device_get_display_name(device.get()));
-            GST_INFO("Device added: %s", name.get());
+            GST_INFO_OBJECT(GST_MESSAGE_SRC(message), "Device added: %s", name.get());
 #endif
             manager->addDevice(WTFMove(device));
             break;
@@ -370,7 +370,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
             gst_message_parse_device_removed(message, &device.outPtr());
 #ifndef GST_DISABLE_GST_DEBUG
             name.reset(gst_device_get_display_name(device.get()));
-            GST_INFO("Device removed: %s", name.get());
+            GST_INFO_OBJECT(GST_MESSAGE_SRC(message), "Device removed: %s", name.get());
 #endif
             manager->removeDevice(WTFMove(device));
             break;
@@ -380,7 +380,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
             gst_message_parse_device_changed(message, &device.outPtr(), &oldDevice.outPtr());
 #ifndef GST_DISABLE_GST_DEBUG
             name.reset(gst_device_get_display_name(device.get()));
-            GST_INFO("Device changed: %s", name.get());
+            GST_INFO_OBJECT(GST_MESSAGE_SRC(message), "Device changed: %s", name.get());
 #endif
             manager->updateDevice(WTFMove(device), WTFMove(oldDevice));
             break;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -26,6 +26,7 @@
 
 #include "GStreamerCaptureDevice.h"
 #include "GStreamerCommon.h"
+#include "PipeWireCaptureDevice.h"
 
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakHashSet.h>
@@ -53,7 +54,7 @@ public:
 class GStreamerCapturer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerCapturer> {
 public:
     GStreamerCapturer(GStreamerCaptureDevice&&, GRefPtr<GstCaps>&&);
-    GStreamerCapturer(ASCIILiteral sourceFactory, GRefPtr<GstCaps>&&, CaptureDevice::DeviceType);
+    GStreamerCapturer(const PipeWireCaptureDevice&);
     virtual ~GStreamerCapturer();
 
     void tearDown(bool disconnectSignals = true);
@@ -64,7 +65,7 @@ public:
     void removeObserver(GStreamerCapturerObserver&);
     void forEachObserver(NOESCAPE const Function<void(GStreamerCapturerObserver&)>&);
 
-    void setupPipeline();
+    virtual void setupPipeline();
     void start();
     void stop();
     bool isStopped() const;
@@ -96,9 +97,9 @@ protected:
     GRefPtr<GstElement> m_valve;
     GRefPtr<GstElement> m_capsfilter;
     std::optional<GStreamerCaptureDevice> m_device { };
+    std::optional<PipeWireCaptureDevice> m_pipewireDevice { };
     GRefPtr<GstCaps> m_caps;
     GRefPtr<GstElement> m_pipeline;
-    ASCIILiteral m_sourceFactory;
 
 private:
     CaptureDevice::DeviceType m_deviceType;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
@@ -24,15 +24,12 @@
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 #include "GStreamerCaptureDeviceManager.h"
 
-#include "GStreamerCommon.h"
 #include "GStreamerVideoCaptureSource.h"
-#include <gio/gunixfdlist.h>
+#include "PipeWireCaptureDevice.h"
 #include <wtf/UUID.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
-
-static const Seconds s_dbusCallTimeout = 10_ms;
 
 GStreamerDisplayCaptureDeviceManager& GStreamerDisplayCaptureDeviceManager::singleton()
 {
@@ -64,84 +61,50 @@ CaptureSourceOrError GStreamerDisplayCaptureDeviceManager::createDisplayCaptureS
 {
     const auto it = m_sessions.find(device.persistentId());
     if (it != m_sessions.end()) {
-        return GStreamerVideoCaptureSource::createPipewireSource(device.persistentId().isolatedCopy(),
-            it->value->nodeAndFd, WTFMove(hashSalts), constraints, device.type());
+        auto& node = it->value;
+        PipeWireCaptureDevice pipewireCaptureDevice { *node, device.persistentId(), device.type(), device.label(), device.groupId() };
+        return GStreamerVideoCaptureSource::createPipewireSource(WTFMove(pipewireCaptureDevice), WTFMove(hashSalts), constraints);
     }
 
-    GUniqueOutPtr<GError> error;
-    m_proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
-        static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
-        "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.ScreenCast", nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("Unable to connect to the Deskop portal: %s", error->message);
-        return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
-    }
+    if (!m_portal)
+        m_portal = DesktopPortalScreenCast::create();
+    if (!m_portal)
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
 
-    auto token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
-    auto sessionToken = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
-    GVariantBuilder options;
-    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
-    g_variant_builder_add(&options, "{sv}", "session_handle_token", g_variant_new_string(sessionToken.ascii().data()));
-
-    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "CreateSession", g_variant_new("(a{sv})", &options),
-        G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("Unable to create a Deskop portal session: %s", error->message);
-        return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
-    }
-
-    GUniqueOutPtr<char> objectPath;
-    g_variant_get(result.get(), "(o)", &objectPath.outPtr());
-    waitResponseSignal(objectPath.get());
-
-    auto requestPath = String::fromLatin1(objectPath.get());
-    auto sessionPath = makeStringByReplacingAll(requestPath, "/request/"_s, "/session/"_s);
-    sessionPath = makeStringByReplacingAll(sessionPath, token, sessionToken);
+    auto session = m_portal->createScreencastSession();
+    if (!session)
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
 
     // FIXME: Maybe check this depending on device.type().
     auto outputType = GStreamerDisplayCaptureDeviceManager::PipeWireOutputType::Monitor | GStreamerDisplayCaptureDeviceManager::PipeWireOutputType::Window;
 
-    token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
+    GVariantBuilder options;
     g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
     g_variant_builder_add(&options, "{sv}", "types", g_variant_new_uint32(static_cast<uint32_t>(outputType)));
     g_variant_builder_add(&options, "{sv}", "multiple", g_variant_new_boolean(false));
 
-    auto propertiesResult = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "org.freedesktop.DBus.Properties.Get",
-        g_variant_new("(ss)", "org.freedesktop.portal.ScreenCast", "version"), G_DBUS_CALL_FLAGS_NONE,
-        s_dbusCallTimeout.millisecondsAs<int>(), nullptr, nullptr));
-    if (propertiesResult) {
-        GRefPtr<GVariant> property;
-        g_variant_get(propertiesResult.get(), "(v)", &property.outPtr());
-        if (g_variant_get_uint32(property.get()) >= 2) {
+    if (auto version = m_portal->getProperty("version")) {
+        if (g_variant_get_uint32(version.get()) >= 2) {
             // Enable embedded cursor. FIXME: Should be checked in the constraints.
             g_variant_builder_add(&options, "{sv}", "cursor_mode", g_variant_new_uint32(2));
         }
     }
 
-    result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "SelectSources",
-        g_variant_new("(oa{sv})", sessionPath.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("SelectSources error: %s", error->message);
-        return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
-    }
-    g_variant_get(result.get(), "(o)", &objectPath.outPtr());
-    waitResponseSignal(objectPath.get());
+    auto result = session->selectSources(options);
+    if (!result)
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
 
-    token = makeString("WebKit"_s, weakRandomNumber<uint32_t>());
-    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
-    result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "Start",
-        g_variant_new("(osa{sv})", sessionPath.ascii().data(), "", &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("Start error: %s", error->message);
-        return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
-    }
+    GUniqueOutPtr<char> objectPath;
+    g_variant_get(result.get(), "(o)", &objectPath.outPtr());
+    m_portal->waitResponseSignal(ASCIILiteral::fromLiteralUnsafe(objectPath.get()));
+
+    result = session->start();
+    if (!result)
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
 
     std::optional<uint32_t> nodeId;
     g_variant_get(result.get(), "(o)", &objectPath.outPtr());
-    waitResponseSignal(objectPath.get(), [&nodeId](GVariant* parameters) mutable {
+    m_portal->waitResponseSignal(ASCIILiteral::fromLiteralUnsafe(objectPath.get()), [&nodeId](GVariant* parameters) mutable {
         uint32_t portalResponse;
         GRefPtr<GVariant> responseData;
         g_variant_get(parameters, "(u@a{sv})", &portalResponse, &responseData.outPtr());
@@ -172,59 +135,23 @@ CaptureSourceOrError GStreamerDisplayCaptureDeviceManager::createDisplayCaptureS
         return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
     }
 
-    GRefPtr<GUnixFDList> fdList;
-    int fd = -1;
-    g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
-    result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
-        g_variant_new("(oa{sv})", sessionPath.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("Unable to request display capture. Error: %s", error->message);
-        return CaptureSourceOrError({ { } , MediaAccessDenialReason::PermissionDenied });
-    }
+    auto nodeData = session->openPipewireRemote();
+    if (!nodeData)
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
 
-    int fdOut;
-    g_variant_get(result.get(), "(h)", &fdOut);
-    fd = g_unix_fd_list_get(fdList.get(), fdOut, nullptr);
-
-    NodeAndFD nodeAndFd = { *nodeId, fd };
-    auto session = makeUnique<GStreamerDisplayCaptureDeviceManager::Session>(nodeAndFd, WTFMove(sessionPath));
-    m_sessions.add(device.persistentId(), WTFMove(session));
-    return GStreamerVideoCaptureSource::createPipewireSource(device.persistentId().isolatedCopy(), nodeAndFd, WTFMove(hashSalts), constraints, device.type());
+    nodeData->objectId = *nodeId;
+    PipeWireCaptureDevice pipewireCaptureDevice { *nodeData, device.persistentId(), device.type(), device.label(), device.groupId() };
+    m_sessions.add(device.persistentId(), makeUnique<PipeWireNodeData>(WTFMove(*nodeData)));
+    return GStreamerVideoCaptureSource::createPipewireSource(WTFMove(pipewireCaptureDevice), WTFMove(hashSalts), constraints);
 }
 
 void GStreamerDisplayCaptureDeviceManager::stopSource(const String& persistentID)
 {
-    auto session = m_sessions.take(persistentID);
-    GUniqueOutPtr<GError> error;
-    auto proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
-        static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
-        "org.freedesktop.portal.Desktop", session->path.ascii().data(), "org.freedesktop.portal.Session", nullptr, &error.outPtr()));
-    if (error) {
-        WTFLogAlways("Unable to connect to the Deskop portal: %s", error->message);
+    if (UNLIKELY(!m_portal))
         return;
-    }
-    auto dbusCallTimeout = 100_ms;
-    auto result = adoptGRef(g_dbus_proxy_call_sync(proxy.get(), "Close", nullptr, G_DBUS_CALL_FLAGS_NONE,
-        dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
-    if (error)
-        WTFLogAlways("Portal session could not be closed: %s", error->message);
-}
 
-void GStreamerDisplayCaptureDeviceManager::waitResponseSignal(const char* objectPath, ResponseCallback&& callback)
-{
-    RELEASE_ASSERT(!m_currentResponseCallback);
-    m_currentResponseCallback = WTFMove(callback);
-    auto* connection = g_dbus_proxy_get_connection(m_proxy.get());
-    auto signalId = g_dbus_connection_signal_subscribe(connection, "org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request",
-        "Response", objectPath, nullptr, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE, reinterpret_cast<GDBusSignalCallback>(+[](GDBusConnection*, const char* /* senderName */, const char* /* objectPath */, const char* /* interfaceName */, const char* /* signalName */, GVariant* parameters, gpointer userData) {
-            auto& manager = *reinterpret_cast<GStreamerDisplayCaptureDeviceManager*>(userData);
-            manager.notifyResponse(parameters);
-        }), this, nullptr);
-
-    while (m_currentResponseCallback)
-        g_main_context_iteration(nullptr, false);
-
-    g_dbus_connection_signal_unsubscribe(connection, signalId);
+    auto session = m_sessions.take(persistentID);
+    m_portal->closeSession(session->path);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -25,17 +25,17 @@
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 #include "CaptureDevice.h"
 #include "GStreamerVideoCapturer.h"
+#include "PipeWireCaptureDevice.h"
+#include "RealtimeMediaSourceCapabilities.h"
 #include "RealtimeVideoCaptureSource.h"
 #include "VideoFrameGStreamer.h"
 
 namespace WebCore {
 
-using NodeAndFD = GStreamerVideoCapturer::NodeAndFD;
-
 class GStreamerVideoCaptureSource final : public RealtimeVideoCaptureSource, GStreamerCapturerObserver {
 public:
     static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*);
-    static CaptureSourceOrError createPipewireSource(String&& deviceID, const NodeAndFD&, MediaDeviceHashSalts&&, const MediaConstraints*, CaptureDevice::DeviceType);
+    static CaptureSourceOrError createPipewireSource(const PipeWireCaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*);
 
     WEBCORE_EXPORT static VideoCaptureFactory& factory();
 
@@ -56,8 +56,8 @@ public:
     std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const final;
 
 protected:
-    GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, ASCIILiteral sourceFactory, CaptureDevice::DeviceType, const NodeAndFD&);
     GStreamerVideoCaptureSource(GStreamerCaptureDevice&&, MediaDeviceHashSalts&&);
+    GStreamerVideoCaptureSource(const PipeWireCaptureDevice&, MediaDeviceHashSalts&&);
     virtual ~GStreamerVideoCaptureSource();
     void startProducingData() final;
     void stopProducingData() final;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -35,14 +35,12 @@ class GStreamerVideoCapturer final : public GStreamerCapturer {
     friend class MockRealtimeVideoSourceGStreamer;
 public:
     GStreamerVideoCapturer(GStreamerCaptureDevice&&);
-    GStreamerVideoCapturer(ASCIILiteral sourceFactory, CaptureDevice::DeviceType);
+    GStreamerVideoCapturer(const PipeWireCaptureDevice&);
     ~GStreamerVideoCapturer() = default;
 
-    GstElement* createSource() final;
+    void setupPipeline() final;
     GstElement* createConverter() final;
     const char* name() final { return "Video"; }
-
-    using NodeAndFD = std::pair<uint32_t, int>;
 
     using SinkVideoFrameCallback = Function<void(Ref<VideoFrameGStreamer>&&)>;
     void setSinkVideoFrameCallback(SinkVideoFrameCallback&&);
@@ -50,15 +48,12 @@ public:
 private:
     bool setSize(const IntSize&);
     const IntSize& size() const { return m_size; }
+
     bool setFrameRate(double);
     void reconfigure();
 
-    GstVideoInfo getBestFormat();
+    bool isCapturingDisplay() const;
 
-    void setPipewireNodeAndFD(const NodeAndFD& nodeAndFd) { m_nodeAndFd = nodeAndFd; }
-    bool isCapturingDisplay() const { return m_nodeAndFd.has_value(); }
-
-    std::optional<NodeAndFD> m_nodeAndFd;
     GRefPtr<GstElement> m_videoSrcMIMETypeFilter;
     std::pair<unsigned long, SinkVideoFrameCallback> m_sinkVideoFrameCallback;
     IntSize m_size;

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDevice.h
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2018 Metrological Group B.V.
- * Copyright (C) 2020 Igalia S.L.
- * Author: Thibault Saunier <tsaunier@igalia.com>
- * Author: Alejandro G. Castro <alex@igalia.com>
+ * Copyright (C) 2025 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,26 +21,27 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
-#include "GStreamerCapturer.h"
+#include "CaptureDevice.h"
+#include "PipeWireNodeData.h"
 
 namespace WebCore {
 
-class GStreamerAudioCapturer final : public GStreamerCapturer {
+class PipeWireCaptureDevice : public CaptureDevice {
+    WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    GStreamerAudioCapturer(GStreamerCaptureDevice&&);
-    GStreamerAudioCapturer(const PipeWireCaptureDevice&);
-    ~GStreamerAudioCapturer() = default;
+    PipeWireCaptureDevice(PipeWireNodeData& nodeData, const String& persistentId, DeviceType type, const String& label, const String& groupId = emptyString())
+        : CaptureDevice(persistentId, type, label, groupId)
+        , m_nodeData(nodeData)
+    {
+    }
 
-    GstElement* createConverter() final;
-    const char* name() final { return "Audio"; }
-
-    bool setSampleRate(int);
-
-    using SinkAudioDataCallback = Function<void(GRefPtr<GstSample>&&, MediaTime&&)>;
-    void setSinkAudioCallback(SinkAudioDataCallback&&);
+    uint32_t objectId() const { return m_nodeData.objectId; }
+    int fd() const { return m_nodeData.fd; }
+    const GRefPtr<GstCaps>& caps() const { return m_nodeData.caps; }
 
 private:
-    std::pair<unsigned long, SinkAudioDataCallback> m_sinkAudioDataCallback;
+    PipeWireNodeData m_nodeData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "PipeWireCaptureDeviceManager.h"
+
+#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
+
+#include "GStreamerVideoCaptureSource.h"
+#include "MockRealtimeMediaSourceCenter.h"
+#include <wtf/Scope.h>
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY(webkit_pipewire_capture_device_manager_debug);
+#define GST_CAT_DEFAULT webkit_pipewire_capture_device_manager_debug
+
+RefPtr<PipeWireCaptureDeviceManager> PipeWireCaptureDeviceManager::create(OptionSet<CaptureDevice::DeviceType> deviceTypes)
+{
+    return adoptRef(*new PipeWireCaptureDeviceManager(deviceTypes));
+}
+
+PipeWireCaptureDeviceManager::PipeWireCaptureDeviceManager(OptionSet<CaptureDevice::DeviceType> deviceTypes)
+    : m_deviceTypes(deviceTypes)
+    , m_pipewireDeviceProvider(adoptGRef(gst_device_provider_factory_get_by_name("pipewiredeviceprovider")))
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_pipewire_capture_device_manager_debug, "webkitpipewirecapturedevicemanager", 0, "WebKit PipeWire Capture Device Manager");
+    });
+}
+
+void PipeWireCaptureDeviceManager::computeCaptureDevices()
+{
+    if (MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled())
+        return;
+
+    if (!m_pipewireDeviceProvider || !gstObjectHasProperty(GST_OBJECT_CAST(m_pipewireDeviceProvider.get()), "fd"_s)) {
+        GST_WARNING("PipeWire Device Provider is missing or too old. Please install PipeWire >= 0.3.64.");
+        return;
+    }
+
+    if (!m_portal)
+        m_portal = DesktopPortalCamera::create();
+
+    GST_DEBUG("Checking with Camera portal");
+    if (!m_portal || !m_portal->isCameraPresent()) {
+        GST_DEBUG("Portal not present or has no camera");
+        return;
+    }
+
+    if (!m_portal->accessCamera()) {
+        GST_DEBUG("Camera access denied");
+        return;
+    }
+
+    auto fd = m_portal->openCameraPipewireRemote();
+    if (!fd)
+        return;
+
+    GST_DEBUG("FD from portal: %d", *fd);
+    g_object_set(m_pipewireDeviceProvider.get(), "fd", *fd, nullptr);
+    gst_device_provider_start(m_pipewireDeviceProvider.get());
+
+    GList* devices = gst_device_provider_get_devices(m_pipewireDeviceProvider.get());
+    GST_DEBUG("Provisioning VideoCaptureDeviceManager with %u device(s).", g_list_length(devices));
+    auto& manager = GStreamerVideoCaptureDeviceManager::singleton();
+    while (devices) {
+        manager.addDevice(adoptGRef(GST_DEVICE_CAST(devices->data)));
+        devices = g_list_delete_link(devices, devices);
+    }
+
+    gst_device_provider_stop(m_pipewireDeviceProvider.get());
+}
+
+CaptureSourceOrError PipeWireCaptureDeviceManager::createCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints)
+{
+    GST_DEBUG("Creating capture source for device %s", device.persistentId().ascii().data());
+    if (MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled())
+        return GStreamerVideoCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints);
+
+    // We don't support audio capture yet.
+    if (!m_deviceTypes.contains(CaptureDevice::DeviceType::Camera))
+        return CaptureSourceOrError({ { }, MediaAccessDenialReason::PermissionDenied });
+
+    return GStreamerVideoCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints);
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
+
+#include "DesktopPortal.h"
+#include "MediaConstraints.h"
+#include "MediaDeviceHashSalts.h"
+#include "PipeWireCaptureDevice.h"
+#include "RealtimeMediaSource.h"
+
+#include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class PipeWireCaptureDeviceManager : public RefCounted<PipeWireCaptureDeviceManager> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static RefPtr<PipeWireCaptureDeviceManager> create(OptionSet<CaptureDevice::DeviceType>);
+    PipeWireCaptureDeviceManager(OptionSet<CaptureDevice::DeviceType>);
+
+    void computeCaptureDevices();
+    const Vector<CaptureDevice>& captureDevices() const { return m_devices; }
+    CaptureSourceOrError createCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*);
+
+private:
+    OptionSet<CaptureDevice::DeviceType> m_deviceTypes;
+    RefPtr<DesktopPortalCamera> m_portal;
+    GRefPtr<GstDeviceProvider> m_pipewireDeviceProvider;
+    Vector<CaptureDevice> m_devices;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireNodeData.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireNodeData.h
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2018 Metrological Group B.V.
- * Copyright (C) 2020 Igalia S.L.
- * Author: Thibault Saunier <tsaunier@igalia.com>
- * Author: Alejandro G. Castro <alex@igalia.com>
+ * Copyright (C) 2025 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,26 +21,28 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
-#include "GStreamerCapturer.h"
+#include "GStreamerCommon.h"
 
 namespace WebCore {
 
-class GStreamerAudioCapturer final : public GStreamerCapturer {
-public:
-    GStreamerAudioCapturer(GStreamerCaptureDevice&&);
-    GStreamerAudioCapturer(const PipeWireCaptureDevice&);
-    ~GStreamerAudioCapturer() = default;
+struct PipeWireNodeData {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    GstElement* createConverter() final;
-    const char* name() final { return "Audio"; }
+    PipeWireNodeData(uint32_t objectId)
+        : objectId(objectId)
+        , persistentId(emptyString())
+        , fd(-1)
+        , path(emptyString())
+        , label(emptyString())
+    {
+    }
 
-    bool setSampleRate(int);
-
-    using SinkAudioDataCallback = Function<void(GRefPtr<GstSample>&&, MediaTime&&)>;
-    void setSinkAudioCallback(SinkAudioDataCallback&&);
-
-private:
-    std::pair<unsigned long, SinkAudioDataCallback> m_sinkAudioDataCallback;
+    uint32_t objectId;
+    String persistentId;
+    int fd;
+    GRefPtr<GstCaps> caps;
+    String path;
+    String label;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c28c004edc00e3010cb74e7aba5b17d80bd2f99e
<pre>
[GStreamer][MediaStream] video capture source for Camera portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=244004">https://bugs.webkit.org/show_bug.cgi?id=244004</a>

Reviewed by Xabier Rodriguez-Calvar.

When available on a desktop host, WebKitGTK can now leverage the XDG desktop portal for Camera
access so no specific sandbox exception is required. After successful communication through the
portal, the WebProcess receives a FD pointing to the PipeWire session created by the portal. To
expose the device we then create a GStreamer pipewiredeviceprovider and pass the fd to it.

* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp:
(WTF::adoptGRef):
(WTF::refGPtr&lt;GstDeviceProvider&gt;):
(WTF::derefGPtr&lt;GstDeviceProvider&gt;):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp: Added.
(WebCore::createDBusProxy):
(WebCore::DesktopPortalCamera::create):
(WebCore::DesktopPortalCamera::DesktopPortalCamera):
(WebCore::DesktopPortalScreenCast::create):
(WebCore::DesktopPortalScreenCast::DesktopPortalScreenCast):
(WebCore::DesktopPortal::DesktopPortal):
(WebCore::DesktopPortal::getProperty):
(WebCore::DesktopPortal::waitResponseSignal):
(WebCore::DesktopPortalCamera::isCameraPresent):
(WebCore::DesktopPortalCamera::accessCamera):
(WebCore::DesktopPortalCamera::openCameraPipewireRemote):
(WebCore::DesktopPortalScreenCast::createScreencastSession):
(WebCore::DesktopPortalScreenCast::closeSession):
(WebCore::DesktopPortalScreenCast::ScreencastSession::selectSources):
(WebCore::DesktopPortalScreenCast::ScreencastSession::start):
(WebCore::DesktopPortalScreenCast::ScreencastSession::openPipewireRemote):
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h: Added.
(WebCore::DesktopPortal::waitResponseSignal):
(WebCore::DesktopPortal::notifyResponse):
(WebCore::DesktopPortalScreenCast::ScreencastSession::ScreencastSession):
(WebCore::DesktopPortalScreenCast::ScreencastSession::path const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::GStreamerAudioCapturer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::addDevice):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::GStreamerCapturer):
(WebCore::GStreamerCapturer::createSource):
(WebCore::GStreamerCapturer::caps):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp:
(WebCore::GStreamerDisplayCaptureDeviceManager::createDisplayCaptureSource):
(WebCore::GStreamerDisplayCaptureDeviceManager::stopSource):
(WebCore::GStreamerDisplayCaptureDeviceManager::waitResponseSignal): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureDeviceManager::GStreamerVideoCaptureDeviceManager):
(WebCore::GStreamerVideoCaptureDeviceManager::computeCaptureDevices):
(WebCore::GStreamerVideoCaptureDeviceManager::createVideoCaptureSource):
(WebCore::GStreamerVideoCaptureSource::createPipewireSource):
(WebCore::GStreamerVideoCaptureSource::GStreamerVideoCaptureSource):
(WebCore::m_capturer):
(WebCore::GStreamerVideoCaptureSource::settingsDidChange):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::GStreamerVideoCapturer):
(WebCore::GStreamerVideoCapturer::isCapturingDisplay const):
(WebCore::GStreamerVideoCapturer::setupPipeline):
(WebCore::GStreamerVideoCapturer::setSize):
(WebCore::GStreamerVideoCapturer::reconfigure):
(WebCore::GStreamerVideoCapturer::createSource): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDevice.h: Copied from Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h.
(WebCore::PipeWireCaptureDevice::PipeWireCaptureDevice):
(WebCore::PipeWireCaptureDevice::objectId const):
(WebCore::PipeWireCaptureDevice::fd const):
(WebCore::PipeWireCaptureDevice::caps const):
* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp: Added.
(WebCore::PipeWireCaptureDeviceManager::create):
(WebCore::PipeWireCaptureDeviceManager::PipeWireCaptureDeviceManager):
(WebCore::PipeWireCaptureDeviceManager::computeCaptureDevices):
(WebCore::PipeWireCaptureDeviceManager::createCaptureSource):
* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h: Added.
(WebCore::PipeWireCaptureDeviceManager::captureDevices const):
* Source/WebCore/platform/mediastream/gstreamer/PipeWireNodeData.h: Copied from Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h.
(WebCore::PipeWireNodeData::PipeWireNodeData):
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bubblewrapSpawn):

Canonical link: <a href="https://commits.webkit.org/292932@main">https://commits.webkit.org/292932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c8633a4908a9827ca01b529ae5879d558a68748

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48032 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99548 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74298 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31477 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13196 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104610 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83343 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18176 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29713 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->