### PR TITLE
AX: [AX Thread Text APIs] Soft line breaks trim "space" from text runs

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that with the isolated tree text markers, we include the trimmed space at soft line breaks.
+
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'Good '
+PASS: paragraph.indexForTextMarker(startOfLine) === 0
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'morning '
+PASS: paragraph.indexForTextMarker(startOfLine) === 5
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'world.'
+PASS: paragraph.indexForTextMarker(startOfLine) === 13
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Good morning world.

--- a/LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space.html
+++ b/LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+Renders as:
+ 
+```
+  Good
+  morning
+  world.
+```
+-->
+
+<p id="paragraph" style="width: 80px">
+Good morning world.
+</p>
+
+<script>
+
+/*
+This test verifies that our new behaior on the isolated tree, to include the spaces that were trimmed during soft line break rendering, works as expected.
+This differs from what we do on the live tree, where the range of that space character isn't navigable.
+*/
+
+if (window.accessibilityController) {
+    var output = "This test ensures that with the isolated tree text markers, we include the trimmed space at soft line breaks.\n\n";
+
+    var paragraph = accessibilityController.accessibleElementById("paragraph");
+    var textMarkerRange = paragraph.textMarkerRangeForElement(paragraph)
+    var currentMarker = paragraph.startTextMarkerForTextMarkerRange(textMarkerRange);
+
+    var lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    var startOfLine = paragraph.startTextMarkerForTextMarkerRange(lineRange);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'Good '");
+    output += expect("paragraph.indexForTextMarker(startOfLine)", "0");
+
+    currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
+    currentMarker = paragraph.nextTextMarker(currentMarker);
+
+    lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    startOfLine = paragraph.startTextMarkerForTextMarkerRange(lineRange);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'morning '");
+    output += expect("paragraph.indexForTextMarker(startOfLine)", "5");
+
+    currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
+    currentMarker = paragraph.nextTextMarker(currentMarker);
+
+    lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    startOfLine = paragraph.startTextMarkerForTextMarkerRange(lineRange);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'world.'");
+    output += expect("paragraph.indexForTextMarker(startOfLine)", "13");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/mac/line-range-at-soft-breaks-expected.txt
+++ b/LayoutTests/accessibility/mac/line-range-at-soft-breaks-expected.txt
@@ -1,7 +1,7 @@
 This test verifies that all characters in each line are included in the line range when at soft line breaks.
 
-PASS: paragraph.stringForTextMarkerRange(lineRange) === 'WebKit is the web browser engine used by Safari, Mail, App Store, and many'
-PASS: paragraph.stringForTextMarkerRange(lineRange) === 'other apps on macOS, iOS, and Linux. Get started contributing code, or'
+PASS: paragraph.stringForTextMarkerRange(lineRange).trim() === 'WebKit is the web browser engine used by Safari, Mail, App Store, and many'
+PASS: paragraph.stringForTextMarkerRange(lineRange).trim() === 'other apps on macOS, iOS, and Linux. Get started contributing code, or'
 PASS: paragraph.stringForTextMarkerRange(lineRange) === 'reporting bugs.'
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/line-range-at-soft-breaks.html
+++ b/LayoutTests/accessibility/mac/line-range-at-soft-breaks.html
@@ -19,13 +19,13 @@ if (window.accessibilityController) {
     var currentMarker = paragraph.startTextMarkerForTextMarkerRange(textMarkerRange);
     
     var lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
-    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'WebKit is the web browser engine used by Safari, Mail, App Store, and many'");
+    output += expect("paragraph.stringForTextMarkerRange(lineRange).trim()", "'WebKit is the web browser engine used by Safari, Mail, App Store, and many'");
     
     currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
     currentMarker = paragraph.nextTextMarker(currentMarker);
 
     lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
-    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'other apps on macOS, iOS, and Linux. Get started contributing code, or'");
+    output += expect("paragraph.stringForTextMarkerRange(lineRange).trim()", "'other apps on macOS, iOS, and Linux. Get started contributing code, or'");
     
     currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
     currentMarker = paragraph.nextTextMarker(currentMarker);

--- a/LayoutTests/accessibility/mac/line-requests-starting-after-first-line-expected.txt
+++ b/LayoutTests/accessibility/mac/line-requests-starting-after-first-line-expected.txt
@@ -1,6 +1,6 @@
 This test verifies that requesting the current line range for a line that is not the first line works as expected.
 
-PASS: paragraph.stringForTextMarkerRange(lineRange) === 'Hello world.'
+PASS: paragraph.stringForTextMarkerRange(lineRange).trim() === 'Hello world.'
 PASS: paragraph.stringForTextMarkerRange(lineRange) === 'Here is a link'
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/line-requests-starting-after-first-line.html
+++ b/LayoutTests/accessibility/mac/line-requests-starting-after-first-line.html
@@ -19,7 +19,10 @@ if (window.accessibilityController) {
 
     currentMarker = advanceTextMarker(currentMarker, 1, paragraph);
     var lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
-    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'Hello world.'");
+    // The expectations for these soft line break line-range strings are trimmed since we added new behavior (isolated tree only) to
+    // include the spaces that were trimmed during rendering. We have a isolated-tree specific test in the isolated-tree/ folder
+    // to validate that behavior.
+    output += expect("paragraph.stringForTextMarkerRange(lineRange).trim()", "'Hello world.'");
 
     currentMarker = advanceTextMarker(currentMarker, 13, paragraph);
     lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);

--- a/LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space-expected.txt
@@ -1,0 +1,9 @@
+This test ensures that spaces that were trimmed when rendering soft line breaks are included in ranges that span over them.
+
+PASS: paragraph.stringForTextMarkerRange(range) === 'Good morning'
+PASS: paragraph.stringForTextMarkerRange(range) === 'Good morning world'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Good morning world.

--- a/LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space.html
+++ b/LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!--
+Renders as:
+ 
+```
+  Good
+  morning
+  world.
+```
+-->
+
+
+<p id="paragraph" style="width: 80px">
+Good morning world.
+</p>
+
+<script>
+
+if (window.accessibilityController) {
+    var output = "This test ensures that spaces that were trimmed when rendering soft line breaks are included in ranges that span over them.\n\n";
+
+    var paragraph = accessibilityController.accessibleElementById("paragraph");
+    var textMarkerRange = paragraph.textMarkerRangeForElement(paragraph)
+    var startMarker = paragraph.startTextMarkerForTextMarkerRange(textMarkerRange); // Position before "Good"
+    var endMarker = paragraph.textMarkerForIndex(12); // Position after "morning".
+
+    var range = paragraph.textMarkerRangeForMarkers(startMarker, endMarker);
+    output += expect("paragraph.stringForTextMarkerRange(range)", "'Good morning'");
+
+    endMarker = paragraph.textMarkerForIndex(18); // Position after "world".
+    range = paragraph.textMarkerRangeForMarkers(startMarker, endMarker);
+    output += expect("paragraph.stringForTextMarkerRange(range)", "'Good morning world'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -113,17 +113,12 @@ struct AXTextRuns {
     bool containsOnlyASCII { true };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns)
+    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, bool containsOnlyASCII = true)
         : containingBlock(containingBlock)
         , runs(WTFMove(textRuns))
-    {
-        for (const auto& run : runs) {
-            if (!run.text.containsOnlyASCII()) {
-                containsOnlyASCII = false;
-                break;
-            }
-        }
-    }
+        , containsOnlyASCII(containsOnlyASCII)
+    { }
+
     String debugDescription() const;
 
     size_t size() const { return runs.size(); }


### PR DESCRIPTION
#### ca3a2787246df9e900fe011fb8b504299d6eb8e6
<pre>
AX: [AX Thread Text APIs] Soft line breaks trim &quot;space&quot; from text runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=290864">https://bugs.webkit.org/show_bug.cgi?id=290864</a>
<a href="https://rdar.apple.com/problem/148366358">rdar://problem/148366358</a>

Reviewed by Tyler Wilcock.

Prior to this point, AXTextRun(s) were not aware of trimmed spaces that occur when rendering soft line
breaks. This means that when text is rendered like the following (as a result of width constraints)

```
Hello
world
```

and we get a text marker range that spans across this line break, we would return a string of &quot;Helloworld&quot;,
rather than &quot;Hello world&quot;, which is what happens on the live tree.

To solve this problem, we re-add these trimmed characters when constructing the AXTextRuns, which is done
by looking for any gaps in the DOM offsets. By doing so, we now properly consider this character when
computing ranges, indices of text markers, and other APIs.

This change also creates new behavior. Now, the space character that isn&apos;t actually rendered is now exposed
to ATs. This means, as an example, users can navigate by character to it. This character won&apos;t have any
width, since it isn&apos;t rendered, but is included in the string and ranges we serve.

Two tests were added to verify this change. Additionally, two tests were updated to &quot;trim&quot; the new space
character we expose at the end of lines, so that the live and isolated trees can share the same test
expectations. Our new tests will provide the coverage gap that this creates.

* LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/soft-line-breaks-include-space.html: Copied from LayoutTests/accessibility/mac/line-range-at-soft-breaks.html.
* LayoutTests/accessibility/mac/line-range-at-soft-breaks-expected.txt:
* LayoutTests/accessibility/mac/line-range-at-soft-breaks.html:
* LayoutTests/accessibility/mac/line-requests-starting-after-first-line-expected.txt:
* LayoutTests/accessibility/mac/line-requests-starting-after-first-line.html:
* LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-range-across-soft-break-includes-space.html: Added.
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::AXTextRuns):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::AXTextRuns): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/293140@main">https://commits.webkit.org/293140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b396767952ab0971bb89cfe0e88b7ad7001f193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74596 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31783 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83586 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30190 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->