### PR TITLE
[JSC] Add signpost intervals for compiler queued and ready time

### DIFF
--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -107,12 +107,31 @@ public:
 
     void runMainThreadFinalizationTasks();
 
+    enum class SignpostDetail { None, Canceled };
+
+    CString signpostMessage();
+
+    void beginSignpost()
+    {
+        if (UNLIKELY(Options::useCompilerSignpost()))
+            beginSignpostImpl();
+    }
+
+    void endSignpost(SignpostDetail detail = SignpostDetail::None)
+    {
+        if (UNLIKELY(Options::useCompilerSignpost()))
+            endSignpostImpl(detail);
+    }
+
 protected:
     bool computeCompileTimes() const;
     bool reportCompileTimes() const;
 
     enum CompilationPath { FailPath, BaselinePath, DFGPath, FTLPath, CancelPath };
     virtual CompilationPath compileInThreadImpl() = 0;
+
+    void beginSignpostImpl();
+    void endSignpostImpl(SignpostDetail);
 
     JITPlanStage m_stage { JITPlanStage::Preparing };
     JITCompilationMode m_mode;
@@ -121,6 +140,7 @@ protected:
     CodeBlock* m_codeBlock;
     JITWorklistThread* m_thread { nullptr };
     Vector<RefPtr<SharedTask<void()>>> m_mainThreadFinalizationTasks;
+    CString m_signpostMessage; // Non-null iff Options::useCompilerSignpost()
 };
 
 } // namespace JSC

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -265,6 +265,8 @@ WTF_EXTERN_C_END
     M(RegisterImportMap) \
     M(JSCGarbageCollector) \
     M(JSCJITCompiler) \
+    M(JSCJITPlanQueued) \
+    M(JSCJITPlanReady) \
     M(JSCJSGlobalObject) \
     M(IPCConnection) \
     M(StreamClientConnection) \


### PR DESCRIPTION
#### 3301280be56f93356aca74d5157472b7cb6201de
<pre>
[JSC] Add signpost intervals for compiler queued and ready time
<a href="https://bugs.webkit.org/show_bug.cgi?id=290813">https://bugs.webkit.org/show_bug.cgi?id=290813</a>
<a href="https://rdar.apple.com/148287594">rdar://148287594</a>

Reviewed by Yijia Huang.

There&apos;s already signpost intervals to mark when a plan is actively
being compiled. Let&apos;s add signposts for the intervals that the plan
is (a) in the worklist queue and (b) ready but not yet finalized. These
latencies can also be significant and may help with tuning the
JITWorklist policies.

This implementation marks the signposts while the JITWorklist lock
is held which leads to the simplest implementation. I&apos;ve checked
that this doesn&apos;t seem to impact the contention on the lock to a
level that is meaningful for benchmarks. We could move this to out
from under the lock, but that would complicate the code a bit
since these intervals cross thread boundaries.

Formatting the CodeBlock into the signpost metadata is relatively
costly, so this is done upfront once per plan and saved. This does cost
8 bytes in the JITPlan even when signposts are disabled, but that
seems acceptable.

* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::JITPlan):
(JSC::JITPlan::cancel):
(JSC::JITPlan::notifyCompiling):
(JSC::JITPlan::notifyReady):
(JSC::signpostId):
(JSC::JITPlan::signpostMessage):
(JSC::JITPlan::beginSignpostImpl):
(JSC::JITPlan::endSignpostImpl):
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::beginSignpost):
(JSC::JITPlan::endSignpost):
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::enqueue):
(JSC::JITWorklist::completeAllReadyPlansForVM):
(JSC::JITWorklist::cancelAllPlansForVM):
* Source/WTF/wtf/SystemTracing.h:

Canonical link: <a href="https://commits.webkit.org/293052@main">https://commits.webkit.org/293052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540c59b3978a3a018cc40542e58fc573a6686484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48245 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74428 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31616 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47688 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90392 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96339 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83480 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20897 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18403 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29926 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/119964 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24579 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33668 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->