### PR TITLE
[macOS] Add a version of `-_setCustomSwipeViewsTopContentInset:` that supports all 4 rect edges

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -853,6 +853,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setCustomSwipeViews:(NSArray *)customSwipeViews WK_API_AVAILABLE(macos(10.13.4));
 - (void)_setDidMoveSwipeSnapshotCallback:(void(^)(CGRect))callback WK_API_AVAILABLE(macos(10.13.4));
 - (void)_setCustomSwipeViewsTopContentInset:(float)topContentInset WK_API_AVAILABLE(macos(10.13.4));
+- (void)_setCustomSwipeViewsObscuredContentInsets:(NSEdgeInsets)contentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 - (NSView *)_fullScreenPlaceholderView WK_API_AVAILABLE(macos(10.13.4));
 - (NSWindow *)_fullScreenWindow WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -56,6 +56,7 @@
 - (void)_setSelectedColorForColorPicker:(NSColor *)color;
 
 @property (nonatomic, readonly) BOOL _secureEventInputEnabledForTesting;
+@property (nonatomic, readonly) NSRect _windowRelativeBoundsForCustomSwipeViewsForTesting;
 
 - (void)_createFlagsChangedEventMonitorForTesting;
 - (BOOL)_hasFlagsChangedEventMonitorForTesting;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -133,6 +133,11 @@
     return _impl->inSecureInputState();
 }
 
+- (NSRect)_windowRelativeBoundsForCustomSwipeViewsForTesting
+{
+    return _impl->windowRelativeBoundsForCustomSwipeViews();
+}
+
 - (void)_setSelectedColorForColorPicker:(NSColor *)color
 {
     _page->colorPickerClient().didChooseColor(WebCore::colorFromCocoaColor(color));

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "SameDocumentNavigationType.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/BoxExtents.h>
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
@@ -157,7 +158,8 @@ public:
     void gestureEventWasNotHandledByWebCore(PlatformScrollEvent, WebCore::FloatPoint origin);
 
     void setCustomSwipeViews(Vector<RetainPtr<NSView>> views) { m_customSwipeViews = WTFMove(views); }
-    void setCustomSwipeViewsTopContentInset(float topContentInset) { m_customSwipeViewsTopContentInset = topContentInset; }
+    const WebCore::FloatBoxExtent& customSwipeViewsObscuredContentInsets() const { return m_customSwipeViewsObscuredContentInsets; }
+    void setCustomSwipeViewsObscuredContentInsets(WebCore::FloatBoxExtent&& insets) { m_customSwipeViewsObscuredContentInsets = WTFMove(insets); }
     WebCore::FloatRect windowRelativeBoundsForCustomSwipeViews() const;
     void setDidMoveSwipeSnapshotCallback(BlockPtr<void (CGRect)>&& callback) { m_didMoveSwipeSnapshotCallback = WTFMove(callback); }
 #elif PLATFORM(IOS_FAMILY)
@@ -413,7 +415,7 @@ private:
     Vector<RetainPtr<CALayer>> m_currentSwipeLiveLayers;
 
     Vector<RetainPtr<NSView>> m_customSwipeViews;
-    float m_customSwipeViewsTopContentInset { 0 };
+    WebCore::FloatBoxExtent m_customSwipeViewsObscuredContentInsets;
     WebCore::FloatRect m_currentSwipeCustomViewBounds;
 
     BlockPtr<void (CGRect)> m_didMoveSwipeSnapshotCallback;

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -311,7 +311,11 @@ FloatRect ViewGestureController::windowRelativeBoundsForCustomSwipeViews() const
     FloatRect swipeArea;
     for (const auto& view : m_customSwipeViews)
         swipeArea.unite([view convertRect:[view bounds] toView:nil]);
-    swipeArea.setHeight(swipeArea.height() - m_customSwipeViewsTopContentInset);
+    swipeArea.move(m_customSwipeViewsObscuredContentInsets.left(), m_customSwipeViewsObscuredContentInsets.bottom());
+    swipeArea.contract({
+        m_customSwipeViewsObscuredContentInsets.left() + m_customSwipeViewsObscuredContentInsets.right(),
+        m_customSwipeViewsObscuredContentInsets.bottom() + m_customSwipeViewsObscuredContentInsets.top(),
+    });
     return swipeArea;
 }
 
@@ -410,9 +414,13 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     FloatRect swipeArea;
     FloatBoxExtent obscuredContentInsets;
     if (!m_customSwipeViews.isEmpty()) {
-        obscuredContentInsets.setTop(m_customSwipeViewsTopContentInset);
+        obscuredContentInsets = m_customSwipeViewsObscuredContentInsets;
         swipeArea = m_currentSwipeCustomViewBounds;
-        swipeArea.expand(0, m_customSwipeViewsTopContentInset);
+        swipeArea.expand({
+            obscuredContentInsets.left() + obscuredContentInsets.right(),
+            obscuredContentInsets.bottom() + obscuredContentInsets.top(),
+        });
+        swipeArea.move(-obscuredContentInsets.left(), -obscuredContentInsets.bottom());
 
         for (const auto& view : m_customSwipeViews) {
             CALayer *layer = [view layer];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -588,6 +588,7 @@ public:
     _WKWarningView *warningView() { return m_warningView.get(); }
 
     ViewGestureController* gestureController() { return m_gestureController.get(); }
+    RefPtr<ViewGestureController> protectedGestureController() const;
     ViewGestureController& ensureGestureController();
     Ref<ViewGestureController> ensureProtectedGestureController();
     void setAllowsBackForwardNavigationGestures(bool);
@@ -599,7 +600,9 @@ public:
     void setMagnification(double);
     double magnification() const;
     void setCustomSwipeViews(NSArray *);
-    void setCustomSwipeViewsTopContentInset(float);
+    WebCore::FloatRect windowRelativeBoundsForCustomSwipeViews() const;
+    WebCore::FloatBoxExtent customSwipeViewsObscuredContentInsets() const;
+    void setCustomSwipeViewsObscuredContentInsets(WebCore::FloatBoxExtent&&);
     bool tryToSwipeWithEvent(NSEvent *, bool ignoringPinnedState);
     void setDidMoveSwipeSnapshotCallback(BlockPtr<void (CGRect)>&&);
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4879,9 +4879,30 @@ void WebViewImpl::setCustomSwipeViews(NSArray *customSwipeViews)
     ensureProtectedGestureController()->setCustomSwipeViews(views);
 }
 
-void WebViewImpl::setCustomSwipeViewsTopContentInset(float topContentInset)
+FloatRect WebViewImpl::windowRelativeBoundsForCustomSwipeViews() const
 {
-    ensureProtectedGestureController()->setCustomSwipeViewsTopContentInset(topContentInset);
+    if (!m_gestureController)
+        return { };
+
+    return protectedGestureController()->windowRelativeBoundsForCustomSwipeViews();
+}
+
+FloatBoxExtent WebViewImpl::customSwipeViewsObscuredContentInsets() const
+{
+    if (!m_gestureController)
+        return { };
+
+    return m_gestureController->customSwipeViewsObscuredContentInsets();
+}
+
+RefPtr<ViewGestureController> WebViewImpl::protectedGestureController() const
+{
+    return m_gestureController;
+}
+
+void WebViewImpl::setCustomSwipeViewsObscuredContentInsets(FloatBoxExtent&& insets)
+{
+    ensureProtectedGestureController()->setCustomSwipeViewsObscuredContentInsets(WTFMove(insets));
 }
 
 bool WebViewImpl::tryToSwipeWithEvent(NSEvent *event, bool ignoringPinnedState)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -49,6 +49,7 @@ cocoa/UISideCompositingScope.mm
 cocoa/UserMediaCaptureUIDelegate.mm
 ios/IOSMouseEventTestHarness.mm
 
+Tests/mac/CustomSwipeViewTests.mm
 Tests/WebKitCocoa/AVFoundationPreference.mm
 Tests/WebKitCocoa/AdaptiveImageGlyph.mm
 Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3973,6 +3973,7 @@
 		F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-clear-selection.html"; sourceTree = "<group>"; };
 		F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "selected-text-image-link-and-editable.html"; sourceTree = "<group>"; };
 		F4D9818E2196B911008230FC /* editable-nested-lists.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "editable-nested-lists.html"; sourceTree = "<group>"; };
+		F4DA1FF02D9A165D0069AF6D /* CustomSwipeViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomSwipeViewTests.mm; sourceTree = "<group>"; };
 		F4DADCF62BABA65B008B398F /* ElementTargetingTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementTargetingTests.mm; sourceTree = "<group>"; };
 		F4DADCFF2BABA80C008B398F /* element-targeting-1.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-1.html"; sourceTree = "<group>"; };
 		F4DD79E12AD4BDCB000C6821 /* InitializeWebViewWhenChangingUserDefaults.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InitializeWebViewWhenChangingUserDefaults.mm; sourceTree = "<group>"; };
@@ -6132,6 +6133,7 @@
 				37FB72951DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm */,
 				F4613F1C27DC2EDD007CCDE6 /* ContextMenuTests.mm */,
 				7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */,
+				F4DA1FF02D9A165D0069AF6D /* CustomSwipeViewTests.mm */,
 				E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */,
 				939BA91614103412001A01BD /* DeviceScaleFactorOnBack.mm */,
 				F4D5D69425AF8BE400205280 /* DisableAutomaticSpellingCorrection.mm */,

--- a/Tools/TestWebKitAPI/Tests/mac/CustomSwipeViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CustomSwipeViewTests.mm
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivateForTesting.h>
+
+namespace TestWebKitAPI {
+
+TEST(CustomSwipeViewTests, WindowRelativeBoundsForCustomSwipeViews)
+{
+    RetainPtr customSwipeView = adoptNS([[NSView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView addSubview:customSwipeView.get()];
+    [webView _setCustomSwipeViews:@[ customSwipeView.get() ]];
+    [webView _setCustomSwipeViewsObscuredContentInsets:NSEdgeInsetsMake(100, 200, 50, 50)];
+
+    __auto_type boundsForCustomSwipeView = [webView _windowRelativeBoundsForCustomSwipeViewsForTesting];
+    EXPECT_EQ(boundsForCustomSwipeView.origin.x, 200.0);
+    EXPECT_EQ(boundsForCustomSwipeView.origin.y, 50.0);
+    EXPECT_EQ(boundsForCustomSwipeView.size.width, 550.0);
+    EXPECT_EQ(boundsForCustomSwipeView.size.height, 450.0);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### c2abdb76db274ba599d89d60075d88eb268e80c0
<pre>
[macOS] Add a version of `-_setCustomSwipeViewsTopContentInset:` that supports all 4 rect edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=290731">https://bugs.webkit.org/show_bug.cgi?id=290731</a>
<a href="https://rdar.apple.com/144614910">rdar://144614910</a>

Reviewed by Abrar Rahman Protyasha.

Add an alternate version of `-_setCustomSwipeViewsTopContentInset:` that takes an `NSEdgeInsets`
struct instead of just a single value denoting the top content inset, and reimplement the existing
method in terms of the new method.

See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(coreBoxExtentsFromEdgeInsets):
(-[WKWebView _setObscuredContentInsets:immediate:]):

Pull logic to convert `NSEdgeInsets` into a `WebCore::FloatBoxExtent` out into a separate static
helper, so that I can reuse it below.

(-[WKWebView _setCustomSwipeViewsTopContentInset:]):

Reimplement this in terms of `-_setCustomSwipeViewsObscuredContentInsets:`.

(-[WKWebView _setCustomSwipeViewsObscuredContentInsets:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _windowRelativeBoundsForCustomSwipeViewsForTesting]):

Add a simple testing hook to ask for the window-relative bounds for custom swipe views. This isn&apos;t
really exposed in any other sensible way for API tests, so I fell back to adding a new testing hook
instead.

* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::windowRelativeBoundsForCustomSwipeViews const):

Add support for all 4 rect edges here. Instead of just shrinking `swipeArea` by the top inset, we
now shrink `swipeArea` by all 4 sides (note that this is in AppKit window coordinates, so the origin
is in the bottom left corner).

(WebKit::ViewGestureController::beginSwipeGesture):

This previously re-expanded the `windowRelativeBoundsForCustomSwipeViews` by the top content inset;
we adjust this to do the same for all 4 rect edges, by unapplying the shrinking by obscured insets
above.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::windowRelativeBoundsForCustomSwipeViews const):
(WebKit::WebViewImpl::customSwipeViewsObscuredContentInsets const):
(WebKit::WebViewImpl::protectedGestureController const):

Add a `protectedGestureController` const getter that returns a `RefPtr`.

(WebKit::WebViewImpl::setCustomSwipeViewsObscuredContentInsets):
(WebKit::WebViewImpl::setCustomSwipeViewsTopContentInset): Deleted.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/mac/CustomSwipeViewTests.mm: Copied from Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h.
(TestWebKitAPI::TEST(CustomSwipeViewTests, WindowRelativeBoundsForCustomSwipeViews)):

Add a new simple API test to exercise this SPI, using the new test helper property.

Canonical link: <a href="https://commits.webkit.org/292988@main">https://commits.webkit.org/292988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb7af194e81d2da5259af72e51e884947925ff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31552 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13282 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47589 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104725 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24698 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27396 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18293 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24659 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24481 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->