### PR TITLE
Address Safer CPP Warnings in AccessibilityListBox.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,7 +1,6 @@
 Modules/cookie-store/CookieStore.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
-accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityRenderObject.cpp
 accessibility/AccessibilityScrollbar.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -4,7 +4,6 @@ Modules/storage/WorkerStorageConnection.cpp
 Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/websockets/WebSocket.cpp
 accessibility/AXSearchManager.cpp
-accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityRenderObject.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -245,7 +245,6 @@ accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityList.cpp
-accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMenuList.cpp
 accessibility/AccessibilityMenuListOption.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -98,7 +98,6 @@ accessibility/AXTextMarker.cpp
 accessibility/AccessibilityARIAGridRow.cpp
 accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityList.cpp
-accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
 accessibility/AccessibilityMenuListOption.cpp

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -61,7 +61,7 @@ void AccessibilityListBox::addChildren()
         m_subtreeDirty = false;
     });
 
-    auto* selectElement = dynamicDowncast<HTMLSelectElement>(node());
+    RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node());
     if (!selectElement)
         return;
 
@@ -106,11 +106,11 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityListBox::visibleChildren(
     return result;
 }
 
-AccessibilityObject* AccessibilityListBox::listBoxOptionAccessibilityObject(HTMLElement* element) const
+AccessibilityObject* AccessibilityListBox::listBoxOptionAccessibilityObject(RefPtr<HTMLElement> element) const
 {
     // FIXME: Why does AccessibilityMenuListPopup::menuListOptionAccessibilityObject check inRenderedDocument, but this does not?
-    if (auto* document = this->document())
-        return document->axObjectCache()->getOrCreate(element);
+    if (RefPtr document = this->document())
+        return document->axObjectCache()->getOrCreate(element.get());
     return nullptr;
 }
 
@@ -121,7 +121,7 @@ AccessibilityObject* AccessibilityListBox::elementAccessibilityHitTest(const Int
     if (!m_renderer)
         return nullptr;
     
-    Node* node = m_renderer->node();
+    RefPtr node = m_renderer->node();
     if (!node)
         return nullptr;
     
@@ -131,7 +131,7 @@ AccessibilityObject* AccessibilityListBox::elementAccessibilityHitTest(const Int
     const auto& children = const_cast<AccessibilityListBox*>(this)->unignoredChildren();
     unsigned length = children.size();
     for (unsigned i = 0; i < length; ++i) {
-        LayoutRect rect = downcast<RenderListBox>(*m_renderer).itemBoundingBoxRect(parentRect.location(), i);
+        LayoutRect rect = downcast<RenderListBox>(m_renderer.get())->itemBoundingBoxRect(parentRect.location(), i);
         // The cast to HTMLElement below is safe because the only other possible listItem type
         // would be a WMLElement, but WML builds don't use accessibility features at all.
         if (rect.contains(point)) {

--- a/Source/WebCore/accessibility/AccessibilityListBox.h
+++ b/Source/WebCore/accessibility/AccessibilityListBox.h
@@ -49,7 +49,7 @@ private:
     explicit AccessibilityListBox(AXID, RenderObject&);
 
     bool isAccessibilityListBoxInstance() const final { return true; }
-    AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;
+    AccessibilityObject* listBoxOptionAccessibilityObject(RefPtr<HTMLElement>) const;
     AccessibilityObject* elementAccessibilityHitTest(const IntPoint&) const final;
 };
     


### PR DESCRIPTION
#### fe86447ab0c6db97db7756cc92cc9b655cc474fa
<pre>
Address Safer CPP Warnings in AccessibilityListBox.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290775">https://bugs.webkit.org/show_bug.cgi?id=290775</a>
<a href="https://rdar.apple.com/problem/148260716">rdar://problem/148260716</a>

Reviewed by NOBODY (OOPS!).

Address Safer CPP Warnings in AccessibilityListBox.cpp.

* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::addChildren):
(WebCore::AccessibilityListBox::listBoxOptionAccessibilityObject const):
(WebCore::AccessibilityListBox::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityListBox.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe86447ab0c6db97db7756cc92cc9b655cc474fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100563 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13236 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88222 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPITabs.ExecuteScriptJSONTypes (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104667 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24640 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17973 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83385 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82807 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5040 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18233 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24601 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29770 "Build is in progress. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Checked out pull request; Found 52766 issues; Found 4 new failures in accessibility/AccessibilityListBox.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->