### PR TITLE
Track cookies version in WebsiteDataStore instead of NetworkProcessProxy

### DIFF
--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -57,6 +57,7 @@ NetworkStorageSession::~NetworkStorageSession()
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     unregisterCookieChangeListenersIfNecessary();
 #endif
+    clearCookiesVersionChangeCallbacks();
 }
 
 void NetworkStorageSession::setCookie(const Cookie& cookie)

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -100,6 +100,7 @@ NetworkStorageSession::NetworkStorageSession(PAL::SessionID sessionID, const Str
 
 NetworkStorageSession::~NetworkStorageSession()
 {
+    clearCookiesVersionChangeCallbacks();
 }
 
 void NetworkStorageSession::setCookieDatabase(UniqueRef<CookieJarDB>&& cookieDatabase)

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -77,6 +77,7 @@ NetworkStorageSession::NetworkStorageSession(PAL::SessionID sessionID, IsInMemor
 
 NetworkStorageSession::~NetworkStorageSession()
 {
+    clearCookiesVersionChangeCallbacks();
     g_signal_handlers_disconnect_matched(m_cookieStorage.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
 }
 

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -137,7 +137,8 @@ void WebCookieManager::setCookie(PAL::SessionID sessionID, const Vector<Cookie>&
         for (auto& cookie : cookies)
             storageSession->setCookie(cookie);
         storageSession->setCookiesVersion(cookiesVersion);
-    }
+    } else
+        RELEASE_LOG_ERROR(Storage, "%p - WebCookieManager::setCookie failed to set cookies and version (%" PRIu64 ") for session %" PRIu64, this, cookiesVersion, sessionID.toUInt64());
     completionHandler();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -524,6 +524,8 @@ void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDa
 #elif USE(SOUP)
     addResult.iterator->value = makeUnique<NetworkStorageSession>(sessionID);
 #endif
+
+    addResult.iterator->value->setCookiesVersion(parameters.networkSessionParameters.cookiesVersion);
 }
 
 void NetworkProcess::addWebsiteDataStore(WebsiteDataStoreParameters&& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -106,6 +106,7 @@ struct NetworkSessionCreationParameters {
     bool isBlobRegistryTopOriginPartitioningEnabled { false };
     bool isOptInCookiePartitioningEnabled { false };
     bool shouldSendPrivateTokenIPCForTesting { false };
+    uint64_t cookiesVersion { 0 };
 
     UnifiedOriginStorageLevel unifiedOriginStorageLevel { UnifiedOriginStorageLevel::Standard };
     uint64_t perOriginStorageQuota;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -80,6 +80,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     bool isBlobRegistryTopOriginPartitioningEnabled;
     bool isOptInCookiePartitioningEnabled;
     bool shouldSendPrivateTokenIPCForTesting;
+    uint64_t cookiesVersion;
 
     WebKit::UnifiedOriginStorageLevel unifiedOriginStorageLevel;
     uint64_t perOriginStorageQuota;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -597,7 +597,7 @@ void NetworkDataTaskCocoa::resume()
     if (CheckedPtr session = m_session.get()) {
         CheckedPtr storageSession = session->networkStorageSession();
         if (storageSession && storageSession->cookiesVersion() < m_requiredCookiesVersion) {
-            RELEASE_LOG(Loading, "%p - NetworkDataTaskCocoa::resume: task is delayed because cookies version (%" PRIu64 ") is lower than required (%" PRIu64 ")", this, storageSession->cookiesVersion(), m_requiredCookiesVersion);
+            RELEASE_LOG(Loading, "%p - NetworkDataTaskCocoa::resume: task is delayed because cookies version (%" PRIu64 ") of session (%" PRIu64 ") is lower than required (%" PRIu64 ")", this, storageSession->cookiesVersion(), storageSession->sessionID().toUInt64(), m_requiredCookiesVersion);
             storageSession->addCookiesVersionChangeCallback(m_requiredCookiesVersion, [weakThis = ThreadSafeWeakPtr { *this }] {
                 if (auto protectedThis = weakThis.get()) {
                     RELEASE_LOG(Loading, "%p - NetworkDataTaskCocoa::resume: task delayed by cookies version is started", protectedThis.get());

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -101,8 +101,8 @@ void HTTPCookieStore::cookiesForURL(WTF::URL&& url, CompletionHandler<void(Vecto
 void HTTPCookieStore::setCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void()>&& completionHandler)
 {
     filterAppBoundCookies(WTFMove(cookies), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (auto&& appBoundCookies) mutable {
-        if (RefPtr networkProcess = networkProcessLaunchingIfNecessary())
-            networkProcess->setCookies(m_sessionID, WTFMove(appBoundCookies), WTFMove(completionHandler));
+        if (RefPtr dataStore = m_owningDataStore.get())
+            dataStore->setCookies(WTFMove(appBoundCookies), WTFMove(completionHandler));
         else
             completionHandler();
     });

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -141,7 +141,6 @@ public:
     void dataTaskWithRequest(WebPageProxy&, PAL::SessionID, WebCore::ResourceRequest&&, const std::optional<WebCore::SecurityOriginData>& topOrigin, bool shouldRunAtForegroundPriority, CompletionHandler<void(API::DataTask&)>&&);
 
     void addAllowedFirstPartyForCookies(WebProcessProxy&, const WebCore::RegistrableDomain& firstPartyForCookies, LoadedWebArchive, CompletionHandler<void()>&&);
-    void setCookies(PAL::SessionID, Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
 
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData)>&&);
     void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, const HashSet<WebCore::ProcessIdentifier>&, CompletionHandler<void()>&&);
@@ -349,8 +348,6 @@ public:
     void resetResourceMonitorThrottlerForTesting(PAL::SessionID, CompletionHandler<void()>&&);
 #endif
 
-    uint64_t cookiesVersion() const { return m_cookiesVersion; }
-
 private:
     explicit NetworkProcessProxy();
 
@@ -490,8 +487,6 @@ private:
     RetainPtr<id> m_backgroundObserver;
     RetainPtr<id> m_foregroundObserver;
 #endif
-
-    uint64_t m_cookiesVersion { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2065,8 +2065,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
     loadParameters.isPerformingHTTPFallback = isPerformingHTTPFallback == IsPerformingHTTPFallback::Yes;
     loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(url);
-    if (RefPtr networkProcess = protectedWebsiteDataStore()->networkProcessIfExists())
-        loadParameters.requiredCookiesVersion = networkProcess->cookiesVersion();
+    loadParameters.requiredCookiesVersion = protectedWebsiteDataStore()->cookiesVersion();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (protectedPreferences()->iFrameResourceMonitoringEnabled())

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -43,6 +43,7 @@
 #include "StorageAccessStatus.h"
 #include "UnifiedOriginStorageLevel.h"
 #include "WebBackForwardCache.h"
+#include "WebCookieManagerMessages.h"
 #include "WebFrameProxy.h"
 #include "WebKit2Initialize.h"
 #include "WebNotificationManagerProxy.h"
@@ -2178,6 +2179,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
     networkSessionParameters.isOptInCookiePartitioningEnabled = isOptInCookiePartitioningEnabled();
 #endif
+    networkSessionParameters.cookiesVersion = cookiesVersion();
     networkSessionParameters.unifiedOriginStorageLevel = m_configuration->unifiedOriginStorageLevel();
     networkSessionParameters.perOriginStorageQuota = perOriginStorageQuota();
     networkSessionParameters.originQuotaRatio = originQuotaRatio();
@@ -2908,4 +2910,10 @@ void WebsiteDataStore::resetResourceMonitorThrottlerForTesting(CompletionHandler
     protectedNetworkProcess()->resetResourceMonitorThrottlerForTesting(m_sessionID, WTFMove(completionHandler));
 }
 #endif
+
+void WebsiteDataStore::setCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void()>&& completionHandler)
+{
+    protectedNetworkProcess()->sendWithAsyncReply(Messages::WebCookieManager::SetCookie(m_sessionID, WTFMove(cookies), ++m_cookiesVersion), WTFMove(completionHandler));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -516,6 +516,8 @@ public:
 #endif
 
     bool isRemovingData() const { return!!m_removeDataTaskCounter.value(); }
+    uint64_t cookiesVersion() const { return m_cookiesVersion; }
+    void setCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
 
 private:
     enum class ForceReinitialization : bool { No, Yes };
@@ -666,6 +668,7 @@ private:
     HashSet<URL> m_persistedSiteURLs;
 
     RemoveDataTaskCounter m_removeDataTaskCounter;
+    uint64_t m_cookiesVersion { 0 };
 };
 
 }


### PR DESCRIPTION
#### d368e411b41ece6af3d1942a7ec9ac2d33ad63da
<pre>
Track cookies version in WebsiteDataStore instead of NetworkProcessProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=290802">https://bugs.webkit.org/show_bug.cgi?id=290802</a>
<a href="https://rdar.apple.com/148175761">rdar://148175761</a>

Reviewed by Chris Dumez.

In existing implementation, we compare NetworkDataTaskCocoa::m_requiredCookiesVersion against its storage session&apos;s
m_cookiesVersion to decide whether a load task is ready to start (see NetworkDataTaskCocoa::resume). The problem is
NetworkStorageSession::m_cookiesVersion is updated when cookie is set for the session (in WebCookieManager::setCookie),
while NetworkDataTaskCocoa::m_requiredCookiesVersion is set with NetworkProcessProxy::m_cookiesVersion, which is updated
when cookeis are set for *any* session. Therefore, a load might be delayed unexpectedly since the comparison is wrong.

To fix this, now we keep track of cookies version number for each session in WebsiteDataStore (NetworkStorageSession)
instead of NetworkProcessProxy. UI process will send the cookies version number to network process when session is added
and when cookie is set via API for that session.

This patch also makes some other changes to make the mechanism more robust, including adding more logs, ensuring cookies
version number always increases, invoking cookies version change callbacks with target version lower than updated
version (previously only invoking callbacks with target version matching updated version), and clearing callbacks when
session is destroyed.

* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::setCookiesVersion):
(WebCore::NetworkStorageSession::addCookiesVersionChangeCallback):
(WebCore::NetworkStorageSession::clearCookiesVersionChangeCallbacks):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::~NetworkStorageSession):
* Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp:
(WebCore::NetworkStorageSession::~NetworkStorageSession):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::~NetworkStorageSession):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::setCookie):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::addStorageSession):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::resume):
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::setCookies):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::preconnectTo):
(WebKit::NetworkProcessProxy::setCookies): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::setCookies):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::cookiesVersion const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, CookiesSetInAnotherStoreBeforeLoad)):

Canonical link: <a href="https://commits.webkit.org/293040@main">https://commits.webkit.org/293040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a035a07904b949e2608c8372b0f1705e1f44389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25798 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74429 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31619 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100723 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13369 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6252 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104828 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24800 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83478 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82910 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18407 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->