### PR TITLE
Add a separate flag for `aria-owns` support for referenceTarget

### DIFF
--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled-expected.txt
@@ -1,0 +1,15 @@
+Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: group.isAttributeSupported('AXOwns') === true
+PASS: group.childrenCount === 2
+PASS: group.ariaOwnsElementAtIndex(0).domIdentifier === 'shadow-host'
+PASS: group.childAtIndex(1).domIdentifier === 'shadow-host'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Item 1
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ShadowRootReferenceTargetEnabledForAriaOwns=false ] -->
+<html>
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="group" role="group" aria-owns="shadow-host">
+    <span id="light-span" role="button">Item 1</span>
+</div>
+
+<!-- The role is present to ensure this element is not ignored for accessibility. -->
+<fancy-span id="shadow-host" role="button">
+    <template shadowrootmode="closed" shadowrootreferencetarget="inner-span">
+        <span id="inner-span" role="button">Inner span</span>
+    </template>
+</fancy-span>
+
+<script>
+description("Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.");
+
+var group = accessibilityController.accessibleElementById("group");
+
+let output = expect("group.isAttributeSupported('AXOwns')", "true");
+output += expect("group.childrenCount", "2");
+
+output += expect("group.ariaOwnsElementAtIndex(0).domIdentifier", "'shadow-host'");
+output += expect("group.childAtIndex(1).domIdentifier", "'shadow-host'");
+
+debug(output);
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled-expected.txt
@@ -1,0 +1,15 @@
+Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: group.isAttributeSupported('AXOwns') === true
+PASS: group.childrenCount === 2
+PASS: group.ariaOwnsElementAtIndex(0).domIdentifier === 'inner-span'
+PASS: group.childAtIndex(1).domIdentifier === 'inner-span'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Item 1
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="group" role="group" aria-owns="shadow-host">
+    <span id="light-span" role="button">Item 1</span>
+</div>
+
+<!-- The role is present to ensure this element is not ignored for accessibility. -->
+<fancy-span id="shadow-host" role="button">
+    <template shadowrootmode="closed" shadowrootreferencetarget="inner-span">
+        <span id="inner-span" role="button">Inner span</span>
+    </template>
+</fancy-span>
+
+<script>
+description("Reference target does not support aria-owns, i.e.,the ownership is not forwarded to the referenced element.");
+
+var group = accessibilityController.accessibleElementById("group");
+
+let output = expect("group.isAttributeSupported('AXOwns')", "true");
+output += expect("group.childrenCount", "2");
+
+output += expect("group.ariaOwnsElementAtIndex(0).domIdentifier", "'inner-span'");
+output += expect("group.childAtIndex(1).domIdentifier", "'inner-span'");
+
+debug(output);
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6963,6 +6963,21 @@ ShadowRootReferenceTargetEnabled:
       default: false
   sharedPreferenceForWebProcess: true
 
+ShadowRootReferenceTargetEnabledForAriaOwns:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "referenceTarget support for aria-owns"
+  humanReadableDescription: "Enable referenceTarget support for aria-owns and ariaOwnsElements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 # When enabling this, don't enable on watchOS or the macOS base system (which don't have Vision.framework).
 # You can detect these by running isVisionFrameworkAvailable().
 ShapeDetection:

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2468,7 +2468,8 @@ std::optional<Vector<Ref<Element>>> Element::elementsArrayForAttributeInternal(c
     if (!elements)
         return std::nullopt;
 
-    if (document().settings().shadowRootReferenceTargetEnabled()) {
+    if (document().settings().shadowRootReferenceTargetEnabled()
+        && (attributeName != aria_ownsAttr || document().settings().shadowRootReferenceTargetEnabledForAriaOwns())) {
         elements = compactMap(elements.value(), [&](Ref<Element>& element) -> std::optional<Ref<Element>> {
             if (RefPtr deepReferenceTarget = element->resolveReferenceTarget())
                 return *deepReferenceTarget;


### PR DESCRIPTION
#### 460a176c39c0c5eba214b3ca6848c3c12c93f93d
<pre>
Add a separate flag for `aria-owns` support for referenceTarget
<a href="https://bugs.webkit.org/show_bug.cgi?id=290744">https://bugs.webkit.org/show_bug.cgi?id=290744</a>

Reviewed by Tyler Wilcock.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-disabled.html: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-owns-enabled.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::elementsArrayForAttributeInternal const):

Canonical link: <a href="https://commits.webkit.org/293634@main">https://commits.webkit.org/293634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c768fd93394abc421c16d3e6e07842d8ca0df2ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48940 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91661 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106466 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97601 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21357 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6135 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19795 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31207 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121217 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25841 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33891 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->