### PR TITLE
[css-anchor-position-1] Implement swapping due to a try-tactic for self-alignment properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The chosen position fallbacks changes when the base style differs assert_equals: expected 20 but got 0
+PASS The chosen position fallbacks changes when the base style differs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt
@@ -1,15 +1,15 @@
 
 PASS , justify-self:start;align-self:start, justify-self:start;align-self:start, ltr, horizontal-tb
-FAIL flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-block, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb assert_equals: offsetTop expected 360 but got 0
-FAIL flip-block flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-start, justify-self:start;align-self:end, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-block flip-start, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-inline flip-start, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb assert_equals: offsetTop expected 360 but got 0
-FAIL flip-block flip-inline flip-start, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-inline, justify-self:left;align-self:start, justify-self:right;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-start, justify-self:right;align-self:start, justify-self:start;align-self:self-end, ltr, horizontal-tb assert_equals: offsetLeft expected 0 but got 360
+PASS flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb
+PASS flip-block, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb
+PASS flip-block flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb
+PASS flip-start, justify-self:start;align-self:end, justify-self:end;align-self:start, ltr, horizontal-tb
+PASS flip-block flip-start, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb
+PASS flip-inline flip-start, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb
+PASS flip-block flip-inline flip-start, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb
+PASS flip-inline, justify-self:left;align-self:start, justify-self:right;align-self:start, ltr, horizontal-tb
+PASS flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, horizontal-tb
+PASS flip-start, justify-self:right;align-self:start, justify-self:start;align-self:self-end, ltr, horizontal-tb
 PASS , justify-self:start
 PASS , justify-self:end
 PASS , justify-self:self-start
@@ -22,20 +22,20 @@ PASS , align-self:self-start
 PASS , align-self:self-end
 PASS , align-self:flex-start
 PASS , align-self:flex-end
-FAIL flip-inline, justify-self:start assert_equals: expected "end" but got "start"
-FAIL flip-inline, justify-self:end assert_equals: expected "start" but got "end"
-FAIL flip-inline, justify-self:self-start assert_equals: expected "self-end" but got "self-start"
-FAIL flip-inline, justify-self:self-end assert_equals: expected "self-start" but got "self-end"
-FAIL flip-inline, justify-self:flex-start assert_equals: expected "flex-end" but got "flex-start"
-FAIL flip-inline, justify-self:flex-end assert_equals: expected "flex-start" but got "flex-end"
-FAIL flip-inline, justify-self:left assert_equals: expected "right" but got "left"
-FAIL flip-inline, justify-self:right assert_equals: expected "left" but got "right"
-FAIL flip-block, align-self:start assert_equals: expected "end" but got "start"
-FAIL flip-block, align-self:end assert_equals: expected "start" but got "end"
-FAIL flip-block, align-self:self-start assert_equals: expected "self-end" but got "self-start"
-FAIL flip-block, align-self:self-end assert_equals: expected "self-start" but got "self-end"
-FAIL flip-block, align-self:flex-start assert_equals: expected "flex-end" but got "flex-start"
-FAIL flip-block, align-self:flex-end assert_equals: expected "flex-start" but got "flex-end"
-FAIL flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, vertical-rl assert_equals: offsetLeft expected 360 but got 0
-FAIL flip-start, justify-self:left;align-self:start, justify-self:start;align-self:self-end, rtl, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+PASS flip-inline, justify-self:start
+PASS flip-inline, justify-self:end
+PASS flip-inline, justify-self:self-start
+PASS flip-inline, justify-self:self-end
+PASS flip-inline, justify-self:flex-start
+PASS flip-inline, justify-self:flex-end
+PASS flip-inline, justify-self:left
+PASS flip-inline, justify-self:right
+PASS flip-block, align-self:start
+PASS flip-block, align-self:end
+PASS flip-block, align-self:self-start
+PASS flip-block, align-self:self-end
+PASS flip-block, align-self:flex-start
+PASS flip-block, align-self:flex-end
+PASS flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, vertical-rl
+PASS flip-start, justify-self:left;align-self:start, justify-self:start;align-self:self-end, rtl, horizontal-tb
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1066,6 +1066,10 @@ static CSSPropertyID flipStart(CSSPropertyID propertyID, WritingMode writingMode
             return CSSPropertyMarginBlockStart;
         case CSSPropertyMarginInlineEnd:
             return CSSPropertyMarginBlockEnd;
+        case CSSPropertyAlignSelf:
+            return CSSPropertyJustifySelf;
+        case CSSPropertyJustifySelf:
+            return CSSPropertyAlignSelf;
         default:
             return propertyID;
         }


### PR DESCRIPTION
#### 79b8df526100e9ab5ae9fa45da73c00f595abdc0
<pre>
[css-anchor-position-1] Implement swapping due to a try-tactic for self-alignment properties
<a href="https://rdar.apple.com/148137397">rdar://148137397</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290665">https://bugs.webkit.org/show_bug.cgi?id=290665</a>

Reviewed by Antti Koivisto.

This commit implements swapping due to a try-tactic [1] for self-alignment
properties (align-self and justify-self)

[1]: <a href="https://drafts.csswg.org/css-anchor-position-1/#swap-due-to-a-try-tactic">https://drafts.csswg.org/css-anchor-position-1/#swap-due-to-a-try-tactic</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::flipStart):
    - Swap values of align-self and justify-self when applying flip-start tactic.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::oppositeItemPosition):
    - Add function to flip ItemPosition values.

(WebCore::Style::BuilderConverter::convertSelfOrDefaultAlignmentData):
    - Flip position value when a position-try fallback is specified
      and the current property is align-self or justify-self.

Canonical link: <a href="https://commits.webkit.org/293328@main">https://commits.webkit.org/293328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db88bf11d4d06d4ea6cd0ea2d2c7dcabb6101fa5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101589 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14040 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55403 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48555 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83503 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19358 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30814 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->