### PR TITLE
wip

### DIFF
--- a/JSTests/stress/loop-unrolling-variable-with-switch-char.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-char.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x.length; i++) {
+        switch (x[i]) {
+            case 'a':
+                sum += 1;
+                break;
+            case 'b':
+                sum += 2;
+                break;
+            case 'c':
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(['a', 'b', 'c', 'd']);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/JSTests/stress/loop-unrolling-variable-with-switch-imm.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-imm.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x; i++) {
+        switch (i) {
+            case 0:
+                sum += 1;
+                break;
+            case 1:
+                sum += 2;
+                break;
+            case 2:
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(4);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/JSTests/stress/loop-unrolling-variable-with-switch-string.js
+++ b/JSTests/stress/loop-unrolling-variable-with-switch-string.js
@@ -1,0 +1,30 @@
+function test(x) {
+    let sum = 0;
+    for (let i = 0; i < x.length; i++) {
+        switch (x[i]) {
+            case 'aa':
+                sum += 1;
+                break;
+            case 'bb':
+                sum += 2;
+                break;
+            case 'cc':
+                sum += 3;
+                break;
+            default:
+                sum += 10;
+                break;
+        }
+    }
+    return sum;
+}
+noInline(test);
+
+let expected = 0;
+for (let i = 0; i < 1e5; i++) {
+    let res = test(['aa', 'bb', 'cc', 'dd']);
+    if (i == 0)
+        expected = res;
+    if (expected != res)
+        throw new Error("bad");
+}

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -119,6 +119,11 @@ CString CodeBlock::inferredName() const
     }
 }
 
+String CodeBlock::inferredNameAndHashAsString() const
+{
+    return makeString(inferredName(), "#"_s, hashAsStringIfPossible());
+}
+
 bool CodeBlock::hasHash() const
 {
     return !!m_hash;
@@ -163,7 +168,7 @@ CString CodeBlock::hashAsStringIfPossible() const
 
 void CodeBlock::dumpAssumingJITType(PrintStream& out, JITType jitType) const
 {
-    out.print(inferredName(), "#", hashAsStringIfPossible());
+    out.print(inferredNameAndHashAsString());
     out.print(":[", RawPointer(this), "->");
     if (!!m_alternative)
         out.print(RawPointer(alternative()), "->");

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -145,6 +145,7 @@ public:
     UnlinkedCodeBlock* unlinkedCodeBlock() const { return m_unlinkedCode.get(); }
 
     CString inferredName() const;
+    String inferredNameAndHashAsString() const;
     CodeBlockHash hash() const;
     bool hasHash() const;
     bool isSafeToComputeHash() const;

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.cpp
@@ -143,6 +143,14 @@ Node* CloneHelper::cloneNodeImpl(BasicBlock* into, Node* node)
             clone->child1() = cloneEdge(node->child1());
             return clone;
         }
+        case Switch: {
+            Node* clone = into->cloneAndAppend(m_graph, node);
+            SwitchData& cloneData = *m_graph.m_switchData.add();
+            cloneData = *clone->switchData();
+            clone->setOpInfo(OpInfo(&cloneData));
+            clone->child1() = cloneEdge(node->child1());
+            return clone;
+        }
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return nullptr;

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -53,6 +53,8 @@ private:
 };
 
 #define FOR_EACH_NODE_CLONE_STATUS(CLONE_STATUS) \
+    CLONE_STATUS(AllocatePropertyStorage, Common) /* alias of Transition */ \
+    CLONE_STATUS(ArithAbs, Common) \
     CLONE_STATUS(ArithAdd, Common) \
     CLONE_STATUS(ArithBitAnd, Common) \
     CLONE_STATUS(ArithBitLShift, Common) \
@@ -60,47 +62,237 @@ private:
     CLONE_STATUS(ArithBitOr, Common) \
     CLONE_STATUS(ArithBitRShift, Common) \
     CLONE_STATUS(ArithBitXor, Common) \
+    CLONE_STATUS(ArithCeil, Common) \
+    CLONE_STATUS(ArithClz32, Common) \
     CLONE_STATUS(ArithDiv, Common) \
+    CLONE_STATUS(ArithF16Round, Common) \
+    CLONE_STATUS(ArithFloor, Common) \
+    CLONE_STATUS(ArithFRound, Common) \
+    CLONE_STATUS(ArithIMul, Common) \
+    CLONE_STATUS(ArithMax, Common) \
+    CLONE_STATUS(ArithMin, Common) \
     CLONE_STATUS(ArithMod, Common) \
     CLONE_STATUS(ArithMul, Common) \
+    CLONE_STATUS(ArithNegate, Common) \
+    CLONE_STATUS(ArithPow, Common) \
+    CLONE_STATUS(ArithRandom, Common) \
+    CLONE_STATUS(ArithRound, Common) \
+    CLONE_STATUS(ArithSqrt, Common) \
     CLONE_STATUS(ArithSub, Common) \
+    CLONE_STATUS(ArithTrunc, Common) \
+    CLONE_STATUS(ArithUnary, Common) \
+    CLONE_STATUS(ArrayIncludes, Common) \
+    CLONE_STATUS(ArrayIndexOf, Common) \
+    CLONE_STATUS(ArrayPop, Common) \
+    CLONE_STATUS(ArrayPush, Common) \
+    CLONE_STATUS(ArraySlice, Common) \
+    CLONE_STATUS(ArraySplice, Common) \
+    CLONE_STATUS(Arrayify, Common) \
     CLONE_STATUS(ArrayifyToStructure, Common) \
     CLONE_STATUS(AssertNotEmpty, Common) \
     CLONE_STATUS(BitURShift, Common) \
+    CLONE_STATUS(BooleanToNumber, Common) \
+    CLONE_STATUS(BottomValue, Common) \
     CLONE_STATUS(Branch, Special) \
+    CLONE_STATUS(Call, Common) \
+    CLONE_STATUS(CallCustomAccessorGetter, Common) /* alias of CallCustomAccessorData */ \
+    CLONE_STATUS(CallDirectEval, Common) \
+    CLONE_STATUS(CallVarargs, Common) /* alias of CallVarargsData */ \
     CLONE_STATUS(Check, Common) \
     CLONE_STATUS(CheckArray, Common) \
+    CLONE_STATUS(CheckBadValue, Common) \
+    CLONE_STATUS(CheckIdent, Common) \
+    CLONE_STATUS(CheckIsConstant, Common) \
+    CLONE_STATUS(CheckNotEmpty, Common) \
     CLONE_STATUS(CheckStructure, Common) \
+    CLONE_STATUS(CheckStructureOrEmpty, Common) \
     CLONE_STATUS(CheckVarargs, Common) \
+    CLONE_STATUS(CompareBelow, Common) \
+    CLONE_STATUS(CompareBelowEq, Common) \
     CLONE_STATUS(CompareEq, Common) \
+    CLONE_STATUS(CompareEqPtr, Common) \
     CLONE_STATUS(CompareGreater, Common) \
     CLONE_STATUS(CompareGreaterEq, Common) \
     CLONE_STATUS(CompareLess, Common) \
     CLONE_STATUS(CompareLessEq, Common) \
     CLONE_STATUS(CompareStrictEq, Common) \
+    CLONE_STATUS(ConstantStoragePointer, Common) \
+    CLONE_STATUS(Construct, Common) \
+    CLONE_STATUS(ConstructVarargs, Common) /* alias of CallVarargsData */ \
+    CLONE_STATUS(CreateActivation, Common) \
+    CLONE_STATUS(CreateDirectArguments, Common) \
+    CLONE_STATUS(CreateRest, Common) \
+    CLONE_STATUS(DataViewGetByteLength, Common) \
+    CLONE_STATUS(DataViewGetByteLengthAsInt52, Common) \
+    CLONE_STATUS(DataViewGetFloat, Common) \
+    CLONE_STATUS(DataViewGetInt, Common) \
+    CLONE_STATUS(DataViewSet, Common) /* alias of DataViewData */ \
+    CLONE_STATUS(DateGetTime, Common) \
+    CLONE_STATUS(DateSetTime, Common) \
+    CLONE_STATUS(Dec, Common) \
+    CLONE_STATUS(DeleteById, Common) \
+    CLONE_STATUS(DirectCall, Common) \
+    CLONE_STATUS(DirectConstruct, Common) \
+    CLONE_STATUS(DirectTailCallInlinedCaller, Common) \
+    CLONE_STATUS(DoubleAsInt32, Common) \
+    CLONE_STATUS(DoubleConstant, Common) \
     CLONE_STATUS(DoubleRep, Common) \
+    CLONE_STATUS(EnumeratorGetByVal, Common) \
+    CLONE_STATUS(EnumeratorHasOwnProperty, Common) \
+    CLONE_STATUS(EnumeratorNextUpdateIndexAndMode, Common) \
+    CLONE_STATUS(EnumeratorNextUpdatePropertyName, Common) \
+    CLONE_STATUS(EnumeratorPutByVal, Common) \
     CLONE_STATUS(ExitOK, Common) \
+    CLONE_STATUS(ExtractFromTuple, Common) \
     CLONE_STATUS(FilterCallLinkStatus, Common) \
+    CLONE_STATUS(FilterGetByStatus, Common) /* alias of GetByStatus */ \
+    CLONE_STATUS(FilterInByStatus, Common) /* alias of InByStatus */ \
+    CLONE_STATUS(FilterPutByStatus, Common) /* alias of PutByStatus */ \
     CLONE_STATUS(Flush, Common) \
+    CLONE_STATUS(GetArrayLength, Common) \
     CLONE_STATUS(GetButterfly, Common) \
+    CLONE_STATUS(GetById, Common) /* alias GetByIdData */ \
+    CLONE_STATUS(GetByIdFlush, Common) /* alias GetByIdData */ \
+    CLONE_STATUS(GetByIdMegamorphic, Common) /* alias of GetByIdData */ \
+    CLONE_STATUS(GetByIdWithThis, Common) /* alias of GetByIdData */ \
+    CLONE_STATUS(GetByIdWithThisMegamorphic, Common) /* alias of GetByIdData */ \
+    CLONE_STATUS(GetByOffset, Common) /* alias of StorageAccessData */ \
     CLONE_STATUS(GetByVal, Common) \
+    CLONE_STATUS(GetByValMegamorphic, Common) \
+    CLONE_STATUS(GetByValWithThis, Common) \
+    CLONE_STATUS(GetByValWithThisMegamorphic, Common) \
+    CLONE_STATUS(GetClosureVar, Common) \
+    CLONE_STATUS(GetExecutable, Common) \
+    CLONE_STATUS(GetGlobalLexicalVariable, Common) \
+    CLONE_STATUS(GetGlobalVar, Common) \
+    CLONE_STATUS(GetIndexedPropertyStorage, Common) \
+    CLONE_STATUS(GetInternalField, Common) \
     CLONE_STATUS(GetLocal, Common) \
+    CLONE_STATUS(GetPropertyEnumerator, Common) \
+    CLONE_STATUS(GetPrototypeOf, Common) \
+    CLONE_STATUS(GetRegExpObjectLastIndex, Common) \
+    CLONE_STATUS(GetRestLength, Common) \
+    CLONE_STATUS(GetScope, Common) \
+    CLONE_STATUS(GetUndetachedTypeArrayLength, Common) \
+    CLONE_STATUS(GlobalIsNaN, Common) \
+    CLONE_STATUS(HasOwnProperty, Common) \
+    CLONE_STATUS(HasIndexedProperty, Common) \
+    CLONE_STATUS(InById, Common) \
+    CLONE_STATUS(InByVal, Common) \
+    CLONE_STATUS(InByValMegamorphic, Common) \
+    CLONE_STATUS(Inc, Common) \
+    CLONE_STATUS(InstanceOf, Common) \
+    CLONE_STATUS(InstanceOfCustom, Common) \
+    CLONE_STATUS(InstanceOfMegamorphic, Common) \
+    CLONE_STATUS(Int52Constant, Common) \
+    CLONE_STATUS(Int52Rep, Common) \
     CLONE_STATUS(InvalidationPoint, Common) \
+    CLONE_STATUS(IsCellWithType, Common) \
+    CLONE_STATUS(IsEmptyStorage, Common) \
+    CLONE_STATUS(IsNumber, Common) \
+    CLONE_STATUS(IsObject, Common) \
     CLONE_STATUS(JSConstant, Common) \
     CLONE_STATUS(Jump, Common) \
+    CLONE_STATUS(LoadMapValue, Common) \
+    CLONE_STATUS(LoadVarargs, Common) /* alias of LoadVarargsData */ \
+    CLONE_STATUS(LogicalNot, Common) \
     CLONE_STATUS(LoopHint, Common) \
+    CLONE_STATUS(MakeAtomString, Common) \
+    CLONE_STATUS(MakeRope, Common) \
+    CLONE_STATUS(MapGet, Common) \
+    CLONE_STATUS(MapHash, Common) \
+    CLONE_STATUS(MapIteratorKey, Common) \
+    CLONE_STATUS(MapIteratorNext, Common) \
+    CLONE_STATUS(MapIteratorValue, Common) \
+    CLONE_STATUS(MapSet, Common) \
+    CLONE_STATUS(MatchStructure, Common) /* alias of MatchStructureData */ \
     CLONE_STATUS(MovHint, Common) \
+    CLONE_STATUS(MultiGetByOffset, Common) /* alias of MultiGetByOffsetData */ \
+    CLONE_STATUS(MultiPutByOffset, Common) /* alias of MultiPutByOffsetData */ \
+    CLONE_STATUS(NewArray, Common) \
+    CLONE_STATUS(NewArrayBuffer, Common) \
     CLONE_STATUS(NewArrayWithConstantSize, Common) \
     CLONE_STATUS(NewArrayWithSize, Common) \
+    CLONE_STATUS(NewArrayWithSpread, Common) /* alias of BitVector */ \
+    CLONE_STATUS(NewFunction, Common) \
+    CLONE_STATUS(NewInternalFieldObject, Common) \
+    CLONE_STATUS(NewMap, Common) \
+    CLONE_STATUS(NewObject, Common) \
+    CLONE_STATUS(NewRegExp, Common) \
+    CLONE_STATUS(NewRegExpUntyped, Common) \
+    CLONE_STATUS(NewSet, Common) \
+    CLONE_STATUS(NormalizeMapKey, Common) \
+    CLONE_STATUS(NumberToStringWithValidRadixConstant, Common) \
+    CLONE_STATUS(NukeStructureAndSetButterfly, Common) \
+    CLONE_STATUS(ObjectAssign, Common) \
+    CLONE_STATUS(ObjectKeys, Common) \
+    CLONE_STATUS(ObjectToString, Common) \
+    CLONE_STATUS(ParseInt, Common) \
     CLONE_STATUS(PhantomLocal, Common) \
     CLONE_STATUS(Phi, PreCloned) \
     CLONE_STATUS(PurifyNaN, Common) \
+    CLONE_STATUS(PutById, Common) \
+    CLONE_STATUS(PutByIdFlush, Common) \
+    CLONE_STATUS(PutByIdMegamorphic, Common) \
+    CLONE_STATUS(PutByIdWithThis, Common) \
+    CLONE_STATUS(PutByOffset, Common) /* alias of StorageAccessData */ \
     CLONE_STATUS(PutByVal, Common) \
     CLONE_STATUS(PutByValAlias, Common) \
-    CLONE_STATUS(SetArgumentDefinitely, Common) \
+    CLONE_STATUS(PutByValDirect, Common) \
+    CLONE_STATUS(PutByValWithThis, Common) \
+    CLONE_STATUS(PutClosureVar, Common) \
+    CLONE_STATUS(PutGlobalVariable, Common) \
+    CLONE_STATUS(PutInternalField, Common) \
+    CLONE_STATUS(PutStructure, Common) /* alias of Transition */ \
+    CLONE_STATUS(ReallocatePropertyStorage, Common) /* alias of Transition */ \
+    CLONE_STATUS(RegExpTest, Common) \
+    CLONE_STATUS(RegExpTestInline, Common) \
+    CLONE_STATUS(ResolveRope, Common) \
+    CLONE_STATUS(SameValue, Common) \
+    CLONE_STATUS(SetAdd, Common) \
+    CLONE_STATUS(SetArgumentCountIncludingThis, Common) \
+    CLONE_STATUS(SetArgumentDefinitely, Common) /* alias of VariableAccessData */ \
+    CLONE_STATUS(SetArgumentMaybe, Common) /* alias of VariableAccessData */ \
+    CLONE_STATUS(SetCallee, Common) \
     CLONE_STATUS(SetLocal, Common) \
+    CLONE_STATUS(SkipScope, Common) \
+    CLONE_STATUS(Spread, Common) \
+    CLONE_STATUS(StringCharAt, Common) \
+    CLONE_STATUS(StringCharCodeAt, Common) \
+    CLONE_STATUS(StringCodePointAt, Common) \
+    CLONE_STATUS(StringFromCharCode, Common) \
+    CLONE_STATUS(StringIndexOf, Common) \
+    CLONE_STATUS(StringLocaleCompare, Common) \
+    CLONE_STATUS(StringReplace, Common) \
+    CLONE_STATUS(StringReplaceString, Common) \
+    CLONE_STATUS(StringSlice, Common) \
+    CLONE_STATUS(StringSubstring, Common) \
+    CLONE_STATUS(StrCat, Common) \
+    CLONE_STATUS(Switch, Special) \
+    CLONE_STATUS(TailCallForwardVarargsInlinedCaller, Common) /* alias of CallVarargsData */ \
+    CLONE_STATUS(TailCallInlinedCaller, Common) \
+    CLONE_STATUS(TailCallVarargsInlinedCaller, Common) /* alias of CallVarargsData */ \
+    CLONE_STATUS(ToLength, Common) \
+    CLONE_STATUS(ToLowerCase, Common) \
+    CLONE_STATUS(ToPrimitive, Common) \
+    CLONE_STATUS(ToString, Common) \
+    CLONE_STATUS(ToThis, Common) \
+    CLONE_STATUS(TypeOf, Common) \
+    CLONE_STATUS(TypeOfIsFunction, Common) \
+    CLONE_STATUS(TypeOfIsObject, Common) \
+    CLONE_STATUS(TypeOfIsUndefined, Common) \
+    CLONE_STATUS(UInt32ToNumber, Common) \
+    CLONE_STATUS(ValueAdd, Common) \
+    CLONE_STATUS(ValueBitAnd, Common) \
+    CLONE_STATUS(ValueBitLShift, Common) \
+    CLONE_STATUS(ValueBitOr, Common) \
+    CLONE_STATUS(ValueBitRShift, Common) \
+    CLONE_STATUS(ValueBitXor, Common) \
+    CLONE_STATUS(ValueNegate, Common) \
     CLONE_STATUS(ValueRep, Common) \
+    CLONE_STATUS(ValueSub, Common) \
     CLONE_STATUS(ValueToInt32, Common) \
+    CLONE_STATUS(VarargsLength, Common) /* alias of LoadVarargsData */ \
     CLONE_STATUS(ZombieHint, Common)
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -444,6 +444,9 @@ public:
 
                 if (!CloneHelper::isNodeCloneable(m_graph, cloneableCache, node)) {
                     dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since D@", node->index(), " with op ", node->op(), " is not cloneable");
+                    if (node->op() != ForceOSRExit) {
+                        // dataLogLn("Function: ", m_graph.m_codeBlock->inferredNameAndHashAsString(), " skipping loop with header ", *data.header(), " since D@", node->index(), " with op ", node->op(), " is not cloneable");
+                    }
                     return false;
                 }
             }
@@ -494,7 +497,7 @@ public:
         //  BodyGraph_1 -----       -- BodyGraph_1  |
         //   |T                         |F          |
         //  Next                       Next <--------
-        auto convertTailBranchToNextJump = [&](BasicBlock* tail, BasicBlock* taken) {
+        auto updateTailBranch = [&](BasicBlock* tail, BasicBlock* taken) {
             BasicBlock* notTaken = next;
             auto* terminal = tail->terminal();
             if (data.isOperandConstant()) {
@@ -510,7 +513,8 @@ public:
                 tail->insertBeforeTerminal(constant);
                 terminal->child1() = Edge(constant, KnownBooleanUse);
                 notTaken = header;
-            }
+            } else if (data.inverseCondition.value())
+                std::swap(taken, notTaken);
 
             terminal->branchData()->taken = BranchTarget(taken);
             terminal->branchData()->notTaken = BranchTarget(notTaken);
@@ -565,7 +569,7 @@ public:
                 if (body == tail) {
                     ASSERT(tail->terminal()->isBranch());
                     bool isTakenNextInPartialMode = taken == next && !data.isOperandConstant();
-                    convertTailBranchToNextJump(clone, isTakenNextInPartialMode ? header : taken);
+                    updateTailBranch(clone, isTakenNextInPartialMode ? header : taken);
                 } else {
                     for (uint32_t i = 0; i < body->numSuccessors(); ++i) {
                         auto& successor = clone->successor(i);
@@ -580,7 +584,7 @@ public:
         }
 
         // 6. Replace the original loop tail branch with a jump to the last header clone.
-        convertTailBranchToNextJump(tail, taken);
+        updateTailBranch(tail, taken);
 
         // Done clone.
         if (!m_blockInsertionSet.execute()) {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -582,7 +582,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, useLoopUnrolling, true, Normal, nullptr) \
-    v(Bool, usePartialLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, usePartialLoopUnrolling, true, Normal, nullptr) \
     v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
     v(Bool, disallowLoopUnrollingForNonInnermost, false, Normal, nullptr) \
     v(Unsigned, maxLoopUnrollingCount, 2, Normal, nullptr) \


### PR DESCRIPTION
#### 5ce14960a21b33c620a8b40176d0f68b6621cede
<pre>
wip
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce14960a21b33c620a8b40176d0f68b6621cede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97945 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48475 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74584 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13540 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88533 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13317 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6450 "Found 1 new test failure: workers/bomb.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47917 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90673 "Found 13 new JSC stress test failures: stress/getbyoffset-cse-consistency-2.js.ftl-eager-no-cjit, stress/getbyoffset-cse-consistency-2.js.ftl-eager-no-cjit-b3o1, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-no-inline-validate, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-no-put-stack-validate, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-validate-sampling-profiler, sunspider-1.0/string-fasta.js.ftl-eager, sunspider-1.0/string-fasta.js.ftl-eager-no-cjit, sunspider-1.0/string-fasta.js.ftl-eager-no-cjit-b3o1, sunspider-1.0/string-fasta.js.ftl-no-cjit-b3o0, sunspider-1.0/string-fasta.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105439 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96568 "Found 13 new JSC stress test failures: stress/getbyoffset-cse-consistency-2.js.ftl-eager-no-cjit, stress/getbyoffset-cse-consistency-2.js.ftl-eager-no-cjit-b3o1, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-no-inline-validate, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-no-put-stack-validate, stress/getbyoffset-cse-consistency-2.js.ftl-no-cjit-validate-sampling-profiler, sunspider-1.0/string-fasta.js.ftl-eager, sunspider-1.0/string-fasta.js.ftl-eager-no-cjit, sunspider-1.0/string-fasta.js.ftl-eager-no-cjit-b3o1, sunspider-1.0/string-fasta.js.ftl-no-cjit-b3o0, sunspider-1.0/string-fasta.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25025 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18242 "Found 1 new test failure: fast/block/inside-inlines/basic-float-intrusion.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83024 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18649 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30155 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120193 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24808 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33704 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->