### PR TITLE
AX: For every clearChildren-addChildren cycle, we create new AccessibilityImageMapLink instances and never clean them up, causing a memory leak

### DIFF
--- a/LayoutTests/accessibility/image-map-title-causes-crash-expected.txt
+++ b/LayoutTests/accessibility/image-map-title-causes-crash-expected.txt
@@ -1,10 +1,8 @@
- 1
-Requesting the title of an AccessibilityImageMapLink can cause a crash when the map's area element has been removed.
+This test ensures that we don't crash when requesting the title of all objects after dynamic area element removal.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
+PASS: No crash.
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+ 1

--- a/LayoutTests/accessibility/image-map-title-causes-crash.html
+++ b/LayoutTests/accessibility/image-map-title-causes-crash.html
@@ -1,47 +1,42 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script>
-
-    function removeAreaElement() {
-        document.getElementById("test").innerHTML=1
-    }
-
-    function queryTitleOnDecendants(accessibilityObject) {
-        accessibilityObject.title
-
-        var count = accessibilityObject.childrenCount;
-        for (var i = 0; i < count; ++i)
-            queryTitleOnDecendants(accessibilityObject.childAtIndex(i));
-    }
-</script>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
 <img usemap="#map">
-<map name="map" id="test"><area href="javascript:document.getElementById('result').innerHTML='area clicked'" /></map>
-
-<p id="description"></p>
-<div id="console"></div>
-
+<map name="map" id="map"><area href="javascript:document.getElementById('result').innerHTML='area clicked'" /></map>
+    
 <script>
-    description("Requesting the title of an AccessibilityImageMapLink can cause a crash when the map's area element has been removed.");
+var output = "This test ensures that we don't crash when requesting the title of all objects after dynamic area element removal.\n\n";
 
-    if (window.accessibilityController) {
-        // First build up full accessibility tree.
-        document.body.focus();
-        queryTitleOnDecendants(accessibilityController.focusedElement);
-        
-        removeAreaElement()
-        
-        // Now call request the title for each accessibility object.
-        document.body.focus();
-        queryTitleOnDecendants(accessibilityController.focusedElement);
-    }
+function queryTitleOnDescendants(object) {
+    object.title;
 
+    var count = object.childrenCount;
+    for (var i = 0; i < count; ++i)
+        queryTitleOnDescendants(object.childAtIndex(i));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    queryTitleOnDescendants(webarea);
+
+    // Remove the <area>, replacing it with a static text of "1".
+    document.getElementById("map").innerHTML = 1;
+    setTimeout(async function() {
+        queryTitleOnDescendants(webarea);
+        output += "PASS: No crash.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/fragile/area-role-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/fragile/area-role-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL el-area assert_equals: <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex"> expected "link" but got ""
+PASS el-area
 PASS el-area-no-href
 

--- a/LayoutTests/platform/glib/accessibility/image-map2-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/image-map2-expected.txt
@@ -22,12 +22,12 @@ AXPlatformAttributes: computed-role:generic, tag:div
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition: { 18.0000, 55.0000 }
+AXPosition: { 18.0000, 54.0000 }
 AXSize: { 123.000, 62.0000 }
 AXTitle: Link1
 AXDescription:
 AXValue:
-AXFocusable: 0
+AXFocusable: 1
 AXFocused: 0
 AXSelectable: 0
 AXSelected: 0
@@ -42,12 +42,12 @@ AXPlatformAttributes: computed-role:link, tag:area
 AXRole: AXLink
 AXParent: AXWebArea
 AXChildren: 0
-AXPosition: { 20.0000, 119.000 }
+AXPosition: { 20.0000, 118.000 }
 AXSize: { 122.000, 14.0000 }
 AXTitle: Link2
 AXDescription:
 AXValue:
-AXFocusable: 0
+AXFocusable: 1
 AXFocused: 0
 AXSelectable: 0
 AXSelected: 0

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -238,7 +238,6 @@ accessibility/AXObjectCache.cpp
 accessibility/AXObjectCache.h
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
-accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityList.cpp
 accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -94,7 +94,6 @@ accessibility/AXRemoteFrame.cpp
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AccessibilityARIAGridRow.cpp
-accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityList.cpp
 accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 bool AXCoreObject::isLink() const
 {
     auto role = roleValue();
-    return role == AccessibilityRole::Link || role == AccessibilityRole::WebCoreLink || role == AccessibilityRole::ImageMapLink;
+    return role == AccessibilityRole::Link || role == AccessibilityRole::WebCoreLink;
 }
 
 bool AXCoreObject::isList() const
@@ -108,7 +108,6 @@ bool AXCoreObject::isImplicitlyInteractive() const
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::DateTime:
     case AccessibilityRole::Details:
-    case AccessibilityRole::ImageMapLink:
     case AccessibilityRole::LandmarkSearch:
     case AccessibilityRole::Link:
     case AccessibilityRole::ListBox:

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -178,7 +178,6 @@ enum class AccessibilityRole : uint8_t {
     Inline,
     Image,
     ImageMap,
-    ImageMapLink,
     Insertion,
     Label,
     LandmarkBanner,
@@ -371,8 +370,6 @@ ALWAYS_INLINE String accessibilityRoleToString(AccessibilityRole role)
         return "Image"_s;
     case AccessibilityRole::ImageMap:
         return "ImageMap"_s;
-    case AccessibilityRole::ImageMapLink:
-        return "ImageMapLink"_s;
     case AccessibilityRole::Insertion:
         return "Insertion"_s;
     case AccessibilityRole::Label:

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -34,19 +34,11 @@
 
 namespace WebCore {
     
-class AccessibilityImageMapLink final : public AccessibilityMockObject {
+class AccessibilityImageMapLink final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityImageMapLink> create(AXID);
+    static Ref<AccessibilityImageMapLink> create(AXID, HTMLAreaElement&);
     virtual ~AccessibilityImageMapLink();
     
-    void setHTMLAreaElement(HTMLAreaElement*);
-    HTMLAreaElement* areaElement() const { return m_areaElement.get(); }
-    
-    void setHTMLMapElement(HTMLMapElement* element) { m_mapElement = element; }    
-    HTMLMapElement* mapElement() const { return m_mapElement.get(); }
-    
-    Node* node() const final { return m_areaElement.get(); }
-
     AccessibilityRole determineAccessibilityRole() final;
     bool isEnabled() const final { return true; }
 
@@ -60,17 +52,13 @@ public:
     LayoutRect elementRect() const final;
 
 private:
-    explicit AccessibilityImageMapLink(AXID);
+    explicit AccessibilityImageMapLink(AXID, HTMLAreaElement&);
 
-    void detachFromParent() final;
     Path elementPath() const final;
     RenderElement* imageMapLinkRenderer() const;
     void accessibilityText(Vector<AccessibilityText>&) const final;
     bool isImageMapLink() const final { return true; }
     bool supportsPath() const final { return true; }
-
-    WeakPtr<HTMLAreaElement, WeakPtrImplWithEventTargetData> m_areaElement;
-    WeakPtr<HTMLMapElement, WeakPtrImplWithEventTargetData> m_mapElement;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -609,6 +609,18 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
         }
     }
 
+    if (UNLIKELY(is<HTMLAreaElement>(child.node()))) {
+        // Despite the DOM parent for <area> elements being <map>, we expose <area> elements as children
+        // of the <img> using the <map>. This provides a better experience for AT users, e.g. a screenreader
+        // would hear "image map" or "group" plus the image description, then the links, which provides the
+        // added context for what the links represent.
+        //
+        // Due to the difference in DOM vs. expected AX hierarchy, make sure area elements are only inserted
+        // by their associated image as children.
+        if (child.parentObject() != this)
+            return;
+    }
+
     // If the parent is asking for this child's children, then either it's the first time (and clearing is a no-op),
     // or its visibility has changed. In the latter case, this child may have a stale child cached.
     // This can prevent aria-hidden changes from working correctly. Hence, whenever a parent is getting children, ensure data is not stale.

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1711,14 +1711,6 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
                         if (is<AccessibilityImageMapLink>(child) && !result.contains(child))
                             result.append(child);
                     }
-                } else {
-                    // We couldn't retrieve the already existing image-map links from the parent image, so create a new one.
-                    ASSERT_NOT_REACHED("Unexpectedly missing image-map link parent AX object.");
-                    auto& areaObject = downcast<AccessibilityImageMapLink>(*cache->create(AccessibilityRole::ImageMapLink));
-                    areaObject.setHTMLAreaElement(uncheckedDowncast<HTMLAreaElement>(current));
-                    areaObject.setHTMLMapElement(parentMap);
-                    areaObject.setParent(associatedAXImage(*parentMap));
-                    result.append(areaObject);
                 }
             }
         }
@@ -2316,18 +2308,14 @@ void AccessibilityRenderObject::addImageMapChildren()
     if (!map)
         return;
 
+    WeakPtr cache = axObjectCache();
+    if (!cache)
+        return;
     for (auto& area : descendantsOfType<HTMLAreaElement>(*map)) {
         // add an <area> element for this child if it has a link
         if (!area.isLink())
             continue;
-        auto& areaObject = uncheckedDowncast<AccessibilityImageMapLink>(*axObjectCache()->create(AccessibilityRole::ImageMapLink));
-        areaObject.setHTMLAreaElement(&area);
-        areaObject.setHTMLMapElement(map.get());
-        areaObject.setParent(this);
-        if (!areaObject.isIgnored())
-            addChild(areaObject);
-        else
-            axObjectCache()->remove(areaObject.objectID());
+        addChild(cache->getOrCreate(area));
     }
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -658,7 +658,6 @@ static constexpr std::pair<AccessibilityRole, RoleNameEntry> roleNames[] = {
     { AccessibilityRole::Inline, { "text", N_("text") } },
     { AccessibilityRole::Image, { "image", N_("image") } },
     { AccessibilityRole::ImageMap, { "image map", N_("image map") } },
-    { AccessibilityRole::ImageMapLink, { "link", N_("link") } },
     { AccessibilityRole::Insertion, { "content insertion", N_("content insertion") } },
     { AccessibilityRole::Label, { "label", N_("label") } },
     { AccessibilityRole::LandmarkBanner, { "landmark", N_("landmark") } },

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -251,7 +251,6 @@ static Atspi::Role atspiRole(AccessibilityRole role)
         return Atspi::Role::TableCell;
     case AccessibilityRole::Link:
     case AccessibilityRole::WebCoreLink:
-    case AccessibilityRole::ImageMapLink:
         return Atspi::Role::Link;
     case AccessibilityRole::ImageMap:
         return Atspi::Role::ImageMap;

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -396,7 +396,6 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::Grid, NSAccessibilityTableRole },
         { AccessibilityRole::TreeGrid, NSAccessibilityTableRole },
         { AccessibilityRole::WebCoreLink, NSAccessibilityLinkRole },
-        { AccessibilityRole::ImageMapLink, NSAccessibilityLinkRole },
         { AccessibilityRole::ImageMap, NSAccessibilityImageMapRole },
         { AccessibilityRole::ListMarker, NSAccessibilityListMarkerRole },
         { AccessibilityRole::WebArea, NSAccessibilityWebAreaRole },

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -310,7 +310,6 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     case AccessibilityRole::ColorWell:
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::Heading:
-    case AccessibilityRole::ImageMapLink:
     case AccessibilityRole::Image:
     case AccessibilityRole::Link:
     case AccessibilityRole::ListBox:
@@ -900,7 +899,6 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::Slider:
     case AccessibilityRole::Image:
-    case AccessibilityRole::ImageMapLink:
     case AccessibilityRole::ProgressIndicator:
     case AccessibilityRole::Meter:
     case AccessibilityRole::MenuItem:

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1091,7 +1091,7 @@ static NSArray *children(AXCoreObject& backingObject)
     if (backingObject.isTreeItem())
         return makeNSArray(backingObject.ariaTreeItemContent());
 
-    return makeNSArray(backingObject.unignoredChildren());
+    return makeNSArray(unignoredChildren);
 }
 
 static NSString *roleString(AXCoreObject& backingObject)

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -109,7 +109,6 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     switch (AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr))) {
     case AccessibilityRole::Button:
     case AccessibilityRole::Checkbox:
-    case AccessibilityRole::ImageMapLink:
     case AccessibilityRole::Link:
     case AccessibilityRole::WebCoreLink:
     case AccessibilityRole::ListBoxOption:


### PR DESCRIPTION
#### eed31338f551e7934e2a8901262a1238cb8b1142
<pre>
AX: For every clearChildren-addChildren cycle, we create new AccessibilityImageMapLink instances and never clean them up, causing a memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=284125">https://bugs.webkit.org/show_bug.cgi?id=284125</a>
<a href="https://rdar.apple.com/141013232">rdar://141013232</a>

Reviewed by Joshua Hoffman.

Like most other things generated by AXObjectCache::create(AccessibilityRole), AccessibilityImageMapLinks are never
are not persisted between clear-children add-children cycles, and are never passed in a call to AXObjectCache::remove,
meaning they leak forever.

Fix this by making AccessibilityImageMapLink subclass AccessibilityNodeObject, inherently tying their lifetime to the
HTMLAreaElement that they represent.

This commit also eliminates redundant role ImageMapLink. There is no reason for this role to exist over other existing
roles, WebCoreLink and Link.

* LayoutTests/accessibility/image-map-title-causes-crash-expected.txt:
* LayoutTests/accessibility/image-map-title-causes-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/html-aam/fragile/area-role-expected.txt:
* LayoutTests/platform/glib/accessibility/image-map2-expected.txt:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isLink const):
(WebCore::AXCoreObject::isImplicitlyInteractive const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::accessibilityRoleToString):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedImageMapUIElement):
(WebCore::AXObjectCache::createFromNode):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::create):
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::AccessibilityImageMapLink):
(WebCore::AccessibilityImageMapLink::create):
(WebCore::AccessibilityImageMapLink::parentObject const):
(WebCore::AccessibilityImageMapLink::determineAccessibilityRole):
(WebCore::AccessibilityImageMapLink::anchorElement const):
(WebCore::AccessibilityImageMapLink::url const):
(WebCore::AccessibilityImageMapLink::imageMapLinkRenderer const):
(WebCore::AccessibilityImageMapLink::elementPath const):
(WebCore::AccessibilityImageMapLink::elementRect const):
(WebCore::AccessibilityImageMapLink::setHTMLAreaElement): Deleted.
(WebCore::AccessibilityImageMapLink::detachFromParent): Deleted.
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::addImageMapChildren):
(WebCore::AccessibilityRenderObject::addChildren):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::atspiRole):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityCanFuzzyHitTest]):
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(children):

Canonical link: <a href="https://commits.webkit.org/293278@main">https://commits.webkit.org/293278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d8c7ea231b698b91624de8cdba9aa98d5be26e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26074 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74607 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31798 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100996 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13573 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6484 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47963 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83595 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18701 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30211 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->