### PR TITLE
[Model Element] Enable stereo content rendering for simulator

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
@@ -61,13 +61,9 @@
     dispatch_once(&onceToken, ^{
         NSString * const debugFlag = @"ModelDebugEnableStereoContent";
         id value = [[NSUserDefaults standardUserDefaults] objectForKey:debugFlag];
-        if (![value isKindOfClass:NSNumber.class] && ![value isKindOfClass:NSString.class]) {
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-            stereoContentEnabled = NO;
-#else
+        if (![value isKindOfClass:NSNumber.class] && ![value isKindOfClass:NSString.class])
             stereoContentEnabled = YES;
-#endif
-        } else
+        else
             stereoContentEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:debugFlag];
 
         RELEASE_LOG_INFO(ModelElement, "Stereo content enabled: %d", stereoContentEnabled);


### PR DESCRIPTION
#### e9c11070524025bf9a5e40ab060d9b46714eb84f
<pre>
[Model Element] Enable stereo content rendering for simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=290830">https://bugs.webkit.org/show_bug.cgi?id=290830</a>
<a href="https://rdar.apple.com/145169448">rdar://145169448</a>

Reviewed by Mike Wyrzykowski.

If debug flag for stereo content is not set, default to YES for
both device and simulator.

* Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm:
(+[WKPageHostedModelView _usesStereoContent]):

Canonical link: <a href="https://commits.webkit.org/293058@main">https://commits.webkit.org/293058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52a31bc9973ce95faa9588380ff6301f19117570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13099 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24758 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18084 "Found 1 new test failure: ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82880 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20907 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29888 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->