### PR TITLE
AX: Remove unnecessary detachment check from AccessibilityObject::insertChild

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -231,7 +231,6 @@ Modules/websockets/WebSocketChannelInspector.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
 Modules/webtransport/WebTransport.cpp
 StyleBuilderGenerated.cpp
-accessibility/AXCoreObject.cpp
 accessibility/AXImage.cpp
 accessibility/AXLogger.cpp
 accessibility/AXObjectCache.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -458,8 +458,10 @@ AXCoreObject::AXValue AXCoreObject::value()
     if (supportsRangeValue())
         return valueForRange();
 
-    if (roleValue() == AccessibilityRole::SliderThumb)
-        return parentObject()->valueForRange();
+    if (roleValue() == AccessibilityRole::SliderThumb) {
+        RefPtr parent = parentObject();
+        return parent ? parent->valueForRange() : 0.0f;
+    }
 
     if (isHeading())
         return headingLevel();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1307,7 +1307,6 @@ public:
     AXCoreObject* deepestLastChildIncludingIgnored(bool updateChildrenIfNeeded);
 
     virtual void detachFromParent() = 0;
-    virtual bool isDetachedFromParent() = 0;
 
     AccessibilityChildrenVector listboxSelectedChildren();
     AccessibilityChildrenVector selectedRows();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -630,15 +630,6 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
         // Pass m_subtreeDirty flag down to the child so that children cache gets reset properly.
         if (m_subtreeDirty)
             child.setNeedsToUpdateSubtree();
-    } else {
-        // For some reason the grand children might be detached so that we need to regenerate the
-        // children list of this child.
-        for (const auto& grandChild : child.unignoredChildren(/* updateChildrenIfNeeded */ false)) {
-            if (grandChild->isDetachedFromParent()) {
-                child.clearChildren();
-                break;
-            }
-        }
     }
 
 #if USE(ATSPI)

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -550,7 +550,7 @@ public:
 #else
     void detachFromParent() override { }
 #endif
-    bool isDetachedFromParent() override { return false; }
+    virtual bool isDetachedFromParent() { return false; }
 
     void setSelectedChildren(const AccessibilityChildrenVector&) override { }
     AccessibilityChildrenVector visibleChildren() override { return { }; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -733,19 +733,6 @@ void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& se
     });
 }
 
-bool AXIsolatedObject::isDetachedFromParent()
-{
-    ASSERT(!isMainThread());
-
-    if (parent())
-        return false;
-
-    // Check whether this is the root node, in which case we should return false.
-    if (RefPtr root = tree()->rootNode())
-        return root->objectID() != objectID();
-    return false;
-}
-
 bool AXIsolatedObject::isInDescriptionListTerm() const
 {
     return Accessibility::findAncestor<AXIsolatedObject>(*this, false, [&] (const auto& ancestor) {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -376,7 +376,6 @@ private:
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
     AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }
     void setChildrenIDs(Vector<AXID>&&);
-    bool isDetachedFromParent() final;
     AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String explicitLiveRegionStatus() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionStatus); }
     const String explicitLiveRegionRelevant() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionRelevant); }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1172,12 +1172,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return nil;
     }
 
-    if (backingObject->isDetachedFromParent()) {
-        AXLOG("backingObject is detached from parent!!!");
-        AXLOG(backingObject);
-        return nil;
-    }
-
     if ([attributeName isEqualToString:NSAccessibilityRoleAttribute])
         return roleString(*backingObject);
 


### PR DESCRIPTION
#### f0592d1e077beba8a2ca0e891f2d0ebc139ff41e
<pre>
AX: Remove unnecessary detachment check from AccessibilityObject::insertChild
<a href="https://bugs.webkit.org/show_bug.cgi?id=290805">https://bugs.webkit.org/show_bug.cgi?id=290805</a>
<a href="https://rdar.apple.com/148284256">rdar://148284256</a>

Reviewed by Chris Fleizach.

In this commit:

<a href="https://github.com/WebKit/WebKit/commit/f031d0084a1585510bf5a6009a26fad4b4541255">https://github.com/WebKit/WebKit/commit/f031d0084a1585510bf5a6009a26fad4b4541255</a>

This detachment check was added to workaround an issue where an AccessibilityMockObject (no other AccessibilityObject subclass
can return true for this function, though AXIsolatedObject can). This was fine when it was added, as getting the unignored
children for an object used to be cheap. However, now that we include ignored objects in the tree, this is very much
not cheap, and there is no layout test proving why it&apos;s necessary. If this problem does actually exist, we should fix
the root cause, rather than have an expensive workaround in one of our hottest functions.

The branch deleted here eliminates 17k main-thread samples (of 48k total) while holding VO-Right on <a href="http://html.spec.whatwg.org.">http://html.spec.whatwg.org.</a>

This commit also eliminates an isDetachedFromParent() early-exit from (-[WebAccessibilityObjectWrapper accessibilityAttributeValue:],
thus allowing it to be removed from AXIsolatedObject and made non-virtual (it&apos;s still used on iOS). This was added in this commit
to fix a crash when getting the value from a detached slider:

<a href="https://github.com/WebKit/WebKit/commit/ffdd4e28536b70c03e7ae0da4095a1c0e8d25b20">https://github.com/WebKit/WebKit/commit/ffdd4e28536b70c03e7ae0da4095a1c0e8d25b20</a>

We can fix this crash in a more performant way by null-checking parentObject() in AXCoreObject::value(), rather than
adding virtual function overhead to every single accessibilityAttributeValue call.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::value):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::isDetachedFromParent):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::isDetachedFromParent): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/293300@main">https://commits.webkit.org/293300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d767ff68affd297179926b8567e90acd7577f31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74923 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32090 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83380 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30653 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->