### PR TITLE
[macOS] Add style adjustment methods and paint method for color swatch for vector-based controls

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7877,3 +7877,6 @@ imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-f
 
 # This test hits an assert in debug
 webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
+
+# The color input only has a swatch overlay on macOS
+fast/forms/color/input-color-swatch-overlay-appearance.html [ Skip ]

--- a/LayoutTests/fast/forms/color/input-color-parts-appearance-expected.html
+++ b/LayoutTests/fast/forms/color/input-color-parts-appearance-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+input {
+    appearance:none;
+}
+#s1::-webkit-color-swatch {
+    appearance:none;
+}
+#s1::-webkit-color-swatch-wrapper {
+    appearance:none;
+}
+</style>
+</head>
+<input id="s1" type='color'>
+</html>

--- a/LayoutTests/fast/forms/color/input-color-parts-appearance.html
+++ b/LayoutTests/fast/forms/color/input-color-parts-appearance.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+input {
+    appearance:none;
+}
+</style>
+</head>
+<input type='color'>
+</html>

--- a/LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance-expected.txt
+++ b/LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance-expected.txt
@@ -1,0 +1,11 @@
+Test that the used appearance for the swatch overlay is 'none' when the swatch uses `appearance: none` by comparing styles.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The style of an swatch overlay with appearance forced to `none` is the same as the style of an overlay whose swatch has style `appearance: none`.
+PASS The non-appearance-related styles were the same for both overlays.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance.html
+++ b/LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/platform-helper.js"></script>
+<script src="../resources/common.js"></script>
+<style>
+#styled::-webkit-color-swatch {
+    appearance:none;
+}
+</style>
+</head>
+<input id='styled' type='color'>
+<input id='unstyled' type='color'>
+<script>
+description("Test that the used appearance for the swatch overlay is 'none' when the swatch uses `appearance: none` by comparing styles.");
+
+let overlayForUnstyledSwatch = getElementByPseudoId(internals.shadowRoot(unstyled), "-internal-color-swatch-overlay");
+let overlayForStyledSwatch = getElementByPseudoId(internals.shadowRoot(styled), "-internal-color-swatch-overlay");
+
+overlayForUnstyledSwatch.style.appearance = 'none';
+
+let overlayStylesForStyledSwatch = getComputedStyle(overlayForStyledSwatch);
+let overlayStylesForUnstyledSwatch = getComputedStyle(overlayForUnstyledSwatch);
+
+var mismatchOccurred = false;
+let propertiesToSkip = [`WebkitAppearance`, `webkitAppearance`, `appearance`, `-webkit-appearance`];
+
+for (const property in overlayStylesForStyledSwatch) {
+    if (!propertiesToSkip.includes(property)) {
+        let overlayPropertyForStyledSwatch = overlayStylesForStyledSwatch[property];
+        let overlayPropertyForUnstyledSwatch = overlayStylesForUnstyledSwatch[property];
+        
+        if (overlayPropertyForStyledSwatch != overlayPropertyForUnstyledSwatch) {
+            debug("Style mistmatch for property: " + property + ": " + overlayPropertyForStyledSwatch + " != " + overlayPropertyForUnstyledSwatch);
+            mismatchOccurred = true;
+        }
+    }
+}
+
+debug("The style of an swatch overlay with appearance forced to `none` is the same as the style of an overlay whose swatch has style `appearance: none`.");
+
+let testResult = mismatchOccurred ? "FAIL One or more of the non-appearance-related styles differed between overlays." : "PASS The non-appearance-related styles were the same for both overlays."
+
+debug(testResult);
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2427,3 +2427,6 @@ imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-complex-001.s
 
 # webkit.org/b/290848 : AX: accessibility/mac/line-boundary-at-br.html asserts on Debug
 [ Debug ] accessibility/mac/line-boundary-at-br.html [ Skip ]
+
+# The color input only has a swatch overlay on macOS
+fast/forms/color/input-color-swatch-overlay-appearance.html [ Pass ]

--- a/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
@@ -1,85 +1,85 @@
 initial state
 
 getComputedStyle(swatch).backgroundColor is rgb(0, 0, 0)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 239, 213)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(srgb 1 0.937255 0.835294)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(68, 68, 68)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
 
 alpha: false, colorSpace: display-p3, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.266667 0.266667 0.266667)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 0, 104)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
 
 alpha: false, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 2 0 0.5)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(40, 40, 40)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
 
 alpha: false, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.156863 0.156863 0.156863)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
-swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
+swatch.innerHTML is <div useragentpart="-internal-color-swatch-overlay" style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -387,6 +387,9 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
         return CSSValueApplePayButton;
 #endif
     case StyleAppearance::ColorWell:
+    case StyleAppearance::ColorWellSwatch:
+    case StyleAppearance::ColorWellSwatchOverlay:
+    case StyleAppearance::ColorWellSwatchWrapper:
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
 #endif

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -265,6 +265,10 @@
             "status": "non-standard",
             "user-agent-part": true
         },
+        "-internal-color-swatch-overlay": {
+            "status": "non-standard",
+            "user-agent-part": true
+        },
         "-webkit-color-swatch-wrapper": {
             "status": "non-standard",
             "user-agent-part": true

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1023,7 +1023,12 @@ input[type="color"] {
 #endif
 }
 
+input[type="color"]::-internal-color-swatch-overlay {
+    appearance: auto;
+}
+
 input[type="color"]::-webkit-color-swatch-wrapper {
+    appearance: auto;
     display: flex;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border-radius: inherit;
@@ -1038,6 +1043,7 @@ input[type="color"]::-webkit-color-swatch-wrapper {
 }
 
 input[type="color"]::-webkit-color-swatch {
+    appearance: auto;
     background-color: #000000;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border-radius: inherit;

--- a/Source/WebCore/platform/StyleAppearance.cpp
+++ b/Source/WebCore/platform/StyleAppearance.cpp
@@ -106,6 +106,15 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::ColorWell:
         ts << "color-well"_s;
         break;
+    case StyleAppearance::ColorWellSwatch:
+        ts << "color-well-swatch"_s;
+        break;
+    case StyleAppearance::ColorWellSwatchOverlay:
+        ts << "color-well-swatch-overlay"_s;
+        break;
+    case StyleAppearance::ColorWellSwatchWrapper:
+        ts << "color-well-swatch-wrapper"_s;
+        break;
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
         ts << "image-controls-button"_s;

--- a/Source/WebCore/platform/StyleAppearance.h
+++ b/Source/WebCore/platform/StyleAppearance.h
@@ -61,6 +61,9 @@ enum class StyleAppearance : uint8_t {
     TextField,
     // Internal-only Values
     ColorWell,
+    ColorWellSwatch,
+    ColorWellSwatchOverlay,
+    ColorWellSwatchWrapper,
 #if ENABLE(SERVICE_CONTROLS)
     ImageControlsButton,
 #endif

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -290,6 +290,11 @@ protected:
     virtual bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
     virtual void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) { }
 
+    virtual void adjustColorWellSwatchStyle(RenderStyle&, const Element*) const { }
+    virtual void adjustColorWellSwatchOverlayStyle(RenderStyle&, const Element*) const { }
+    virtual void adjustColorWellSwatchWrapperStyle(RenderStyle&, const Element*) const { }
+    virtual bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+
     virtual void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const;
     virtual bool paintInnerSpinButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -64,6 +64,11 @@ protected:
     bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&) override;
     void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
+    void adjustColorWellSwatchStyle(RenderStyle&, const Element*) const override;
+    void adjustColorWellSwatchOverlayStyle(RenderStyle&, const Element*) const override;
+    void adjustColorWellSwatchWrapperStyle(RenderStyle&, const Element*) const override;
+    bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
     void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const override;
     bool paintInnerSpinButton(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -52,6 +52,7 @@
 #import "RenderText.h"
 #import "Theme.h"
 #import "TypedElementDescendantIteratorInlines.h"
+#import "UserAgentParts.h"
 #import "UserAgentScripts.h"
 #import "UserAgentStyleSheets.h"
 #import <CoreGraphics/CoreGraphics.h>
@@ -426,6 +427,46 @@ void RenderThemeCocoa::adjustColorWellStyle(RenderStyle& style, const Element* e
 #endif
 
     RenderTheme::adjustColorWellStyle(style, element);
+}
+
+void RenderThemeCocoa::adjustColorWellSwatchStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustColorWellSwatchStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustColorWellSwatchStyle(style, element);
+}
+
+void RenderThemeCocoa::adjustColorWellSwatchOverlayStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustColorWellSwatchOverlayStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustColorWellSwatchOverlayStyle(style, element);
+}
+
+void RenderThemeCocoa::adjustColorWellSwatchWrapperStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustColorWellSwatchWrapperStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustColorWellSwatchWrapperStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintColorWellSwatch(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintColorWellSwatchForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintColorWellSwatch(box, paintInfo, rect);
 }
 
 bool RenderThemeCocoa::paintColorWell(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -155,6 +155,9 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings& settin
     case StyleAppearance::Button:
     case StyleAppearance::Checkbox:
     case StyleAppearance::ColorWell:
+    case StyleAppearance::ColorWellSwatch:
+    case StyleAppearance::ColorWellSwatchOverlay:
+    case StyleAppearance::ColorWellSwatchWrapper:
     case StyleAppearance::DefaultButton:
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
@@ -975,6 +978,7 @@ void RenderThemeMac::createColorWellSwatchSubtree(HTMLElement& swatch)
     Ref document = swatch.document();
     Ref div = HTMLDivElement::create(document);
     swatch.appendChild(ContainerNode::ChildChange::Source::Parser, div);
+    div->setUserAgentPart(UserAgentParts::internalColorSwatchOverlay());
     div->setInlineStyleProperty(CSSPropertyHeight, "100%"_s);
     div->setInlineStyleProperty(CSSPropertyWidth, "100%"_s);
     div->setInlineStyleProperty(CSSPropertyClipPath, "polygon(0 0, 100% 0, 0 100%)"_s);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3789,6 +3789,9 @@ enum class WebCore::StyleAppearance : uint8_t {
     TextArea,
     TextField,
     ColorWell,
+    ColorWellSwatch,
+    ColorWellSwatchOverlay,
+    ColorWellSwatchWrapper,
 #if ENABLE(SERVICE_CONTROLS)
     ImageControlsButton,
 #endif


### PR DESCRIPTION
#### 8801f12419402594b4b2b66a282f75f7a36507d7
<pre>
[macOS] Add style adjustment methods and paint method for color swatch for vector-based controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=290776#">https://bugs.webkit.org/show_bug.cgi?id=290776#</a>
<a href="https://rdar.apple.com/148261180">rdar://148261180</a>

Reviewed by Aditya Keerthi.

Updated support for the vector-based color control. Added new StyleAppearances
`ColorWellSwatch`, `ColorWellSwatchOverlay`, and `ColorWellSwatchWrapper`
so that style adjustments can be performed on the input&apos;s shadow DOM elements
as needed, and so that the color swatch can be painted if needed.

Updated Mac test expectations for fast/forms/color/color-input-swatch.html
to include the new user agent part.

Added two new layout tests. `input-color-swatch-overlay-appearance.html`
ensures that, when the color swatch has `appearance: none`, the color
swatch overlay has a used appearance of &apos;none&apos;. This is done by inferring
the used appearance based on the overlay&apos;s computed styles.

`input-color-parts-appearance.html` ensures that a color input with
style `appearance: none` displays the same as a color input with
`appearance: none` set for the input, its color swatch wrapper,
and its color swatch.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/color/input-color-parts-appearance-expected.html: Added.
* LayoutTests/fast/forms/color/input-color-parts-appearance.html: Added.
* LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance-expected.txt: Added.
* LayoutTests/fast/forms/color/input-color-swatch-overlay-appearance.html: Added.
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/html.css:
(input[type=&quot;color&quot;]::-internal-color-swatch-overlay):
(input[type=&quot;color&quot;]::-webkit-color-swatch-wrapper):
(input[type=&quot;color&quot;]::-webkit-color-swatch):
* Source/WebCore/platform/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/StyleAppearance.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::parentOfElementUsesPrimitiveAppearance):
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::adjustColorWellSwatchStyle const):
(WebCore::RenderTheme::adjustColorWellSwatchOverlayStyle const):
(WebCore::RenderTheme::adjustColorWellSwatchWrapperStyle const):
(WebCore::RenderTheme::paintColorWellSwatch):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::adjustColorWellSwatchStyle const):
(WebCore::RenderThemeCocoa::adjustColorWellSwatchOverlayStyle const):
(WebCore::RenderThemeCocoa::adjustColorWellSwatchWrapperStyle const):
(WebCore::RenderThemeCocoa::paintColorWellSwatch):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::createColorWellSwatchSubtree):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/293442@main">https://commits.webkit.org/293442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee4d743c769cdfd7c8adaef80c4a5bf321f29a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75233 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32369 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106319 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84197 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83695 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21239 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19632 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31060 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->