### PR TITLE
Address Safer cpp failures in WebFrame

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -542,8 +542,8 @@ void WebFrame::removeFromTree()
 
 void WebFrame::didFinishLoadInAnotherProcess()
 {
-    if (m_coreFrame)
-        m_coreFrame->didFinishLoadInAnotherProcess();
+    if (RefPtr coreFrame = m_coreFrame.get())
+        coreFrame->didFinishLoadInAnotherProcess();
 }
 
 void WebFrame::invalidatePolicyListeners()
@@ -559,12 +559,12 @@ void WebFrame::invalidatePolicyListeners()
 
 void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& policyDecision)
 {
-    if (m_page) {
+    if (RefPtr page = m_page.get()) {
 #if ENABLE(APP_BOUND_DOMAINS)
-        m_page->setIsNavigatingToAppBoundDomain(policyDecision.isNavigatingToAppBoundDomain, Ref { *this });
+        page->setIsNavigatingToAppBoundDomain(policyDecision.isNavigatingToAppBoundDomain, Ref { *this });
 #endif
         if (auto& message = policyDecision.consoleMessage)
-            m_page->addConsoleMessage(m_frameID, message->messageSource, message->messageLevel, message->message);
+            page->addConsoleMessage(m_frameID, message->messageSource, message->messageLevel, message->message);
     }
 
     if (!m_coreFrame)
@@ -579,9 +579,9 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
 
     if (forNavigationAction && localFrameLoaderClient() && policyDecision.websitePoliciesData) {
         ASSERT(page());
-        if (page())
-            page()->setAllowsContentJavaScriptFromMostRecentNavigation(policyDecision.websitePoliciesData->allowsContentJavaScript);
-        localFrameLoaderClient()->applyWebsitePolicies(WTFMove(*policyDecision.websitePoliciesData));
+        if (RefPtr page = this->page())
+            page->setAllowsContentJavaScriptFromMostRecentNavigation(policyDecision.websitePoliciesData->allowsContentJavaScript);
+        protectedLocalFrameLoaderClient()->applyWebsitePolicies(WTFMove(*policyDecision.websitePoliciesData));
     }
 
     m_policyDownloadID = policyDecision.downloadID;
@@ -607,14 +607,14 @@ void WebFrame::startDownload(const WebCore::ResourceRequest& request, const Stri
         ASSERT_NOT_REACHED();
         return;
     }
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     auto topOrigin = localFrame && localFrame->document() ? std::optional { localFrame->document()->topOrigin().data() } : std::nullopt;
     auto policyDownloadID = *std::exchange(m_policyDownloadID, std::nullopt);
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     isAppBound = m_isNavigatingToAppBoundDomain;
     if (localFrame)
-        WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::StartDownload(policyDownloadID, request, topOrigin, isAppBound, suggestedName, fromDownloadAttribute, localFrame->frameID(), localFrame->pageID()), 0);
+        WebProcess::singleton().ensureProtectedNetworkProcessConnection()->protectedConnection()->send(Messages::NetworkConnectionToWebProcess::StartDownload(policyDownloadID, request, topOrigin, isAppBound, suggestedName, fromDownloadAttribute, localFrame->frameID(), localFrame->pageID()), 0);
 }
 
 void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader, const ResourceRequest& request, const ResourceResponse& response)
@@ -623,7 +623,7 @@ void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader,
         ASSERT_NOT_REACHED();
         return;
     }
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     auto topOrigin = localFrame && localFrame->document() ? std::optional { localFrame->document()->topOrigin().data() } : std::nullopt;
     auto policyDownloadID = *std::exchange(m_policyDownloadID, std::nullopt);
 
@@ -639,7 +639,7 @@ void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader,
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     isAppBound = m_isNavigatingToAppBoundDomain;
-    webProcess.ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
+    webProcess.ensureProtectedNetworkProcessConnection()->protectedConnection()->send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
 }
 
 void WebFrame::addConsoleMessage(MessageSource messageSource, MessageLevel messageLevel, const String& message, uint64_t requestID)
@@ -716,10 +716,11 @@ String WebFrame::selectionAsString() const
 
 IntSize WebFrame::size() const
 {
-    if (!m_coreFrame)
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
         return IntSize();
 
-    RefPtr frameView = m_coreFrame->virtualView();
+    RefPtr frameView = coreFrame->virtualView();
     if (!frameView)
         return IntSize();
 
@@ -740,7 +741,8 @@ bool WebFrame::isFrameSet() const
 
 bool WebFrame::isMainFrame() const
 {
-    return m_coreFrame && m_coreFrame->isMainFrame();
+    RefPtr coreFrame = m_coreFrame.get();
+    return coreFrame && coreFrame->isRootFrame();
 }
 
 bool WebFrame::isRootFrame() const
@@ -915,10 +917,11 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
 
 IntRect WebFrame::contentBounds() const
 {
-    if (!m_coreFrame)
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
         return IntRect();
     
-    RefPtr view = m_coreFrame->virtualView();
+    RefPtr view = coreFrame->virtualView();
     if (!view)
         return IntRect();
     
@@ -927,10 +930,11 @@ IntRect WebFrame::contentBounds() const
 
 IntRect WebFrame::visibleContentBounds() const
 {
-    if (!m_coreFrame)
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
         return IntRect();
     
-    RefPtr view = m_coreFrame->virtualView();
+    RefPtr view = coreFrame->virtualView();
     if (!view)
         return IntRect();
     
@@ -954,10 +958,11 @@ IntRect WebFrame::visibleContentBoundsExcludingScrollbars() const
 
 IntSize WebFrame::scrollOffset() const
 {
-    if (!m_coreFrame)
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
         return IntSize();
     
-    RefPtr view = m_coreFrame->virtualView();
+    RefPtr view = coreFrame->virtualView();
     if (!view)
         return IntSize();
 
@@ -979,10 +984,11 @@ bool WebFrame::hasHorizontalScrollbar() const
 
 bool WebFrame::hasVerticalScrollbar() const
 {
-    if (!m_coreFrame)
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
         return false;
 
-    RefPtr view = m_coreFrame->virtualView();
+    RefPtr view = coreFrame->virtualView();
     if (!view)
         return false;
 
@@ -1213,7 +1219,7 @@ RetainPtr<CFDataRef> WebFrame::webArchiveData(FrameFilterFunction callback, void
 
 RefPtr<WebImage> WebFrame::createSelectionSnapshot() const
 {
-    auto snapshot = snapshotSelection(*coreLocalFrame(), { { WebCore::SnapshotFlags::ForceBlackText, WebCore::SnapshotFlags::Shareable }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() });
+    auto snapshot = snapshotSelection(*protectedCoreLocalFrame(), { { WebCore::SnapshotFlags::ForceBlackText, WebCore::SnapshotFlags::Shareable }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() });
     if (!snapshot)
         return nullptr;
 
@@ -1320,7 +1326,7 @@ bool WebFrame::handleContextMenuEvent(const PlatformMouseEvent& platformMouseEve
     bool handled = frame->eventHandler().sendContextMenuEvent(platformMouseEvent);
 #if ENABLE(CONTEXT_MENUS)
     if (handled)
-        page()->contextMenu().show();
+        protectedPage()->contextMenu().show();
 #endif
     return handled;
 }


### PR DESCRIPTION
#### c9cdb1f390be4b3f78fa3eeb4d1cef306896e891
<pre>
Address Safer cpp failures in WebFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=290742">https://bugs.webkit.org/show_bug.cgi?id=290742</a>
<a href="https://rdar.apple.com/problem/148226339">rdar://problem/148226339</a>

Reviewed by NOBODY (OOPS!).

Fix clang static analyzer warnings in WebFrame.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didFinishLoadInAnotherProcess):
(WebKit::WebFrame::didReceivePolicyDecision):
(WebKit::WebFrame::startDownload):
(WebKit::WebFrame::convertMainResourceLoadToDownload):
(WebKit::WebFrame::size const):
(WebKit::WebFrame::isMainFrame const):
(WebKit::WebFrame::jsContextForServiceWorkerWorld):
(WebKit::WebFrame::contentBounds const):
(WebKit::WebFrame::visibleContentBounds const):
(WebKit::WebFrame::scrollOffset const):
(WebKit::WebFrame::hasVerticalScrollbar const):
(WebKit::WebFrame::createSelectionSnapshot const):
(WebKit::WebFrame::handleContextMenuEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9cdb1f390be4b3f78fa3eeb4d1cef306896e891

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100821 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13432 "Found 2 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-top-level-navigation.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88405 "Found 16 new API test failures: TestWebKitAPI.SiteIsolation.OpenProvisionalFailure, TestWebKitAPI.SiteIsolation.ProtocolProcessSeparation, TestWebKitAPI.SiteIsolation.ChildNavigatingToNewDomain, TestWebKitAPI.SiteIsolation.ChildNavigatingToSameDomain, TestWebKitAPI.SiteIsolation.IframeOpener, TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage, TestWebKitAPI.SiteIsolation.CancelProvisionalLoad, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure, TestWebKitAPI.SiteIsolation.FindStringSelectionSameOriginFrames, TestWebKitAPI.SiteIsolation.ProvisionalLoadFailureOnCrossSiteRedirect ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13209 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47790 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83199 "Found 20 new API test failures: TestWebKitAPI.SiteIsolation.OpenProvisionalFailure, TestWebKitAPI.SiteIsolation.NavigationWithIFrames, TestWebKitAPI.SiteIsolation.ProtocolProcessSeparation, TestWebKitAPI.SiteIsolation.ChildNavigatingToNewDomain, TestWebKitAPI.SiteIsolation.ChildNavigatingToSameDomain, TestWebKitAPI.SiteIsolation.IframeOpener, TestWebKitAPI.SiteIsolation.FindStringSelection, TestWebKitAPI.SiteIsolation.LoadingCallbacksAndPostMessage, TestWebKitAPI.SiteIsolation.CancelProvisionalLoad, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6402 "Found 4 new test failures: http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-top-level-navigation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24898 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18134 "Found 4 new test failures: http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-top-level-navigation.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82948 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27550 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5231 "Found 4 new test failures: http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-top-level-navigation.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18505 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->