### PR TITLE
[JSC] Fix JITWorklist notify policy logic

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -42,17 +42,11 @@ class JITWorklistThread final : public AutomaticThread {
     friend class WorkScope;
     friend class JITWorklist;
 
-    enum class State : uint8_t {
-        NotCompiling,
-        Compiling,
-    };
-
 public:
     JITWorklistThread(const AbstractLocker&, JITWorklist&);
 
     ASCIILiteral name() const final;
 
-    State state() const { return m_state; }
     const Safepoint* safepoint() const { return m_safepoint; }
 
 private:
@@ -64,10 +58,10 @@ private:
     void threadIsStopping(const AbstractLocker&) final;
 
     Lock m_rightToRun;
-    State m_state { State::NotCompiling };
     JITWorklist& m_worklist;
     RefPtr<JITPlan> m_plan { nullptr };
     Safepoint* m_safepoint { nullptr };
+    bool m_isActive { false };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### a3bc81f2b56f938615a061ac34779984ec601f7b
<pre>
[JSC] Fix JITWorklist notify policy logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=290760">https://bugs.webkit.org/show_bug.cgi?id=290760</a>
<a href="https://rdar.apple.com/148249925">rdar://148249925</a>

Reviewed by Keith Miller.

Fix two issues with the policy logic guarding notify in
JITWorklist::enqueue():

Problem 1: (benign) race in thread state accounting

There is a window between the end of work() and the next call to
poll() where the mutator will think a notify call is necessary
but it is not because of when the shared state is updated. This is
a benign race (both correctness and perf) because:

Case 1: Number of active threads == Options::numberOfWorklistThreads()
In this case, notifyOne() may be called unnecessarily, but notifyOne() will
internally be a no-op (and avoid syscalls) since no thread is waiting.

Case 2: Number of active threads &lt; Options::numberOfWorklistThreads()
In this case, the notifyOne() will always be called once, either for
an actually waiting thread (there is at least one) or for the racing one,
so the race again doesn&apos;t matter.

Though benign, seems worth fixing for clarity, and also to set up for
more sophisticated (auto-)scaling policies where an accurate count does matter.

Problem 2: Unnecessary notifyOne when
m_ongoingCompilationsPerTier[tier] == m_maximumNumberOfConcurrentCompilationsPerTier[tier]

Note that on Darwin, the default configuration is:
    Options::numberOfWorklistThreads() = 3
    Options::numberOfDFGCompilerThreads() = 3
    Options::numberOfFTLCompilerThreads() = 3

so this only matters when setting a non-default value.
But in those non-default configurations, if
m_ongoingCompilationsPerTier[tier] == m_maximumNumberOfConcurrentCompilationsPerTier[tier]
we shouldn&apos;t bother waking up a worklist thread since poll() will do
the m_ongoingCompilationsPerTier check and immediate return the thread
back to waiting.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::enqueue):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::poll):
(JSC::JITWorklistThread::work):
* Source/JavaScriptCore/jit/JITWorklistThread.h:

Canonical link: <a href="https://commits.webkit.org/292951@main">https://commits.webkit.org/292951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/714e38ff970fcef0f32b8c567ccb849345a69943

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48093 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100567 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/6117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47535 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/90240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104671 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96186 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20833 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27356 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18237 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24605 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119812 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24427 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->