### PR TITLE
Return the correct origins in permissions.getAll() if all urls and/or hosts match pattern(s) have been granted

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -56,8 +56,25 @@ void WebExtensionContext::permissionsGetAll(CompletionHandler<void(Vector<String
     for (auto& permission : currentPermissions())
         permissions.append(permission);
 
-    for (auto& matchPattern : currentPermissionMatchPatterns())
+    bool hasGrantedAccessToAllURLsOrHosts = false;
+
+    for (auto& matchPattern : currentPermissionMatchPatterns()) {
+        if (matchPattern->matchesAllHosts()) {
+            hasGrantedAccessToAllURLsOrHosts = true;
+            continue;
+        }
+
         origins.append(matchPattern->string());
+    }
+
+    if (hasGrantedAccessToAllURLsOrHosts) {
+        auto combinedPermissionMatchPatterns = protectedExtension()->combinedPermissionMatchPatterns();
+
+        for (auto& matchPattern : combinedPermissionMatchPatterns) {
+            if (matchPattern->matchesAllHosts())
+                origins.append(matchPattern->string());
+        }
+    }
 
     completionHandler(WTFMove(permissions), WTFMove(origins));
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -330,6 +330,7 @@ public:
     // These are not the currently allowed permission patterns.
     const MatchPatternSet& requestedPermissionMatchPatterns();
     const MatchPatternSet& optionalPermissionMatchPatterns();
+    const MatchPatternSet combinedPermissionMatchPatterns() { return requestedPermissionMatchPatterns().unionWith(optionalPermissionMatchPatterns()); }
 
     // Permission patterns requested by the extension in their manifest.
     // These determine which websites the extension can communicate with.


### PR DESCRIPTION
#### aabff0b8adf8165f88b48632222ad3d6e1c88b9f
<pre>
Return the correct origins in permissions.getAll() if all urls and/or hosts match pattern(s) have been granted
<a href="https://bugs.webkit.org/show_bug.cgi?id=290812">https://bugs.webkit.org/show_bug.cgi?id=290812</a>
<a href="https://rdar.apple.com/147872012">rdar://147872012</a>

Reviewed by Timothy Hatcher.

This patch fixes a bug where we&apos;d always return the all hosts match pattern,
*://*/*, from permissions.getAll() after Safari grants an extension access to
all websites. This is problematic if, for example, an extension specifies the
all URLs match pattern, &lt;all_urls&gt;, in their manifest and checks for it with
permissions.getAll().

This is happening because Safari is just explicitly granting the all hosts
match pattern when allowing all website access. I looked into fixing this bug
on the Safari-side, but I think it&apos;s riskier. If an extension already has the
all hosts match pattern granted, but really specifies the all URLs match pattern
in its manifest, it&apos;d put permissions in a bad state unless we also wrote some
sort of migration code to fix the quirk.

As such, I&apos;ve decided to fix the bug on the WebKit-side. To do so, we need to
update the permissions.getAll() method to return the all URLs and/or all hosts
match pattern(s) if it&apos;s been granted access to one or both of the patterns. To
decide which pattern(s) to return, we look in the manifest.

I wrote a bunch of new unit tests to validate this fix.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsGetAll):
Modify this method to behave as described in the commit message summary.

* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::combinedPermissionMatchPatterns):
Introduce a new method that returns both optional and requested host permissions, used by
permissionsGetAll().

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, Basics)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GetAllOriginsMatchesManifest)):
Write new tests to validate the patch.

Canonical link: <a href="https://commits.webkit.org/293133@main">https://commits.webkit.org/293133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/038d0a64d5a04951e19295686839f81a27e75ede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26020 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74577 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100945 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13534 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105436 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83014 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5331 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18646 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15877 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->