### PR TITLE
Worker and SharedWorker constructors should fail asynchronously in case of cross origin URLs

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt
@@ -4,7 +4,7 @@ Workers should be governed by 'child-src'.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS var w = new Worker('/security/contentSecurityPolicy/resources/alert-fail.js'); threw exception SecurityError: The operation is insecure..
+PASS The worker failed asynchronously
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked.html
@@ -8,7 +8,8 @@
 <body>
     <script>
         description("Workers should be governed by 'child-src'.");
-        injectWorker("/security/contentSecurityPolicy/resources/alert-fail.js", EXPECT_BLOCK);
+        const isAsync = true;
+        injectWorker("/security/contentSecurityPolicy/resources/alert-fail.js", EXPECT_BLOCK, isAsync);
     </script>
     <script src="/js-test-resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-wildcard-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-wildcard-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/extensions/resources/script.js because it appears in neither the script-src directive nor the default-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/extensions/resources/script.js because it appears in neither the script-src directive nor the default-src directive of the Content Security Policy.
 
 Test that CSP for manifest V3 extensions does not allow wildcards for the default-src directive.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-partial-wildcard-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-partial-wildcard-expected.txt
@@ -1,3 +1,3 @@
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/worker.py?type=post-message-pass&csp=script-src%20%27self%27%20%27unsafe-inline%27 because it does not appear in the worker-src directive of the Content Security Policy.
-ALERT: SecurityError: The operation is insecure.
+ALERT: PASS
 Test that CSP for manifest V3 extensions blocks partial wildcards for the worker-src directive. Test passes if we alert with an error.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-wildcard-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-wildcard-expected.txt
@@ -1,3 +1,3 @@
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/worker.py?type=post-message-pass&csp=script-src%20%27self%27%20%27unsafe-inline%27 because it does not appear in the worker-src directive of the Content Security Policy.
-ALERT: SecurityError: The operation is insecure.
+ALERT: PASS
 Test that CSP for manifest V3 extensions blocks wildcards for the worker-src directive. Test passes if we alert with an error.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/child-src-test.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/child-src-test.js
@@ -44,8 +44,22 @@ function injectFrameRedirectingTo(url, shouldBlock) {
     injectFrame("/security/contentSecurityPolicy/resources/redir.py?url=" + url, shouldBlock);
 }
 
-function injectWorker(url, expectBlock) {
+function injectWorker(url, expectBlock, isAsync) {
     window.onload = function() {
+        if (isAsync) {
+            try {
+                const w = new Worker(url);
+                if (expectBlock == EXPECT_BLOCK) {
+                    w.onerror = () => {
+                        testPassed("The worker failed asynchronously");
+                        finishJSTest();
+                    }
+                }
+            } catch(e) {
+                testFailed("Constructing a worker failed with " + e);
+            }
+            return;
+        }
         if (expectBlock == EXPECT_BLOCK)
             shouldThrow("var w = new Worker('" + url + "');");
         else

--- a/LayoutTests/http/tests/workers/resources/worker-redirect.js
+++ b/LayoutTests/http/tests/workers/resources/worker-redirect.js
@@ -27,7 +27,7 @@ function testCrossOriginLoad()
     try {
         var worker = createWorker('http://localhost:8000/workers/resources/worker-redirect-target.js');
         worker.onerror = function(evt) {
-            log("FAIL: threw error when attempting to cross origin while loading the worker script.");
+            log("PASS: threw error when attempting to cross origin while loading the worker script.");
             runNextTest();
         }
         worker.onmessage = function(evt) {
@@ -35,7 +35,7 @@ function testCrossOriginLoad()
             runNextTest();
         }
     } catch (ex) {
-        log("SUCCESS: threw exception (" + ex + ") when attempting to cross origin while loading the worker script.");
+        log("FAIL: threw exception (" + ex + ") when attempting to cross origin while loading the worker script.");
         runNextTest();
     }
 }

--- a/LayoutTests/http/tests/workers/worker-document-domain-security-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-document-domain-security-expected.txt
@@ -1,3 +1,4 @@
-PASS: Got security error.
+PASS: No exception thrown when accessing a worker from another domain.
 PASS: No exception throw when accessing a same-origin URL after setting document.domain.
+PASS: Got error event
 

--- a/LayoutTests/http/tests/workers/worker-document-domain-security.html
+++ b/LayoutTests/http/tests/workers/worker-document-domain-security.html
@@ -2,8 +2,10 @@
 <body>
 <div id=result></div>
 <script>
-if (window.testRunner)
+if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
 
 if (window.internals)
     window.internals.settings.setTreatIPAddressAsDomain(true);
@@ -16,13 +18,15 @@ function log(message)
 document.domain = "0.0.1";
 
 try {
-    new Worker("http://0.0.1/worker.js");
-    log("FAIL: No exception thrown when accessing a worker from another domain.");
+    const worker = new Worker("http://0.0.1/worker.js");
+    log("PASS: No exception thrown when accessing a worker from another domain.");
+    worker.onerror = () => {
+        log("PASS: Got error event");
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
 } catch (error) {
-    if (error.code == 18)
-        log("PASS: Got security error.");
-    else
-        log("FAIL: Got error code " + error.code + ". Expected error code 18.");
+    log("FAIL: Got error code " + error.code + ". Expected error code 18.");
 }
 
 try {
@@ -30,6 +34,8 @@ try {
     log("PASS: No exception throw when accessing a same-origin URL after setting document.domain.");
 } catch (error) {
     log("FAIL: Got error code " + error.code + ".");
+    if (window.testRunner)
+        testRunner.notifyDone();
 }
 
 </script>

--- a/LayoutTests/http/tests/workers/worker-invalid-url-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-invalid-url-expected.txt
@@ -1,4 +1,5 @@
 Test worker invalid url exceptions. Should print one "PASS" statement.
 
-PASS: Got security error.
+PASS: No exception thrown when accessing a worker from another domain.
+PASS: Got error event
 

--- a/LayoutTests/http/tests/workers/worker-invalid-url.html
+++ b/LayoutTests/http/tests/workers/worker-invalid-url.html
@@ -3,8 +3,10 @@
 <p>Test worker invalid url exceptions. Should print one "PASS" statement.</p>
 <div id=result></div>
 <script>
-if (window.testRunner)
+if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
 
 function log(message)
 {
@@ -12,13 +14,15 @@ function log(message)
 }
 
 try {
-    new Worker("http://example.com/worker.js");
-    log("FAIL: No exception thrown when accessing a worker from another domain.");
+    const worker = new Worker("http://example.com/worker.js");
+    log("PASS: No exception thrown when accessing a worker from another domain.");
+    worker.onerror = () => {
+        log("PASS: Got error event");
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
 } catch (error) {
-    if (error.code == 18)
-        log("PASS: Got security error.");
-    else
-        log("FAIL: Got error code " + error.code + ". Expected error code 18.");
+    log("FAIL: Got error code " + error.code + ". Expected error code 18.");
 }
 </script>
 </body>

--- a/LayoutTests/http/tests/workers/worker-redirect-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-redirect-expected.txt
@@ -3,7 +3,7 @@ CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/workers/resour
 CONSOLE MESSAGE: Cannot load http://localhost:8000/workers/resources/worker-redirect-target.js due to access control checks.
 Test that loading the worker's script does not allow a cross origin redirect (bug 26146)
 
-SUCCESS: threw exception (SecurityError: The operation is insecure.) when attempting to cross origin while loading the worker script.
+PASS: threw error when attempting to cross origin while loading the worker script.
 SUCCESS: threw error when attempting to redirected cross origin while loading the worker script.
 DONE
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/testharness-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/testharness-helper.js
@@ -84,43 +84,41 @@ function assert_service_worker_is_loaded(url, description) {
 }
 
 // Given the URL of a worker that pings its opener upon load, this
-// function builds a test that asserts that the constructor throws
-// a SecurityError, and that a CSP event fires.
+// function builds a test that asserts that the an error event is
+// fired on the worker, and that a CSP event fires.
 function assert_worker_is_blocked(url, description) {
   async_test(t => {
+    var w = new Worker(url);
+    w.onmessage = t.unreached_func("Ping should not be sent.");
     // If |url| is a blob, it will be stripped down to "blob" for reporting.
     var reportedURL = new URL(url).protocol == "blob:" ? "blob" : url;
-    waitUntilCSPEventForURL(t, reportedURL)
-      .then(t.step_func_done(e => {
-        assert_equals(e.blockedURI, reportedURL);
-        assert_equals(e.violatedDirective, "worker-src");
-        assert_equals(e.effectiveDirective, "worker-src");
-      }));
-
-    // TODO(mkwst): We shouldn't be throwing here. We should be firing an
-    // `error` event on the Worker. https://crbug.com/663298
-    assert_throws_dom("SecurityError", function () {
-      var w = new Worker(url);
-    });
+    Promise.all([
+      waitUntilCSPEventForURL(t, reportedURL)
+        .then(t.step_func(e => {
+          assert_equals(e.blockedURI, reportedURL);
+          assert_equals(e.violatedDirective, "worker-src");
+          assert_equals(e.effectiveDirective, "worker-src");
+        })),
+      waitUntilEvent(w, "error")
+    ]).then(t.step_func_done());
   }, description);
 }
 
 function assert_shared_worker_is_blocked(url, description) {
   async_test(t => {
+    var w = new SharedWorker(url);
+    w.onmessage = t.unreached_func("Ping should not be sent.");
     // If |url| is a blob, it will be stripped down to "blob" for reporting.
     var reportedURL = new URL(url).protocol == "blob:" ? "blob" : url;
-    waitUntilCSPEventForURL(t, reportedURL)
-      .then(t.step_func_done(e => {
-        assert_equals(e.blockedURI, reportedURL);
-        assert_equals(e.violatedDirective, "worker-src");
-        assert_equals(e.effectiveDirective, "worker-src");
-      }));
-
-    // TODO(mkwst): We shouldn't be throwing here. We should be firing an
-    // `error` event on the SharedWorker. https://crbug.com/663298
-    assert_throws_dom("SecurityError", function () {
-      var w = new SharedWorker(url);
-    });
+    Promise.all([
+      waitUntilCSPEventForURL(t, reportedURL)
+        .then(t.step_func(e => {
+          assert_equals(e.blockedURI, reportedURL);
+          assert_equals(e.violatedDirective, "worker-src");
+          assert_equals(e.effectiveDirective, "worker-src");
+        })),
+      waitUntilEvent(w, "error")
+    ]).then(t.step_func_done());
   }, description);
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt
@@ -1,14 +1,14 @@
 
 FAIL sec-fetch-site - Not sent to non-trustworthy same-origin destination, no options assert_not_own_property: unexpected property "sec-fetch-site" is found on object
-FAIL sec-fetch-site - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-site - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-site - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-site - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 FAIL sec-fetch-mode - Not sent to non-trustworthy same-origin destination, no options assert_not_own_property: unexpected property "sec-fetch-mode" is found on object
-FAIL sec-fetch-mode - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-mode - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 FAIL sec-fetch-dest - Not sent to non-trustworthy same-origin destination, no options assert_not_own_property: unexpected property "sec-fetch-dest" is found on object
-FAIL sec-fetch-dest - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-dest - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 PASS sec-fetch-user - Not sent to non-trustworthy same-origin destination, no options
-FAIL sec-fetch-user - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-user - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-user - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-user - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_cross_origin_security_err-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_cross_origin_security_err-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Cross-origin classic workers should fail to fetch The operation is insecure.
-FAIL Cross-origin module workers should fail to fetch The operation is insecure.
+PASS Cross-origin classic workers should fail to fetch
+PASS Cross-origin module workers should fail to fetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt
@@ -1,12 +1,12 @@
 
 PASS non-parsable URL
-FAIL unsupported_scheme URL of the shared worker is cross-origin
+PASS unsupported_scheme
 PASS data_url
-FAIL javascript_url URL of the shared worker is cross-origin
-FAIL about_blank URL of the shared worker is cross-origin
-FAIL opera_com URL of the shared worker is cross-origin
-FAIL port_81 URL of the shared worker is cross-origin
-FAIL https_port_80 URL of the shared worker is cross-origin
-FAIL https_port_8000 URL of the shared worker is cross-origin
-FAIL http_port_8012 URL of the shared worker is cross-origin
+PASS javascript_url
+PASS about_blank
+PASS opera_com
+PASS port_81
+PASS https_port_80
+PASS https_port_8000
+PASS http_port_8012
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt
@@ -1,12 +1,12 @@
 
 PASS non-parsable URL
-FAIL unsupported_scheme The operation is insecure.
+PASS unsupported_scheme
 PASS data_url
-FAIL about_blank The operation is insecure.
-FAIL example_invalid The operation is insecure.
-FAIL port_81 The operation is insecure.
-FAIL https_port_80 The operation is insecure.
-FAIL https_port_8000 The operation is insecure.
-FAIL http_post_8012 The operation is insecure.
-FAIL javascript_url The operation is insecure.
+PASS about_blank
+PASS example_invalid
+PASS port_81
+PASS https_port_80
+PASS https_port_8000
+PASS http_post_8012
+PASS javascript_url
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Create a dedicated worker in a data url frame assert_equals: expected "PASS" but got "Worker construction unexpectedly synchronously failed"
-FAIL Create a dedicated worker in a data url dedicated worker assert_equals: expected "PASS" but got "Worker construction unexpectedly synchronously failed"
+PASS Create a dedicated worker in a data url frame
+PASS Create a dedicated worker in a data url dedicated worker
 PASS Create a data url dedicated worker in a data url frame
 PASS Create a data url dedicated worker in a data url dedicated worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-failure-expected.txt
@@ -5,5 +5,5 @@ PASS Worker construction for non-existent script should dispatch an ErrorEvent.
 PASS Static import for non-existent script should dispatch an ErrorEvent.
 PASS Dynamic import for non-existent script should throw an exception.
 PASS Worker construction for an invalid URL should throw an exception.
-FAIL Worker construction for a file URL should fail The operation is insecure.
+PASS Worker construction for a file URL should fail
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-failure-expected.txt
@@ -4,5 +4,5 @@ PASS Worker construction for non-existent script should dispatch an ErrorEvent.
 PASS Static import for non-existent script should dispatch an ErrorEvent.
 PASS Dynamic import for non-existent script should throw an exception.
 PASS SharedWorker construction for an invalid URL should throw an exception.
-FAIL SharedWorker construction for a file URL should throw an exception. URL of the shared worker is cross-origin
+PASS SharedWorker construction for a file URL should throw an exception.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/shared-worker-in-data-url-context.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/shared-worker-in-data-url-context.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Create a shared worker in a data url frame assert_equals: expected "PASS" but got "SharedWorker construction unexpectedly synchronously failed"
+PASS Create a shared worker in a data url frame
 PASS Create a data url shared worker in a data url frame
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt
@@ -1,14 +1,14 @@
 
 PASS sec-fetch-site - Not sent to non-trustworthy same-origin destination, no options
-FAIL sec-fetch-site - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-site - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-site - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-site - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 PASS sec-fetch-mode - Not sent to non-trustworthy same-origin destination, no options
-FAIL sec-fetch-mode - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-mode - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 PASS sec-fetch-dest - Not sent to non-trustworthy same-origin destination, no options
-FAIL sec-fetch-dest - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-dest - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 PASS sec-fetch-user - Not sent to non-trustworthy same-origin destination, no options
-FAIL sec-fetch-user - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL sec-fetch-user - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL sec-fetch-user - Not sent to non-trustworthy same-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
+FAIL sec-fetch-user - Not sent to non-trustworthy cross-site destination, no options promise_test: Unhandled rejection with value: object "[object Event]"
 

--- a/LayoutTests/platform/mac-wk1/http/tests/workers/worker-redirect-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/workers/worker-redirect-expected.txt
@@ -3,7 +3,7 @@ CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/workers/resour
 CONSOLE MESSAGE: Cannot load http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/workers/resources/worker-redirect-target.js due to access control checks.
 Test that loading the worker's script does not allow a cross origin redirect (bug 26146)
 
-SUCCESS: threw exception (SecurityError: The operation is insecure.) when attempting to cross origin while loading the worker script.
+PASS: threw error when attempting to cross origin while loading the worker script.
 SUCCESS: threw error when attempting to redirected cross origin while loading the worker script.
 DONE
 

--- a/LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-expected.txt
@@ -2,6 +2,7 @@ main frame - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame
 CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/resources/compass.jpg because 'block-all-mixed-content' appears in the Content Security Policy.
+CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/resources/compass.jpg because 'block-all-mixed-content' appears in the Content Security Policy.
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9401,6 +9401,20 @@ WirelessPlaybackTargetAPIEnabled:
       "PLATFORM(VISION)" : false
       default: true
 
+WorkerAsynchronousURLErrorHandlingEnabled:
+  type: bool
+  status: preview
+  category: dom
+  humanReadableName: "Worker asynchronous URL error handling"
+  humanReadableDescription: "Worker asynchronous URL error handling"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WriteRichTextDataWhenCopyingOrDragging:
   type: bool
   status: internal

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -58,13 +58,19 @@ FetchOptions AbstractWorker::workerFetchOptions(const WorkerOptions& options, Fe
 
 ExceptionOr<URL> AbstractWorker::resolveURL(const String& url)
 {
-    auto& context = *scriptExecutionContext();
+    Ref context = *scriptExecutionContext();
 
     // FIXME: This should use the dynamic global scope (bug #27887).
-    URL scriptURL = context.completeURL(url);
+    URL scriptURL = context->completeURL(url);
     if (!scriptURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 
+    return scriptURL;
+}
+
+std::optional<Exception> AbstractWorker::validateURL(ScriptExecutionContext& context, const URL& scriptURL)
+{
+    // Per the specification, any same-origin URL (including blob: URLs) can be used. data: URLs can also be used, but they create a worker with an opaque origin.
     if (!context.protectedSecurityOrigin()->canRequest(scriptURL, OriginAccessPatternsForWebProcess::singleton()) && !scriptURL.protocolIsData())
         return Exception { ExceptionCode::SecurityError };
 
@@ -72,7 +78,7 @@ ExceptionOr<URL> AbstractWorker::resolveURL(const String& url)
     if (!context.checkedContentSecurityPolicy()->allowWorkerFromSource(scriptURL))
         return Exception { ExceptionCode::SecurityError };
 
-    return scriptURL;
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/AbstractWorker.h
+++ b/Source/WebCore/workers/AbstractWorker.h
@@ -53,6 +53,8 @@ protected:
     // Helper function that converts a URL to an absolute URL and checks the result for validity.
     ExceptionOr<URL> resolveURL(const String& url);
 
+    static std::optional<Exception> validateURL(ScriptExecutionContext&, const URL&);
+
     intptr_t asID() const { return reinterpret_cast<intptr_t>(this); }
 
 private:


### PR DESCRIPTION
#### e9a2fa13c71e43068c10d9394e78bb068a53f646
<pre>
Worker and SharedWorker constructors should fail asynchronously in case of cross origin URLs
<a href="https://rdar.apple.com/148229314">rdar://148229314</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290745">https://bugs.webkit.org/show_bug.cgi?id=290745</a>

Reviewed by Anne Van Kesteren.

Align with the spec and fail asynchronously in case of bad URL checks.
This aligns with the spec and Firefox behavior.
As discussed in <a href="https://github.com/web-platform-tests/wpt/issues/41745">https://github.com/web-platform-tests/wpt/issues/41745</a>, Chrome  also plans to align to the spec, and the web compatibility story seems favorable.
We add a runtime flag for now, in preview state, but off by default for now to further validate the web compatibility story.

We do a small refactoring to share more code between Worker and SharedWorker.
We update WPT tests from upstream to cope with the change of behavior and we update our local tests acccordingly.

* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-wildcard-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-partial-wildcard-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/worker-src/manifest-v3-worker-src-block-wildcard-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/child-src-test.js:
(window.onload):
(injectWorker):
* LayoutTests/http/tests/workers/resources/worker-redirect.js:
(testCrossOriginLoad.try.worker.onerror):
(testCrossOriginLoad):
* LayoutTests/http/tests/workers/worker-document-domain-security-expected.txt:
* LayoutTests/http/tests/workers/worker-document-domain-security.html:
* LayoutTests/http/tests/workers/worker-invalid-url-expected.txt:
* LayoutTests/http/tests/workers/worker-invalid-url.html:
* LayoutTests/http/tests/workers/worker-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/testharness-helper.js:
(async_test): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/Worker_cross_origin_security_err-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-failure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-failure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/shared-worker-in-data-url-context.window-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt:
* LayoutTests/platform/mac-wk1/http/tests/workers/worker-redirect-expected.txt:
* LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/workers/AbstractWorker.cpp:
(WebCore::AbstractWorker::resolveURL):
(WebCore::AbstractWorker::validateURL):
* Source/WebCore/workers/AbstractWorker.h:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::create):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):

Canonical link: <a href="https://commits.webkit.org/293014@main">https://commits.webkit.org/293014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da5dd207ba20cc896fa4d8d1720da2f9f8e31904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25789 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31612 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6244 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47683 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90387 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104819 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96334 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82905 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20879 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24752 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119959 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24574 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33666 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->