### PR TITLE
[web-animations] `finish` animation event listener is not fired if registered in the `finished` promise

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation.html
@@ -133,6 +133,10 @@ promise_test(async t => {
     scroller.scrollTop =  maxScroll;
     await animation.finished;
 
+    // Wait for the next animation frame for the previous "finish"
+    // event to have dispatched.
+    await waitForNextFrame();
+
     var sent_finish_event = false;
     animation.onfinish = function() {
       sent_finish_event = true;

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation-expected.txt
@@ -19,4 +19,5 @@ PASS An exception should be thrown when finishing if the effective playback rate
 PASS An exception is NOT thrown when finishing if the effective playback rate is negative and the target effect end is infinity
 PASS Finishing an animation fires finish event on orphaned element
 PASS Finishing a canceled animation sets the current and start times
+PASS Finishing an animation fires finish event when a finish event listener is added as the finished promise resolves
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation.html
@@ -326,5 +326,13 @@ promise_test(async t => {
 
 }, 'Finishing a canceled animation sets the current and start times');
 
+promise_test(async t => {
+  const animation = createDiv(t).animate(null, 1);
+  await animation.finished;
+  const eventWatcher = new EventWatcher(t, animation, 'finish', waitForNextFrame);
+  await eventWatcher.wait_for('finish');
+}, 'Finishing an animation fires finish event when a finish event listener is '
+  + 'added as the finished promise resolves');
+
 </script>
 </body>

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1123,16 +1123,15 @@ void WebAnimation::finishNotificationSteps()
     //    queue along with its target, animation. For the scheduled event time, use the result of converting animation's target
     //    effect end to an origin-relative time.
     //    Otherwise, queue a task to dispatch finishEvent at animation. The task source for this task is the DOM manipulation task source.
-    if (hasEventListeners(eventNames().finishEvent)) {
-        auto scheduledTime = [&]() -> std::optional<WebAnimationTime> {
-            if (auto* documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline.get())) {
-                if (auto animationEndTime = convertAnimationTimeToTimelineTime(effectEndTime()))
-                    return documentTimeline->convertTimelineTimeToOriginRelativeTime(*animationEndTime);
-            }
-            return std::nullopt;
-        }();
-        enqueueAnimationPlaybackEvent(eventNames().finishEvent, currentTime(), scheduledTime);
-    }
+    auto scheduledTime = [&]() -> std::optional<WebAnimationTime> {
+        if (auto* documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline.get())) {
+            if (auto animationEndTime = convertAnimationTimeToTimelineTime(effectEndTime()))
+                return documentTimeline->convertTimelineTimeToOriginRelativeTime(*animationEndTime);
+        }
+        return std::nullopt;
+    }();
+    enqueueAnimationPlaybackEvent(eventNames().finishEvent, currentTime(), scheduledTime);
+
     if (auto keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get())) {
         if (RefPtr target = keyframeEffect->target()) {
             if (auto* page = target->document().page())


### PR DESCRIPTION
#### ee17ed1f873e979d15fe21ada5376d39db683acd
<pre>
[web-animations] `finish` animation event listener is not fired if registered in the `finished` promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=290836">https://bugs.webkit.org/show_bug.cgi?id=290836</a>

Reviewed by NOBODY (OOPS!).

Dispatch of animation events is asynchronous. The relevant steps of the &quot;update animations and send
events&quot; procedure [0] for events is:

1. advance the current time of an animation and enqueue animation events (if any),
2. perform a microtask checkpoint,
3. dispatch any queued animation events.

In the case of an animation that naturally advances to its finished state, a `finish` event would be
enqueued in step 1, then the `finished` promise would yield JS code execution in step 2, and finally
the `finish` event enqueued in step 1 would be dispatched in step 3.

As part of <a href="https://commits.webkit.org/262123@main">https://commits.webkit.org/262123@main</a> we made it so that we only enqueue `finish` events
if a `finish` event listener is currently registered. However, in the case where a `finish` event
listener is added after that event should have been enqueued, for instance during step 2 above,
then the `finish` event would not be dispatched.

We now remove this check and add an additional subtest to the WPT test devoted to testing the finishing
behavior of Web Animations in `web-animations/timing-model/animations/finishing-an-animation.html`.

Addressing this also brought to a light an issue in a Scroll-driven Animations WPT where we expected
that a `finished` promise resolving meant any pending `finish` event would have been dispatched. We
fix this test to wait another frame before making this assumption. That test passed in both Safari
and Chrome due to both browsers suffering from the issue being fixed here. A Chromium bug was filed [1].

[0] <a href="https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events">https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events</a>
[1] <a href="https://issues.chromium.org/issues/407497938">https://issues.chromium.org/issues/407497938</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/finishing-an-animation.html:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::finishNotificationSteps):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee17ed1f873e979d15fe21ada5376d39db683acd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31599 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104805 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83461 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82894 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18377 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->