### PR TITLE
StabilityTracer: MobileNotes at WebKit: WebKit::AuxiliaryProcessProxy::protectedConnection const

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3549,10 +3549,9 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
         weakThis->sendToProcessContainingFrame(frameID, Messages::WebPage::ExecuteEditCommand(commandName, argument));
     };
 
-    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName)) {
-        if (auto replyID = willPerformPasteCommand(*pasteAccessCategory, WTFMove(completionHandler), frameID))
-            protectedWebsiteDataStore()->protectedNetworkProcess()->protectedConnection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
-    } else
+    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName))
+        willPerformPasteCommand(*pasteAccessCategory, WTFMove(completionHandler), frameID);
+    else
         completionHandler();
 }
 


### PR DESCRIPTION
#### 8d4bcdd23b51a62872c9c72896235b33b20dafd1
<pre>
StabilityTracer: MobileNotes at WebKit: WebKit::AuxiliaryProcessProxy::protectedConnection const
<a href="https://rdar.apple.com/145887512">rdar://145887512</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290763">https://bugs.webkit.org/show_bug.cgi?id=290763</a>

Reviewed by NOBODY (OOPS!).

WebPageProxy::willPerformPasteCommand() queues an async IPC to
the Network Process. It&apos;s ok if the Network Process hasn&apos;t launched
yet because the IPC is queued.

But using waitForAsyncReplyAndDispatchImmediately requires the
Network Process to be fully launched. We&apos;re hitting the release
assert in AuxiliaryProcessProxy::protectedConnection because
the Network Process hasn&apos;t fully launched at the time of use.

But we don&apos;t need to hang the UI Process here until it recievies
a response from the Network Process because there are no synchronous
operations happening right after it. So we can simply remove the
call to waitForAsyncReplyAndDispatchImmediately.

So now WebPageProxy sends an IPC to the Network Process to grant
the Web Process file access for that file URL and the Network Process
will send IPC to the Web Process once access is granted.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::executeEditCommand):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d4bcdd23b51a62872c9c72896235b33b20dafd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100588 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88244 "Found 10 new API test failures: TestWebKitAPI.PasteImage.PastePNGFile, TestWebKitAPI.PasteMixedContent.ImageFileAndPlainText, TestWebKitAPI.PasteMixedContent.ImageFileAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileAndURL, TestWebKitAPI.PasteMixedContent.ImageFileAndWebArchive, TestWebKitAPI.PasteMixedContent.ImageFileWithHTMLAndURL, TestWebKitAPI.PasteImage.PasteTIFFFile, TestWebKitAPI.PasteMixedContent.ImageFileAndRTF, TestWebKitAPI.PasteImage.PasteJPEGFile, TestWebKitAPI.PasteImage.PasteGIFFile (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54700 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47556 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24665 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17994 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82826 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18259 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29795 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->