### PR TITLE
WebRTC encoded transform is transferring the RTC encoded frame array buffer

### DIFF
--- a/LayoutTests/http/wpt/webrtc/audio-video-transform.js
+++ b/LayoutTests/http/wpt/webrtc/audio-video-transform.js
@@ -9,6 +9,10 @@ class AudioVideoRTCRtpTransformer {
                 this.trySendKeyFrameRequest = true;
             else if (event.data === "tryGenerateKeyFramePromiseHandling")
                 this.tryGenerateKeyFramePromiseHandling = true;
+            else if (event.data === "checkDataAfterWrite")
+                this.checkDataAfterWrite = true;
+            else if (event.data === "checkModifiedDataAfterWrite")
+                this.checkModifiedDataAfterWrite = true;
             else if (event.data === "tryAccessingDataTwice")
                 this.tryAccessingDataTwice = true;
             else if (event.data === "tryAccessingMetadata")
@@ -41,7 +45,22 @@ class AudioVideoRTCRtpTransformer {
                 this.context.options.port.postMessage(chunk.value.getMetadata());
             }
 
+           let valueData = null;
+           if (this.checkModifiedDataAfterWrite)
+               valueData = structuredClone(chunk.value.data);
+
             this.writer.write(chunk.value);
+
+            if (this.checkDataAfterWrite) {
+                this.checkDataAfterWrite = false;
+                this.context.options.port.postMessage(!chunk.value.length ? "PASS" : "FAIL");
+            }
+
+            if (this.checkModifiedDataAfterWrite) {
+                this.checkModifiedDataAfterWrite = false;
+                this.context.options.port.postMessage((!chunk.value.length && !valueData.length) ? "PASS" : "FAIL");
+            }
+
 
             if (this.tryGenerateKeyFrame) {
                 this.tryGenerateKeyFrame = false;

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
@@ -6,6 +6,8 @@ PASS key frame on audio receiver
 PASS generate key frame on video receiver
 PASS send request key frame on video sender
 PASS generate key frame promise handling on video sender
+PASS Check data after write
+PASS Check modified data after write
 PASS Check data getter
 PASS Check metadata getter
 

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
@@ -103,6 +103,34 @@ promise_test((test) => {
 }, "generate key frame promise handling on video sender");
 
 promise_test(async (test) => {
+    audioReceiverTransform.port.postMessage("checkDataAfterWrite");
+    await waitForMessage(audioReceiverTransform.port, "PASS");
+
+    audioSenderTransform.port.postMessage("checkDataAfterWrite");
+    await waitForMessage(audioSenderTransform.port, "PASS");
+
+    videoReceiverTransform.port.postMessage("checkDataAfterWrite");
+    await waitForMessage(videoReceiverTransform.port, "PASS");
+
+    videoSenderTransform.port.postMessage("checkDataAfterWrite");
+    await waitForMessage(videoSenderTransform.port, "PASS");
+}, "Check data after write");
+
+promise_test(async (test) => {
+    audioReceiverTransform.port.postMessage("checkModifiedDataAfterWrite");
+    await waitForMessage(audioReceiverTransform.port, "PASS");
+
+    audioSenderTransform.port.postMessage("checkModifiedDataAfterWrite");
+    await waitForMessage(audioSenderTransform.port, "PASS");
+
+    videoReceiverTransform.port.postMessage("checkModifiedDataAfterWrite");
+    await waitForMessage(videoReceiverTransform.port, "PASS");
+
+    videoSenderTransform.port.postMessage("checkModifiedDataAfterWrite");
+    await waitForMessage(videoSenderTransform.port, "PASS");
+}, "Check modified data after write");
+
+promise_test(async (test) => {
     audioReceiverTransform.port.postMessage("tryAccessingDataTwice");
     await waitForExpectedMessage(audioReceiverTransform.port, "PASS");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https-expected.txt
@@ -1,7 +1,7 @@
 
 
-FAIL Receiver and sender read, modifiy and write video frames. assert_equals: expected "got expected" but got "unexpected value: lastByte (got 1, expected 1),  frame data length (got 532, expected 0), rtpTimestamp (got undefined, expected null)"
-FAIL Receiver and sender read, modifiy and write audio frames. assert_equals: expected "got expected" but got "unexpected value: lastByte (got 1, expected 1),  frame data length (got 98, expected 0), rtpTimestamp (got undefined, expected null)"
+PASS Receiver and sender read, modifiy and write video frames.
+PASS Receiver and sender read, modifiy and write audio frames.
 PASS Sender reads frames but doesn't write them back. Receiver doesn't receive any frames.
 PASS Sender skips some frames and only writes one back. Receiver only receives that frame.
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -41,7 +41,7 @@ RTCEncodedFrame::RTCEncodedFrame(Ref<RTCRtpTransformableFrame>&& frame)
 RefPtr<JSC::ArrayBuffer> RTCEncodedFrame::data() const
 {
     if (!m_data)
-        m_data = JSC::ArrayBuffer::create(m_frame->data());
+        m_data = m_isNeutered ? JSC::ArrayBuffer::create(static_cast<size_t>(0U), 1) : JSC::ArrayBuffer::create(m_frame->data());
     return m_data;
 }
 
@@ -50,11 +50,18 @@ void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
     m_data = &buffer;
 }
 
-Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame()
+Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame(JSC::VM& vm, ShouldNeuter shouldNeuter)
 {
-    if (m_data) {
-        m_frame->setData(m_data->span());
-        m_data = nullptr;
+    ASSERT(!m_isNeutered);
+    if (shouldNeuter == ShouldNeuter::Yes) {
+        m_isNeutered = true;
+        if (m_data) {
+            m_frame->setData(m_data->span());
+
+            JSC::ArrayBufferContents emptyBuffer;
+            bool result = m_data->transferTo(vm, emptyBuffer);
+            ASSERT_UNUSED(result, result);
+        }
     }
     return m_frame;
 }

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
@@ -34,6 +34,7 @@
 
 namespace JSC {
 class ArrayBuffer;
+class VM;
 }
 
 namespace WebCore {
@@ -45,7 +46,8 @@ public:
     RefPtr<JSC::ArrayBuffer> data() const;
     void setData(JSC::ArrayBuffer&);
 
-    Ref<RTCRtpTransformableFrame> rtcFrame();
+    enum class ShouldNeuter : bool { No, Yes };
+    Ref<RTCRtpTransformableFrame> rtcFrame(JSC::VM&, ShouldNeuter = ShouldNeuter::Yes);
 
     Ref<RTCRtpTransformableFrame> serialize();
 
@@ -54,6 +56,7 @@ protected:
 
     Ref<RTCRtpTransformableFrame> m_frame;
     mutable RefPtr<JSC::ArrayBuffer> m_data;
+    bool m_isNeutered { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -204,7 +204,8 @@ static void transformFrame(std::span<const uint8_t> data, JSDOMGlobalObject& glo
 template<typename Frame>
 void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const ThreadSafeWeakPtr<RTCRtpSFrameTransform>& weakTransform)
 {
-    auto rtcFrame = frame.rtcFrame();
+    Ref vm = globalObject.vm();
+    auto rtcFrame = frame.rtcFrame(vm, RTCEncodedFrame::ShouldNeuter::No);
     auto chunk = rtcFrame->data();
     auto result = processFrame(chunk, transformer, identifier, weakTransform);
     std::span<const uint8_t> transformedChunk;

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -99,7 +99,8 @@ ExceptionOr<Ref<WritableStream>> RTCRtpScriptTransformer::writable()
                 return Exception { ExceptionCode::InvalidStateError };
 
             auto& globalObject = *context.globalObject();
-            auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
+            Ref vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
 
             auto frameConversionResult = convert<IDLUnion<IDLInterface<RTCEncodedAudioFrame>, IDLInterface<RTCEncodedVideoFrame>>>(globalObject, value);
             if (UNLIKELY(frameConversionResult.hasException(scope)))
@@ -107,9 +108,9 @@ ExceptionOr<Ref<WritableStream>> RTCRtpScriptTransformer::writable()
 
             auto frame = frameConversionResult.releaseReturnValue();
             auto rtcFrame = WTF::switchOn(frame, [&](RefPtr<RTCEncodedAudioFrame>& value) {
-                return value->rtcFrame();
+                return value->rtcFrame(vm);
             }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
-                return value->rtcFrame();
+                return value->rtcFrame(vm);
             });
 
             // If no data, skip the frame since there is nothing to packetize or decode.


### PR DESCRIPTION
#### 46084f77562256a58a623e8267d7b016c84e06d4
<pre>
WebRTC encoded transform is transferring the RTC encoded frame array buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=290850">https://bugs.webkit.org/show_bug.cgi?id=290850</a>
<a href="https://rdar.apple.com/problem/148343876">rdar://problem/148343876</a>

Reviewed by Eric Carlson.

As per spec, the encoded frame array buffer should be transferred when written to the writable stream.
We do so and add a test to validate this.
We do not need to neuter the frame array buffer for SFrameTransform since it is just passing the frame after modifying the data,
as per <a href="https://w3c.github.io/webrtc-encoded-transform/#sframe-transform-algorithm.">https://w3c.github.io/webrtc-encoded-transform/#sframe-transform-algorithm.</a>

Covered by updated and existing tests.

* LayoutTests/http/wpt/webrtc/audio-video-transform.js:
(AudioVideoRTCRtpTransformer):
(AudioVideoRTCRtpTransformer.prototype.process):
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt:
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::data const):
(WebCore::RTCEncodedFrame::rtcFrame):
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::transformFrame):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::writable):

Canonical link: <a href="https://commits.webkit.org/293232@main">https://commits.webkit.org/293232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d700be344ed0d81fd0ef6737e8174fcf79247574

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31985 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48273 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83270 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25347 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->