### PR TITLE
[ Gardening ] [ iOS ] 18x TestWebKitAPI.WebAuthenticationPanel* (api-tests) are flaky timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -428,7 +428,12 @@ TEST(WebAuthenticationPanel, NoPanelNfcSucceed)
 }
 #endif
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_NoPanelHidSuccess)
+#else
 TEST(WebAuthenticationPanel, NoPanelHidSuccess)
+#endif
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
@@ -441,7 +446,12 @@ TEST(WebAuthenticationPanel, NoPanelHidSuccess)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccess1)
+#else
 TEST(WebAuthenticationPanel, PanelHidSuccess1)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -462,7 +472,12 @@ TEST(WebAuthenticationPanel, PanelHidSuccess1)
     checkPanel([delegate panel], @"", @[adoptNS([[NSNumber alloc] initWithInt:_WKWebAuthenticationTransportUSB]).get()], _WKWebAuthenticationTypeGet);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccess2)
+#else
 TEST(WebAuthenticationPanel, PanelHidSuccess2)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html"];
@@ -534,7 +549,12 @@ TEST(WebAuthenticationPanel, PanelRacy2)
 }
 #endif // HAVE(NEAR_FIELD)
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelTwice)
+#else
 TEST(WebAuthenticationPanel, PanelTwice)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -738,7 +758,12 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
     EXPECT_TRUE(webAuthenticationPanelFailed);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelHidCtapNoCredentialsFound)
+#else
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
@@ -772,7 +797,12 @@ TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
     Util::run(&webAuthenticationPanelUpdateNoCredentialsFound);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_FakePanelHidSuccess)
+#else
 TEST(WebAuthenticationPanel, FakePanelHidSuccess)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -808,7 +838,12 @@ TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
     [webView waitForMessage:@"Operation timed out."];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_NullPanelHidSuccess)
+#else
 TEST(WebAuthenticationPanel, NullPanelHidSuccess)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -882,7 +917,12 @@ TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
     [webView waitForMessage:@"Operation timed out."];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelHidSuccessCancelNoCrash)
+#else
 TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
@@ -899,7 +939,12 @@ TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_PanelHidCtapNoCredentialsFoundCancelNoCrash)
+#else
 TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
@@ -1135,7 +1180,12 @@ TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
     EXPECT_TRUE(webAuthenticationPanelUpdatePINInvalid);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_GetAssertionPin)
+#else
 TEST(WebAuthenticationPanel, GetAssertionPin)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html"];
@@ -1152,7 +1202,12 @@ TEST(WebAuthenticationPanel, GetAssertionPin)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_GetAssertionInternalUV)
+#else
 TEST(WebAuthenticationPanel, GetAssertionInternalUV)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html"];
@@ -1168,7 +1223,12 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUV)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_GetAssertionInternalUVPinFallback)
+#else
 TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html"];
@@ -1185,7 +1245,12 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_GetAssertionPinAuthBlockedError)
+#else
 TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html"];
@@ -1204,7 +1269,12 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
     EXPECT_TRUE(webAuthenticationPanelUpdatePINAuthBlocked);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_GetAssertionPinInvalidErrorAndRetry)
+#else
 TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html"];
@@ -1258,7 +1328,12 @@ TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
     [webView waitForMessage:@"Operation timed out."];
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_MultipleAccounts)
+#else
 TEST(WebAuthenticationPanel, MultipleAccounts)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
@@ -1353,7 +1428,12 @@ TEST(WebAuthenticationPanel, LANoCredential)
     Util::run(&webAuthenticationPanelUpdateLANoCredential);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_LAMakeCredentialAllowLocalAuthenticator)
+#else
 TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
+#endif
 {
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la" withExtension:@"html"];
@@ -1420,7 +1500,12 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)
     cleanUpKeychain();
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionNoMockNoUserGesture)
+#else
 TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
+#endif
 {
     reset();
     webAuthenticationPanelRequestNoGesture = false;
@@ -1693,7 +1778,12 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     EXPECT_EQ(result.attestation, AttestationConveyancePreference::Indirect);
 }
 
+// FIXME rdar://145102423
+#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
+TEST(WebAuthenticationPanel, DISABLED_MakeCredentialSPITimeout)
+#else
 TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
+#endif
 {
     reset();
 


### PR DESCRIPTION
#### c354fcdbc0fa8de5159c2dc76ba6bf7f35fd2fdc
<pre>
[ Gardening ] [ iOS ] 18x TestWebKitAPI.WebAuthenticationPanel* (api-tests) are flaky timeouts
<a href="https://rdar.apple.com/145102423">rdar://145102423</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, NoPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess1)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccess2)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelTwice)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, FakePanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, NullPanelHidSuccess)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPin)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUV)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MultipleAccounts)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)):

Canonical link: <a href="https://commits.webkit.org/293038@main">https://commits.webkit.org/293038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803fea6a15831efe13fed8cb2083aa583fec6135

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97794 "18 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/48323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99839 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/17713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/25872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/48323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/17713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/17713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/6303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/47766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/17713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/24874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/25872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/25246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15811 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/24835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/26231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->