### PR TITLE
Move TestWebKitAPI/cocoa pixel lookup and color comparison utilities to their own file

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1240,6 +1240,7 @@
 		CE78705F2107AB980053AC67 /* MoveOnlyLifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE78705D2107AB8C0053AC67 /* MoveOnlyLifecycleLogger.cpp */; };
 		CEA7F57D2089624B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm in Sources */ = {isa = PBXBuildFile; fileRef = CEA7F57B20895F5B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm */; };
 		D04CF93F285C77CA005D6337 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D04CF93E285C77C9005D6337 /* MachSendRight.cpp */; };
+		D2E870752D9A96F50010AA23 /* TestCocoaImageAndCocoaColor.mm in Sources */ = {isa = PBXBuildFile; fileRef = D2CC7CF32D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.mm */; };
 		D84FAD9A29FAC1D0008D338F /* RenderStyleChange.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */; };
 		D8CE9D8B2D79ED180064D7B1 /* PageLoadEmptyURL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D8CE9D8A2D79ED180064D7B1 /* PageLoadEmptyURL.cpp */; };
 		DD0EDF8D2798A6AD005152AD /* libgtest.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = F3FC3EE213678B7300126A65 /* libgtest.a */; };
@@ -3684,6 +3685,8 @@
 		CEDA12402437C9EA00C28A9E /* editable-region-composited-and-non-composited-overlap.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "editable-region-composited-and-non-composited-overlap.html"; path = "ios/editable-region-composited-and-non-composited-overlap.html"; sourceTree = SOURCE_ROOT; };
 		D04CF93E285C77C9005D6337 /* MachSendRight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MachSendRight.cpp; sourceTree = "<group>"; };
 		D20C03AE2B704A26004C414A /* download.example.webarchive */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; name = download.example.webarchive; path = Tests/WebKitCocoa/download.example.webarchive; sourceTree = "<group>"; };
+		D2CC7CF22D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = cocoa/TestCocoaImageAndCocoaColor.h; sourceTree = "<group>"; };
+		D2CC7CF32D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = cocoa/TestCocoaImageAndCocoaColor.mm; sourceTree = "<group>"; };
 		D3BE5E341E4CE85E00FD563A /* WKWebViewGetContents.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewGetContents.mm; sourceTree = "<group>"; };
 		D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStyleChange.cpp; sourceTree = "<group>"; };
 		D8CE9D8A2D79ED180064D7B1 /* PageLoadEmptyURL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PageLoadEmptyURL.cpp; sourceTree = "<group>"; };
@@ -4248,6 +4251,8 @@
 				A17C58432C9BE200009DD0B5 /* TestBundleLoader.h */,
 				CE640CA52370A4F300C5CAA4 /* TestCocoa.h */,
 				CE640CA62370A4F300C5CAA4 /* TestCocoa.mm */,
+				D2CC7CF22D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.h */,
+				D2CC7CF32D9A8D6B00011B9E /* TestCocoaImageAndCocoaColor.mm */,
 				5CE7594822A883A500C12409 /* TestContextMenuDriver.h */,
 				5CE7594722A883A500C12409 /* TestContextMenuDriver.mm */,
 				DF6BC4702534E120008F63CC /* TestDownloadDelegate.h */,
@@ -7394,6 +7399,7 @@
 				E3EFB02F25506503003C2F96 /* SystemBeep.mm in Sources */,
 				7CCE7F161A411AE600447C4C /* TerminateTwice.cpp in Sources */,
 				7CCE7EA91A411A1D00447C4C /* TestBrowsingContextLoadDelegate.mm in Sources */,
+				D2E870752D9A96F50010AA23 /* TestCocoaImageAndCocoaColor.mm in Sources */,
 				5CE7594922A883D200C12409 /* TestContextMenuDriver.mm in Sources */,
 				F46128CB211D475100D9FADB /* TestDraggingInfo.mm in Sources */,
 				F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -29,6 +29,7 @@
 
 #import "HTTPServer.h"
 #import "TestCocoa.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebExtensionMatchPatternPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "HTTPServer.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "HTTPServer.h"
+#import "TestCocoaImageAndCocoaColor.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import "TestWebExtensionsDelegate.h"

--- a/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(APPKIT)
+OBJC_CLASS NSImage;
+using CocoaImage = NSImage;
+using CocoaColor = NSColor;
+#else
+OBJC_CLASS UIImage;
+using CocoaImage = UIImage;
+using CocoaColor = UIColor;
+#endif
+
+namespace TestWebKitAPI::Util {
+
+CocoaColor *pixelColor(CocoaImage *, CGPoint = CGPointZero);
+CocoaColor *toSRGBColor(CocoaColor *);
+bool compareColors(CocoaColor *, CocoaColor *);
+
+} // namespace TestWebKitAPI::Util

--- a/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.mm
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TestCocoaImageAndCocoaColor.h"
+
+namespace TestWebKitAPI::Util {
+
+CocoaColor *pixelColor(CocoaImage *image, CGPoint point)
+{
+#if USE(APPKIT)
+    auto imageRef = [image CGImageForProposedRect:nullptr context:nil hints:nil];
+    auto *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
+    auto *color = [bitmap colorAtX:point.x y:point.y];
+    return color;
+#else
+    image = [image.imageAsset imageWithTraitCollection:UITraitCollection.currentTraitCollection];
+
+    UIGraphicsBeginImageContext(image.size);
+
+    [image drawAtPoint:CGPointZero];
+
+    auto context = UIGraphicsGetCurrentContext();
+    auto *data = (unsigned char *)CGBitmapContextGetData(context);
+    if (!data)
+        return nil;
+
+    unsigned offset = ((image.size.width * point.y) + point.x) * 4;
+    auto *color = [UIColor colorWithRed:data[offset] / 255.0 green:data[offset + 1] / 255.0 blue:data[offset + 2] / 255.0 alpha:data[offset + 3] / 255.0];
+
+    UIGraphicsEndImageContext();
+
+    return color;
+#endif
+}
+
+CocoaColor *toSRGBColor(CocoaColor *color)
+{
+#if USE(APPKIT)
+    return [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
+#else
+    return color;
+#endif
+}
+
+bool compareColors(CocoaColor *color1, CocoaColor *color2)
+{
+    if (color1 == color2 || [color1 isEqual:color2])
+        return true;
+
+    if (!color1 || !color2)
+        return false;
+
+    color1 = toSRGBColor(color1);
+    color2 = toSRGBColor(color2);
+
+    CGFloat red1, green1, blue1, alpha1;
+    [color1 getRed:&red1 green:&green1 blue:&blue1 alpha:&alpha1];
+
+    CGFloat red2, green2, blue2, alpha2;
+    [color2 getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
+
+    return fabs(red1 - red2) < 0.01 && fabs(green1 - green2) < 0.01 && fabs(blue1 - blue2) < 0.01 && fabs(alpha1 - alpha2) < 0.01;
+}
+
+} // namespace TestWebKitAPI::Util

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -32,16 +32,6 @@
 #include "Utilities.h"
 #include "WTFTestUtilities.h"
 
-#if USE(APPKIT)
-OBJC_CLASS NSImage;
-using CocoaImage = NSImage;
-using CocoaColor = NSColor;
-#else
-OBJC_CLASS UIImage;
-using CocoaImage = UIImage;
-using CocoaColor = UIColor;
-#endif
-
 #ifdef __OBJC__
 
 @class TestWebExtensionTab;
@@ -168,10 +158,6 @@ NSData *makePNGData(CGSize, SEL colorSelector);
 enum class Appearance { Light, Dark };
 
 void performWithAppearance(Appearance, void (^block)(void));
-
-CocoaColor *pixelColor(CocoaImage *, CGPoint = CGPointZero);
-CocoaColor *toSRGBColor(CocoaColor *);
-bool compareColors(CocoaColor *, CocoaColor *);
 
 #endif
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -1028,63 +1028,6 @@ void performWithAppearance(Appearance appearance, void (^block)(void))
 #endif
 }
 
-CocoaColor *pixelColor(CocoaImage *image, CGPoint point)
-{
-#if USE(APPKIT)
-    auto imageRef = [image CGImageForProposedRect:nullptr context:nil hints:nil];
-    auto *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
-    auto *color = [bitmap colorAtX:point.x y:point.y];
-    return color;
-#else
-    image = [image.imageAsset imageWithTraitCollection:UITraitCollection.currentTraitCollection];
-
-    UIGraphicsBeginImageContext(image.size);
-
-    [image drawAtPoint:CGPointZero];
-
-    auto context = UIGraphicsGetCurrentContext();
-    auto *data = (unsigned char *)CGBitmapContextGetData(context);
-    if (!data)
-        return nil;
-
-    unsigned offset = ((image.size.width * point.y) + point.x) * 4;
-    auto *color = [UIColor colorWithRed:data[offset] / 255.0 green:data[offset + 1] / 255.0 blue:data[offset + 2] / 255.0 alpha:data[offset + 3] / 255.0];
-
-    UIGraphicsEndImageContext();
-
-    return color;
-#endif
-}
-
-CocoaColor *toSRGBColor(CocoaColor *color)
-{
-#if USE(APPKIT)
-    return [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
-#else
-    return color;
-#endif
-}
-
-bool compareColors(CocoaColor *color1, CocoaColor *color2)
-{
-    if (color1 == color2 || [color1 isEqual:color2])
-        return true;
-
-    if (!color1 || !color2)
-        return false;
-
-    color1 = toSRGBColor(color1);
-    color2 = toSRGBColor(color2);
-
-    CGFloat red1, green1, blue1, alpha1;
-    [color1 getRed:&red1 green:&green1 blue:&blue1 alpha:&alpha1];
-
-    CGFloat red2, green2, blue2, alpha2;
-    [color2 getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
-
-    return fabs(red1 - red2) < 0.01 && fabs(green1 - green2) < 0.01 && fabs(blue1 - blue2) < 0.01 && fabs(alpha1 - alpha2) < 0.01;
-}
-
 } // namespace Util
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### b12d8eff27e01777629a0999cb7a228de070ccba
<pre>
Move TestWebKitAPI/cocoa pixel lookup and color comparison utilities to their own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=290751">https://bugs.webkit.org/show_bug.cgi?id=290751</a>

Reviewed by Youenn Fablet.

This allows them to be used in tests that don&apos;t require
ENABLE(WK_WEB_EXTENSIONS).

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
* Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.h: Added.
* Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.mm: Added.
(TestWebKitAPI::Util::pixelColor):
(TestWebKitAPI::Util::toSRGBColor):
(TestWebKitAPI::Util::compareColors):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(TestWebKitAPI::Util::pixelColor): Deleted.
(TestWebKitAPI::Util::toSRGBColor): Deleted.
(TestWebKitAPI::Util::compareColors): Deleted.

Canonical link: <a href="https://commits.webkit.org/292928@main">https://commits.webkit.org/292928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a635bc148e1f04cc9d236870bb2382c547fb27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74291 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100497 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13185 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104601 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24573 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83337 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82758 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18164 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24535 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->