### PR TITLE
REGRESSION(292808@main?)[Win] RELEASE_ASSERT_NOT_REACHED fails in JSC::Wasm::BBQJITImpl::BBQJIT::RegisterBinding::toValue() for workers/worker-to-worker.html

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -386,13 +386,6 @@ RegisterBinding RegisterBinding::fromValue(Value value)
     return binding;
 }
 
-RegisterBinding RegisterBinding::none()
-{
-    RegisterBinding binding;
-    binding.m_kind = None;
-    return binding;
-}
-
 RegisterBinding RegisterBinding::scratch()
 {
     RegisterBinding binding;
@@ -415,27 +408,15 @@ Value RegisterBinding::toValue() const
     }
 }
 
-bool RegisterBinding::isNone() const
-{
-    return m_kind == None;
-}
-
-bool RegisterBinding::isValid() const
-{
-    return m_kind != None;
-}
-
-bool RegisterBinding::isScratch() const
-{
-    return m_kind == Scratch;
-}
-
 bool RegisterBinding::operator==(RegisterBinding other) const
 {
     if (m_kind != other.m_kind)
         return false;
 
-    return m_kind == None || (m_index == other.m_index && m_type == other.m_type);
+    if (m_kind == None || m_kind == Scratch)
+        return true;
+
+    return m_index == other.m_index && m_type == other.m_type;
 }
 
 void RegisterBinding::dump(PrintStream& out) const
@@ -453,17 +434,14 @@ void RegisterBinding::dump(PrintStream& out) const
     case Temp:
         out.print("Temp(", m_index, ")");
         break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
     }
 }
 
 unsigned RegisterBinding::hash() const
 {
     return pairIntHash(static_cast<unsigned>(m_kind), m_index);
-}
-
-uint32_t RegisterBinding::encode() const
-{
-    return m_uintValue;
 }
 
 ControlData::ControlData(BBQJIT& generator, BlockType blockType, BlockSignature signature, LocalOrTempIndex enclosedHeight, RegisterSet liveScratchGPRs = { }, RegisterSet liveScratchFPRs = { })

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -423,27 +423,15 @@ public:
             Scratch = 3, // Denotes a register bound for use as a scratch, not as a local or temp's location.
         };
 
-        RegisterBinding()
-            : m_uintValue(0)
-        { }
-
-        RegisterBinding(uint32_t uintValue)
-            : m_uintValue(uintValue)
-        { }
-
+        static RegisterBinding none() { return RegisterBinding(); }
         static RegisterBinding fromValue(Value value);
-
-        static RegisterBinding none();
-
         static RegisterBinding scratch();
 
         Value toValue() const;
 
-        bool isNone() const;
-
-        bool isValid() const;
-
-        bool isScratch() const;
+        bool isNone() const { return m_kind == None; }
+        bool isValid() const { return m_kind != None; }
+        bool isScratch() const { return m_kind == Scratch; }
 
         bool operator==(RegisterBinding other) const;
 
@@ -451,20 +439,14 @@ public:
 
         unsigned hash() const;
 
-        uint32_t encode() const;
-
-        union {
-            uint32_t m_uintValue;
-            struct {
-                TypeKind m_type;
-                unsigned m_kind : 3;
-                unsigned m_index : LocalIndexBits;
-            };
-        };
+        TypeKind m_type { 0 };
+        unsigned m_kind : 3 { None };
+        unsigned m_index : LocalIndexBits { 0 };
     };
 
     // Tables mapping from each register to the current value bound to it.
     struct RegisterBindings {
+        RegisterBindings() = default;
         void dump(PrintStream& out) const;
         // FIXME: We should really compress this since it's copied by slow paths to know how to restore the correct state.
         std::array<RegisterBinding, 32> m_gprBindings { RegisterBinding::none() }; // Tables mapping from each register to the current value bound to it.


### PR DESCRIPTION
#### 4e6dec1c3f8e540bd1cd967dbf937cde961748e9
<pre>
REGRESSION(292808@main?)[Win] RELEASE_ASSERT_NOT_REACHED fails in JSC::Wasm::BBQJITImpl::BBQJIT::RegisterBinding::toValue() for workers/worker-to-worker.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=290650">https://bugs.webkit.org/show_bug.cgi?id=290650</a>
<a href="https://rdar.apple.com/148248212">rdar://148248212</a>

Reviewed by Yusuke Suzuki.

RegisterBinding was using a bitfield to pack its members. On Windows this bitfield wasn&apos;t bitfielding (packing) properly. So
the other 32-bit union member used to initialize everything at once didn&apos;t initialize all the members. This patch
fixes this by removing the union and default initializing each of the fields. Clang/GCC are smart enough to convert
these into a single zero store anyway. Also, move some code to the header so it can be inlined more.

* LayoutTests/workers/wasm-references/test.js:
(runTest):
(runTest.worker.onmessage): Deleted.
(doGC): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::RegisterBinding::dump const):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:

Canonical link: <a href="https://commits.webkit.org/292958@main">https://commits.webkit.org/292958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e16d0598f9412755474f8c3de17612798600d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74327 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47514 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90219 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104650 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96165 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18216 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29753 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119791 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24406 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33633 "Found 4 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default, microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js.no-llint, wasm.yaml/wasm/stress/spilled-constant-block-argument.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/spilled-constant-block-result.js.wasm-bbq-no-consts (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->