### PR TITLE
Recognize autofill as a user interaction

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction-expected.txt
@@ -1,0 +1,8 @@
+This tests that autofilling obscured inputs is considered as user interaction with the site.
+
+PASS 127.0.0.1 did not have user interaction
+PASS 127.0.0.1 had user interaction
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+    <script>
+    jsTestIsAsync = true;
+    function runTest() {
+        setEnableFeature(true, function () {
+            const loopbackAddr = "127.0.0.1";
+            if (testRunner.isStatisticsHasHadUserInteraction(loopbackAddr)) {
+                testFailed(`${loopbackAddr} already had user interaction`);
+            } else {
+                testPassed(`${loopbackAddr} did not have user interaction`);
+            }
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+            }
+
+            var tf = document.getElementById('tf');
+            internals?.setAutofilledAndObscured(tf, true);
+            setTimeout(() => {
+                if (testRunner.isStatisticsHasHadUserInteraction(`http://${loopbackAddr}`)) {
+                    testPassed(`${loopbackAddr} had user interaction`);
+                } else {
+                    testFailed(`${loopbackAddr} did not have user interaction`);
+                }
+                setEnableFeature(false, finishJSTest);
+            }, 100);
+        });
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    This tests that autofilling obscured inputs is considered as user interaction with the site.<br>
+    <form name="fm">
+        <input type="password" id="tf" value="Field value" />
+    </form>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction-expected.txt
@@ -1,0 +1,8 @@
+This tests that autofilling obscured inputs is considered as user interaction with the site.
+
+PASS 127.0.0.1 did not have user interaction
+PASS 127.0.0.1 had user interaction
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+    <script>
+    jsTestIsAsync = true;
+    function runTest() {
+        setEnableFeature(true, function () {
+            const loopbackAddr = "127.0.0.1";
+            if (testRunner.isStatisticsHasHadUserInteraction(loopbackAddr)) {
+                testFailed(`${loopbackAddr} already had user interaction`);
+            } else {
+                testPassed(`${loopbackAddr} did not have user interaction`);
+            }
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+            }
+
+            var tf = document.getElementById('tf');
+            internals?.setAutofilledAndViewable(tf, true);
+            setTimeout(() => {
+                if (testRunner.isStatisticsHasHadUserInteraction(`http://${loopbackAddr}`)) {
+                    testPassed(`${loopbackAddr} had user interaction`);
+                } else {
+                    testFailed(`${loopbackAddr} did not have user interaction`);
+                }
+                setEnableFeature(false, finishJSTest);
+            }, 100);
+        });
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    This tests that autofilling obscured inputs is considered as user interaction with the site.<br>
+    <form name="fm">
+        <input type="password" id="tf" value="Field value" />
+    </form>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction-expected.txt
@@ -1,0 +1,8 @@
+This tests that autofilling obscured inputs is considered as user interaction with the site.
+
+PASS 127.0.0.1 did not have user interaction
+PASS 127.0.0.1 had user interaction
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+    <script>
+    jsTestIsAsync = true;
+    function runTest() {
+        setEnableFeature(true, function () {
+            const loopbackAddr = "127.0.0.1";
+            if (testRunner.isStatisticsHasHadUserInteraction(loopbackAddr)) {
+                testFailed(`${loopbackAddr} already had user interaction`);
+            } else {
+                testPassed(`${loopbackAddr} did not have user interaction`);
+            }
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+            }
+
+            var tf = document.getElementById('tf');
+            window.internals?.setAutofilled(tf, true);
+            setTimeout(() => {
+                if (testRunner.isStatisticsHasHadUserInteraction(`http://${loopbackAddr}`)) {
+                    testPassed(`${loopbackAddr} had user interaction`);
+                } else {
+                    testFailed(`${loopbackAddr} did not have user interaction`);
+                }
+                setEnableFeature(false, finishJSTest);
+            }, 100);
+        });
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    This tests that autofilling obscured inputs is considered as user interaction with the site.<br>
+    <form name="fm">
+        <input type="password" id="tf" value="Field value" />
+    </form>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -70,6 +70,7 @@
 #include "RenderStyleSetters.h"
 #include "RenderTextControlSingleLine.h"
 #include "RenderTheme.h"
+#include "ResourceLoadObserver.h"
 #include "ScopedEventQueue.h"
 #include "SearchInputType.h"
 #include "Settings.h"
@@ -1532,10 +1533,21 @@ URL HTMLInputElement::src() const
     return document().completeURL(attributeWithoutSynchronization(srcAttr));
 }
 
+void HTMLInputElement::logUserInteraction()
+{
+    if (!document().frame() || !document().frame()->localMainFrame())
+        return;
+    if (RefPtr mainFrameDocument = document().frame()->localMainFrame()->document())
+        ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
+}
+
 void HTMLInputElement::setAutofilled(bool autoFilled)
 {
     if (autoFilled == m_isAutoFilled)
         return;
+
+    if (autoFilled)
+        logUserInteraction();
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Autofill, autoFilled);
     m_isAutoFilled = autoFilled;
@@ -1546,6 +1558,9 @@ void HTMLInputElement::setAutofilledAndViewable(bool autoFilledAndViewable)
     if (autoFilledAndViewable == m_isAutoFilledAndViewable)
         return;
 
+    if (autoFilledAndViewable)
+        logUserInteraction();
+
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::WebKitAutofillStrongPasswordViewable, autoFilledAndViewable);
     m_isAutoFilledAndViewable = autoFilledAndViewable;
 }
@@ -1554,6 +1569,9 @@ void HTMLInputElement::setAutofilledAndObscured(bool autoFilledAndObscured)
 {
     if (autoFilledAndObscured == m_isAutoFilledAndObscured)
         return;
+
+    if (autoFilledAndObscured)
+        logUserInteraction();
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::WebKitAutofillAndObscured, autoFilledAndObscured);
     m_isAutoFilledAndObscured = autoFilledAndObscured;

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -445,6 +445,8 @@ private:
     bool computeWillValidate() const final;
     void requiredStateChanged() final;
 
+    void logUserInteraction();
+
     void updateType(const AtomString& typeAttributeValue);
     void runPostTypeUpdateTasks();
 


### PR DESCRIPTION
#### fdc846a6dcfb6f978308992990890ad587c43795
<pre>
Recognize autofill as a user interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=290788">https://bugs.webkit.org/show_bug.cgi?id=290788</a>
<a href="https://rdar.apple.com/148268327">rdar://148268327</a>

Reviewed by Aditya Keerthi.

Currently autofill is not logged as a user interaction, despite it requiring
explicit user consent. This patch resolves that problem by logging a user
interaction on form autofill.

* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-obscured-user-interaction.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-and-viewable-user-interaction.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/input-autofilled-user-interaction.html: Added.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::logUserInteraction):
(WebCore::HTMLInputElement::setAutofilled):
(WebCore::HTMLInputElement::setAutofilledAndViewable):
(WebCore::HTMLInputElement::setAutofilledAndObscured):
* Source/WebCore/html/HTMLInputElement.h:

Canonical link: <a href="https://commits.webkit.org/293263@main">https://commits.webkit.org/293263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4253e3d91b8a077e0582724219b057ed146758e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74708 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31890 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18368 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83696 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83149 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21009 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Checked out pull request; Reviewed by Aditya Keerthi; Compiled WebKit (cancelled)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18848 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30341 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->