### PR TITLE
[libpas] Remove dead code

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -28,8 +28,6 @@
 
 #include "pas_config.h"
 
-#define PAS_SUBPAGE_SIZE                 4096
-
 #define PAS_USE_SMALL_SEGREGATED_OVERRIDE     true
 #define PAS_USE_MEDIUM_SEGREGATED_OVERRIDE    true
 #define PAS_USE_SMALL_BITFIT_OVERRIDE         true
@@ -73,14 +71,6 @@
    paths for sharing_shift == PAS_BITVECTOR_WORD_SHIFT. */
 #define PAS_SMALL_SHARING_SHIFT          5
 
-#define PAS_APPROXIMATE_LARGE_SIZE_SHIFT 10
-#define PAS_APPROXIMATE_LARGE_SIZE       ((size_t)1 << PAS_APPROXIMATE_LARGE_SIZE_SHIFT)
-
-/* This is the minimum object size in small allocators and we rely on this to lay out alloc
-   bits. */
-#define PAS_MIN_OBJECT_SIZE_SHIFT        4
-#define PAS_MIN_OBJECT_SIZE              ((size_t)1 << PAS_MIN_OBJECT_SIZE_SHIFT)
-
 #define PAS_MIN_MEDIUM_ALIGN_SHIFT       9
 #define PAS_MIN_MEDIUM_ALIGN             ((size_t)1 << PAS_MIN_MEDIUM_ALIGN_SHIFT)
 
@@ -90,9 +80,6 @@
 #define PAS_MEDIUM_SHARING_SHIFT         3
 
 #define PAS_MIN_OBJECTS_PER_PAGE         6
-
-/* Expresses the probability using integers in the range 0..UINT_MAX (inclusive) */
-#define PAS_PROBABILITY_OF_SHARED_PAGE_INELIGIBILITY 0x1fffffff
 
 #ifdef PAS_LIBMALLOC
 #define PAS_DEALLOCATION_LOG_SIZE        10

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -396,14 +396,6 @@ pas_root* pas_root_ensure_for_libmalloc_enumeration(void)
 
 #define PAS_SYSTEM_COMPACT_POINTER_SIZE 4
 
-#if PAS_CPU(ADDRESS64)
-#if PAS_ARM64 && PAS_OS(DARWIN) && !PAS_PLATFORM(IOS_FAMILY_SIMULATOR)
-#if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
-#define PAS_HAVE_36BIT_ADDRESS 1
-#endif
-#endif
-#endif // PAS_CPU(ADDRESS64)
-
 static inline vm_address_t decode_system_compact_pointer(pas_root* root, uint32_t value)
 {
     PAS_UNUSED_PARAM(root);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
@@ -221,9 +221,6 @@ PAS_API extern bool pas_medium_segregated_page_config_variant_is_enabled_overrid
 #define PAS_SEGREGATED_PAGE_CONFIG_SPECIALIZATION_DECLARATIONS(lower_case_page_config_name) \
     PAS_SEGREGATED_PAGE_CONFIG_TLC_SPECIALIZATION_DECLARATIONS(lower_case_page_config_name)
 
-#define PAS_SEGREGATED_PAGE_CONFIG_GOOD_MAX_OBJECT_SIZE(object_payload_size, min_num_objects) \
-    ((object_payload_size) / (min_num_objects))
-
 static inline bool pas_segregated_page_config_is_enabled(pas_segregated_page_config config,
                                                          pas_heap_runtime_config* runtime_config)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
@@ -33,8 +33,6 @@
 
 PAS_BEGIN_EXTERN_C;
 
-#define PAS_BOOTSTRAP_FOR_SMALL_FREE_LIST_MINIMUM_SIZE 4u
-
 #define PAS_SIMPLE_FREE_HEAP_NAME pas_small_medium_bootstrap_free_heap
 #define PAS_SIMPLE_FREE_HEAP_ID(suffix) pas_small_medium_bootstrap_free_heap ## suffix
 #include "pas_simple_free_heap_declarations.def"


### PR DESCRIPTION
#### 45883c2ef9c426fb59a9c675d301d3a34c9c45b4
<pre>
[libpas] Remove dead code
<a href="https://bugs.webkit.org/show_bug.cgi?id=290809">https://bugs.webkit.org/show_bug.cgi?id=290809</a>
<a href="https://rdar.apple.com/148286375">rdar://148286375</a>

Reviewed by Yijia Huang.

This code is not used, but generally looks like it could be and can thus
be confusing. I have left in utility macros which plausibly could be
used (PAS_COLD) as well as ones tightly coupled with other macros
(..._MINALIGN, paired with ..._MINALIGN_SHIFT).

* Source/bmalloc/libpas/src/libpas/pas_internal_config.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h:
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h:

Canonical link: <a href="https://commits.webkit.org/292987@main">https://commits.webkit.org/292987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b906c022e7d55094c0af62714d019aaa45349006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7473 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102738 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48161 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25710 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/102738 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/102738 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47603 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/90308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96254 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20862 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27410 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18307 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24673 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119880 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24495 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->