### PR TITLE
http/tests/security/wrong-global-object-after-javascript-url.html hits an assertion

### DIFF
--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -385,6 +385,8 @@ public:
     virtual void didExceedNetworkUsageThreshold();
 #endif
 
+    virtual bool shouldSuppressLayoutMilestones() const { return false; }
+
 protected:
     explicit LocalFrameLoaderClient(FrameLoader&);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5856,6 +5856,9 @@ void LocalFrameView::addPaintPendingMilestones(OptionSet<LayoutMilestone> milest
 
 void LocalFrameView::fireLayoutRelatedMilestonesIfNeeded()
 {
+    if (m_frame->loader().client().shouldSuppressLayoutMilestones())
+        return;
+
     OptionSet<LayoutMilestone> requestedMilestones;
     OptionSet<LayoutMilestone> milestonesAchieved;
     Page* page = m_frame->page();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -642,7 +642,7 @@ public:
 
     void addPaintPendingMilestones(OptionSet<LayoutMilestone>);
     void firePaintRelatedMilestonesIfNeeded();
-    void fireLayoutRelatedMilestonesIfNeeded();
+    WEBCORE_EXPORT void fireLayoutRelatedMilestonesIfNeeded();
     OptionSet<LayoutMilestone> milestonesPendingPaint() const { return m_milestonesPendingPaint; }
 
     bool visualUpdatesAllowedByClient() const { return m_visualUpdatesAllowedByClient; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -793,7 +793,27 @@ void WebLocalFrameLoaderClient::completePageTransitionIfNeeded()
 
     webPage->didCompletePageTransition();
     m_didCompletePageTransition = true;
+
+    // We suppress layout related milestones during page transition but we need to make sure
+    // we eventually dispatch when the transition is complete.
+    fireLayoutRelatedMilestonesIfNeeded();
+
     WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WEBLOCALFRAMELOADERCLIENT_COMPLETE_PAGE_TRANSITION_IF_NEEDED);
+}
+
+bool WebLocalFrameLoaderClient::shouldSuppressLayoutMilestones() const
+{
+    return m_frame->isMainFrame() && !m_didCompletePageTransition;
+}
+
+void WebLocalFrameLoaderClient::fireLayoutRelatedMilestonesIfNeeded()
+{
+    ASSERT(!shouldSuppressLayoutMilestones());
+    RefPtr localFrame = m_frame->coreLocalFrame();
+    if (!localFrame || !localFrame->isMainFrame())
+        return;
+    if (RefPtr view = localFrame->view())
+        view->fireLayoutRelatedMilestonesIfNeeded();
 }
 
 void WebLocalFrameLoaderClient::setDocumentVisualUpdatesAllowed(bool allowed)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -82,6 +82,9 @@ private:
     
     void detachedFromParent2() final;
     void detachedFromParent3() final;
+
+    bool shouldSuppressLayoutMilestones() const final;
+    void fireLayoutRelatedMilestonesIfNeeded();
     
     void assignIdentifierToInitialRequest(WebCore::ResourceLoaderIdentifier, WebCore::IsMainResourceLoad, WebCore::DocumentLoader*, const WebCore::ResourceRequest&) final;
     


### PR DESCRIPTION
#### bd20485fedcd7603fded7c7f2eb011738d61e8d9
<pre>
http/tests/security/wrong-global-object-after-javascript-url.html hits an assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=290774">https://bugs.webkit.org/show_bug.cgi?id=290774</a>
<a href="https://rdar.apple.com/148121607">rdar://148121607</a>

Reviewed by Alan Baradlay.

We were hitting the following assertion in `WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone()`:
```
ASSERT(!m_frame-&gt;isMainFrame() || webPage-&gt;corePage()-&gt;settings().suppressesIncrementalRendering() || m_didCompletePageTransition);
```

This basically means that we&apos;re sending a layout milestone notification even though `m_didCompletePageTransition`
is false. `m_didCompletePageTransition` is set to false during the early page load to avoid flashing white content
on navigation.

To address the issue, update LocalFrameView::fireLayoutRelatedMilestonesIfNeeded() to ask the client if we should
suppress layout milestones or not.

* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fireLayoutRelatedMilestonesIfNeeded):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/293120@main">https://commits.webkit.org/293120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbae10c52f7f095d227e4ab7c92dfb404ca37f78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97916 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31738 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100919 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13510 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82991 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27630 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5313 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18619 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15866 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30126 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->