### PR TITLE
REGRESSION (281882@main): LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child.html fails.

### DIFF
--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest-expected.html
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>This tests that we don't leave bits behind, when an absolute positioned content-visibility: auto child is hidden due to content-visibility: hidden.</title>
+<style>
+#container {
+    height: 100px;
+    width: 100px;
+    content-visibility: hidden;
+}
+
+#content {
+    position: absolute;
+    height: 50px;
+    width: 50px;
+    background: green;
+    content-visibility: auto;
+}
+</style>
+</head>
+<body>
+<div id=container>
+    <div id=content></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest.html
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>This tests that we don't leave bits behind, when an absolute positioned content-visibility: auto child is hidden due to content-visibility: hidden.</title>
+<style>
+#container {
+    height: 100px;
+    width: 100px;
+}
+
+#content {
+    position: absolute;
+    height: 50px;
+    width: 50px;
+    background: green;
+    content-visibility: auto;
+}
+</style>
+</head>
+<body>
+<div id=container>
+    <div id=content></div>
+</div>
+<script>
+setTimeout(function() {
+    document.getElementById("container").style.contentVisibility = "hidden";
+    document.documentElement.classList.remove("reftest-wait");
+}, 0);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
+++ b/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
@@ -1,5 +1,6 @@
 (repaint rects
   (rect 0 0 200 200)
   (rect 0 0 50 50)
+  (rect 0 0 200 200)
 )
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -901,19 +901,14 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         }
 
         // Keep layer hierarchy visibility bits up to date if visibility or skipped content state changes.
-        bool wasVisible = m_style.usedVisibility() == Visibility::Visible && !m_style.isSkippedRootOrSkippedContent();
-        bool willBeVisible = newStyle.usedVisibility() == Visibility::Visible && !newStyle.isSkippedRootOrSkippedContent();
-        if (wasVisible != willBeVisible) {
-            if (CheckedPtr layer = enclosingLayer()) {
-                if (willBeVisible) {
-                    auto* renderBox = dynamicDowncast<RenderBox>(*this);
-                    if (m_style.isSkippedRootOrSkippedContent() && renderBox && isSkippedContentRoot(*renderBox))
-                        layer->dirtyVisibleContentStatus();
-                    else
-                        layer->setHasVisibleContent();
-                } else if (layer->hasVisibleContent() && (this == &layer->renderer() || layer->renderer().style().usedVisibility() != Visibility::Visible))
-                    layer->dirtyVisibleContentStatus();
-            }
+        if (m_style.usedVisibility() != newStyle.usedVisibility()) {
+            if (CheckedPtr layer = enclosingLayer())
+                layer->dirtyVisibleContentStatus();
+        }
+
+        if (m_style.usedContentVisibility() != newStyle.usedContentVisibility()) {
+            if (CheckedPtr layer = enclosingLayer())
+                layer->dirtyVisibleContentStatus();
         }
 
         auto needsInvalidateEventRegion = [&] {

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1472,6 +1472,7 @@ void RenderLayer::computeRepaintRectsIncludingDescendants()
 
 void RenderLayer::compositingStatusChanged(LayoutUpToDate layoutUpToDate)
 {
+    updateDescendantDependentFlags();
     if (parent() || isRenderViewLayer())
         computeRepaintRectsIncludingDescendants();
     if (layoutUpToDate == LayoutUpToDate::No)


### PR DESCRIPTION
#### 6ee5bd84aa85a20079fbf8e63c42439c7a9b5cec
<pre>
REGRESSION (281882@main): LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child.html fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290723">https://bugs.webkit.org/show_bug.cgi?id=290723</a>
&lt;<a href="https://rdar.apple.com/148183112">rdar://148183112</a>&gt;

Reviewed by Alan Baradlay.

Changing the value of content-visibility requires that child layers recompute
their visible content status (RenderLayer::computeHasVisibleContent() checks
isSkippedContent(), not hasSkippedContent()).

We also can&apos;t use the fast path of setHasVisibleContent() (instead of setting
the dirty bit) when setting visibility:visible, since the layer can still be
hidden (by content-visibility, or overflow truncation).

Duplicate the existing repaint rect test to have a reftest equivalent.

* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest-expected.html: Added.
* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-reftest.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):

Canonical link: <a href="https://commits.webkit.org/293085@main">https://commits.webkit.org/293085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c708e75e5e9cc2db8a3e742d08cf8bd24cda7de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74462 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31646 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6296 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6373 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18109 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84540 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18455 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24809 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29978 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->