### PR TITLE
[ Gardening ] REGRESSION(284275@main): [ iOS ] 9x TestWebKitAPI.DownloadProgress* (api-tests) are constant timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -399,7 +399,12 @@ static void* progressObservingContext = &progressObservingContext;
 // End-to-end test of subscribing to progress on a successful download. The client
 // should be able to receive an NSProgress that is updated as the download makes
 // progress, and the NSProgress should be unpublished when the download finishes.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_BasicSubscriptionAndProgressUpdates)
+#else
 TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -423,7 +428,12 @@ TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
 }
 
 // Similar test as before, but initiating the download before receiving its response.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_StartDownloadFromNavigationAction)
+#else
 TEST(DownloadProgress, StartDownloadFromNavigationAction)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -439,7 +449,12 @@ TEST(DownloadProgress, StartDownloadFromNavigationAction)
 }
 
 // If the download is canceled, the progress should be unpublished.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_LoseProgressWhenDownloadIsCanceled)
+#else
 TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -455,7 +470,12 @@ TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
 }
 
 // If the download fails, the progress should be unpublished.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_LoseProgressWhenDownloadFails)
+#else
 TEST(DownloadProgress, LoseProgressWhenDownloadFails)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -471,7 +491,12 @@ TEST(DownloadProgress, LoseProgressWhenDownloadFails)
 }
 
 // Canceling the progress should cancel the download.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_CancelDownloadWhenProgressIsCanceled)
+#else
 TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -501,7 +526,12 @@ TEST(DownloadProgress, PublishProgressAfterDownloadFinished)
 }
 
 // Test the behavior of a download of unknown length.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_IndeterminateDownloadSize)
+#else
 TEST(DownloadProgress, IndeterminateDownloadSize)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -523,7 +553,12 @@ TEST(DownloadProgress, IndeterminateDownloadSize)
 }
 
 // Test the behavior when a download continues returning data beyond its expected length.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_ExtraData)
+#else
 TEST(DownloadProgress, ExtraData)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -543,7 +578,12 @@ TEST(DownloadProgress, ExtraData)
 }
 
 // Clients should be able to publish progress on a download that has already started.
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_PublishProgressOnPartialDownload)
+#else
 TEST(DownloadProgress, PublishProgressOnPartialDownload)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -568,7 +608,12 @@ TEST(DownloadProgress, PublishProgressOnPartialDownload)
     [testRunner.get() tearDown];
 }
 
+// FIXME rdar://145103161
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(DownloadProgress, DISABLED_ProgressExtendedAttributeSetAfterPartialDownloadStops)
+#else
 TEST(DownloadProgress, ProgressExtendedAttributeSetAfterPartialDownloadStops)
+#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 


### PR DESCRIPTION
#### 59de080f64322a7c4e1f1dd2a735a175523da048
<pre>
[ Gardening ] REGRESSION(284275@main): [ iOS ] 9x TestWebKitAPI.DownloadProgress* (api-tests) are constant timeouts
<a href="https://rdar.apple.com/145103161">rdar://145103161</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)):
(TEST(DownloadProgress, StartDownloadFromNavigationAction)):
(TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)):
(TEST(DownloadProgress, LoseProgressWhenDownloadFails)):
(TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)):
(TEST(DownloadProgress, IndeterminateDownloadSize)):
(TEST(DownloadProgress, ExtraData)):
(TEST(DownloadProgress, PublishProgressOnPartialDownload)):
(TEST(DownloadProgress, ProgressExtendedAttributeSetAfterPartialDownloadStops)):

Canonical link: <a href="https://commits.webkit.org/293036@main">https://commits.webkit.org/293036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d81aea54fa60bbfc6a5a4fc37b4fcf81023761a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97787 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17412 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/48316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99832 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/17706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/25865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/102899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/48316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/17706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/102899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/17706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/17706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/25865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/25239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/7629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15808 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/26224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->