### PR TITLE
[ResourceMonitor] Add telemetry to measure unloading events.

### DIFF
--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ResourceMonitor.h"
 
+#include "DiagnosticLoggingClient.h"
+#include "DiagnosticLoggingKeys.h"
 #include "Document.h"
 #include "FrameLoader.h"
 #include "HTMLIFrameElement.h"
@@ -187,6 +189,15 @@ void ResourceMonitor::updateNetworkUsageThreshold(size_t threshold)
         checkNetworkUsageExcessIfNecessary();
 }
 
+static DiagnosticLoggingClient::ValueDictionary diagnosticValues()
+{
+    DiagnosticLoggingClient::ValueDictionary dictionary;
+    dictionary.set(DiagnosticLoggingKeys::unloadCountKey(), 0);
+    dictionary.set(DiagnosticLoggingKeys::unloadPreventedByThrottlerCountKey(), 0);
+    dictionary.set(DiagnosticLoggingKeys::unloadPreventedByStickyActivationCountKey(), 1);
+    return dictionary;
+}
+
 void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
 {
     ASSERT(!parentResourceMonitorIfExists() || !parentResourceMonitorIfExists()->isEligible());
@@ -205,6 +216,9 @@ void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
 
         // If the frame has sticky user activation, don't do offloading.
         if (RefPtr protectedWindow = frame->window(); protectedWindow && protectedWindow->hasStickyActivation()) {
+            if (RefPtr page = frame->protectedPage())
+                page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(DiagnosticLoggingKeys::iframeResourceMonitoringKey(), "IFrame ResourceMonitoring Throttled"_s, diagnosticValues(), ShouldSample::No);
+
             RESOURCEMONITOR_RELEASE_LOG("But the frame has sticky user activation so ignoring.");
             return;
         }

--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
@@ -816,5 +816,27 @@ String DiagnosticLoggingKeys::textTrackModeKey()
     return "textTrackMode"_s;
 }
 
+#if ENABLE(CONTENT_EXTENSIONS)
+String DiagnosticLoggingKeys::iframeResourceMonitoringKey()
+{
+    return "IFrameResourceMonitoring"_s;
+}
+
+String DiagnosticLoggingKeys::unloadCountKey()
+{
+    return "unloadCount"_s;
+}
+
+String DiagnosticLoggingKeys::unloadPreventedByThrottlerCountKey()
+{
+    return "unloadPreventedByThrottlerCount"_s;
+}
+
+String DiagnosticLoggingKeys::unloadPreventedByStickyActivationCountKey()
+{
+    return "unloadPreventedByStickyActivationCount"_s;
+}
+#endif
+
 } // namespace WebCore
 

--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
@@ -186,6 +186,13 @@ public:
     WEBCORE_EXPORT static String memoryUsageToDiagnosticLoggingKey(uint64_t memoryUsage);
     WEBCORE_EXPORT static String foregroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
     WEBCORE_EXPORT static String backgroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    static String iframeResourceMonitoringKey();
+    static String unloadCountKey();
+    static String unloadPreventedByThrottlerCountKey();
+    static String unloadPreventedByStickyActivationCountKey();
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6c5c593beb7df067cdf84f6d50e0fb7cbfd31e4f
<pre>
[ResourceMonitor] Add telemetry to measure unloading events.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290853">https://bugs.webkit.org/show_bug.cgi?id=290853</a>
<a href="https://rdar.apple.com/148348965">rdar://148348965</a>

Reviewed by Ben Nham.

Add telemetry to measure on the field how much following events are triggering:
- iframe is unloaded
- iframe unloading is prevented by throttler
- iframe unloading is prevented by sticky activation

* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::diagnosticValues):
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
(WebCore::DiagnosticLoggingKeys::iframeResourceMonitoringKey):
(WebCore::DiagnosticLoggingKeys::unloadCountKey):
(WebCore::DiagnosticLoggingKeys::unloadPreventedByThrottlerCountKey):
(WebCore::DiagnosticLoggingKeys::unloadPreventedByStickyActivationCountKey):
* Source/WebCore/page/DiagnosticLoggingKeys.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::valueDictionaryForResult):
(WebCore::LocalFrame::showResourceMonitoringError):
(WebCore::LocalFrame::reportResourceMonitoringWarning):

Canonical link: <a href="https://commits.webkit.org/293059@main">https://commits.webkit.org/293059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e93609c290caca2e36b9f66a6b5210456f8d5e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74451 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31636 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100748 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13388 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47717 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24825 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27503 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24786 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/29955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24608 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->