### PR TITLE
Use-time currentcolor resolution in drop-shadow()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test currentcolor inheritance in drop-shadow()
+PASS Test currentcolor inheritance in drop-shadow() after color mutation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Filter Effects: Inheritance of 'currentcolor' in drop-shadow()</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#funcdef-filter-drop-shadow">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#filter {
+    color: red;
+    filter: drop-shadow(100px 0px 0px currentcolor);
+}
+#target {
+  background-color: black;
+  color: green;
+  width: 100px;
+  height: 100px;
+  filter: inherit;
+}
+</style>
+<div id="filter">
+  <div id="target"></div>
+</div>
+<script>
+test(function() {
+    assert_equals(getComputedStyle(target).filter, "drop-shadow(rgb(0, 128, 0) 100px 0px 0px)");
+}, "Test currentcolor inheritance in drop-shadow()");
+
+test(function() {
+    target.style.color = "blue";
+    assert_equals(getComputedStyle(target).filter, "drop-shadow(rgb(0, 0, 255) 100px 0px 0px)");
+}, "Test currentcolor inheritance in drop-shadow() after color mutation");
+
+</script>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2931,6 +2931,7 @@ rendering/shapes/ShapeOutsideInfo.cpp
 rendering/style/BorderData.cpp
 rendering/style/BorderValue.cpp
 rendering/style/ContentData.cpp
+rendering/style/DropShadowFilterOperationWithStyleColor.cpp
 rendering/style/FillLayer.cpp
 rendering/style/GapLength.cpp
 rendering/style/GridPosition.cpp

--- a/Source/WebCore/css/values/filter-effects/CSSFilterFunctionDescriptor.h
+++ b/Source/WebCore/css/values/filter-effects/CSSFilterFunctionDescriptor.h
@@ -75,13 +75,13 @@ template<> struct CSSFilterFunctionDescriptor<CSSValueDropShadow> {
     static constexpr bool isPixelFilterFunction = true;
     static constexpr bool isColorFilterFunction = false;
 
-    static constexpr auto defaultColorValue = Color::transparentBlack; // FIXME: This should be "currentcolor", but that requires filters to be able to store StyleColors.
+    static constexpr auto defaultColorValue = Style::CurrentColor { };
     static constexpr auto defaultStdDeviationValue = CSS::LengthRaw<> { CSS::LengthUnit::Px, 0 };
 
     static constexpr auto initialColorValueForInterpolation = Color::transparentBlack;
     static constexpr auto initialLengthValueForInterpolation = CSS::LengthRaw<> { CSS::LengthUnit::Px, 0 };
 
-    static constexpr auto operationType = FilterOperation::Type::DropShadow;
+    static constexpr auto operationType = FilterOperation::Type::DropShadowWithStyleColor;
 };
 
 // https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -477,7 +477,7 @@ void AcceleratedEffect::validateFilters(const AcceleratedEffectValues& baseValue
         // from the other filter operations and it will be applied to the layer as the last filer.
         ASSERT(longestFilterList);
         for (auto& operation : *longestFilterList) {
-            if (operation->type() == FilterOperation::Type::DropShadow && operation != longestFilterList->last())
+            if ((operation->type() == FilterOperation::Type::DropShadow || operation->type() == FilterOperation::Type::DropShadowWithStyleColor) && operation != longestFilterList->last())
                 return false;
         }
 

--- a/Source/WebCore/platform/animation/AnimationUtilities.h
+++ b/Source/WebCore/platform/animation/AnimationUtilities.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Color.h"
 #include "CompositeOperation.h"
 #include "IntPoint.h"
 #include "IterationCompositeOperation.h"
@@ -38,13 +39,17 @@ struct BlendingContext {
     CompositeOperation compositeOperation { CompositeOperation::Replace };
     IterationCompositeOperation iterationCompositeOperation { IterationCompositeOperation::Replace };
     double currentIteration { 0 };
+    Color fromCurrentColor { };
+    Color toCurrentColor { };
 
-    BlendingContext(double progress = 0, bool isDiscrete = false, CompositeOperation compositeOperation = CompositeOperation::Replace, IterationCompositeOperation iterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0)
+    BlendingContext(double progress = 0, bool isDiscrete = false, CompositeOperation compositeOperation = CompositeOperation::Replace, IterationCompositeOperation iterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0, Color fromCurrentColor = { }, Color toCurrentColor = { })
         : progress(progress)
         , isDiscrete(isDiscrete)
         , compositeOperation(compositeOperation)
         , iterationCompositeOperation(iterationCompositeOperation)
         , currentIteration(currentIteration)
+        , fromCurrentColor(fromCurrentColor)
+        , toCurrentColor(toCurrentColor)
     {
     }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3877,12 +3877,13 @@ bool GraphicsLayerCA::createFilterAnimationsFromKeyframes(const KeyframeValueLis
         return false;
 
     const FilterOperations& operations = static_cast<const FilterAnimationValue&>(valueList.at(listIndex)).value();
-    // Make sure the platform layer didn't fallback to using software filter compositing instead.
-    if (!filtersCanBeComposited(operations))
-        return false;
 
     // FIXME: We can't currently hardware animate shadows.
-    if (operations.hasFilterOfType<FilterOperation::Type::DropShadow>())
+    if (operations.hasFilterOfType<FilterOperation::Type::DropShadowWithStyleColor>())
+        return false;
+
+    // Make sure the platform layer didn't fallback to using software filter compositing instead.
+    if (!filtersCanBeComposited(operations))
         return false;
 
     removeAnimation(animationName, valueList.property());

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -62,6 +62,9 @@ static unsigned keyValueCountForFilter(const FilterOperation& filterOperation)
     case FilterOperation::Type::AppleInvertLightness:
         ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
         break;
+    case FilterOperation::Type::DropShadowWithStyleColor:
+        ASSERT_NOT_REACHED(); // Replaced by DropShadow.
+        break;
     case FilterOperation::Type::Passthrough:
         return 0;
     }
@@ -140,6 +143,7 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
         case FilterOperation::Type::Default:
         case FilterOperation::Type::Reference:
         case FilterOperation::Type::None:
+        case FilterOperation::Type::DropShadowWithStyleColor:
             ASSERT_NOT_REACHED();
             break;
         case FilterOperation::Type::DropShadow: {
@@ -189,6 +193,7 @@ void PlatformCAFilters::updatePresentationModifiers(const FilterOperations& filt
         case FilterOperation::Type::Default:
         case FilterOperation::Type::Reference:
         case FilterOperation::Type::None:
+        case FilterOperation::Type::DropShadowWithStyleColor:
             ASSERT_NOT_REACHED();
             return;
         case FilterOperation::Type::DropShadow: {
@@ -252,6 +257,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
         case FilterOperation::Type::Default:
         case FilterOperation::Type::Reference:
         case FilterOperation::Type::None:
+        case FilterOperation::Type::DropShadowWithStyleColor:
             ASSERT_NOT_REACHED();
             return nil;
         case FilterOperation::Type::DropShadow: {

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -939,6 +939,9 @@ bool PlatformCALayerCocoa::filtersCanBeComposited(const FilterOperations& filter
             if (i < (filters.size() - 1))
                 return false;
             break;
+        case FilterOperation::Type::DropShadowWithStyleColor:
+            ASSERT_NOT_REACHED();
+            break;
         default:
             break;
         }

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -27,6 +27,7 @@
 #include "FilterOperations.h"
 
 #include "AnimationUtilities.h"
+#include "DropShadowFilterOperationWithStyleColor.h"
 #include "FEGaussianBlur.h"
 #include "ImageBuffer.h"
 #include "IntSize.h"
@@ -81,8 +82,9 @@ IntOutsets FilterOperations::outsets() const
             totalOutsets += outsets;
             break;
         }
-        case FilterOperation::Type::DropShadow: {
-            auto& dropShadowOperation = downcast<DropShadowFilterOperation>(operation.get());
+        case FilterOperation::Type::DropShadow:
+        case FilterOperation::Type::DropShadowWithStyleColor: {
+            auto& dropShadowOperation = downcast<DropShadowFilterOperationBase>(operation.get());
             float stdDeviation = dropShadowOperation.stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
             
@@ -240,6 +242,15 @@ FilterOperations FilterOperations::blend(const FilterOperations& to, const Blend
     }
 
     return FilterOperations { WTFMove(operations) };
+}
+
+bool FilterOperations::requiresRepaintForCurrentColorChange() const
+{
+    for (auto& operation : m_operations) {
+        if (operation->requiresRepaintForCurrentColorChange())
+            return true;
+    }
+    return false;
 }
 
 TextStream& operator<<(TextStream& ts, const FilterOperations& filters)

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -85,6 +85,8 @@ public:
     bool transformColor(Color&) const;
     bool inverseTransformColor(Color&) const;
 
+    bool requiresRepaintForCurrentColorChange() const;
+
     WEBCORE_EXPORT bool canInterpolate(const FilterOperations&, CompositeOperation) const;
     WEBCORE_EXPORT FilterOperations blend(const FilterOperations&, const BlendingContext&) const;
 

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -28,6 +28,7 @@
 #include "CSSFilter.h"
 
 #include "ColorMatrix.h"
+#include "DropShadowFilterOperationWithStyleColor.h"
 #include "FEColorMatrix.h"
 #include "FEComponentTransfer.h"
 #include "FEDropShadow.h"
@@ -130,6 +131,12 @@ static RefPtr<FilterEffect> createDropShadowEffect(const DropShadowFilterOperati
 {
     float std = dropShadowOperation.stdDeviation();
     return FEDropShadow::create(std, std, dropShadowOperation.x(), dropShadowOperation.y(), dropShadowOperation.color(), 1);
+}
+
+static RefPtr<FilterEffect> createDropShadowEffect(const Style::DropShadowFilterOperationWithStyleColor& dropShadowOperation, const RenderStyle& style)
+{
+    float std = dropShadowOperation.stdDeviation();
+    return FEDropShadow::create(std, std, dropShadowOperation.x(), dropShadowOperation.y(), style.colorResolvingCurrentColor(dropShadowOperation.styleColor()), 1);
 }
 
 static RefPtr<FilterEffect> createGrayScaleEffect(const BasicColorMatrixFilterOperation& colorMatrixOperation)
@@ -262,6 +269,10 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
 
         case FilterOperation::Type::DropShadow:
             function = createDropShadowEffect(uncheckedDowncast<DropShadowFilterOperation>(operation));
+            break;
+
+        case FilterOperation::Type::DropShadowWithStyleColor:
+            function = createDropShadowEffect(uncheckedDowncast<Style::DropShadowFilterOperationWithStyleColor>(operation), renderer.style());
             break;
 
         case FilterOperation::Type::Grayscale:

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6271,7 +6271,21 @@ void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const Rend
     else if (m_filters)
         m_filters->removeReferenceFilterClients();
 
-    if (diff >= StyleDifference::RepaintLayer && oldStyle && oldStyle->filter() != renderer().style().filter())
+    auto filterChanged = [&] {
+        if (!m_filters)
+            return false;
+        if (diff < StyleDifference::RepaintLayer)
+            return false;
+        if (!oldStyle)
+            return false;
+        if (oldStyle->filter() != renderer().style().filter())
+            return true;
+        auto currentColorChanged = oldStyle->color() != renderer().style().color();
+        if (currentColorChanged && oldStyle->filter().requiresRepaintForCurrentColorChange())
+            return true;
+        return false;
+    };
+    if (filterChanged())
         clearLayerFilters();
 }
 

--- a/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp
+++ b/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DropShadowFilterOperationWithStyleColor.h"
+
+#include "ColorBlending.h"
+
+namespace WebCore {
+namespace Style {
+
+Ref<DropShadowFilterOperation> DropShadowFilterOperationWithStyleColor::createEquivalentWithResolvedColor(const RenderStyle& style)
+{
+    auto resolvedColor = m_styleColor.resolveColor(style.color());
+    return DropShadowFilterOperation::create(location(), stdDeviation(), resolvedColor);
+}
+
+bool DropShadowFilterOperationWithStyleColor::operator==(const FilterOperation& operation) const
+{
+    if (!isSameType(operation))
+        return false;
+    auto& other = downcast<DropShadowFilterOperationWithStyleColor>(operation);
+    return nonColorEqual(other) && m_styleColor == other.m_styleColor;
+}
+
+RefPtr<FilterOperation> DropShadowFilterOperationWithStyleColor::blend(const FilterOperation* from, const BlendingContext& context, bool blendToPassthrough)
+{
+    if (from && !from->isSameType(*this))
+        return this;
+
+    auto toColor = m_styleColor.resolveColor(context.toCurrentColor);
+
+    if (blendToPassthrough) {
+        return DropShadowFilterOperationWithStyleColor::create(
+            WebCore::blend(m_location, IntPoint(), context),
+            WebCore::blend(m_stdDeviation, 0, context),
+            WebCore::blend(toColor, WebCore::Color::transparentBlack, context));
+    }
+
+    auto* fromOperation = downcast<DropShadowFilterOperationWithStyleColor>(from);
+    IntPoint fromLocation = fromOperation ? fromOperation->location() : IntPoint();
+    int fromStdDeviation = fromOperation ? fromOperation->stdDeviation() : 0;
+
+    auto fromColor = fromOperation ? fromOperation->styleColor().resolveColor(context.fromCurrentColor) : WebCore::Color::transparentBlack;
+
+    return DropShadowFilterOperationWithStyleColor::create(
+        WebCore::blend(fromLocation, m_location, context),
+        std::max(WebCore::blend(fromStdDeviation, m_stdDeviation, context), 0),
+        WebCore::blend(fromColor, toColor, context));
+}
+
+void DropShadowFilterOperationWithStyleColor::dump(TextStream& ts) const
+{
+    ts << "drop-shadow("_s << x() << ' ' << y() << ' ' << location() << ' ';
+    ts << styleColor() << ')';
+}
+
+}
+}

--- a/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.h
+++ b/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FilterOperation.h"
+#include "StyleColor.h"
+
+namespace WebCore {
+namespace Style {
+
+class DropShadowFilterOperationWithStyleColor : public DropShadowFilterOperationBase {
+public:
+    static Ref<DropShadowFilterOperationWithStyleColor> create(const IntPoint& location, int stdDeviation, const Style::Color& color)
+    {
+        return adoptRef(*new DropShadowFilterOperationWithStyleColor(location, stdDeviation, color));
+    }
+
+    Ref<DropShadowFilterOperation> createEquivalentWithResolvedColor(const RenderStyle&);
+
+    Ref<FilterOperation> clone() const override
+    {
+        return adoptRef(*new DropShadowFilterOperationWithStyleColor(location(), stdDeviation(), m_styleColor));
+    }
+
+    const Style::Color& styleColor() const { return m_styleColor; }
+
+    RefPtr<FilterOperation> blend(const FilterOperation* from, const BlendingContext&, bool blendToPassthrough = false) override;
+
+private:
+    bool operator==(const FilterOperation&) const override;
+    bool requiresRepaintForCurrentColorChange() const override { return m_styleColor.containsCurrentColor(); }
+
+    void dump(TextStream&) const override;
+
+    DropShadowFilterOperationWithStyleColor(const IntPoint& location, int stdDeviation, const Style::Color& color)
+        : DropShadowFilterOperationBase(Type::DropShadowWithStyleColor, location, stdDeviation)
+        , m_styleColor(color)
+    {
+    }
+
+    Style::Color m_styleColor;
+};
+
+}
+}
+
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(Style::DropShadowFilterOperationWithStyleColor, type() == WebCore::FilterOperation::Type::DropShadowWithStyleColor)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1236,6 +1236,12 @@ bool RenderStyle::changeRequiresLayerRepaint(const RenderStyle& other, OptionSet
     }
 #endif
 
+    bool currentColorDiffers = m_inheritedData->color != other.m_inheritedData->color;
+    if (currentColorDiffers) {
+        if (filter().requiresRepaintForCurrentColorChange() || backdropFilter().requiresRepaintForCurrentColorChange())
+            return true;
+    }
+
     return false;
 }
 

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -54,7 +54,7 @@ static void interpolateStandardProperty(CSSPropertyID property, RenderStyle& des
         return;
 
     auto isDiscrete = !wrapper->canInterpolate(from, to, compositeOperation);
-    Context context { property, progress, isDiscrete, compositeOperation, iterationCompositeOperation, currentIteration, client };
+    Context context { property, progress, isDiscrete, compositeOperation, iterationCompositeOperation, currentIteration, from.color(), to.color(), client };
     if (!CSSProperty::animationUsesNonNormalizedDiscreteInterpolation(property))
         context.normalizeProgress();
     wrapper->interpolate(destination, from, to, context);
@@ -186,7 +186,7 @@ static std::pair<const CSSCustomPropertyValue*, const CSSCustomPropertyValue*> c
 
 static void interpolateCustomProperty(const AtomString& customProperty, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation compositeOperation, IterationCompositeOperation iterationCompositeOperation, double currentIteration, const Client& client)
 {
-    Context context { customProperty, progress, false, compositeOperation, iterationCompositeOperation, currentIteration, client };
+    Context context { customProperty, progress, false, compositeOperation, iterationCompositeOperation, currentIteration, from.color(), to.color(), client };
 
     auto [fromValue, toValue] = customPropertyValuesForInterpolation(customProperty, from, to);
     if (!fromValue || !toValue)

--- a/Source/WebCore/style/StyleInterpolationContext.h
+++ b/Source/WebCore/style/StyleInterpolationContext.h
@@ -41,8 +41,8 @@ struct Context : BlendingContext {
     const Client& client;
     AnimatableCSSProperty property;
 
-    Context(const AnimatableCSSProperty& property, double progress, bool isDiscrete, CompositeOperation compositeOperation, IterationCompositeOperation iterationCompositeOperation, double currentIteration, const Client& client)
-        : BlendingContext(progress, isDiscrete, compositeOperation, iterationCompositeOperation, currentIteration)
+    Context(const AnimatableCSSProperty& property, double progress, bool isDiscrete, CompositeOperation compositeOperation, IterationCompositeOperation iterationCompositeOperation, double currentIteration, WebCore::Color fromColor,  WebCore::Color toColor, const Client& client)
+        : BlendingContext(progress, isDiscrete, compositeOperation, iterationCompositeOperation, currentIteration, fromColor, toColor)
         , client(client)
         , property(property)
     {

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -387,7 +387,7 @@ inline Visibility blendFunc(Visibility from, Visibility to, const Context& conte
     if (fromVal == toVal)
         return to;
     // The composite operation here is irrelevant.
-    double result = blendFunc(fromVal, toVal, { context.property, context.progress, false, CompositeOperation::Replace, IterationCompositeOperation::Replace, 0, context.client });
+    double result = blendFunc(fromVal, toVal, { context.property, context.progress, false, CompositeOperation::Replace, IterationCompositeOperation::Replace, 0, { }, { }, context.client });
     return result > 0. ? Visibility::Visible : (to != Visibility::Visible ? to : from);
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -726,13 +726,8 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 
         includedProperties = { };
 
-        if (!inheritedStyleEqual) {
+        if (!inheritedStyleEqual)
             includedProperties.add(PropertyCascade::PropertyType::Inherited);
-            // FIXME: See toStyleColorWithResolvedCurrentColor().
-            bool mayContainResolvedCurrentcolor = style.disallowsFastPathInheritance() && hasExplicitlyInherited;
-            if (mayContainResolvedCurrentcolor && parentStyle.color() != cacheEntry->parentRenderStyle->color())
-                includedProperties.add(PropertyCascade::PropertyType::NonInherited);
-        }
         if (hasExplicitlyInherited)
             includedProperties.add(PropertyCascade::PropertyType::ExplicitlyInherited);
         if (!matchResult.nonCacheablePropertyIds.isEmpty())

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -340,18 +340,6 @@ Color toStyleColor(const CSS::Color& value, Ref<const Document> document, const 
     return toStyleColor(value, resolutionState);
 }
 
-Color toStyleColorWithResolvedCurrentColor(const CSS::Color& value, Ref<const Document> document, RenderStyle& style, const CSSToLengthConversionData& conversionData, ForVisitedLink forVisitedLink)
-{
-    // FIXME: 'currentcolor' should be resolved at use time to make it inherit correctly. https://bugs.webkit.org/show_bug.cgi?id=210005
-    if (CSS::containsCurrentColor(value)) {
-        // Color is an inherited property so depending on it effectively makes the property inherited.
-        style.setHasExplicitlyInheritedProperties();
-        style.setDisallowsFastPathInheritance();
-    }
-
-    return toStyleColor(value, document, style, conversionData, forVisitedLink);
-}
-
 auto ToCSS<Color>::operator()(const Color& value, const RenderStyle& style) -> CSS::Color
 {
     return CSS::Color { CSS::ResolvedColor { style.colorResolvingCurrentColor(value) } };

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -176,7 +176,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Color&);
 
 Color toStyleColor(const CSS::Color&, ColorResolutionState&);
 Color toStyleColor(const CSS::Color&, Ref<const Document>, const RenderStyle&, const CSSToLengthConversionData&, ForVisitedLink);
-Color toStyleColorWithResolvedCurrentColor(const CSS::Color&, Ref<const Document>, RenderStyle&, const CSSToLengthConversionData&, ForVisitedLink);
 
 template<> struct ToCSS<Color> {
     auto operator()(const Color&, const RenderStyle&) -> CSS::Color;

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -28,6 +28,7 @@
 #include "CSSDropShadowFunction.h"
 #include "CSSPrimitiveValue.h"
 #include "Document.h"
+#include "DropShadowFilterOperationWithStyleColor.h"
 #include "FilterOperation.h"
 #include "RenderStyle.h"
 #include "StyleColor.h"
@@ -36,10 +37,10 @@
 namespace WebCore {
 namespace Style {
 
-CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperation> operation, const RenderStyle& style)
+CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperationWithStyleColor> operation, const RenderStyle& style)
 {
     return {
-        .color = toCSS(Style::Color { operation->color() }, style),
+        .color = toCSS(operation->styleColor(), style),
         .location = {
             toCSS(Length<> { static_cast<float>(operation->location().x()) }, style),
             toCSS(Length<> { static_cast<float>(operation->location().y()) }, style)
@@ -53,12 +54,12 @@ Ref<FilterOperation> createFilterOperation(const CSS::DropShadow& filter, const 
     int x = roundForImpreciseConversion<int>(toStyle(filter.location.x(), conversionData).value);
     int y = roundForImpreciseConversion<int>(toStyle(filter.location.y(), conversionData).value);
     int stdDeviation = filter.stdDeviation ? roundForImpreciseConversion<int>(toStyle(*filter.stdDeviation, conversionData).value) : 0;
-    auto color = filter.color ? style.colorResolvingCurrentColor(toStyleColorWithResolvedCurrentColor(*filter.color, document, style, conversionData, ForVisitedLink::No)) : style.color();
+    auto color = filter.color ? toStyleColor(*filter.color, document, style, conversionData, ForVisitedLink::No) : Style::Color { CurrentColor { } };
 
-    return DropShadowFilterOperation::create(
+    return DropShadowFilterOperationWithStyleColor::create(
         IntPoint { x, y },
         stdDeviation,
-        color.isValid() ? color : WebCore::Color::transparentBlack
+        color
     );
 }
 

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.h
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.h
@@ -26,7 +26,6 @@
 
 namespace WebCore {
 
-class DropShadowFilterOperation;
 class CSSToLengthConversionData;
 class Document;
 class FilterOperation;
@@ -37,8 +36,9 @@ struct DropShadow;
 }
 
 namespace Style {
+class DropShadowFilterOperationWithStyleColor;
 
-CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperation>, const RenderStyle&);
+CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperationWithStyleColor>, const RenderStyle&);
 Ref<FilterOperation> createFilterOperation(const CSS::DropShadow&, const Document&, RenderStyle&, const CSSToLengthConversionData&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/filter-effects/StyleFilterProperty.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilterProperty.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSFilterProperty.h"
 #include "Document.h"
+#include "DropShadowFilterOperationWithStyleColor.h"
 #include "FilterOperations.h"
 #include "StyleBlurFunction.h"
 #include "StyleBrightnessFunction.h"
@@ -82,8 +83,8 @@ CSS::FilterProperty toCSSFilterProperty(const FilterOperations& filterOperations
         case FilterOperation::Type::Blur:
             list.value.append(CSS::BlurFunction { toCSSBlur(downcast<BlurFilterOperation>(op), style) });
             break;
-        case FilterOperation::Type::DropShadow:
-            list.value.append(CSS::DropShadowFunction { toCSSDropShadow(downcast<DropShadowFilterOperation>(op), style) });
+        case FilterOperation::Type::DropShadowWithStyleColor:
+            list.value.append(CSS::DropShadowFunction { toCSSDropShadow(downcast<DropShadowFilterOperationWithStyleColor>(op), style) });
             break;
         default:
             ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### e55d2e52f72128530e13f647633807cb30e7d4b6
<pre>
Use-time currentcolor resolution in drop-shadow()
<a href="https://bugs.webkit.org/show_bug.cgi?id=290835">https://bugs.webkit.org/show_bug.cgi?id=290835</a>
<a href="https://rdar.apple.com/148317306">rdar://148317306</a>

Reviewed by Sam Weinig.

Fix the last case where we resolve currentcolor at computed-value time.
Besides fixing the inheritance behavior this allows cleaning up various awkward leftovers in the codebase.

To achieve this without a layer violation we add a new FilterOperation type DropShadowFilterOperationWithStyleColor
that lives outside the platform layer. Drop-shadow filters in RenderStyle use this type. It gets resolved and converted to
DropShadowFilterOperation if it needs to passed to the platform layers/IPC.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-inheritance.html: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/animation/AnimationUtilities.h:
(WebCore::BlendingContext::BlendingContext):

Include current from/to colors so we can resolve currentcolor everywhere in blending code.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::keyValueCountForFilter):
(WebCore::PlatformCAFilters::presentationModifiers):
(WebCore::PlatformCAFilters::updatePresentationModifiers):
(WebCore::PlatformCAFilters::setFiltersOnLayer):
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::DropShadowFilterOperationBase::nonColorEqual const):
(WebCore::DropShadowFilterOperationBase::isIdentity const):
(WebCore::DropShadowFilterOperationBase::outsets const):
(WebCore::DropShadowFilterOperation::operator== const):
(WebCore::DropShadowFilterOperation::blend):
(WebCore::DropShadowFilterOperation::dump const):
(WebCore::operator&lt;&lt;):
(WebCore::DropShadowFilterOperation::isIdentity const): Deleted.
(WebCore::DropShadowFilterOperation::outsets const): Deleted.
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
(WebCore::FilterOperation::isDropShadowBase const):
(WebCore::FilterOperation::requiresRepaintForCurrentColorChange const):
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::requiresRepaintForCurrentColorChange const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::createDropShadowEffect):
(WebCore::CSSFilter::buildFilterFunctions):

Map to DropShadowFilterOperationWithStyleColor

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateFiltersAfterStyleChange):

Reset cached filter on currentcolor change if needed.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::resolveFilters):
(WebCore::RenderLayerBacking::updateFilters):
(WebCore::RenderLayerBacking::updateBackdropFilters):

Convert to DropShadowFilterOperation if needed.

* Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp: Added.
(WebCore::Style::DropShadowFilterOperationWithStyleColor::createEquivalentWithResolvedColor):
(WebCore::Style::DropShadowFilterOperationWithStyleColor::operator== const):
(WebCore::Style::DropShadowFilterOperationWithStyleColor::blend):
(WebCore::Style::DropShadowFilterOperationWithStyleColor::dump const):
* Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.h: Added.
(WebCore::Style::DropShadowFilterOperationWithStyleColor::create):
(WebCore::Style::DropShadowFilterOperationWithStyleColor::styleColor const):
(WebCore::Style::DropShadowFilterOperationWithStyleColor::DropShadowFilterOperationWithStyleColor):

The new style-only filter operation type is in the Style namespace.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayerRepaint const):
* Source/WebCore/style/StyleInterpolation.cpp:
(WebCore::Style::Interpolation::interpolateStandardProperty):
(WebCore::Style::Interpolation::interpolateCustomProperty):
* Source/WebCore/style/StyleInterpolationContext.h:
(WebCore::Style::Interpolation::Context::Context):
* Source/WebCore/style/StyleInterpolationFunctions.h:
(WebCore::Style::Interpolation::blendFunc):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::applyMatchedProperties):

Hack not needed anymore.

* Source/WebCore/style/values/color/StyleColor.cpp:
(WebCore::Style::toStyleColorWithResolvedCurrentColor): Deleted.

Hack not needed anymore.

* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
(WebCore::Style::toCSSDropShadow):
(WebCore::Style::createFilterOperation):
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.h:
* Source/WebCore/style/values/filter-effects/StyleFilterProperty.cpp:
(WebCore::Style::toCSSFilterProperty):

Canonical link: <a href="https://commits.webkit.org/293027@main">https://commits.webkit.org/293027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcba6ded386b26536e15aa5ba8aa453e7f143ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97721 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25799 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31620 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88337 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6330 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104829 "Hash fcba6ded for PR 43380 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/104829 "Hash fcba6ded for PR 43380 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84497 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/104829 "Hash fcba6ded for PR 43380 does not build (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5163 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18408 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24762 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->