### PR TITLE
[css-values-5] Add support for CSS url request modifiers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .square {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="square"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Request URL Modifiers: crossorigin(anonymous)</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@webkit.org">
+<link rel="match" href="url-image-ref.html">
+<meta name="assert" content="A url with the request URL modifier crossorigin(anonymous) requires a response with the appropriate headers.">
+<style>
+  .test {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+    background-image: url("http://{{hosts[][]}}:{{ports[http][1]}}/css/support/1x1-red.png" crossorigin(anonymous));
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .square {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="square"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Request URL Modifiers: crossorigin(anonymous)</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@webkit.org">
+<link rel="match" href="url-image-ref.html">
+<meta name="assert" content="A url with the request URL modifier crossorigin(anonymous) requires a response with the appropriate headers.">
+<style>
+  .test {
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    background-image: url("http://{{hosts[][]}}:{{ports[http][1]}}/css/support/1x1-green.png?pipe=header(Access-Control-Allow-Origin,*)" crossorigin(anonymous));
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .square {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="square"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Request URL Modifiers: crossorigin(use-credentials)</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@webkit.org">
+<link rel="match" href="url-image-ref.html">
+<meta name="assert" content="A url with the request URL modifier crossorigin(use-credentials) requires a response with the appropriate headers.">
+<style>
+  .test {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+    background-image: url("http://{{hosts[][]}}:{{ports[http][1]}}/css/support/1x1-green.png" crossorigin(use-credentials));
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .square {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="square"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Request URL Modifiers: crossorigin(use-credentials)</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@webkit.org">
+<link rel="match" href="url-image-ref.html">
+<meta name="assert" content="A url with the request URL modifier crossorigin(use-credentials) requires a response with the appropriate headers.">
+<style>
+  .test {
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    background-image: url("http://{{hosts[][]}}:{{ports[http][1]}}/css/support/1x1-green.png?pipe=header(Access-Control-Allow-Origin,http://{{hosts[][]}}:{{ports[http][0]}})|header(Access-Control-Allow-Credentials,true)" crossorigin(use-credentials));
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .square {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if background is green and no red.</p>
+<div class="square"></div>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1737,6 +1737,20 @@ CSSTypedOMColorEnabled:
     WebCore:
       default: false
 
+CSSURLModifiersEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS URL Modifiers"
+  humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 URL modifiers"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSUnprefixedBackdropFilterEnabled:
   type: bool
   status: Backdropfilter_feature_status

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1023,6 +1023,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSPrimitiveNumericUnits.h
     css/values/primitives/CSSSymbol.h
     css/values/primitives/CSSURL.h
+    css/values/primitives/CSSURLModifiers.h
     css/values/primitives/CSSUnevaluatedCalc.h
 
     css/values/shapes/CSSBasicShape.h
@@ -1564,6 +1565,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/LinkLoader.h
     loader/LinkLoaderClient.h
     loader/LoadSchedulingMode.h
+    loader/LoadedFromOpaqueSource.h
     loader/LoaderMalloc.h
     loader/LoaderStrategy.h
     loader/LocalFrameLoaderClient.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1164,6 +1164,7 @@ css/values/primitives/CSSPrimitiveNumericTypes+SymbolReplacement.cpp
 css/values/primitives/CSSPrimitiveNumericUnits.cpp
 css/values/primitives/CSSSymbol.cpp
 css/values/primitives/CSSURL.cpp
+css/values/primitives/CSSURLModifiers.cpp
 css/values/primitives/CSSUnevaluatedCalc.cpp
 css/values/shapes/CSSCircleFunction.cpp
 css/values/shapes/CSSEllipseFunction.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4884,6 +4884,8 @@
 		BC348BD40DB7F804004ABABA /* WebCoreJSBuiltins.h in Headers */ = {isa = PBXBuildFile; fileRef = BC348BD20DB7F804004ABABA /* WebCoreJSBuiltins.h */; };
 		BC348BD40DB7F804004ABABB /* WebCoreJSBuiltinInternals.h in Headers */ = {isa = PBXBuildFile; fileRef = BC348BD20DB7F804004ABABB /* WebCoreJSBuiltinInternals.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC3A00C82754496D0047C0E5 /* ColorInterpolation.h in Headers */ = {isa = PBXBuildFile; fileRef = BCDC642527517B040038FB39 /* ColorInterpolation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC3AA25C2DA2DD2F00BC27C6 /* CSSURLModifiers.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3AA25A2DA2DD2300BC27C6 /* CSSURLModifiers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC3AA25E2DA2F14700BC27C6 /* LoadedFromOpaqueSource.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3AA25D2DA2F14700BC27C6 /* LoadedFromOpaqueSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC3BC29C0E91AB0F00835588 /* HostWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3BC29B0E91AB0F00835588 /* HostWindow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC3BE12B0E98092F00835588 /* PopupMenuStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3BE12A0E98092F00835588 /* PopupMenuStyle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC3BE9940E9C1C7C00835588 /* RenderScrollbar.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3BE9910E9C1C7C00835588 /* RenderScrollbar.h */; };
@@ -18070,6 +18072,9 @@
 		BC394A392C766D4C001A629A /* CSSAbsoluteColorSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSAbsoluteColorSerialization.h; sourceTree = "<group>"; };
 		BC394A422C779379001A629A /* CSSCalcTree+Copy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSCalcTree+Copy.cpp"; sourceTree = "<group>"; };
 		BC394A432C779379001A629A /* CSSCalcTree+Copy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSCalcTree+Copy.h"; sourceTree = "<group>"; };
+		BC3AA25A2DA2DD2300BC27C6 /* CSSURLModifiers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSURLModifiers.h; sourceTree = "<group>"; };
+		BC3AA25B2DA2DD2300BC27C6 /* CSSURLModifiers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSURLModifiers.cpp; sourceTree = "<group>"; };
+		BC3AA25D2DA2F14700BC27C6 /* LoadedFromOpaqueSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoadedFromOpaqueSource.h; sourceTree = "<group>"; };
 		BC3BC29B0E91AB0F00835588 /* HostWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HostWindow.h; sourceTree = "<group>"; };
 		BC3BE12A0E98092F00835588 /* PopupMenuStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PopupMenuStyle.h; sourceTree = "<group>"; };
 		BC3BE9900E9C1C7C00835588 /* RenderScrollbar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderScrollbar.cpp; sourceTree = "<group>"; };
@@ -35209,6 +35214,7 @@
 				984264EF12D5280A000D88A4 /* LinkLoaderClient.h */,
 				CBB6B2D11CB7ADC6009EDE1A /* LinkPreloadResourceClients.cpp */,
 				CBB6B2D21CB7ADD0009EDE1A /* LinkPreloadResourceClients.h */,
+				BC3AA25D2DA2F14700BC27C6 /* LoadedFromOpaqueSource.h */,
 				45B5D85E2A968620004C85A0 /* LoaderMalloc.cpp */,
 				45B5D85F2A968620004C85A0 /* LoaderMalloc.h */,
 				51ABF64C16392E2800132A7A /* LoaderStrategy.cpp */,
@@ -35408,6 +35414,8 @@
 				BCB271E42CC0142C00265123 /* CSSUnevaluatedCalc.h */,
 				BCC0F3D32D99A9DC0065B859 /* CSSURL.cpp */,
 				BCC0F3D12D99A2270065B859 /* CSSURL.h */,
+				BC3AA25B2DA2DD2300BC27C6 /* CSSURLModifiers.cpp */,
+				BC3AA25A2DA2DD2300BC27C6 /* CSSURLModifiers.h */,
 			);
 			path = primitives;
 			sourceTree = "<group>";
@@ -40836,6 +40844,7 @@
 				4BAFD0E1219242A000C0AB64 /* CSSUnitValue.h in Headers */,
 				4BAFD0D921921EA000C0AB64 /* CSSUnparsedValue.h in Headers */,
 				BCC0F3D22D99A2270065B859 /* CSSURL.h in Headers */,
+				BC3AA25C2DA2DD2F00BC27C6 /* CSSURLModifiers.h in Headers */,
 				BCC0F3D62D99BDD90065B859 /* CSSURLValue.h in Headers */,
 				A80E6CEE0A1989CA007FB8C5 /* CSSValue.h in Headers */,
 				BC4AF44A2CFB85EE0037C65C /* CSSValueAggregates.h in Headers */,
@@ -42975,6 +42984,7 @@
 				E3B2F0EE1D7F4CA900B0C9D1 /* LoadableScriptClient.h in Headers */,
 				46C0D8E628F1E70300BDE218 /* LoadableScriptError.h in Headers */,
 				9759E94914EF1D490026A2DD /* LoadableTextTrack.h in Headers */,
+				BC3AA25E2DA2F14700BC27C6 /* LoadedFromOpaqueSource.h in Headers */,
 				45B5D8612A968620004C85A0 /* LoaderMalloc.h in Headers */,
 				656D37320ADBA5DE00A4554D /* LoaderNSURLExtras.h in Headers */,
 				51E6821016387302003BBF3C /* LoaderStrategy.h in Headers */,

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -37,24 +37,23 @@
 
 namespace WebCore {
 
-Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& value, RefPtr<CSSValue>&& hotSpot, LoadedFromOpaqueSource loadedFromOpaqueSource)
+Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& value, RefPtr<CSSValue>&& hotSpot)
 {
     auto* imageValue = dynamicDowncast<CSSImageValue>(value.get());
     auto originalURL = imageValue ? imageValue->url() : CSS::URL::none();
-    return adoptRef(*new CSSCursorImageValue(WTFMove(value), WTFMove(hotSpot), WTFMove(originalURL), loadedFromOpaqueSource));
+    return adoptRef(*new CSSCursorImageValue(WTFMove(value), WTFMove(hotSpot), WTFMove(originalURL)));
 }
 
-Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL)
 {
-    return adoptRef(*new CSSCursorImageValue(WTFMove(imageValue), WTFMove(hotSpot), WTFMove(originalURL), loadedFromOpaqueSource));
+    return adoptRef(*new CSSCursorImageValue(WTFMove(imageValue), WTFMove(hotSpot), WTFMove(originalURL)));
 }
 
-CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&& originalURL)
     : CSSValue(ClassType::CursorImage)
     , m_originalURL(WTFMove(originalURL))
     , m_imageValue(WTFMove(imageValue))
     , m_hotSpot(WTFMove(hotSpot))
-    , m_loadedFromOpaqueSource(loadedFromOpaqueSource)
 {
 }
 
@@ -88,7 +87,7 @@ RefPtr<StyleCursorImage> CSSCursorImageValue::createStyleImage(const Style::Buil
             static_cast<int>(downcast<CSSPrimitiveValue>(m_hotSpot->second()).resolveAsNumber(state.cssToLengthConversionData()))
         };
     }
-    return StyleCursorImage::create(styleImage.releaseNonNull(), hotSpot, Style::toStyle(m_originalURL, state), m_loadedFromOpaqueSource);
+    return StyleCursorImage::create(styleImage.releaseNonNull(), hotSpot, Style::toStyle(m_originalURL, state));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -24,7 +24,6 @@
 #include "CSSValue.h"
 #include "CSSValuePair.h"
 #include "IntPoint.h"
-#include "ResourceLoaderOptions.h"
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -38,8 +37,8 @@ class BuilderState;
 
 class CSSCursorImageValue final : public CSSValue {
 public:
-    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, LoadedFromOpaqueSource);
-    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&, LoadedFromOpaqueSource);
+    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot);
+    static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&);
     ~CSSCursorImageValue();
 
     const CSS::URL& originalURL() const { return m_originalURL; }
@@ -55,12 +54,11 @@ public:
     RefPtr<StyleCursorImage> createStyleImage(const Style::BuilderState&) const;
 
 private:
-    CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&, LoadedFromOpaqueSource);
+    CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&);
 
     CSS::URL m_originalURL;
     Ref<CSSValue> m_imageValue;
     RefPtr<CSSValue> m_hotSpot;
-    LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -74,18 +74,17 @@ bool CSSFontFaceSrcLocalValue::equals(const CSSFontFaceSrcLocalValue& other) con
     return m_fontFaceName == other.m_fontFaceName;
 }
 
-CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue(CSS::URL&& location, String&& format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource source)
+CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue(CSS::URL&& location, String&& format, Vector<FontTechnology>&& technologies)
     : CSSValue(ClassType::FontFaceSrcResource)
     , m_location(CSS::resolve(WTFMove(location)))
     , m_format(WTFMove(format))
     , m_technologies(WTFMove(technologies))
-    , m_loadedFromOpaqueSource(source)
 {
 }
 
-Ref<CSSFontFaceSrcResourceValue> CSSFontFaceSrcResourceValue::create(CSS::URL location, String format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource source)
+Ref<CSSFontFaceSrcResourceValue> CSSFontFaceSrcResourceValue::create(CSS::URL location, String format, Vector<FontTechnology>&& technologies)
 {
-    return adoptRef(*new CSSFontFaceSrcResourceValue { WTFMove(location), WTFMove(format), WTFMove(technologies), source });
+    return adoptRef(*new CSSFontFaceSrcResourceValue { WTFMove(location), WTFMove(format), WTFMove(technologies) });
 }
 
 std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecutionContext& context, bool isInitiatingElementInUserAgentShadowTree)
@@ -113,7 +112,7 @@ std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(Sc
         }
     }
 
-    auto request = context.fontLoadRequest(m_location.resolved.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_loadedFromOpaqueSource);
+    auto request = context.fontLoadRequest(m_location.resolved.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_location.modifiers.loadedFromOpaqueSource);
     if (auto* cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
         m_cachedFont = &cachedRequest->cachedFont();
 
@@ -155,8 +154,7 @@ bool CSSFontFaceSrcResourceValue::equals(const CSSFontFaceSrcResourceValue& othe
 {
     return m_location == other.m_location
         && m_format == other.m_format
-        && m_technologies == other.m_technologies
-        && m_loadedFromOpaqueSource == other.m_loadedFromOpaqueSource;
+        && m_technologies == other.m_technologies;
 }
 
 }

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -108,7 +108,7 @@ inline ASCIILiteral cssTextFromFontTech(FontTechnology tech)
 
 class CSSFontFaceSrcResourceValue final : public CSSValue {
 public:
-    static Ref<CSSFontFaceSrcResourceValue> create(CSS::URL, String format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource = LoadedFromOpaqueSource::No);
+    static Ref<CSSFontFaceSrcResourceValue> create(CSS::URL, String format, Vector<FontTechnology>&&);
 
     bool isEmpty() const { return m_location.specified.isEmpty(); }
     std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
@@ -119,12 +119,11 @@ public:
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
 private:
-    explicit CSSFontFaceSrcResourceValue(CSS::URL&&, String&& format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource);
+    explicit CSSFontFaceSrcResourceValue(CSS::URL&&, String&& format, Vector<FontTechnology>&&);
 
     CSS::URL m_location;
     String m_format;
     Vector<FontTechnology> m_technologies;
-    LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     CachedResourceHandle<CachedFont> m_cachedFont;
 };
 

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -43,11 +43,10 @@ CSSImageValue::CSSImageValue()
 {
 }
 
-CSSImageValue::CSSImageValue(CSS::URL&& location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString&& initiatorType)
+CSSImageValue::CSSImageValue(CSS::URL&& location, AtomString&& initiatorType)
     : CSSValue(ClassType::Image)
     , m_location(WTFMove(location))
     , m_initiatorType(WTFMove(initiatorType))
-    , m_loadedFromOpaqueSource(loadedFromOpaqueSource)
 {
 }
 
@@ -56,14 +55,14 @@ Ref<CSSImageValue> CSSImageValue::create()
     return adoptRef(*new CSSImageValue);
 }
 
-Ref<CSSImageValue> CSSImageValue::create(CSS::URL location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
+Ref<CSSImageValue> CSSImageValue::create(CSS::URL location, AtomString initiatorType)
 {
-    return adoptRef(*new CSSImageValue(WTFMove(location), loadedFromOpaqueSource, WTFMove(initiatorType)));
+    return adoptRef(*new CSSImageValue(WTFMove(location), WTFMove(initiatorType)));
 }
 
-Ref<CSSImageValue> CSSImageValue::create(WTF::URL imageURL, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
+Ref<CSSImageValue> CSSImageValue::create(WTF::URL imageURL, AtomString initiatorType)
 {
-    return create(CSS::URL { .specified = imageURL.string(), .resolved = WTFMove(imageURL) }, loadedFromOpaqueSource, WTFMove(initiatorType));
+    return create(CSS::URL { .specified = imageURL.string(), .resolved = WTFMove(imageURL), .modifiers = { } }, WTFMove(initiatorType));
 }
 
 CSSImageValue::~CSSImageValue() = default;
@@ -73,11 +72,16 @@ Ref<CSSImageValue> CSSImageValue::copyForComputedStyle(const CSS::URL& resolvedU
     if (resolvedURL == m_location)
         return const_cast<CSSImageValue&>(*this);
 
-    auto result = create(resolvedURL, m_loadedFromOpaqueSource);
+    auto result = create(resolvedURL);
     result->m_cachedImage = m_cachedImage;
     result->m_initiatorType = m_initiatorType;
     result->m_unresolvedValue = const_cast<CSSImageValue*>(this);
     return result;
+}
+
+bool CSSImageValue::isLoadedFromOpaqueSource() const
+{
+    return m_location.modifiers.loadedFromOpaqueSource == LoadedFromOpaqueSource::Yes;
 }
 
 bool CSSImageValue::isPending() const
@@ -95,7 +99,7 @@ RefPtr<StyleImage> CSSImageValue::createStyleImage(const Style::BuilderState& st
 
     auto newLocation = m_location;
     newLocation.resolved = styleLocation.resolved;
-    auto result = create(WTFMove(newLocation), m_loadedFromOpaqueSource);
+    auto result = create(WTFMove(newLocation));
     result->m_cachedImage = m_cachedImage;
     result->m_initiatorType = m_initiatorType;
     result->m_unresolvedValue = const_cast<CSSImageValue*>(this);
@@ -108,14 +112,18 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
         ASSERT(loader.document());
 
         ResourceLoaderOptions loadOptions = options;
-        loadOptions.loadedFromOpaqueSource = m_loadedFromOpaqueSource;
+
+        CSS::applyModifiersToLoaderOptions(m_location.modifiers, loadOptions);
+
         CachedResourceRequest request(ResourceRequest(m_location.resolved), loadOptions);
         if (m_initiatorType.isEmpty())
             request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
         else
             request.setInitiatorType(m_initiatorType);
+
         if (options.mode == FetchOptions::Mode::Cors)
             request.updateForAccessControl(*loader.document());
+
         m_cachedImage = loader.requestImage(WTFMove(request)).value_or(nullptr);
         for (auto imageValue = this; (imageValue = imageValue->m_unresolvedValue.get()); )
             imageValue->m_cachedImage = m_cachedImage;

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -43,8 +43,8 @@ class BuilderState;
 class CSSImageValue final : public CSSValue {
 public:
     static Ref<CSSImageValue> create();
-    static Ref<CSSImageValue> create(CSS::URL, LoadedFromOpaqueSource, AtomString = { });
-    static Ref<CSSImageValue> create(WTF::URL, LoadedFromOpaqueSource, AtomString = { });
+    static Ref<CSSImageValue> create(CSS::URL, AtomString initiatorType = { });
+    static Ref<CSSImageValue> create(WTF::URL, AtomString initiatorType = { });
     ~CSSImageValue();
 
     Ref<CSSImageValue> copyForComputedStyle(const CSS::URL& resolvedURL) const;
@@ -69,7 +69,7 @@ public:
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
-    bool isLoadedFromOpaqueSource() const { return m_loadedFromOpaqueSource == LoadedFromOpaqueSource::Yes; }
+    bool isLoadedFromOpaqueSource() const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
     {
@@ -82,12 +82,11 @@ public:
 
 private:
     CSSImageValue();
-    CSSImageValue(CSS::URL&&, LoadedFromOpaqueSource, AtomString&&);
+    CSSImageValue(CSS::URL&&, AtomString&&);
 
     CSS::URL m_location;
     std::optional<CachedResourceHandle<CachedImage>> m_cachedImage;
     AtomString m_initiatorType;
-    LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
 };

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1898,3 +1898,21 @@ no-overflow
 
 // view-transition-name
 match-element
+
+// <url>
+// url
+
+// <url-modifier>
+crossorigin
+anonymous
+use-credentials
+integrity
+referrerpolicy
+no-referrer
+no-referrer-when-downgrade
+same-origin
+// origin
+strict-origin
+origin-when-cross-origin
+strict-origin-when-cross-origin
+unsafe-url

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -84,8 +84,8 @@ void StyleRuleImport::setCSSStyleSheet(const String& href, const URL& baseURL, A
 
     Document* document = m_parentStyleSheet ? m_parentStyleSheet->singleOwnerDocument() : nullptr;
     m_styleSheet = StyleSheetContents::create(this, href, context);
-    if ((m_parentStyleSheet && m_parentStyleSheet->isContentOpaque()) || !cachedStyleSheet->isCORSSameOrigin())
-        m_styleSheet->setAsOpaque();
+    if ((m_parentStyleSheet && m_parentStyleSheet->loadedFromOpaqueSource() == LoadedFromOpaqueSource::Yes) || !cachedStyleSheet->isCORSSameOrigin())
+        m_styleSheet->setAsLoadedFromOpaqueSource();
 
     bool parseSucceeded = m_styleSheet->parseAuthorStyleSheet(cachedStyleSheet, document ? &document->securityOrigin() : nullptr);
 
@@ -154,14 +154,14 @@ void StyleRuleImport::requestStyleSheet()
             DefersLoadingPolicy::AllowDefersLoading,
             CachingPolicy::AllowCaching
         };
-        options.loadedFromOpaqueSource = m_parentStyleSheet->isContentOpaque() ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No;
+        options.loadedFromOpaqueSource = m_parentStyleSheet->loadedFromOpaqueSource();
 
         request.setOptions(WTFMove(options));
 
         m_cachedSheet = document->protectedCachedResourceLoader()->requestUserCSSStyleSheet(*page, WTFMove(request));
     } else {
         auto options = request.options();
-        options.loadedFromOpaqueSource = m_parentStyleSheet->isContentOpaque() ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No;
+        options.loadedFromOpaqueSource = m_parentStyleSheet->loadedFromOpaqueSource();
         request.setOptions(WTFMove(options));
         m_cachedSheet = document->protectedCachedResourceLoader()->requestCSSStyleSheet(WTFMove(request)).value_or(nullptr);
     }

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -155,8 +155,8 @@ public:
 
     void shrinkToFit();
 
-    void setAsOpaque() { m_parserContext.isContentOpaque = true; }
-    bool isContentOpaque() const { return m_parserContext.isContentOpaque; }
+    void setAsLoadedFromOpaqueSource() { m_parserContext.loadedFromOpaqueSource = LoadedFromOpaqueSource::Yes; }
+    LoadedFromOpaqueSource loadedFromOpaqueSource() const { return m_parserContext.loadedFromOpaqueSource; }
 
     void setLoadErrorOccured() { m_didLoadErrorOccur = true; }
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -115,6 +115,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssMediaProgressFunctionEnabled { document.settings().cssMediaProgressFunctionEnabled() }
     , cssContainerProgressFunctionEnabled { document.settings().cssContainerProgressFunctionEnabled() }
     , cssRandomFunctionEnabled { document.settings().cssRandomFunctionEnabled() }
+    , cssURLModifiersEnabled { document.settings().cssURLModifiersEnabled() }
     , webkitMediaTextTrackDisplayQuirkEnabled { document.quirks().needsWebKitMediaTextTrackDisplayQuirk() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
@@ -124,7 +125,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
 {
     uint32_t bits = context.isHTMLDocument                  << 0
         | context.hasDocumentSecurityOrigin                 << 1
-        | context.isContentOpaque                           << 2
+        | static_cast<bool>(context.loadedFromOpaqueSource) << 2
         | context.useSystemAppearance                       << 3
         | context.springTimingFunctionEnabled               << 4
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
@@ -154,8 +155,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssMediaProgressFunctionEnabled           << 25
         | context.cssContainerProgressFunctionEnabled       << 26
         | context.cssRandomFunctionEnabled                  << 27
-        | (uint32_t)context.mode                            << 28; // This is multiple bits, so keep it last.
-    add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
+        | context.cssURLModifiersEnabled                    << 28;
+    add(hasher, context.baseURL, context.charset, context.propertySettings, bits, context.mode);
 }
 
 void CSSParserContext::setUASheetMode()

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -27,6 +27,7 @@
 
 #include "CSSParserMode.h"
 #include "CSSPropertyNames.h"
+#include "LoadedFromOpaqueSource.h"
 #include "StyleRuleType.h"
 #include <pal/text/TextEncoding.h>
 #include <wtf/HashFunctions.h>
@@ -49,7 +50,7 @@ struct CSSParserContext {
     // This is only needed to support getMatchedCSSRules.
     bool hasDocumentSecurityOrigin : 1 { false };
 
-    bool isContentOpaque : 1 { false };
+    LoadedFromOpaqueSource loadedFromOpaqueSource : 1 { LoadedFromOpaqueSource::No };
     bool useSystemAppearance : 1 { false };
     bool shouldIgnoreImportRules : 1 { false };
 
@@ -85,6 +86,7 @@ struct CSSParserContext {
     bool cssMediaProgressFunctionEnabled : 1 { false };
     bool cssContainerProgressFunctionEnabled : 1 { false };
     bool cssRandomFunctionEnabled : 1 { false };
+    bool cssURLModifiersEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
 
     // Settings, those affecting properties.

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -590,7 +590,7 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
     if (!range.atEnd())
         return nullptr;
 
-    return CSSFontFaceSrcResourceValue::create(WTFMove(*location), WTFMove(format), WTFMove(technologies), state.context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
+    return CSSFontFaceSrcResourceValue::create(WTFMove(*location), WTFMove(format), WTFMove(technologies));
 }
 
 static RefPtr<CSSValue> consumeFontFaceSrcLocal(CSSParserTokenRange& range, CSS::PropertyParserState&)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -1185,7 +1185,7 @@ RefPtr<CSSValue> consumeImage(CSSParserTokenRange& range, CSS::PropertyParserSta
         if (!imageURL)
             return nullptr;
         range.consumeIncludingWhitespace();
-        return CSSImageValue::create(WTFMove(*imageURL), state.context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
+        return CSSImageValue::create(WTFMove(*imageURL));
     }
 
     if (range.peek().type() == FunctionToken) {
@@ -1260,7 +1260,7 @@ RefPtr<CSSValue> consumeImage(CSSParserTokenRange& range, CSS::PropertyParserSta
 
     if (allowedImageTypes.contains(AllowedImageType::URLFunction)) {
         if (auto imageURL = consumeURLRaw(range, state))
-            return CSSImageValue::create(WTFMove(*imageURL), state.context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
+            return CSSImageValue::create(WTFMove(*imageURL));
     }
 
     return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp
@@ -57,7 +57,7 @@ RefPtr<CSSValue> consumeCursor(CSSParserTokenRange& range, CSS::PropertyParserSt
                 return nullptr;
             hotSpot = CSSValuePair::createNoncoalescing(x.releaseNonNull(), y.releaseNonNull());
         }
-        list.append(CSSCursorImageValue::create(image.releaseNonNull(), WTFMove(hotSpot), state.context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No));
+        list.append(CSSCursorImageValue::create(image.releaseNonNull(), WTFMove(hotSpot)));
         if (!consumeCommaIncludingWhitespace(range))
             return nullptr;
     }

--- a/Source/WebCore/css/values/primitives/CSSURL.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURL.cpp
@@ -51,6 +51,19 @@ void Serialize<URL>::operator()(StringBuilder& builder, const SerializationConte
     } else
         serializeString(value.specified, builder);
 
+    if (value.modifiers.crossorigin) {
+        builder.append(' ');
+        serializationForCSS(builder, context, *value.modifiers.crossorigin);
+    }
+    if (value.modifiers.integrity) {
+        builder.append(' ');
+        serializationForCSS(builder, context, *value.modifiers.integrity);
+    }
+    if (value.modifiers.referrerpolicy) {
+        builder.append(' ');
+        serializationForCSS(builder, context, *value.modifiers.referrerpolicy);
+    }
+
     builder.append(')');
 }
 
@@ -59,10 +72,10 @@ void Serialize<URL>::operator()(StringBuilder& builder, const SerializationConte
 static URL completeURL(const String& string, const WTF::URL& baseURL)
 {
     if (string.isEmpty() || string.startsWith('#'))
-        return URL { .specified = string, .resolved = WTF::URL { string } };
+        return URL { .specified = string, .resolved = WTF::URL { string }, .modifiers = { } };
     if (baseURL.isNull())
-        return URL { .specified = string, .resolved = WTF::URL { } };
-    return URL { .specified = string, .resolved = WTF::URL { baseURL, string } };
+        return URL { .specified = string, .resolved = WTF::URL { }, .modifiers = { } };
+    return URL { .specified = string, .resolved = WTF::URL { baseURL, string }, .modifiers = { } };
 }
 
 std::optional<URL> completeURL(const String& string, const CSSParserContext& context)
@@ -73,6 +86,8 @@ std::optional<URL> completeURL(const String& string, const CSSParserContext& con
     auto result = completeURL(string, context.baseURL);
     if (context.mode == WebVTTMode && !result.resolved.protocolIsData())
         return { };
+
+    result.modifiers.loadedFromOpaqueSource = context.loadedFromOpaqueSource;
 
     return result;
 }

--- a/Source/WebCore/css/values/primitives/CSSURL.h
+++ b/Source/WebCore/css/values/primitives/CSSURL.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "CSSValueTypes.h"
+#include "CSSURLModifiers.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -38,8 +38,9 @@ namespace CSS {
 struct URL {
     WTF::String specified;
     WTF::URL resolved;
+    URLModifiers modifiers;
 
-    static URL none() { return { .specified = { }, .resolved = { } }; }
+    static URL none() { return { .specified = { }, .resolved = { }, .modifiers = { } }; }
     bool isNone() const { return specified.isNull(); }
 
     bool operator==(const URL&) const = default;
@@ -51,6 +52,8 @@ template<size_t I> const auto& get(const URL& value)
         return value.specified;
     if constexpr (I == 1)
         return value.resolved;
+    if constexpr (I == 2)
+        return value.modifiers;
 }
 
 template<> struct Serialize<URL> { void operator()(StringBuilder&, const SerializationContext&, const URL&); };
@@ -65,4 +68,4 @@ bool mayDependOnBaseURL(const URL&);
 } // namespace CSS
 } // namespace WebCore
 
-DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::URL, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::URL, 3)

--- a/Source/WebCore/css/values/primitives/CSSURLModifiers.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURLModifiers.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSURLModifiers.h"
+
+#include "ResourceLoaderOptions.h"
+
+namespace WebCore {
+namespace CSS {
+
+void applyModifiersToLoaderOptions(const URLModifiers& modifiers, ResourceLoaderOptions& loaderOptions)
+{
+    if (modifiers.crossorigin) {
+        // https://www.w3.org/TR/css-values-5/#typedef-request-url-modifier-crossorigin-modifier
+        //
+        // The URL request modifier steps for this modifier given request req are:
+        // 1. Set request's mode to "cors".
+        loaderOptions.mode = FetchOptions::Mode::Cors;
+
+        // 2. If the given value is use-credentials, set request's credentials mode to "include"
+        if (std::holds_alternative<Keyword::UseCredentials>(modifiers.crossorigin->parameters))
+            loaderOptions.credentials = FetchOptions::Credentials::Include;
+    }
+
+    if (modifiers.integrity) {
+        // https://www.w3.org/TR/css-values-5/#typedef-request-url-modifier-integrity-modifier
+        //
+        // The URL request modifier steps for this modifier given request req are to set
+        // request's integrity metadata to the given <string>.
+        loaderOptions.integrity = modifiers.integrity->parameters;
+    }
+
+    if (modifiers.referrerpolicy) {
+        // https://www.w3.org/TR/css-values-5/#typedef-request-url-modifier-referrerpolicy-modifier
+        //
+        // The URL request modifier steps for this modifier given request req are to set
+        // request's referrer policy to the ReferrerPolicy that matches the given value.
+        loaderOptions.referrerPolicy = WTF::switchOn(modifiers.referrerpolicy->parameters,
+            [](Keyword::NoReferrer) {
+                return ReferrerPolicy::NoReferrer;
+            },
+            [](Keyword::NoReferrerWhenDowngrade) {
+                return ReferrerPolicy::NoReferrerWhenDowngrade;
+            },
+            [](Keyword::SameOrigin) {
+                return ReferrerPolicy::SameOrigin;
+            },
+            [](Keyword::Origin) {
+                return ReferrerPolicy::Origin;
+            },
+            [](Keyword::StrictOrigin) {
+                return ReferrerPolicy::StrictOrigin;
+            },
+            [](Keyword::OriginWhenCrossOrigin) {
+                return ReferrerPolicy::OriginWhenCrossOrigin;
+            },
+            [](Keyword::StrictOriginWhenCrossOrigin) {
+                return ReferrerPolicy::StrictOriginWhenCrossOrigin;
+            },
+            [](Keyword::UnsafeUrl) {
+                return ReferrerPolicy::UnsafeUrl;
+            }
+        );
+    }
+
+    loaderOptions.loadedFromOpaqueSource = modifiers.loadedFromOpaqueSource;
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSURLModifiers.h
+++ b/Source/WebCore/css/values/primitives/CSSURLModifiers.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValueTypes.h"
+#include "LoadedFromOpaqueSource.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct ResourceLoaderOptions;
+
+namespace CSS {
+
+// <crossorigin-modifier> = crossorigin( anonymous | use-credentials )
+// https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-crossorigin-modifier
+using URLCrossoriginParameters = std::variant<
+    Keyword::Anonymous,
+    Keyword::UseCredentials
+>;
+using URLCrossoriginFunction = FunctionNotation<CSSValueCrossorigin, URLCrossoriginParameters>;
+
+// <integrity-modifier> = integrity( <string> )
+// https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-integrity-modifier
+using URLIntegrityParameters = String;
+using URLIntegrityFunction = FunctionNotation<CSSValueIntegrity, URLIntegrityParameters>;
+
+// <referrerpolicy-modifier> = referrerpolicy( no-referrer | no-referrer-when-downgrade | same-origin | origin | strict-origin | origin-when-cross-origin | strict-origin-when-cross-origin | unsafe-url )
+// https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-referrerpolicy-modifier
+using URLReferrerpolicyParameters = std::variant<
+    Keyword::NoReferrer,
+    Keyword::NoReferrerWhenDowngrade,
+    Keyword::SameOrigin,
+    Keyword::Origin,
+    Keyword::StrictOrigin,
+    Keyword::OriginWhenCrossOrigin,
+    Keyword::StrictOriginWhenCrossOrigin,
+    Keyword::UnsafeUrl
+>;
+using URLReferrerpolicyFunction = FunctionNotation<CSSValueReferrerpolicy, URLReferrerpolicyParameters>;
+
+// https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier
+// <request-url-modifier> = <crossorigin-modifier> | <integrity-modifier> | <referrerpolicy-modifier>
+struct URLModifiers {
+    std::optional<URLCrossoriginFunction> crossorigin { };
+    std::optional<URLIntegrityFunction> integrity { };
+    std::optional<URLReferrerpolicyFunction> referrerpolicy { };
+
+    // This is not a parsed value, but is implicit from context the modifiers were parsed with.
+    LoadedFromOpaqueSource loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
+
+    bool operator==(const URLModifiers&) const = default;
+};
+
+template<size_t I> const auto& get(const URLModifiers& value)
+{
+    if constexpr (I == 0)
+        return value.crossorigin;
+    else if constexpr (I == 1)
+        return value.integrity;
+    else if constexpr (I == 2)
+        return value.referrerpolicy;
+}
+
+// Applies `URLModifiers` to `ResourceLoaderOptions`.
+void applyModifiersToLoaderOptions(const URLModifiers&, ResourceLoaderOptions&);
+
+} // namespace CSS
+} // namespace WebCore
+
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::URLModifiers, 3)

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -87,10 +87,8 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
     switch (name.nodeName()) {
     case AttributeNames::backgroundAttr: {
         auto url = value.string().trim(isASCIIWhitespace);
-        if (!url.isEmpty()) {
-            auto imageValue = CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No, localName());
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, WTFMove(imageValue)));
-        }
+        if (!url.isEmpty())
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), localName())));
         break;
     }
     case AttributeNames::marginwidthAttr:

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -594,7 +594,7 @@ void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet,
         m_sheet->setTitle(title());
 
     if (!m_sheet->canAccessRules())
-        m_sheet->contents().setAsOpaque();
+        m_sheet->contents().setAsLoadedFromOpaqueSource();
 }
 
 void HTMLLinkElement::setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet* cachedStyleSheet)

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -329,7 +329,7 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
         break;
     case AttributeNames::backgroundAttr:
         if (auto url = value.string().trim(isASCIIWhitespace); !url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No)));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url))));
         break;
     case AttributeNames::valignAttr:
         if (!value.isEmpty())

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -65,7 +65,7 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         break;
     case AttributeNames::backgroundAttr:
         if (!StringView(value).containsOnly<isASCIIWhitespace<UChar>>())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(value), LoadedFromOpaqueSource::No)));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(value))));
         break;
     case AttributeNames::valignAttr:
         if (equalLettersIgnoringASCIICase(value, "top"_s))

--- a/Source/WebCore/loader/LoadedFromOpaqueSource.h
+++ b/Source/WebCore/loader/LoadedFromOpaqueSource.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class LoadedFromOpaqueSource : bool { No, Yes };
+static constexpr unsigned bitWidthOfLoadedFromOpaqueSource = 1;
+
+} // namespace WebCore

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -37,6 +37,7 @@
 #include "FetchOptions.h"
 #include "FetchingWorkerIdentifier.h"
 #include "HTTPHeaderNames.h"
+#include "LoadedFromOpaqueSource.h"
 #include "RequestPriority.h"
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerTypes.h"
@@ -157,9 +158,6 @@ static constexpr unsigned bitWidthOfPreflightPolicy = 2;
 
 enum class ShouldEnableContentExtensionsCheck : bool { No, Yes };
 static constexpr unsigned bitWidthOfShouldEnableContentExtensionsCheck = 1;
-
-enum class LoadedFromOpaqueSource : bool { No, Yes };
-static constexpr unsigned bitWidthOfLoadedFromOpaqueSource = 1;
 
 enum class LoadedFromPluginElement : bool { No, Yes };
 static constexpr unsigned bitWidthOfLoadedFromPluginElement = 1;

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -34,8 +34,8 @@
 
 namespace WebCore {
 
-CachedSVGDocumentReference::CachedSVGDocumentReference(const String& url)
-    : m_url(url)
+CachedSVGDocumentReference::CachedSVGDocumentReference(const Style::URL& location)
+    : m_location { location }
 {
 }
 
@@ -51,14 +51,22 @@ void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const Resour
         return;
 
     auto fetchOptions = options;
+
+    CSS::applyModifiersToLoaderOptions(m_location.modifiers, fetchOptions);
+
+    // FIXME: CSS::applyModifiersToLoaderOptions will set `fetchOptions.mode` to `FetchOptions::Mode::Cors` if `modifiers.crossorigin` is set. This will immediately be undone here. Which should win?
+
     fetchOptions.mode = FetchOptions::Mode::SameOrigin;
-    CachedResourceRequest request(ResourceRequest(loader.document()->completeURL(m_url)), fetchOptions);
+
+    CachedResourceRequest request(ResourceRequest(m_location.resolved), fetchOptions);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
+
     m_document = loader.requestSVGDocument(WTFMove(request)).value_or(nullptr);
+
     if (CachedResourceHandle document = m_document)
         document->addClient(*this);
 
     m_loadRequested = true;
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -27,7 +27,7 @@
 
 #include "CachedResourceHandle.h"
 #include "CachedSVGDocumentClient.h"
-#include <wtf/text/WTFString.h>
+#include "StyleURL.h"
 
 namespace WebCore {
 
@@ -38,7 +38,7 @@ struct ResourceLoaderOptions;
 class CachedSVGDocumentReference final : public CachedSVGDocumentClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
-    CachedSVGDocumentReference(const String&);
+    CachedSVGDocumentReference(const Style::URL&);
 
     virtual ~CachedSVGDocumentReference();
 
@@ -48,7 +48,7 @@ public:
     CachedSVGDocument* document() { return m_document.get(); }
 
 private:
-    String m_url;
+    Style::URL m_location;
     CachedResourceHandle<CachedSVGDocument> m_document;
     bool m_loadRequested { false };
 };

--- a/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
+++ b/Source/WebCore/rendering/style/ReferenceFilterOperation.cpp
@@ -70,7 +70,7 @@ void ReferenceFilterOperation::loadExternalDocumentIfNeeded(CachedResourceLoader
         return;
     if (!SVGURIReference::isExternalURIReference(m_url.resolved.string(), *cachedResourceLoader.protectedDocument()))
         return;
-    m_cachedSVGDocumentReference = makeUnique<CachedSVGDocumentReference>(m_url.resolved.string());
+    m_cachedSVGDocumentReference = makeUnique<CachedSVGDocumentReference>(m_url);
     m_cachedSVGDocumentReference->load(cachedResourceLoader, options);
 }
 

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -44,31 +44,29 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleCursorImage);
 
-Ref<StyleCursorImage> StyleCursorImage::create(const Ref<StyleImage>& image, std::optional<IntPoint> hotSpot, const Style::URL& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+Ref<StyleCursorImage> StyleCursorImage::create(const Ref<StyleImage>& image, std::optional<IntPoint> hotSpot, const Style::URL& originalURL)
 {
-    return adoptRef(*new StyleCursorImage(image, hotSpot, originalURL, loadedFromOpaqueSource));
+    return adoptRef(*new StyleCursorImage(image, hotSpot, originalURL));
 }
 
-Ref<StyleCursorImage> StyleCursorImage::create(Ref<StyleImage>&& image, std::optional<IntPoint> hotSpot, Style::URL&& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+Ref<StyleCursorImage> StyleCursorImage::create(Ref<StyleImage>&& image, std::optional<IntPoint> hotSpot, Style::URL&& originalURL)
 {
-    return adoptRef(*new StyleCursorImage(WTFMove(image), hotSpot, WTFMove(originalURL), loadedFromOpaqueSource));
+    return adoptRef(*new StyleCursorImage(WTFMove(image), hotSpot, WTFMove(originalURL)));
 }
 
-StyleCursorImage::StyleCursorImage(const Ref<StyleImage>& image, std::optional<IntPoint> hotSpot, const Style::URL& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+StyleCursorImage::StyleCursorImage(const Ref<StyleImage>& image, std::optional<IntPoint> hotSpot, const Style::URL& originalURL)
     : StyleMultiImage { Type::CursorImage }
     , m_image { image }
     , m_hotSpot { hotSpot }
     , m_originalURL { originalURL }
-    , m_loadedFromOpaqueSource { loadedFromOpaqueSource }
 {
 }
 
-StyleCursorImage::StyleCursorImage(Ref<StyleImage>&& image, std::optional<IntPoint> hotSpot, Style::URL&& originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
+StyleCursorImage::StyleCursorImage(Ref<StyleImage>&& image, std::optional<IntPoint> hotSpot, Style::URL&& originalURL)
     : StyleMultiImage { Type::CursorImage }
     , m_image { WTFMove(image) }
     , m_hotSpot { hotSpot }
     , m_originalURL { WTFMove(originalURL) }
-    , m_loadedFromOpaqueSource { loadedFromOpaqueSource }
 {
 }
 
@@ -100,7 +98,7 @@ Ref<CSSValue> StyleCursorImage::computedStyleValue(const RenderStyle& style) con
     if (m_hotSpot)
         hotSpot = CSSValuePair::createNoncoalescing(CSSPrimitiveValue::create(m_hotSpot->x()), CSSPrimitiveValue::create(m_hotSpot->y()));
 
-    return CSSCursorImageValue::create(m_image->computedStyleValue(style), WTFMove(hotSpot), Style::toCSS(m_originalURL, style), m_loadedFromOpaqueSource );
+    return CSSCursorImageValue::create(m_image->computedStyleValue(style), WTFMove(hotSpot), Style::toCSS(m_originalURL, style));
 }
 
 ImageWithScale StyleCursorImage::selectBestFitImage(const Document& document)
@@ -115,7 +113,7 @@ ImageWithScale StyleCursorImage::selectBestFitImage(const Document& document)
 
             if (existingImageURL != updatedImageURL) {
                 auto styleURL = Style::URL { .resolved = updatedImageURL };
-                m_image = StyleCachedImage::create(styleURL, CSSImageValue::create(WTFMove(updatedImageURL), m_loadedFromOpaqueSource));
+                m_image = StyleCachedImage::create(styleURL, CSSImageValue::create(WTFMove(updatedImageURL)));
             }
         }
     }

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -35,13 +35,11 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 class SVGCursorElement;
 
-enum class LoadedFromOpaqueSource : bool;
-
 class StyleCursorImage final : public StyleMultiImage {
     WTF_MAKE_TZONE_ALLOCATED(StyleCursorImage);
 public:
-    static Ref<StyleCursorImage> create(const Ref<StyleImage>&, std::optional<IntPoint>, const Style::URL&, LoadedFromOpaqueSource);
-    static Ref<StyleCursorImage> create(Ref<StyleImage>&&, std::optional<IntPoint>, Style::URL&&, LoadedFromOpaqueSource);
+    static Ref<StyleCursorImage> create(const Ref<StyleImage>&, std::optional<IntPoint>, const Style::URL&);
+    static Ref<StyleCursorImage> create(Ref<StyleImage>&&, std::optional<IntPoint>, Style::URL&&);
     virtual ~StyleCursorImage();
 
     bool operator==(const StyleImage&) const final;
@@ -56,8 +54,8 @@ public:
     std::optional<IntPoint> hotSpot() const { return m_hotSpot; }
 
 private:
-    explicit StyleCursorImage(const Ref<StyleImage>&, std::optional<IntPoint> hotSpot, const Style::URL&, LoadedFromOpaqueSource);
-    explicit StyleCursorImage(Ref<StyleImage>&&, std::optional<IntPoint> hotSpot, Style::URL&&, LoadedFromOpaqueSource);
+    explicit StyleCursorImage(const Ref<StyleImage>&, std::optional<IntPoint> hotSpot, const Style::URL&);
+    explicit StyleCursorImage(Ref<StyleImage>&&, std::optional<IntPoint> hotSpot, Style::URL&&);
 
     void setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom) final;
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
@@ -68,7 +66,6 @@ private:
     Ref<StyleImage> m_image;
     std::optional<IntPoint> m_hotSpot;
     Style::URL m_originalURL;
-    LoadedFromOpaqueSource m_loadedFromOpaqueSource;
     WeakHashSet<SVGCursorElement, WeakPtrImplWithEventTargetData> m_cursorElements;
 };
 

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -66,6 +66,8 @@ static void loadPendingImage(Document& document, const StyleImage* styleImage, c
             options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
             break;
         case LoadPolicy::NoCORS:
+            options.mode = FetchOptions::Mode::NoCors;
+            options.credentials = FetchOptions::Credentials::SameOrigin;
             break;
         }
     }

--- a/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
@@ -39,7 +39,7 @@ CSS::FilterReference toCSSFilterReference(Ref<ReferenceFilterOperation> operatio
 
 Ref<FilterOperation> createFilterOperation(const CSS::FilterReference& filter, const Document& document, RenderStyle&, const CSSToLengthConversionData&)
 {
-    auto url = toStyleWithBaseURL(filter.url, document.baseURL());
+    auto url = toStyleWithScriptExecutionContext(filter.url, document);
 
     // FIXME: Unify all the fragment accessing/construction.
     auto fragment = url.resolved.string().startsWith('#')

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -50,16 +50,18 @@ namespace Style {
 //      CSS:    [.specified = "foo/bar.png", .resolved = null-url]
 //      Style:  [.resolved = "foo/bar.png"]
 
-auto toStyleWithBaseURL(const CSS::URL& url, const WTF::URL& baseURL) -> URL
+auto toStyleWithScriptExecutionContext(const CSS::URL& url, const ScriptExecutionContext& context) -> URL
 {
     if (url.resolved.isNull()) {
         return {
-            .resolved = WTF::URL { baseURL, url.specified },
+            .resolved = context.completeURL(url.specified),
+            .modifiers = url.modifiers,
         };
     }
 
     return {
         .resolved = url.resolved,
+        .modifiers = url.modifiers,
     };
 }
 
@@ -68,19 +70,40 @@ auto ToCSS<URL>::operator()(const URL& url, const RenderStyle&) -> CSS::URL
     return {
         .specified = url.resolved.string(),
         .resolved = url.resolved,
+        .modifiers = url.modifiers,
     };
 }
 
 auto ToStyle<CSS::URL>::operator()(const CSS::URL& url, const BuilderState& state) -> URL
 {
-    return toStyleWithBaseURL(url, state.document().baseURL());
+    return toStyleWithScriptExecutionContext(url, state.document());
 }
 
 // MARK: - Logging
 
 TextStream& operator<<(TextStream& ts, const URL& value)
 {
-    return ts << "url(\""_s << value.resolved << "\""_s << ")"_s;
+    ts << "url(\""_s << value.resolved << "\"";
+
+    if (value.modifiers.crossorigin) {
+        ts << " crossorigin("_s;
+        WTF::switchOn(value.modifiers.crossorigin->parameters, [&](const auto& alternative) { ts << alternative; });
+        ts << ")"_s;
+    }
+    if (value.modifiers.integrity) {
+        ts << " integrity("_s;
+        ts << *value.modifiers.integrity;
+        ts << ")"_s;
+    }
+    if (value.modifiers.referrerpolicy) {
+        ts << " referrerpolicy("_s;
+        WTF::switchOn(value.modifiers.referrerpolicy->parameters, [&](const auto& alternative) { ts << alternative; });
+        ts << ")"_s;
+    }
+
+    ts << ")";
+
+    return ts;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleURL.h
+++ b/Source/WebCore/style/values/primitives/StyleURL.h
@@ -28,12 +28,16 @@
 #include "StyleValueTypes.h"
 
 namespace WebCore {
+
+class ScriptExecutionContext;
+
 namespace Style {
 
 struct URL {
     WTF::URL resolved;
+    CSS::URLModifiers modifiers;
 
-    static URL none() { return { .resolved = { } }; }
+    static URL none() { return { .resolved = { }, .modifiers = { } }; }
     bool isNone() const { return resolved.isNull(); }
 
     bool operator==(const URL&) const = default;
@@ -41,13 +45,16 @@ struct URL {
 
 template<size_t I> const auto& get(const URL& value)
 {
-    return value.resolved;
+    if constexpr (!I)
+        return value.resolved;
+    if constexpr (I == 1)
+        return value.modifiers;
 }
 
 // MARK: Conversion
 
-// Special conversion function for use by filters code.
-URL toStyleWithBaseURL(const CSS::URL&, const WTF::URL& baseURL);
+// Special conversion function for use by filters and font-face code.
+URL toStyleWithScriptExecutionContext(const CSS::URL&, const ScriptExecutionContext&);
 
 template<> struct ToCSS<URL> { auto operator()(const URL&, const RenderStyle&) -> CSS::URL; };
 template<> struct ToStyle<CSS::URL> { auto operator()(const CSS::URL&, const BuilderState&) -> URL; };
@@ -59,4 +66,4 @@ TextStream& operator<<(TextStream&, const URL&);
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::URL, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::URL, 2)

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -61,7 +61,7 @@ Ref<CSSFontFaceSrcResourceValue> SVGFontFaceUriElement::createSrcValue() const
 {
     auto location = CSS::completeURL(getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr), document()).value_or(CSS::URL::none());
     auto& format = attributeWithoutSynchronization(formatAttr);
-    return CSSFontFaceSrcResourceValue::create(WTFMove(location), format.isEmpty() ? "svg"_s : format.string(), { FontTechnology::ColorSvg }, LoadedFromOpaqueSource::No);
+    return CSSFontFaceSrcResourceValue::create(WTFMove(location), format.isEmpty() ? "svg"_s : format.string(), { FontTechnology::ColorSvg });
 }
 
 void SVGFontFaceUriElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)


### PR DESCRIPTION
#### 84cb0a95d45843843a64bbc98309204c0c92aa0f
<pre>
[css-values-5] Add support for CSS url request modifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290735">https://bugs.webkit.org/show_bug.cgi?id=290735</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous-negative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-anonymous.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials-negative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-crossorigin-use-credentials.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/url-image-ref.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSCursorImageValue.cpp:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/StyleRuleImport.cpp:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UI.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+URL.cpp:
* Source/WebCore/css/values/primitives/CSSURL.cpp:
* Source/WebCore/css/values/primitives/CSSURL.h:
* Source/WebCore/css/values/primitives/CSSURLModifiers.cpp: Added.
* Source/WebCore/css/values/primitives/CSSURLModifiers.h: Added.
* Source/WebCore/html/HTMLBodyElement.cpp:
* Source/WebCore/html/HTMLLinkElement.cpp:
* Source/WebCore/html/HTMLTableElement.cpp:
* Source/WebCore/html/HTMLTablePartElement.cpp:
* Source/WebCore/loader/LoadedFromOpaqueSource.h: Added.
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/rendering/style/ReferenceFilterOperation.cpp:
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
* Source/WebCore/rendering/style/StyleCursorImage.h:
* Source/WebCore/style/StylePendingResources.cpp:
* Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp:
* Source/WebCore/style/values/primitives/StyleURL.cpp:
* Source/WebCore/style/values/primitives/StyleURL.h:
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cb0a95d45843843a64bbc98309204c0c92aa0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98866 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8745 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103992 "Hash 84cb0a95 for PR 43293 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49455 "Hash 84cb0a95 for PR 43293 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26953 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/103992 "Hash 84cb0a95 for PR 43293 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/49455 "Hash 84cb0a95 for PR 43293 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101870 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14285 "Found 13 new test failures: compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-pseudo-before-image.html fast/images/async-image-composited-show.html fast/images/async-image-multiple-clients-repaint.html fast/images/hdr-background-image.html fast/images/hdr-basic-image.html fast/images/hdr-border-image.html fast/images/hdr-pseudo-before-image.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89290 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/103992 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14076 "Found 2 new test failures: imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-images.https.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7262 "23 flakes 6 failures") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48835 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91556 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84013 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7335 "Found 7 new test failures: fast/images/async-image-composited-show.html fast/images/async-image-multiple-clients-repaint.html http/tests/cache/subresource-fragment-identifier.html http/tests/performance/performance-resource-timing-resourcetimingbufferfull-crash.html http/tests/performance/performance-resource-timing-resourcetimingbufferfull-queue-resource-entry.html imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-images.https.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106361 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97496 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25963 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18927 "Found 18 new test failures: compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-pseudo-before-image.html fast/images/async-image-background-image-repeated.html fast/images/async-image-background-image.html fast/images/async-image-composited-show.html fast/images/async-image-multiple-clients-repaint.html fast/images/hdr-background-image.html fast/images/hdr-basic-image.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/106361 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85488 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/106361 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28385 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6055 "Found 8 new test failures: fast/images/async-image-background-image-repeated.html fast/images/async-image-composited-show.html fast/images/async-image-multiple-clients-repaint.html http/tests/cache/subresource-fragment-identifier.html http/tests/performance/performance-resource-timing-resourcetimingbufferfull-crash.html http/tests/performance/performance-resource-timing-resourcetimingbufferfull-queue-resource-entry.html imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-images.https.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19685 "Hash 84cb0a95 for PR 43293 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25916 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31102 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121112 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25736 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33872 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->