### PR TITLE
Add tests for referenceTarget interaction with aria-controls and aria-describedby

### DIFF
--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt
@@ -1,0 +1,18 @@
+This tests that aria-controls referring to a tabpanel indirectly via referenceTarget works still causes the relevant tab element to be selected when the tabpanel receives focus.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+tab2.isSelected should be false initially
+PASS: tab2.isSelected === false
+tab2.isSelected should be true after focusing panel2Item
+PASS: tab2.isSelected === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tab 1
+Tab 2
+Panel 1
+
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+<ul id="tablist-1" role="tablist">
+    <li id="tab-1" role="tab" tabindex="-1">Tab 1</li>
+    <li id="tab-2" role="tab" tabindex="-1" aria-controls="x-panel-2">Tab 2</li>
+</ul>
+
+<div id="panel-1" role="tabpanel">
+    <h3 tabindex="0">Panel 1</h3>
+</div>
+
+<x-panel id="x-panel-2">
+    <template shadowrootmode="open" shadowrootreferencetarget="panel-2">
+        <div id="panel-2" role="tabpanel">
+            <h2 id="item-in-panel-2" tabindex="0">Panel 2</h2>
+        </div>
+    </template>
+</x-panel>
+
+<script>
+description("This tests that aria-controls referring to a tabpanel indirectly via referenceTarget works still causes the relevant tab element to be selected when the tabpanel receives focus.");
+window.jsTestIsAsync = true;
+var tab2;
+
+(async () => {
+    const tabList = accessibilityController.accessibleElementById('tablist-1');
+    tab2 = tabList.childAtIndex(1);
+
+    let output = "tab2.isSelected should be false initially\n";
+    output += expect("tab2.isSelected", "false");
+
+    // we set KB focus to something in x-panel-2, which means that tab2 should become selected
+    // because it aria-controls x-panel-2
+    const xPanel2 = document.getElementById("x-panel-2");
+    const panel2Item = xPanel2.shadowRoot.getElementById("item-in-panel-2");
+    panel2Item.focus();
+
+    output += "tab2.isSelected should be true after focusing panel2Item\n";
+    output += await expectAsync("tab2.isSelected", "true");
+
+    debug(output);
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt
@@ -1,0 +1,11 @@
+This tests that using aria-describedby to refer to an element indirectly via referenceTarget causes the description to be computed correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: input1.customContent === 'description: Description 1'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html
+++ b/LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <script src="../../../../resources/accessibility-helper.js"></script>
+    <script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+<div class="container">
+    <input id="input-1" aria-describedby="x-description-1">
+    <x-description-1 id="x-description-1">
+        <template shadowrootmode="closed" shadowrootreferencetarget="description-1">
+        <span>FAIL IF INCLUDED</span>
+        <span id="description-1">Description 1</span>
+        </template>
+    </x-description-1>
+</div>
+<script>
+description("This tests that using aria-describedby to refer to an element indirectly via referenceTarget causes the description to be computed correctly.");
+
+var input1 = accessibilityController.accessibleElementById("input-1");
+let output = expect("input1.customContent", "'description: Description 1'");
+
+debug(output);
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 7a69959f4c523e16cefed7b38e19a6dccf7bd99f
<pre>
Add tests for referenceTarget interaction with aria-controls and aria-describedby
<a href="https://bugs.webkit.org/show_bug.cgi?id=290601">https://bugs.webkit.org/show_bug.cgi?id=290601</a>

Reviewed by Tyler Wilcock.

* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-controls.html: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom/reference-target/mac/aria-describedby.html: Added.

Canonical link: <a href="https://commits.webkit.org/293557@main">https://commits.webkit.org/293557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2550d7ef13bb8d3da87767e8083090f43dbe6f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49557 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7354 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83801 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21316 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6134 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19787 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->