### PR TITLE
[SwiftUI] Update the set of supported view modifiers on WebView (part 3)

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -23,7 +23,6 @@
 
 import Foundation
 public import SwiftUI
-@_spi(Private) @_spi(CrossImportOverlay) import WebKit
 
 extension View {
     /// Determines whether horizontal swipe gestures trigger backward and forward page navigation.
@@ -101,7 +100,15 @@ extension View {
 #endif
     }
 
-    @_spi(Private)
+    /// Specifies the visibility of the webpage's natural background color within this view.
+    ///
+    /// By default, WebViews are opaque, and use the page's natural background color as their background color. Use this modifier if you would like to
+    /// not use this behavior and instead provide a custom background using SwiftUI.
+    ///
+    /// - Parameter visibility: The visibility to use for the background.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public nonisolated func webViewContentBackground(_ visibility: Visibility) -> some View {
         environment(\.webViewContentBackground, visibility)
     }


### PR DESCRIPTION
#### 6bcd0944c131d3f3088997a26c691bc8c7e84fc2
<pre>
[SwiftUI] Update the set of supported view modifiers on WebView (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290822">https://bugs.webkit.org/show_bug.cgi?id=290822</a>
<a href="https://rdar.apple.com/148292124">rdar://148292124</a>

Reviewed by Aditya Keerthi.

Expose the `webViewContentBackground` view modifier as API.

Also remove an unused import.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:

Canonical link: <a href="https://commits.webkit.org/293019@main">https://commits.webkit.org/293019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecee6a41385758213059479ce7cb39b587395e7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7493 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102757 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48180 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25729 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/102757 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31573 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100654 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13307 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88287 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/102757 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13079 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6186 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84430 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82866 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18326 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29861 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->