### PR TITLE
Yarr generatePatternCharacterOnce should limit how far away it coalesces characters

### DIFF
--- a/JSTests/stress/regexp-dont-merge-far-apart-characters.js
+++ b/JSTests/stress/regexp-dont-merge-far-apart-characters.js
@@ -1,0 +1,2 @@
+let r = /[ab]c{1000000000}defg/
+r.exec('meow')

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2050,12 +2050,20 @@ class YarrGenerator final : public YarrJITInfo {
 
             unsigned currPosition = currTerm->inputPosition;
 
+            constexpr unsigned maxGroupingDistance = 16;
+
             if (currPosition > lastPosition) {
+                // If the next term is too far away, we'll handle it by itself
+                if (currPosition > lastPosition + maxGroupingDistance)
+                    break;
                 if (currPosition > lastPosition + 1)
                     opList.insertFill(lastPosition - firstPosition + 1, nullptr, currPosition - lastPosition - 1);
                 opList.append(currOp);
                 lastPosition = currPosition;
             } else if (currPosition < firstPosition) {
+                // If the next term is too far away, we'll handle it by itself
+                if (currPosition < firstPosition - maxGroupingDistance)
+                    break;
                 opList.insertFill(0, nullptr, firstPosition - currPosition);
                 opList.first() = currOp;
                 firstPosition = currPosition;


### PR DESCRIPTION
#### 4300c2ca618ec7fd758457844534313154356d91
<pre>
Yarr generatePatternCharacterOnce should limit how far away it coalesces characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=290789">https://bugs.webkit.org/show_bug.cgi?id=290789</a>
<a href="https://rdar.apple.com/148244655">rdar://148244655</a>

Reviewed by Yusuke Suzuki.

Currently, our optimization is able to read pattern characters any number of characters
away, as long as everything in between is empty. This could lead to unnecessary loading
of those intermediate characters. We constrain the JIT to search up to 16 characters in
each direction (two 8B loads), allowing us to group close pattern characters, while not
getting too aggressive with this optimization.

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* JSTests/stress/regexp-dont-merge-far-apart-characters.js:

Canonical link: <a href="https://commits.webkit.org/293011@main">https://commits.webkit.org/293011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ae41f1c311b7bffb6cfe314b2a828aa34529dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74358 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13270 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88250 "Found 1 new API test failure: TestWebKitAPI.MouseEventTests.MouseEnterDoesNotDispatchMultipleMouseMoveEvents (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6139 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47568 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104704 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96219 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24677 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18000 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/data-url-shared.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83405 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82830 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20849 "Found 2 new test failures: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html tables/mozilla/other/body_col.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18271 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29807 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119845 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24460 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33641 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->