### PR TITLE
Web Inspector: Replace uses of var(--console-prompt-min-height) in styles unrelated to the Console Prompt

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css
@@ -25,7 +25,7 @@
  */
 
 .sidebar > .panel.details.layer > .content {
-    bottom: var(--console-prompt-min-height);
+    bottom: var(--panel-min-height);
 }
 
 .panel.details.layer .data-grid {
@@ -57,7 +57,7 @@
     display: flex;
     justify-content: space-between;
     bottom: 0;
-    height: var(--console-prompt-min-height);
+    height: var(--panel-min-height);
     width: 100%;
     border-top: 1px solid var(--border-color);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css
@@ -24,7 +24,7 @@
  */
 
 .sidebar > .panel.details.layer-tree > .content {
-    bottom: var(--console-prompt-min-height);
+    bottom: var(--panel-min-height);
 }
 
 .panel.details.layer-tree .data-grid {
@@ -57,7 +57,7 @@
     position: absolute;
     display: flex;
     bottom: 0;
-    height: var(--console-prompt-min-height);
+    height: var(--panel-min-height);
     width: 100%;
     border-top: 1px solid var(--border-color);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.css
@@ -36,7 +36,7 @@
 
 .sidebar > .panel.navigation > .overflow-shadow {
     position: absolute;
-    bottom: calc(var(--console-prompt-min-height) - 1px);
+    bottom: calc(var(--panel-min-height) - 1px);
     left: 0;
     right: 0;
     height: 1px;

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -93,6 +93,7 @@
 
     --panel-background-color: hsl(0, 0%, 93%);
     --panel-background-color-light: hsl(0, 0%, 96%);
+    --panel-min-height: 30px;
 
     --warning-color: hsl(50, 100%, 94%);
     --warning-background-color: hsl(43, 97%, 84%);


### PR DESCRIPTION
#### 201f2538d544b0c8daeb24c66fc203294d7b33bf
<pre>
Web Inspector: Replace uses of var(--console-prompt-min-height) in styles unrelated to the Console Prompt
<a href="https://bugs.webkit.org/show_bug.cgi?id=279436">https://bugs.webkit.org/show_bug.cgi?id=279436</a>

Reviewed by Devin Rousso.

Replace uses of var(--console-prompt-min-height) in LayerDetailsSidebarPanel.css, LayerTreeDetailsSidebarPanel.css, and NavigationSidebarPanel.css
Create var(--panel-min-height) in Variables.css

* Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css:
(.sidebar &gt; .panel.details.layer &gt; .content):
(.panel.details.layer .bottom-bar):
* Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css:
(.sidebar &gt; .panel.details.layer-tree &gt; .content):
(.panel.details.layer-tree .bottom-bar):
* Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.css:
(.sidebar &gt; .panel.navigation &gt; .overflow-shadow):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):

Canonical link: <a href="https://commits.webkit.org/293053@main">https://commits.webkit.org/293053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/248c1d13c24263e3118c440c13e1d8af23fb0692

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47606 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83128 "Found 1 new API test failure: TestWebKitAPI.AsyncFunction.RoundTrip (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83468 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5090 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18310 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29845 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24498 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->