### PR TITLE
Make it possible to write tests that expect to crash

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		4433A396208044140091ED57 /* SynchronousTimeoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */; };
 		44449DC12718B4B700E821B5 /* OSObjectPtrCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		44449DC22718B4B700E821B5 /* OSObjectPtrCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */; };
+		44599CE72D99E60E00EFD714 /* WTFTestUtilitiesDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44599CE62D99E60E00EFD714 /* WTFTestUtilitiesDarwin.cpp */; };
 		44652CB726FCD405005EC272 /* TypeCastsCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44652CB626FCD405005EC272 /* TypeCastsCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		448110C2253F40300097FC33 /* WebPreferencesTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 448110C1253F40240097FC33 /* WebPreferencesTest.mm */; };
 		448D7E471EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 448D7E451EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp */; };
@@ -2620,6 +2621,7 @@
 		4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SynchronousTimeoutTests.mm; sourceTree = "<group>"; };
 		44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSObjectPtrCocoaARC.mm; sourceTree = "<group>"; };
 		44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSObjectPtrCocoa.mm; sourceTree = "<group>"; };
+		44599CE62D99E60E00EFD714 /* WTFTestUtilitiesDarwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WTFTestUtilitiesDarwin.cpp; sourceTree = "<group>"; };
 		44652CB626FCD405005EC272 /* TypeCastsCocoaARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoaARC.mm; sourceTree = "<group>"; };
 		448110C1253F40240097FC33 /* WebPreferencesTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPreferencesTest.mm; sourceTree = "<group>"; };
 		44817A2E1F0486BF00003810 /* WKRequestActivatedElementInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKRequestActivatedElementInfo.mm; sourceTree = "<group>"; };
@@ -4177,6 +4179,7 @@
 			isa = PBXGroup;
 			children = (
 				0F139E711A423A1D00F590F5 /* cocoa */,
+				44599CE52D99E5D400EFD714 /* darwin */,
 				BC575944126E733C006F0F12 /* InjectedBundle */,
 				2E9660DC16C07D7B00371B42 /* ios */,
 				BCA61C3A11700B9400460D1E /* mac */,
@@ -4907,6 +4910,14 @@
 				5C581D3127C8A01C006B3BC4 /* YouTubePluginReplacement.cpp */,
 			);
 			path = WebCore;
+			sourceTree = "<group>";
+		};
+		44599CE52D99E5D400EFD714 /* darwin */ = {
+			isa = PBXGroup;
+			children = (
+				44599CE62D99E60E00EFD714 /* WTFTestUtilitiesDarwin.cpp */,
+			);
+			path = darwin;
 			sourceTree = "<group>";
 		};
 		448110BF253F3F8D0097FC33 /* cocoa */ = {
@@ -7030,6 +7041,7 @@
 				45F3A6002D8222CD002B4550 /* WorkerPool.cpp in Sources */,
 				46BBEA1B25F9835700D4987A /* WorkQueue.cpp in Sources */,
 				7C83DF631D0A590C00FEBCF3 /* WTFString.cpp in Sources */,
+				44599CE72D99E60E00EFD714 /* WTFTestUtilitiesDarwin.cpp in Sources */,
 				FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tools/TestWebKitAPI/WTFTestUtilities.h
+++ b/Tools/TestWebKitAPI/WTFTestUtilities.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -30,11 +31,16 @@
 
 #pragma once
 
+#include <wtf/Function.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
 namespace TestWebKitAPI {
+
+#if OS(DARWIN)
+void expectReleaseAssert(NOESCAPE const WTF::Function<void()>&);
+#endif
 
 template<size_t length>
 String utf16String(const char16_t (&url)[length])
@@ -46,4 +52,4 @@ String utf16String(const char16_t (&url)[length])
     return builder.toString();
 }
 
-}
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/darwin/WTFTestUtilitiesDarwin.cpp
+++ b/Tools/TestWebKitAPI/darwin/WTFTestUtilitiesDarwin.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WTFTestUtilities.h"
+
+#include <wtf/Assertions.h>
+
+namespace TestWebKitAPI {
+
+#if OS(DARWIN)
+
+constexpr int SIG_WK_WAITPID_ERROR = 101; // Signal for error when waiting for pid.
+
+// Taken from dt_waitpid() in libdarwintest.
+static bool wkWaitPID(pid_t pid, int* exitStatus, int* signalNumber)
+{
+    int status = 0;
+
+    auto handleError = ^{
+        LOG_ERROR("Return SIG_WK_WAITPID_ERROR for error during wkWaitPID()");
+        if (exitStatus)
+            *exitStatus = 0;
+        if (signalNumber)
+            *signalNumber = SIG_WK_WAITPID_ERROR;
+    };
+
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+            continue;
+        LOG_ERROR("waitpid(): errno=%d (%s)", errno, strerror(errno));
+        handleError();
+        return false;
+    }
+
+    if (WIFEXITED(status)) {
+        if (exitStatus)
+            *exitStatus = WEXITSTATUS(status);
+        if (signalNumber)
+            *signalNumber = 0;
+        return !WEXITSTATUS(status);
+    }
+
+    if (WIFSIGNALED(status)) {
+        if (exitStatus)
+            *exitStatus = 0;
+        if (signalNumber)
+            *signalNumber = WTERMSIG(status);
+        return false;
+    }
+
+    handleError();
+    return false;
+}
+
+static void signalHandler(int signal)
+{
+    exit(signal);
+}
+
+static void installSignalHandlers()
+{
+    signal(SIGTRAP, signalHandler);
+}
+
+void expectReleaseAssert(NOESCAPE const WTF::Function<void()>& crashingFunction)
+{
+    pid_t pid = fork();
+
+    EXPECT_NE(pid, -1);
+
+    if (!pid) {
+        // Child process.
+        installSignalHandlers();
+        crashingFunction();
+        exit(0); // Failure since we expect a crash.
+    }
+
+    int status = 0, signal = 0;
+    bool isSuccessfulExit = wkWaitPID(pid, &status, &signal);
+    EXPECT_TRUE(!isSuccessfulExit); // Expect to exit with non-zero status.
+    EXPECT_FALSE(WIFSIGNALED(signal)); // Child should not crash because signal was caught.
+    EXPECT_EQ(status, SIGTRAP); // Check for CRASH() from <wtf/Assertions.h>.
+}
+
+#endif // OS(DARWIN)
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 93d1a3e5d6ac67036e93855761227fb466e1f59d
<pre>
Make it possible to write tests that expect to crash
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=290827">https://bugs.webkit.org/show_bug.cgi?id=290827</a>&gt;
&lt;<a href="https://rdar.apple.com/148306045">rdar://148306045</a>&gt;

Reviewed by NOBODY (OOPS!).

This adds an expectReleaseAssert() helper method that takes a
WTF::Function parameter, then tests that it crashes by doing the
following:

1. Forks the current process.
2. Installs a signal handler in the child.
3. Runs the crashing WTF::Function in the child.
4. Catches the expected signal in the child.
5. Exits the child with an error status matching the signal value.
6. The parent waits for the child to exit, then checks its return value.

This code:
- Does not create a crash log when the expected behavior occurs.
- Does create a crash log when an unexpected crash/kill occurs.
- Includes expectations in expectReleaseAssert() to verify a crash would
  have occurred.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add WTFTestUtilitiesDarwin.cpp.
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, checked_objc_cast)):
- Add comments to each section about what they test.
- Use expectReleaseAssert() to test bad casts.
- Add FIXME comment to use the upcast helper when available.
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast)):
- Add comments to each section about what they test.
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)):
- Add comments to each section about what they test.
- Add FIXME comment to use the upcast helper when available.
- Add more tests for bad cast.
* Tools/TestWebKitAPI/WTFTestUtilities.h:
(TestWebKitAPI::expectReleaseAssert): Add declaration.
* Tools/TestWebKitAPI/darwin/WTFTestUtilitiesDarwin.cpp: Add.
(TestWebKitAPI::wkWaitPID):
- Taken from dt_waitpid() in the libdarwintest project.
(TestWebKitAPI::signalHandler):
(TestWebKitAPI::installSignalHandlers):
(TestWebKitAPI::expectReleaseAssert):
- Implement code to test for release assertions.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d1a3e5d6ac67036e93855761227fb466e1f59d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74392 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6208 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18048 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83446 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82877 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24711 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->