### PR TITLE
AX: Store AXIsolatedObject properties in a vector rather than a hashmap

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -609,13 +609,13 @@ TextStream& operator<<(TextStream& stream, AXNotification notification)
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-WTF::TextStream& operator<<(WTF::TextStream& stream, const AXPropertyMap& map)
+WTF::TextStream& operator<<(WTF::TextStream& stream, const AXPropertyVector& properties)
 {
     stream << "{"_s;
-    for (auto iterator = map.begin(); iterator != map.end(); ++iterator) {
-        if (iterator != map.begin())
+    for (size_t i = 0; i < properties.size(); i++) {
+        if (i)
             stream << ", ";
-        stream << iterator->key;
+        stream << properties[i].first;
     }
     stream << "}"_s;
     return stream;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -128,6 +128,26 @@ private:
     void initializePlatformProperties(const Ref<const AccessibilityObject>&);
 
     void setProperty(AXProperty, AXPropertyValueVariant&&);
+    void setPropertyInVector(AXProperty property, AXPropertyValueVariant&& value)
+    {
+        if (size_t existingIndex = indexOfProperty(property); existingIndex != notFound)
+            m_properties[existingIndex].second = WTFMove(value);
+        else
+            m_properties.append(std::pair(property, WTFMove(value)));
+    }
+    void removePropertyInVector(AXProperty property)
+    {
+        m_properties.removeFirstMatching([&property] (const auto& propertyAndValue) {
+            return propertyAndValue.first == property;
+        });
+    }
+    size_t indexOfProperty(AXProperty property) const
+    {
+        return m_properties.findIf([&property] (const auto& propertyAndValue) {
+            return propertyAndValue.first == property;
+        });
+    }
+    void shrinkPropertiesAfterUpdates() { m_properties.shrinkToFit(); }
     void setObjectProperty(AXProperty, AXCoreObject*);
     void setObjectVectorProperty(AXProperty, const AccessibilityChildrenVector&);
 
@@ -158,7 +178,7 @@ private:
     template<typename T> T propertyValue(AXProperty) const;
 
     // The following method performs a lazy caching of the given property.
-    // If the property is already in m_propertyMap, returns the existing value.
+    // If the property is already in m_properties, returns the existing value.
     // If not, retrieves the property from the main thread and cache it for later use.
     template<typename T> T getOrRetrievePropertyValue(AXProperty);
 
@@ -565,7 +585,7 @@ private:
     bool m_childrenDirty { true };
     Vector<AXID> m_childrenIDs;
     Vector<Ref<AXCoreObject>> m_children;
-    AXPropertyMap m_propertyMap;
+    AXPropertyVector m_properties;
     OptionSet<AXPropertyFlag> m_propertyFlags;
     // Some objects (e.g. display:contents) form their geometry through their children.
     bool m_getsGeometryFromChildren { false };
@@ -579,15 +599,14 @@ private:
 };
 
 template<typename T>
-inline T AXIsolatedObject::propertyValue(AXProperty propertyName) const
+inline T AXIsolatedObject::propertyValue(AXProperty property) const
 {
-    auto it = m_propertyMap.find(propertyName);
-    if (it == m_propertyMap.end())
+    size_t index = indexOfProperty(property);
+    if (index == notFound)
         return { };
 
-    auto value = it->value;
-    return WTF::switchOn(value,
-        [] (T& typedValue) { return typedValue; },
+    return WTF::switchOn(m_properties[index].second,
+        [] (const T& typedValue) { return typedValue; },
         [] (auto&) { ASSERT_NOT_REACHED();
             return T(); }
     );

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -310,12 +310,12 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
     , AXTextRunLineID
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 >;
-using AXPropertyMap = UncheckedKeyHashMap<AXProperty, AXPropertyValueVariant, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
-WTF::TextStream& operator<<(WTF::TextStream&, const AXPropertyMap&);
+using AXPropertyVector = Vector<std::pair<AXProperty, AXPropertyValueVariant>>;
+WTF::TextStream& operator<<(WTF::TextStream&, const AXPropertyVector&);
 
 struct AXPropertyChange {
     AXID axID; // ID of the object whose properties changed.
-    AXPropertyMap properties; // Changed properties.
+    AXPropertyVector properties; // Changed properties.
 };
 
 struct NodeUpdateOptions {
@@ -398,7 +398,7 @@ public:
     void updatePropertiesForSelfAndDescendants(AccessibilityObject&, const AXPropertySet&);
     void updateFrame(AXID, IntRect&&);
     void updateRootScreenRelativePosition();
-    void overrideNodeProperties(AXID, AXPropertyMap&&);
+    void overrideNodeProperties(AXID, AXPropertyVector&&);
 
     double loadingProgress();
     void updateLoadingProgress(double);

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -198,8 +198,8 @@ std::optional<String> AXIsolatedObject::textContent() const
     if (AXObjectCache::useAXThreadTextApis())
         return textMarkerRange().toString();
 #else
-    if (m_propertyMap.contains(AXProperty::TextContent))
-        return stringAttributeValue(AXProperty::TextContent);
+    if (std::optional textContent = optionalAttributeValue<String>(AXProperty::TextContent))
+        return *textContent;
     if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText))
         return String { [attributedText string] };
 #endif // ENABLE(AX_THREAD_TEXT_APIS)


### PR DESCRIPTION
#### 526ce9ddc41dfae67e3d91dc1ecd1d401e120246
<pre>
AX: Store AXIsolatedObject properties in a vector rather than a hashmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=290803">https://bugs.webkit.org/show_bug.cgi?id=290803</a>
<a href="https://rdar.apple.com/148283171">rdar://148283171</a>

Reviewed by Chris Fleizach.

Prior to this commit, m_propertyMap was a HashMap&lt;AXProperty, AXPropertyValueVariant&gt;. Hash maps are inherently wasteful
in terms of memory because they require keeping around empty hash buckets. Given our current AXPropertyValueVariant size
of 48 bytes, storing 5 properties would result in a HashMap size of 912 bytes. Storing those same 5 property pairs in
a vector would only take 240 bytes.

This commit replaces m_propertyMap with a new Vector&lt;std::pair&lt;AXProperty, AXPropertyValueVariant&gt;&gt; m_properties member.
Due to our aggressive trimming of attributes cached per-object in previous patches, most objects have 4 or less properties,
meaning lookups are still fast. TimingScope benchmarks show that property lookups in this new property vector are roughly
equivalent to the old HashMap implementation. But of course, the lookup speed in our vector is much more sensitive to
the addition of more cached properties than the HashMap was, so we&apos;ll need to be very thoughtful about new properties that we add.

This commit saves 400mb on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a> (1.85gb RAM consumed before, 1.45gb RAM consumed after).

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setMathscripts):
(WebCore::AXIsolatedObject::setObjectProperty):
(WebCore::AXIsolatedObject::setObjectVectorProperty):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::cellForColumnAndRow):
(WebCore::AXIsolatedObject::mathRadicand):
(WebCore::AXIsolatedObject::colorValue const):
(WebCore::AXIsolatedObject::intPointAttributeValue const):
(WebCore::AXIsolatedObject::objectAttributeValue const):
(WebCore::AXIsolatedObject::rectAttributeValue const):
(WebCore::AXIsolatedObject::vectorAttributeValue const):
(WebCore::AXIsolatedObject::optionSetAttributeValue const):
(WebCore::AXIsolatedObject::indexRangePairAttributeValue const):
(WebCore::AXIsolatedObject::optionalAttributeValue const):
(WebCore::AXIsolatedObject::uint64AttributeValue const):
(WebCore::AXIsolatedObject::urlAttributeValue const):
(WebCore::AXIsolatedObject::pathAttributeValue const):
(WebCore::AXIsolatedObject::colorAttributeValue const):
(WebCore::AXIsolatedObject::floatAttributeValue const):
(WebCore::AXIsolatedObject::doubleAttributeValue const):
(WebCore::AXIsolatedObject::unsignedAttributeValue const):
(WebCore::AXIsolatedObject::boolAttributeValue const):
(WebCore::AXIsolatedObject::stringAttributeValue const):
(WebCore::AXIsolatedObject::stringAttributeValueNullIfMissing const):
(WebCore::AXIsolatedObject::intAttributeValue const):
(WebCore::AXIsolatedObject::textRuns const):
(WebCore::AXIsolatedObject::getOrRetrievePropertyValue):
(WebCore::AXIsolatedObject::fillChildrenVectorForProperty const):
(WebCore::AXIsolatedObject::titleAttributeValue const):
(WebCore::AXIsolatedObject::stringValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
(WebCore::AXIsolatedObject::propertyValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updatePropertiesForSelfAndDescendants):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::overrideNodeProperties):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::applyPendingChanges):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textContent const):

Canonical link: <a href="https://commits.webkit.org/293056@main">https://commits.webkit.org/293056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4402e4ee1b68f87b1159f561c331e5d08bae8d06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25697 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74367 "13 flakes 106 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47590 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104726 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24699 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18009 "Found 2 new test failures: imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83411 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24660 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29829 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->