### PR TITLE
Fix iOS version for libswiftWebKit in WebKitSwiftOverlayMacros.h

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h
@@ -49,11 +49,11 @@
 
 #elif PLATFORM(IOS) && !PLATFORM(IOS_SIMULATOR)
 #define DECLARE_MIGRATED_NAME(Symbol, macOSVersion, iOSVersion, visionOSVersion) \
-    MIGRATE_SYMBOL("/usr/lib/swift/libswiftWebKit.dylib", 2 /*PLATFORM_IOS*/, macOSVersion, 18.4, Symbol)
+    MIGRATE_SYMBOL("/usr/lib/swift/libswiftWebKit.dylib", 2 /*PLATFORM_IOS*/, iOSVersion, 18.4, Symbol)
 
 #elif PLATFORM(IOS) && PLATFORM(IOS_SIMULATOR)
 #define DECLARE_MIGRATED_NAME(Symbol, macOSVersion, iOSVersion, visionOSVersion) \
-    MIGRATE_SYMBOL("/usr/lib/swift/libswiftWebKit.dylib", 7 /*PLATFORM_IOSSIMULATOR*/, macOSVersion, 15.4, Symbol)
+    MIGRATE_SYMBOL("/usr/lib/swift/libswiftWebKit.dylib", 7 /*PLATFORM_IOSSIMULATOR*/, iOSVersion, 18.4, Symbol)
 
 #elif PLATFORM(VISION) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 #define DECLARE_MIGRATED_NAME(Symbol, macOSVersion, iOSVersion, visionOSVersion) \


### PR DESCRIPTION
#### 99a10095960b97c7aa5752344c5a6eb30b5d65b0
<pre>
Fix iOS version for libswiftWebKit in WebKitSwiftOverlayMacros.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=290783">https://bugs.webkit.org/show_bug.cgi?id=290783</a>
<a href="https://rdar.apple.com/148078096">rdar://148078096</a>

Reviewed by Abrar Rahman Protyasha, Geoffrey Garen, and Elliott Williams.

It was incorrectly using the macOS version on iOS. Switch to the actual
iOS version.

* Source/WebKit/UIProcess/Cocoa/WebKitSwiftOverlayMacros.h:

Canonical link: <a href="https://commits.webkit.org/292982@main">https://commits.webkit.org/292982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fd088bc3d8b77a2c59e5fcaafb745693c6744d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48104 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100578 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54690 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47546 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83395 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82817 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29785 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->