### PR TITLE
REGRESSION(285687@main): [ iOS ] editing/selection/ios/show-selection-in-transformed-container.html is a constant failure.

### DIFF
--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1202,7 +1202,8 @@ IntRect absoluteBoundsForLocalCaretRect(RenderBlock* rendererForCaretPainting, c
 
     LayoutRect localRect(rect);
     rendererForCaretPainting->flipForWritingMode(localRect);
-    return rendererForCaretPainting->localToAbsoluteQuad(FloatRect(localRect), UseTransforms, insideFixed).enclosingBoundingBox();
+    auto absoluteQuad = rendererForCaretPainting->localToAbsoluteQuad(FloatRect(localRect), UseTransforms, insideFixed);
+    return roundedIntRect(absoluteQuad.boundingBox());
 }
 
 HashSet<RefPtr<HTMLImageElement>> visibleImageElementsInRangeWithNonLoadedImages(const SimpleRange& range)


### PR DESCRIPTION
#### 738a9810e37ca8f20192d65cd725fdd26e57993a
<pre>
REGRESSION(285687@main): [ iOS ] editing/selection/ios/show-selection-in-transformed-container.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290790">https://bugs.webkit.org/show_bug.cgi?id=290790</a>
<a href="https://rdar.apple.com/148272125">rdar://148272125</a>

Reviewed by NOBODY (OOPS!).

WIP for EWS — see which tests break (or need to be rebaselined).

* Source/WebCore/editing/Editing.cpp:
(WebCore::absoluteBoundsForLocalCaretRect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/738a9810e37ca8f20192d65cd725fdd26e57993a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74368 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31554 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100623 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13286 "Found 4 new test failures: editing/caret/ios/absolute-caret-position-after-scroll.html editing/selection/ios/caret-when-focusing-editable-element-with-selection.html editing/selection/ios/show-selection-in-transformed-container-2.html editing/selection/simple-line-layout-caret-is-gone.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88269 "Found 1 new API test failure: TestWebKitAPI._WKDownload.DownloadMonitorReturnToForeground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13058 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6164 "Found 1 new test failure: fast/forms/input-text-scroll-left-on-blur.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47591 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83080 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6240 "Found 1 new test failure: fast/forms/input-text-scroll-left-on-blur.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24700 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18012 "Found 3 new test failures: fast/forms/input-text-scroll-left-on-blur.html imported/w3c/web-platform-tests/workers/data-url-shared.html ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83413 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/97190 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82842 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27399 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5088 "Found 1 new test failure: fast/forms/input-text-scroll-left-on-blur.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29830 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119868 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24483 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/119868 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->