### PR TITLE
Address Safer CPP warning in RemoteLayerTreeEventDispatcher.cpp about CALayer forward declaration

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -16,7 +16,6 @@ Shared/Extensions/_WKWebExtensionSQLiteRow.mm
 Shared/Extensions/_WKWebExtensionSQLiteStatement.mm
 UIProcess/API/C/WKPage.cpp
 UIProcess/Automation/WebAutomationSession.h
-UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
 UIProcess/WebProcessPool.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/Inspector/WebInspectorClient.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -594,7 +594,7 @@ UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
 UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
 
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
-UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -23,27 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RemoteLayerTreeEventDispatcher.h"
+#import "config.h"
+#import "RemoteLayerTreeEventDispatcher.h"
 
 #if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
 
-#include "DisplayLink.h"
-#include "Logging.h"
-#include "NativeWebWheelEvent.h"
-#include "RemoteLayerTreeDrawingAreaProxyMac.h"
-#include "RemoteLayerTreeNode.h"
-#include "RemoteScrollingCoordinatorProxyMac.h"
-#include "RemoteScrollingTree.h"
-#include "WebEventConversion.h"
-#include "WebPageProxy.h"
-#include <WebCore/PlatformWheelEvent.h>
-#include <WebCore/ScrollingCoordinatorTypes.h>
-#include <WebCore/ScrollingNodeID.h>
-#include <WebCore/ScrollingThread.h>
-#include <WebCore/WheelEventDeltaFilter.h>
-#include <wtf/SystemTracing.h>
-#include <wtf/TZoneMallocInlines.h>
+#import "DisplayLink.h"
+#import "Logging.h"
+#import "NativeWebWheelEvent.h"
+#import "RemoteLayerTreeDrawingAreaProxyMac.h"
+#import "RemoteLayerTreeNode.h"
+#import "RemoteScrollingCoordinatorProxyMac.h"
+#import "RemoteScrollingTree.h"
+#import "WebEventConversion.h"
+#import "WebPageProxy.h"
+#import <QuartzCore/CALayer.h>
+#import <WebCore/PlatformWheelEvent.h>
+#import <WebCore/ScrollingCoordinatorTypes.h>
+#import <WebCore/ScrollingNodeID.h>
+#import <WebCore/ScrollingThread.h>
+#import <WebCore/WheelEventDeltaFilter.h>
+#import <wtf/SystemTracing.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3319,7 +3319,7 @@
 		0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayLinkObserverID.h; sourceTree = "<group>"; };
 		0F23ADDE2B7D240B00E6199B /* AsyncPDFRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncPDFRenderer.h; sourceTree = "<group>"; };
 		0F23ADDF2B7D240C00E6199B /* AsyncPDFRenderer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncPDFRenderer.mm; sourceTree = "<group>"; };
-		0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerTreeEventDispatcher.cpp; sourceTree = "<group>"; };
+		0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerTreeEventDispatcher.mm; sourceTree = "<group>"; };
 		0F25C4A029A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeEventDispatcher.h; sourceTree = "<group>"; };
 		0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteScrollingCoordinatorProxyMac.mm; sourceTree = "<group>"; };
 		0F2E0DF728F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingCoordinatorProxyMac.h; sourceTree = "<group>"; };
@@ -16230,8 +16230,8 @@
 			children = (
 				0F2E0DF928F0D04E006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.h */,
 				0F2E0DF828F0D04D006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.mm */,
-				0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.cpp */,
 				0F25C4A029A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.h */,
+				0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.mm */,
 				0F2E0DF728F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.h */,
 				0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */,
 				0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */,


### PR DESCRIPTION
#### 3c0f4f4c663a4eb895b082ceafe9503771fb4cef
<pre>
Address Safer CPP warning in RemoteLayerTreeEventDispatcher.cpp about CALayer forward declaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=290782">https://bugs.webkit.org/show_bug.cgi?id=290782</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm: Renamed from Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp.
(WebKit::RemoteLayerTreeEventDispatcher::create):
(WebKit::RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher):
(WebKit::m_wheelEventActivityHysteresis):
(WebKit::m_momentumEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::setScrollingTree):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingTree):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHysteresisUpdated):
(WebKit::RemoteLayerTreeEventDispatcher::hasNodeWithAnimatedScrollChanged):
(WebKit::RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve):
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::continueWheelEventHandling):
(WebKit::RemoteLayerTreeEventDispatcher::determineWheelEventProcessing):
(WebKit::RemoteLayerTreeEventDispatcher::internalHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted):
(WebKit::RemoteLayerTreeEventDispatcher::filteredWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::drawingAreaMac const):
(WebKit::RemoteLayerTreeEventDispatcher::protectedDrawingAreaMac const):
(WebKit::RemoteLayerTreeEventDispatcher::displayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::existingDisplayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLink):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayLinkObserver):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver):
(WebKit::RemoteLayerTreeEventDispatcher::removeDisplayLinkClient):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):
(WebKit::RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTimer):
(WebKit::RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired):
(WebKit::RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingTreeWasRecentlyActive):
(WebKit::RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh):
(WebKit::RemoteLayerTreeEventDispatcher::renderingUpdateComplete):
(WebKit::RemoteLayerTreeEventDispatcher::lockForAnimationChanges):
(WebKit::RemoteLayerTreeEventDispatcher::unlockForAnimationChanges):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenWillChange):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenDidChange):
(WebKit::RemoteLayerTreeEventDispatcher::startFingerDownSignpostInterval):
(WebKit::RemoteLayerTreeEventDispatcher::endFingerDownSignpostInterval):
(WebKit::RemoteLayerTreeEventDispatcher::startMomentumSignpostInterval):
(WebKit::RemoteLayerTreeEventDispatcher::endMomentumSignpostInterval):
(WebKit::RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::didStartRubberbanding):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayDidRefreshCallbacks):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks):
(WebKit::RemoteLayerTreeEventDispatcher::flushMomentumEventLoggingSoon):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/292998@main">https://commits.webkit.org/292998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7628d39e388a84c61e9df12e0cb4f21886af4af9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97573 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48102 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31529 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13251 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88235 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13021 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47544 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104680 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24653 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17982 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82816 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18246 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15786 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24614 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29783 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->