### PR TITLE
Web Inspector: Elements: show a badge for nodes to quickly jump to the assigned `<slot>`

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned-expected.txt
@@ -1,0 +1,22 @@
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.SlotAssigned
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotAssigned.Named.Empty
+PASS: Should not be slotted.
+Adding slot...
+PASS: Should be slotted.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotAssigned.Named.Filled
+PASS: Should be slotted.
+Removing slot...
+PASS: Should not be slotted.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotAssigned.Manual.Empty
+PASS: Should not be slotted.
+Adding assigned node...
+PASS: Should be slotted.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.SlotAssigned.Manual.Filled
+PASS: Should be slotted.
+Removing assigned node...
+PASS: Should not be slotted.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+customElements.define("test-element", class TestElement extends HTMLElement {
+    connectedCallback() {
+        let shadowRoot = this.attachShadow({
+            mode: "open",
+            slotAssignment: this.id.substring(0, this.id.indexOf("-")),
+        });
+
+        this._slotElement = shadowRoot.appendChild(document.createElement("slot"));
+        this._slotElement.name = "test-slot";
+    }
+
+    assign(...nodes) {
+        this._slotElement.assign(...nodes);
+    }
+});
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.SlotAssigned");
+
+    function addTestCase({name, selector, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+
+                let childNodeId = await documentNode.querySelector(selector + "-child");
+                let childNode = WI.domManager.nodeForId(childNodeId);
+                InspectorTest.assert(childNode, `Should find DOM Node for selector '${selector}-child'.`);
+
+                await domNodeHandler(childNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotAssigned.Named.Empty",
+        selector: "#named-empty",
+        async domNodeHandler(childNode) {
+            InspectorTest.expectFalse(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should not be slotted.");
+
+            InspectorTest.log("Adding slot...");
+            await Promise.all([
+                childNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#named-empty-child").slot = "test-slot"`),
+            ]);
+            InspectorTest.expectTrue(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotAssigned.Named.Filled",
+        selector: "#named-filled",
+        async domNodeHandler(childNode) {
+            InspectorTest.expectTrue(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should be slotted.");
+
+            InspectorTest.log("Removing slot...");
+            await Promise.all([
+                childNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#named-filled-child").slot = "invalid-slot"`),
+            ]);
+            InspectorTest.expectFalse(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should not be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotAssigned.Manual.Empty",
+        selector: "#manual-empty",
+        async domNodeHandler(childNode) {
+            InspectorTest.expectFalse(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should not be slotted.");
+
+            InspectorTest.log("Adding assigned node...");
+            await Promise.all([
+                childNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(document.querySelector("#manual-empty-child"))`),
+            ]);
+            InspectorTest.expectTrue(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.SlotAssigned.Manual.Filled",
+        selector: "#manual-filled",
+        async domNodeHandler(childNode) {
+            InspectorTest.expectTrue(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should be slotted.");
+
+            InspectorTest.log("Removing assigned node...");
+            await Promise.all([
+                childNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign()`),
+            ]);
+            InspectorTest.expectFalse(childNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.SlotAssigned), "Should not be slotted.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <test-element id="named-empty">
+        <span slot="invalid-slot" id="named-empty-child"></span>
+    </test-element>
+
+    <test-element id="named-filled">
+        <span slot="test-slot" id="named-filled-child"></span>
+    </test-element>
+
+    <test-element id="manual-empty">
+        <span slot="test-slot" id="manual-empty-child"></span>
+    </test-element>
+
+    <test-element id="manual-filled">
+        <span slot="invalid-slot" id="manual-filled-child"></span>
+    </test-element>
+
+    <script>
+        document.querySelector("#manual-filled").assign(document.querySelector("#manual-filled-child"));
+    </script>
+</body>
+</html>

--- a/LayoutTests/inspector/dom/requestAssignedSlot-expected.txt
+++ b/LayoutTests/inspector/dom/requestAssignedSlot-expected.txt
@@ -1,0 +1,26 @@
+
+== Running test suite: DOM.requestAssignedSlot
+-- Running test case: DOM.requestAssignedSlot.Named.Empty
+PASS: Should not be slotted.
+Adding slot...
+PASS: Should be slotted.
+
+-- Running test case: DOM.requestAssignedSlot.Named.Filled
+PASS: Should be slotted.
+Removing slot...
+PASS: Should not be slotted.
+
+-- Running test case: DOM.requestAssignedSlot.Manual.Empty
+PASS: Should not be slotted.
+Adding assigned node...
+PASS: Should be slotted.
+
+-- Running test case: DOM.requestAssignedSlot.Manual.Filled
+PASS: Should be slotted.
+Removing assigned node...
+PASS: Should not be slotted.
+
+-- Running test case: DOM.requestAssignedSlot.MissingNode
+PASS: Should produce an exception.
+Error: Missing node for given nodeId
+

--- a/LayoutTests/inspector/dom/requestAssignedSlot.html
+++ b/LayoutTests/inspector/dom/requestAssignedSlot.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+customElements.define("test-element", class TestElement extends HTMLElement {
+    connectedCallback() {
+        let shadowRoot = this.attachShadow({
+            mode: "open",
+            slotAssignment: this.id.substring(0, this.id.indexOf("-")),
+        });
+
+        this._slotElement = shadowRoot.appendChild(document.createElement("slot"));
+        this._slotElement.name = "test-slot";
+    }
+
+    assign(...nodes) {
+        this._slotElement.assign(...nodes);
+    }
+});
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("DOM.requestAssignedSlot");
+
+    function addTestCase({name, selector, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+
+                let containerNodeId = await documentNode.querySelector(selector);
+                let containerNode = WI.domManager.nodeForId(containerNodeId);
+                InspectorTest.assert(containerNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let slotNodeId = await containerNode.shadowRoots()[0].querySelector("slot");
+                let slotNode = WI.domManager.nodeForId(slotNodeId);
+                InspectorTest.assert(slotNode, `Should find <slot> inside DOM Node for selector '${selector}'.`);
+
+                let childNodeId = await documentNode.querySelector(selector + "-child");
+                let childNode = WI.domManager.nodeForId(childNodeId);
+                InspectorTest.assert(childNode, `Should find DOM Node for selector '${selector}-child'.`);
+
+                await domNodeHandler(slotNode, childNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "DOM.requestAssignedSlot.Named.Empty",
+        selector: "#named-empty",
+        async domNodeHandler(slotNode, childNode) {
+            InspectorTest.expectNull(await childNode.requestAssignedSlot(), "Should not be slotted.");
+
+            InspectorTest.log("Adding slot...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-empty-child").slot = "test-slot"`);
+            InspectorTest.expectEqual(await childNode.requestAssignedSlot(), slotNode, "Should be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedSlot.Named.Filled",
+        selector: "#named-filled",
+        async domNodeHandler(slotNode, childNode) {
+            InspectorTest.expectEqual(await childNode.requestAssignedSlot(), slotNode, "Should be slotted.");
+
+            InspectorTest.log("Removing slot...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#named-filled-child").slot = "invalid-slot"`);
+            InspectorTest.expectNull(await childNode.requestAssignedSlot(), "Should not be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedSlot.Manual.Empty",
+        selector: "#manual-empty",
+        async domNodeHandler(slotNode, childNode) {
+            InspectorTest.expectNull(await childNode.requestAssignedSlot(), "Should not be slotted.");
+
+            InspectorTest.log("Adding assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-empty").assign(document.querySelector("#manual-empty-child"))`);
+            InspectorTest.expectEqual(await childNode.requestAssignedSlot(), slotNode, "Should be slotted.");
+        },
+    });
+
+    addTestCase({
+        name: "DOM.requestAssignedSlot.Manual.Filled",
+        selector: "#manual-filled",
+        async domNodeHandler(slotNode, childNode) {
+            InspectorTest.expectEqual(await childNode.requestAssignedSlot(), slotNode, "Should be slotted.");
+
+            InspectorTest.log("Removing assigned node...");
+            await InspectorTest.evaluateInPage(`document.querySelector("#manual-filled").assign()`);
+            InspectorTest.expectNull(await childNode.requestAssignedSlot(), "Should not be slotted.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "DOM.requestAssignedSlot.MissingNode",
+        async test() {
+            await InspectorTest.expectException(() => DOMAgent.requestAssignedSlot(9999999));
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <test-element id="named-empty">
+        <span slot="invalid-slot" id="named-empty-child"></span>
+    </test-element>
+
+    <test-element id="named-filled">
+        <span slot="test-slot" id="named-filled-child"></span>
+    </test-element>
+
+    <test-element id="manual-empty">
+        <span slot="test-slot" id="manual-empty-child"></span>
+    </test-element>
+
+    <test-element id="manual-filled">
+        <span slot="invalid-slot" id="manual-filled-child"></span>
+    </test-element>
+
+    <script>
+        document.querySelector("#manual-filled").assign(document.querySelector("#manual-filled-child"));
+    </script>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -290,6 +290,7 @@
                 "flex",
                 "grid",
                 "event",
+                "slot-assigned",
                 "slot-filled"
             ],
             "description": "Relevant layout information about the node. Things not in this list are not important to Web Inspector."

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -287,6 +287,16 @@
             ]
         },
         {
+            "name": "requestAssignedSlot",
+            "description": "Requests the <code>HTMLSlotElement</code> that the node with the given id is assigned to.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId" }
+            ],
+            "returns": [
+                { "name": "slotElementId", "$ref": "NodeId", "optional": true, "description": "Not provided if the given node is not assigned to a <code>HTMLSlotElement</code>." }
+            ]
+        },
+        {
             "name": "requestAssignedNodes",
             "description": "Requests the list of assigned nodes for the <code>HTMLSlotElement</code> with the given id.",
             "parameters": [

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1400,6 +1400,8 @@ void Node::setManuallyAssignedSlot(HTMLSlotElement* slotElement)
         RenderTreeUpdater::tearDownRenderer(*text);
 
     ensureRareData().setManuallyAssignedSlot(slotElement);
+
+    InspectorInstrumentation::didChangeAssignedSlot(*this);
 }
 
 bool Node::hasEverPaintedImages() const

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -130,7 +130,7 @@ public:
     void slotFallbackDidChange(HTMLSlotElement&);
     void resolveSlotsBeforeNodeInsertionOrRemoval();
     void willRemoveAllChildren(ContainerNode&);
-    void willRemoveAssignedNode(const Node&);
+    void willRemoveAssignedNode(Node&);
 
     void didRemoveAllChildrenOfShadowHost();
     void didMutateTextNodesOfShadowHost();

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -66,7 +66,7 @@ public:
     virtual void hostChildElementDidChange(const Element&, ShadowRoot&) = 0;
     virtual void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue, ShadowRoot&) = 0;
 
-    virtual void willRemoveAssignedNode(const Node&, ShadowRoot&) = 0;
+    virtual void willRemoveAssignedNode(Node&, ShadowRoot&) = 0;
     virtual void didRemoveAllChildrenOfShadowHost(ShadowRoot&) = 0;
     virtual void didMutateTextNodesOfShadowHost(ShadowRoot&) = 0;
 
@@ -100,7 +100,7 @@ private:
     void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) final;
 
     const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
-    void willRemoveAssignedNode(const Node&, ShadowRoot&) final;
+    void willRemoveAssignedNode(Node&, ShadowRoot&) final;
 
     void didRemoveAllChildrenOfShadowHost(ShadowRoot&) final;
     void didMutateTextNodesOfShadowHost(ShadowRoot&) final;
@@ -159,7 +159,7 @@ public:
     void hostChildElementDidChange(const Element&, ShadowRoot&) final;
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString&, const AtomString&, ShadowRoot&) final;
 
-    void willRemoveAssignedNode(const Node&, ShadowRoot&) final;
+    void willRemoveAssignedNode(Node&, ShadowRoot&) final;
     void didRemoveAllChildrenOfShadowHost(ShadowRoot&) final;
     void didMutateTextNodesOfShadowHost(ShadowRoot&) final;
 
@@ -222,7 +222,7 @@ inline void ShadowRoot::hostChildElementDidChangeSlotAttribute(Element& element,
     m_slotAssignment->hostChildElementDidChangeSlotAttribute(element, oldValue, newValue, *this);
 }
 
-inline void ShadowRoot::willRemoveAssignedNode(const Node& node)
+inline void ShadowRoot::willRemoveAssignedNode(Node& node)
 {
     if (m_slotAssignment)
         m_slotAssignment->willRemoveAssignedNode(node, *this);

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -266,6 +266,12 @@ void InspectorInstrumentation::willPopShadowRootImpl(InstrumentingAgents& instru
         domAgent->willPopShadowRoot(host, root);
 }
 
+void InspectorInstrumentation::didChangeAssignedSlotImpl(InstrumentingAgents& instrumentingAgents, Node& slotable)
+{
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->didChangeAssignedSlot(slotable);
+}
+
 void InspectorInstrumentation::didChangeAssignedNodesImpl(InstrumentingAgents& instrumentingAgents, Element& slotElement)
 {
     if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -139,6 +139,7 @@ public:
     static void activeStyleSheetsUpdated(Document&);
     static void didPushShadowRoot(Element& host, ShadowRoot&);
     static void willPopShadowRoot(Element& host, ShadowRoot&);
+    static void didChangeAssignedSlot(Node&);
     static void didChangeAssignedNodes(Element& slotElement);
     static void didChangeCustomElementState(Element&);
     static void pseudoElementCreated(Page*, PseudoElement&);
@@ -366,6 +367,7 @@ private:
     static void activeStyleSheetsUpdatedImpl(InstrumentingAgents&, Document&);
     static void didPushShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
     static void willPopShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
+    static void didChangeAssignedSlotImpl(InstrumentingAgents&, Node&);
     static void didChangeAssignedNodesImpl(InstrumentingAgents&, Element& slotElement);
     static void didChangeCustomElementStateImpl(InstrumentingAgents&, Element&);
     static void pseudoElementCreatedImpl(InstrumentingAgents&, PseudoElement&);
@@ -701,6 +703,13 @@ inline void InspectorInstrumentation::willPopShadowRoot(Element& host, ShadowRoo
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(host.document()))
         willPopShadowRootImpl(*agents, host, root);
+}
+
+inline void InspectorInstrumentation::didChangeAssignedSlot(Node& slotable)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(slotable.document()))
+        didChangeAssignedSlotImpl(*agents, slotable);
 }
 
 inline void InspectorInstrumentation::didChangeAssignedNodes(Element& slotElement)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1090,6 +1090,9 @@ OptionSet<InspectorCSSAgent::LayoutFlag> InspectorCSSAgent::layoutFlagsForNode(N
     if (hasJSEventListener(node))
         layoutFlags.add(InspectorCSSAgent::LayoutFlag::Event);
 
+    if (node.assignedSlot())
+        layoutFlags.add(InspectorCSSAgent::LayoutFlag::SlotAssigned);
+
     if (isSlotElementWithAssignedNodes(node))
         layoutFlags.add(InspectorCSSAgent::LayoutFlag::SlotFilled);
 
@@ -1112,6 +1115,8 @@ static RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> 
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Grid));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Event))
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Event));
+    if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::SlotAssigned))
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::SlotAssigned));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::SlotFilled))
         protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::SlotFilled));
     return protocolLayoutFlags;
@@ -1167,6 +1172,11 @@ void InspectorCSSAgent::willRemoveEventListener(EventTarget& target)
 {
     if (auto* node = dynamicDowncast<Node>(target))
         nodeHasLayoutFlagsChange(*node);
+}
+
+void InspectorCSSAgent::didChangeAssignedSlot(Node& slotable)
+{
+    nodeHasLayoutFlagsChange(slotable);
 }
 
 void InspectorCSSAgent::didChangeAssignedNodes(Element& slotElement)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -129,6 +129,7 @@ public:
     void didChangeRendererForDOMNode(Node&);
     void didAddEventListener(EventTarget&);
     void willRemoveEventListener(EventTarget&);
+    void didChangeAssignedSlot(Node&);
     void didChangeAssignedNodes(Element& slotElement);
 
     // InspectorDOMAgent hooks
@@ -141,7 +142,8 @@ public:
         Grid = 1 << 2,
         Event = 1 << 3,
         Scrollable = 1 << 4,
-        SlotFilled = 1 << 5,
+        SlotAssigned = 1 << 5,
+        SlotFilled = 1 << 6,
     };
     OptionSet<LayoutFlag> layoutFlagsForNode(Node&);
     RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> protocolLayoutFlagsForNode(Node&);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -649,6 +649,25 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::requestChildNodes(In
     return { };
 }
 
+Inspector::CommandResult<std::optional<Inspector::Protocol::DOM::NodeId>> InspectorDOMAgent::requestAssignedSlot(Inspector::Protocol::DOM::NodeId nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr slotElement = node->assignedSlot();
+    if (!slotElement)
+        return { };
+
+    auto slotElementId = pushNodePathToFrontend(errorString, slotElement.get());
+    if (!slotElementId)
+        return makeUnexpected(errorString);
+
+    return { slotElementId };
+}
+
 Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> InspectorDOMAgent::requestAssignedNodes(Inspector::Protocol::DOM::NodeId nodeId)
 {
     Inspector::Protocol::ErrorString errorString;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -115,6 +115,7 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> querySelectorAll(Inspector::Protocol::DOM::NodeId, const String& selector);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Node>> getDocument();
     Inspector::Protocol::ErrorStringOr<void> requestChildNodes(Inspector::Protocol::DOM::NodeId, std::optional<int>&& depth);
+    Inspector::CommandResult<std::optional<Inspector::Protocol::DOM::NodeId>> requestAssignedSlot(Inspector::Protocol::DOM::NodeId);
     Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestAssignedNodes(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<void> setAttributeValue(Inspector::Protocol::DOM::NodeId, const String& name, const String& value);
     Inspector::Protocol::ErrorStringOr<void> setAttributesAsText(Inspector::Protocol::DOM::NodeId, const String& text, const String& name);

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1602,6 +1602,8 @@ localizedStrings["Skip Network @ Local Override Popover Options"] = "Skip Networ
 localizedStrings["Slashed Zeros @ Font Details Sidebar Property Value"] = "Slashed Zeros";
 /* Title for a badge applied to HTMLSlotElement that have assigned nodes or nodes that are assigned to HTMLSlotElement. */
 localizedStrings["Slot"] = "Slot";
+/* Title for a badge applied to a node that is assigned to a HTMLSlotElement. */
+localizedStrings["Slotted"] = "Slotted";
 /* Property value for `font-variant-capitals: small-caps`. */
 localizedStrings["Small Capitals @ Font Details Sidebar Property Value"] = "Small Capitals";
 localizedStrings["Snapshot Comparison (%d and %d)"] = "Snapshot Comparison (%d and %d)";

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -811,6 +811,13 @@ WI.DOMNode = class DOMNode extends WI.Object
         target.DOMAgent.requestChildNodes(this.id, depth, mycallback.bind(this));
     }
 
+    async requestAssignedSlot()
+    {
+        let target = WI.assumingMainTarget();
+        let {slotElementId} = await target.DOMAgent.requestAssignedSlot(this.id);
+        return WI.domManager.nodeForId(slotElementId);
+    }
+
     async requestAssignedNodes()
     {
         let target = WI.assumingMainTarget();
@@ -1389,6 +1396,7 @@ WI.DOMNode.LayoutFlag = {
     Rendered: "rendered",
     Event: "event",
     Scrollable: "scrollable",
+    SlotAssigned: "slot-assigned",
     SlotFilled: "slot-filled",
 
     // These are mutually exclusive.

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -542,12 +542,15 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Scrollable));
         }
 
+        // COMPATIBILITY (iOS X.Y, macOS X.Y): `SlotAssigned` value for `CSS.LayoutFlag` did not exist yet.
         // COMPATIBILITY (iOS X.Y, macOS X.Y): `SlotFilled` value for `CSS.LayoutFlag` did not exist yet.
-        if (InspectorBackend.Enum.CSS?.LayoutFlag?.SlotFilled) {
+        if (InspectorBackend.Enum.CSS?.LayoutFlag?.SlotAssigned && InspectorBackend.Enum.CSS?.LayoutFlag?.SlotFilled) {
+            let checked = WI.settings.enabledDOMTreeBadgeTypes.value.some((enabledDOMTreeBadgeType) => enabledDOMTreeBadgeType === WI.DOMTreeElement.BadgeType.SlotAssigned || enabledDOMTreeBadgeType === WI.DOMTreeElement.BadgeType.SlotFilled);
             contextMenu.appendCheckboxItem(WI.UIString("Slot", "Title for a badge applied to HTMLSlotElement that have assigned nodes or nodes that are assigned to HTMLSlotElement."), () => {
-                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.SlotFilled);
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.SlotAssigned, !checked);
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.SlotFilled, !checked);
                 WI.settings.enabledDOMTreeBadgeTypes.save();
-            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.SlotFilled));
+            }, checked);
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -2099,6 +2099,11 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             handleClick = this._handleEventBadgeClicked.bind(this);
             break;
 
+        case WI.DOMTreeElement.BadgeType.SlotAssigned:
+            text = WI.UIString("Slotted", "Title for a badge applied to a node that is assigned to a HTMLSlotElement.");
+            handleClick = this._handleSlotAssignedBadgeClicked.bind(this);
+            break;
+
         case WI.DOMTreeElement.BadgeType.SlotFilled:
             text = WI.UIString("Assigned", "Title for a badge applied to HTMLSlotElement that have assigned nodes.");
             handleClick = this._handleSlotFilledBadgeClicked.bind(this);
@@ -2142,6 +2147,10 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
             case WI.DOMNode.LayoutFlag.Event:
                 this._createBadge(WI.DOMTreeElement.BadgeType.Event);
+                break;
+
+            case WI.DOMNode.LayoutFlag.SlotAssigned:
+                this._createBadge(WI.DOMTreeElement.BadgeType.SlotAssigned);
                 break;
 
             case WI.DOMNode.LayoutFlag.SlotFilled:
@@ -2214,6 +2223,18 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         contentElement.appendChild(detailsSection.element);
 
         this._eventBadgePopover.presentNewContentWithFrame(contentElement, calculateTargetFrame(), preferredEdges);
+    }
+
+    async _handleSlotAssignedBadgeClicked(event)
+    {
+        let slotNode = await this.representedObject.requestAssignedSlot();
+        console.assert(slotNode, this.representedObject);
+        if (!slotNode)
+            return;
+
+        WI.domManager.inspectElement(slotNode.id, {
+            initiatorHint: WI.TabBrowser.TabNavigationInitiator.LinkClick,
+        });
     }
 
     async _handleSlotFilledBadgeClicked(event)
@@ -2361,6 +2382,7 @@ WI.DOMTreeElement.BadgeType = {
     Flex: "flex",
     Grid: "grid",
     Event: "event",
+    SlotAssigned: "slot-assigned",
     SlotFilled: "slot-filled",
 };
 WI.settings.enabledDOMTreeBadgeTypes = new WI.Setting("enabled-dom-tree-badge-types", Object.values(WI.DOMTreeElement.BadgeType));


### PR DESCRIPTION
#### 4f655738a843bebead29eeaf0ffd64e3c92803bc
<pre>
Web Inspector: Elements: show a badge for nodes to quickly jump to the assigned `&lt;slot&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=290808">https://bugs.webkit.org/show_bug.cgi?id=290808</a>

Reviewed by BJ Burg.

It&apos;s not always obvious where the `&lt;slot&gt;` is for the node(s) assigned to it (assuming it&apos;s even nearby in the DOM).
Having a way to quickly see (and jump to) the `&lt;slot&gt;` will help developers more easily understand the content they&apos;re debugging.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
(WebCore::toProtocol):
(WebCore::InspectorCSSAgent::didChangeAssignedSlot): Added.
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeAssignedSlot):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeAssignedSlotImpl):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::setManuallyAssignedSlot):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SlotAssignment.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::NamedSlotAssignment::willRemoveAssignedNode):
(WebCore::NamedSlotAssignment::assignSlots):
(WebCore::NamedSlotAssignment::assignToSlot):
(WebCore::ManualSlotAssignment::willRemoveAssignedNode):
(WebCore::ShadowRoot::willRemoveAssignedNode):
Introduce a new `LayoutFlag.SlotAssigned` in order to (re)use the existing DOM node badging system.
This has the added benefit of debouncing changes, which is ideal since the frontend doesn&apos;t actually need the related `&lt;slot&gt;` until the developer clicks on the &quot;Slotted&quot; badge.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::requestAssignedSlot): Added.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.async requestAssignedSlot): Added.
Add a way for the frontend to request the `&lt;slot&gt;` that the given node is assigned to.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._createBadge):
(WI.DOMTreeElement.prototype._createBadges):
(WI.DOMTreeElement.prototype.async _handleSlotAssignedBadgeClicked): Added.
Show a &quot;Slotted&quot; badge for nodes that are assigned to a `&lt;slot&gt;`.
Clicking it will select the `&lt;slot&gt;`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned.html: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-SlotAssigned-expected.txt: Added.
* LayoutTests/inspector/dom/requestAssignedSlot.html: Added.
* LayoutTests/inspector/dom/requestAssignedSlot-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/293055@main">https://commits.webkit.org/293055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea49052cce9bb16e9647565b2efdb74cecfcad31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100667 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13320 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47635 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104772 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96287 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24744 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18045 "Found 1 new test failure: ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18339 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29874 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119912 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24527 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33658 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->