### PR TITLE
[GTK][WPE] Damage should reset should unite when made full or a rect containing the bounding box is added

### DIFF
--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -141,6 +141,7 @@ public:
         m_rect = rect;
         m_mode = Mode::Full;
         m_rects.clear();
+        m_shouldUnite = false;
         initialize();
     }
 
@@ -167,6 +168,8 @@ public:
         const auto rectsCount = m_rects.size();
         if (!rectsCount || rect.contains(m_minimumBoundingRectangle)) {
             m_rects.clear();
+            if (m_mode == Mode::Rectangles)
+                m_shouldUnite = m_gridCells.width() == 1 && m_gridCells.height() == 1;
             m_rects.append(rect);
             m_minimumBoundingRectangle = rect;
             return true;
@@ -250,7 +253,7 @@ public:
             return false;
 
         // When both Damage are already united and have the same rect, we can just iterate the rects and unite them.
-        if (m_mode == Mode::Rectangles && m_shouldUnite && m_rect == other.m_rect && m_shouldUnite == other.m_shouldUnite) {
+        if (m_mode == Mode::Rectangles && m_shouldUnite && m_mode == other.m_mode && m_rect == other.m_rect && other.m_shouldUnite && m_rects.size() == other.m_rects.size()) {
             for (unsigned i = 0; i < m_rects.size(); ++i)
                 m_rects[i].unite(other.m_rects[i]);
             return true;

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -503,6 +503,21 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[1], IntRect(600, 300, 1, 1));
     EXPECT_EQ(damage.rects()[2], IntRect(300, 600, 1, 1));
     EXPECT_EQ(damage.rects()[3], IntRect(600, 600, 1, 1));
+
+    // Adding a rect covering the current bounding box makes the Damage no longer unified.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_TRUE(damage.add(IntRect { 250, 0, 254, 254 }));
+    EXPECT_EQ(damage.rects().size(), 1);
 }
 
 TEST(Damage, RectsForPainting)


### PR DESCRIPTION
#### 727e3a67027414a6ff88fa94a4b57b0d6a2346b6
<pre>
[GTK][WPE] Damage should reset should unite when made full or a rect containing the bounding box is added
<a href="https://bugs.webkit.org/show_bug.cgi?id=290839">https://bugs.webkit.org/show_bug.cgi?id=290839</a>

Reviewed by Alejandro G. Castro.

In those cases we are clearing the rects vector, so we should initialize m_shouldUnite too.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::makeFull):
(WebCore::Damage::add):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, Unite)):

Canonical link: <a href="https://commits.webkit.org/293004@main">https://commits.webkit.org/293004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/966d38ab341073bf72e756332c0571c53011fefe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13354 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6237 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47676 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82900 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18384 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15788 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24745 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24567 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->