### PR TITLE
[GTK][WPE] Add support for memory-mapped GPU buffers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-transforms-equivalence.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-transforms-equivalence.html
@@ -9,7 +9,7 @@
 Perspective with different transforms can have small anti-aliasing
 pixel differences, so the test should fuzzy patch to the ref.
 -->
-<meta name="fuzzy" content="maxDifference=0-94;totalPixels=0-538">
+<meta name="fuzzy" content="maxDifference=0-178;totalPixels=0-538">
 <style>
 
 #container {

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -73,6 +73,7 @@ platform/graphics/gbm/DMABufBuffer.cpp
 platform/graphics/gbm/DRMDeviceManager.cpp
 platform/graphics/gbm/DRMDeviceNode.cpp
 platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp @no-unify
+platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
 
 platform/graphics/gtk/ColorGtk.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -75,6 +75,7 @@ platform/graphics/gbm/DMABufBuffer.cpp
 platform/graphics/gbm/DRMDeviceManager.cpp
 platform/graphics/gbm/DRMDeviceNode.cpp
 platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp @no-unify
+platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
 
 platform/graphics/libwpe/PlatformDisplayLibWPE.cpp

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -159,5 +159,6 @@ if (USE_GBM)
         platform/graphics/gbm/DRMDeviceManager.h
         platform/graphics/gbm/DRMDeviceNode.h
         platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+        platform/graphics/gbm/MemoryMappedGPUBuffer.h
     )
 endif ()

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2024, 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MemoryMappedGPUBuffer.h"
+
+#if USE(GBM)
+#include "DRMDeviceManager.h"
+#include "DRMDeviceNode.h"
+#include "GBMVersioning.h"
+#include "IntRect.h"
+#include "Logging.h"
+#include "PlatformDisplay.h"
+#include <epoxy/egl.h>
+#include <linux/dma-buf.h>
+#include <sys/ioctl.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/StdLibExtras.h>
+
+#if USE(LIBDRM)
+#include <drm_fourcc.h>
+#include <xf86drm.h>
+#endif
+
+namespace WebCore {
+
+MemoryMappedGPUBuffer::MemoryMappedGPUBuffer(const IntSize& size, OptionSet<BufferFlag> flags)
+    : m_size(size)
+    , m_flags(flags)
+{
+}
+
+MemoryMappedGPUBuffer::~MemoryMappedGPUBuffer()
+{
+    unmapIfNeeded();
+
+    if (m_bo)
+        gbm_bo_destroy(m_bo);
+}
+
+std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSize& size, OptionSet<BufferFlag> flags)
+{
+    auto& manager = WebCore::DRMDeviceManager::singleton();
+    ASSERT(manager.isInitialized());
+
+    auto deviceNode = manager.mainDeviceNode(WebCore::DRMDeviceManager::NodeType::Render);
+    if (!deviceNode) {
+        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to get GBM render device node");
+        return nullptr;
+    }
+
+    auto* device = deviceNode->gbmDevice();
+    if (!device) {
+        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to get GBM device");
+        return nullptr;
+    }
+
+    constexpr uint32_t preferredDMABufFormat = DRM_FORMAT_ABGR8888;
+
+    auto negotiateBufferFormat = [&]() -> std::optional<GLDisplay::DMABufFormat> {
+        const auto& supportedFormats = PlatformDisplay::sharedDisplay().dmabufFormats();
+        for (const auto& format : supportedFormats) {
+            if (format.fourcc != preferredDMABufFormat)
+                continue;
+
+            if (!flags.contains(BufferFlag::ForceLinear))
+                return format;
+
+            if (format.modifiers.contains(DRM_FORMAT_MOD_LINEAR)) {
+                // If a linear buffer is requested - only allow a single modifier.
+                auto useFormat = format;
+                useFormat.modifiers = { DRM_FORMAT_MOD_LINEAR };
+                return useFormat;
+            }
+        }
+
+        return std::nullopt;
+    };
+
+    auto bufferFormat = negotiateBufferFormat();
+    if (!bufferFormat.has_value()) {
+        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to negotiate buffer format");
+        return nullptr;
+    }
+
+    auto buffer = std::unique_ptr<MemoryMappedGPUBuffer>(new MemoryMappedGPUBuffer(size, flags));
+    if (!buffer->allocate(device, bufferFormat.value())) {
+        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
+        return nullptr;
+    }
+
+    if (!buffer->createDMABufFromGBMBufferObject()) {
+        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to create dma-buf from GBM buffer object");
+        return nullptr;
+    }
+
+    return buffer;
+}
+
+bool MemoryMappedGPUBuffer::allocate(struct gbm_device* device, const GLDisplay::DMABufFormat& bufferFormat)
+{
+    m_modifier = DRM_FORMAT_MOD_INVALID;
+    if (!bufferFormat.modifiers.isEmpty())
+        m_bo = gbm_bo_create_with_modifiers2(device, m_size.width(), m_size.height(), bufferFormat.fourcc, bufferFormat.modifiers.data(), bufferFormat.modifiers.size(), GBM_BO_USE_RENDERING);
+
+    if (m_bo)
+        m_modifier = gbm_bo_get_modifier(m_bo);
+    else {
+        m_bo = gbm_bo_create(device, m_size.width(), m_size.height(), bufferFormat.fourcc, GBM_BO_USE_LINEAR);
+        m_modifier = DRM_FORMAT_MOD_INVALID;
+    }
+
+    if (!m_bo || gbm_bo_get_plane_count(m_bo) <= 0)
+        return false;
+
+    return true;
+}
+
+bool MemoryMappedGPUBuffer::isLinear() const
+{
+    ASSERT(m_bo);
+    return gbm_bo_get_plane_count(m_bo) == 1 && (m_modifier == DRM_FORMAT_MOD_INVALID || m_modifier == DRM_FORMAT_MOD_LINEAR);
+}
+
+bool MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject()
+{
+    ASSERT(m_eglAttributes.isEmpty());
+
+    Vector<UnixFileDescriptor> fds;
+    Vector<uint32_t> offsets;
+    Vector<uint32_t> strides;
+
+    auto format = gbm_bo_get_format(m_bo);
+
+    m_eglAttributes = {
+        EGL_WIDTH, static_cast<EGLAttrib>(gbm_bo_get_width(m_bo)),
+        EGL_HEIGHT, static_cast<EGLAttrib>(gbm_bo_get_height(m_bo)),
+        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(format)
+    };
+
+#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
+    if (auto fd = exportGBMBufferObjectAsDMABuf(planeIndex)) \
+        fds.append(WTFMove(fd)); \
+    else \
+        return false; \
+    offsets.append(gbm_bo_get_offset(m_bo, planeIndex)); \
+    strides.append(gbm_bo_get_stride_for_plane(m_bo, planeIndex)); \
+    std::array<EGLint, 6> planeAttributes { \
+        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, static_cast<EGLint>(fds.last().value()), \
+        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLint>(offsets.last()), \
+        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLint>(strides.last()) \
+    }; \
+    m_eglAttributes.append(std::span<const EGLint> { planeAttributes }); \
+    if (m_modifier != DRM_FORMAT_MOD_INVALID) { \
+        std::array<EGLint, 4> modifierAttributes { \
+            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLint>(m_modifier >> 32), \
+            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLint>(m_modifier & 0xffffffff) \
+        }; \
+        m_eglAttributes.append(std::span<const EGLint> { modifierAttributes }); \
+    } \
+    }
+
+    auto planeCount = gbm_bo_get_plane_count(m_bo);
+    if (planeCount > 0)
+        ADD_PLANE_ATTRIBUTES(0);
+    if (planeCount > 1)
+        ADD_PLANE_ATTRIBUTES(1);
+    if (planeCount > 2)
+        ADD_PLANE_ATTRIBUTES(2);
+    if (planeCount > 3)
+        ADD_PLANE_ATTRIBUTES(3);
+
+#undef ADD_PLANE_ATTRIBS
+
+    m_eglAttributes.append(EGL_NONE);
+
+    ASSERT(!m_dmaBuf);
+    m_dmaBuf = DMABufBuffer::create(m_size, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), m_modifier);
+    return true;
+}
+
+int MemoryMappedGPUBuffer::primaryPlaneDmaBufFD() const
+{
+    ASSERT(m_dmaBuf);
+
+    auto& fds = m_dmaBuf->attributes().fds;
+    ASSERT(!fds.isEmpty());
+
+    auto fd = fds[0].value();
+    ASSERT(fd >= 0);
+
+    return fd;
+}
+
+uint32_t MemoryMappedGPUBuffer::primaryPlaneDmaBufStride() const
+{
+    ASSERT(m_dmaBuf);
+
+    auto& strides = m_dmaBuf->attributes().strides;
+    ASSERT(!strides.isEmpty());
+
+    auto stride = strides[0];
+    ASSERT(stride > 0);
+    return stride;
+}
+
+bool MemoryMappedGPUBuffer::mapIfNeeded()
+{
+    if (isMapped())
+        return true;
+
+    ASSERT(isLinear());
+    m_mappedLength = primaryPlaneDmaBufStride() * m_size.height();
+    m_mappedData = mmap(nullptr, m_mappedLength, PROT_READ | PROT_WRITE, MAP_SHARED, primaryPlaneDmaBufFD(), 0);
+    return m_mappedData != MAP_FAILED;
+}
+
+void MemoryMappedGPUBuffer::unmapIfNeeded()
+{
+    if (!isMapped())
+        return;
+
+    munmap(m_mappedData, m_mappedLength);
+    m_mappedData = nullptr;
+    m_mappedLength = 0;
+}
+
+EGLImage MemoryMappedGPUBuffer::createEGLImageFromDMABuf()
+{
+    ASSERT(!m_eglAttributes.isEmpty());
+
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
+    auto eglImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, m_eglAttributes);
+    if (!eglImage)
+        LOG_ERROR("MemoryMappedGPUBuffer::createEGLImageFromDMABuf(), failed to export GBM buffer as EGLImage");
+
+    return eglImage;
+}
+
+UnixFileDescriptor MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(unsigned planeIndex)
+{
+    auto handle = gbm_bo_get_handle_for_plane(m_bo, planeIndex);
+    if (handle.s32 == -1) {
+        LOG_ERROR("MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(), failed to obtain gbm handle for plane %u", planeIndex);
+        return { };
+    }
+
+    int fd = 0;
+    int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(m_bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
+    if (ret < 0) {
+        LOG_ERROR("MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf(), failed to export dma-buf for plane %u", planeIndex);
+        return { };
+    }
+
+    return UnixFileDescriptor { fd, UnixFileDescriptor::Adopt };
+}
+
+void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const MemoryMappedGPUBuffer& srcBuffer, const IntRect& targetRect)
+{
+    ASSERT_UNUSED(scope, &scope.buffer() == this);
+    ASSERT(scope.mode() == AccessScope::Mode::Write);
+    ASSERT(srcBuffer.isLinear());
+    updateContents(scope, srcBuffer.m_mappedData, targetRect, srcBuffer.primaryPlaneDmaBufStride());
+}
+
+void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const void* srcData, const IntRect& targetRect, unsigned bytesPerLine)
+{
+    ASSERT_UNUSED(scope, &scope.buffer() == this);
+    ASSERT(scope.mode() == AccessScope::Mode::Write);
+    ASSERT(isMapped());
+    ASSERT(isLinear());
+
+    uint32_t* dstPixels = static_cast<uint32_t*>(m_mappedData);
+    const uint32_t dstPitch = primaryPlaneDmaBufStride() / 4;
+    const auto dstOffset = targetRect.y() * dstPitch + targetRect.x();
+
+    const uint32_t* srcPixels = static_cast<const uint32_t*>(srcData);
+    const uint32_t srcPitch = bytesPerLine / 4;
+
+    const auto srcPixelSpan = unsafeMakeSpan<const uint32_t>(srcPixels, targetRect.height() * srcPitch);
+    auto dstPixelSpan = unsafeMakeSpan<uint32_t>(dstPixels + dstOffset, m_size.height() * dstPitch - dstOffset);
+
+    if (srcPitch == dstPitch) {
+        memcpySpan(dstPixelSpan, srcPixelSpan);
+        return;
+    }
+
+    for (int32_t y = 0; y < targetRect.height(); ++y)
+        memcpySpan(dstPixelSpan.subspan(y * dstPitch, dstPitch - targetRect.x()), srcPixelSpan.subspan(y * srcPitch, srcPitch));
+}
+
+std::span<uint32_t> MemoryMappedGPUBuffer::mappedDataSpan(AccessScope& scope) const
+{
+    ASSERT_UNUSED(scope, &scope.buffer() == this);
+    ASSERT(isMapped());
+    ASSERT(isLinear());
+    return { static_cast<uint32_t*>(m_mappedData), primaryPlaneDmaBufStride() / 4 };
+}
+
+MemoryMappedGPUBuffer::AccessScope::AccessScope(MemoryMappedGPUBuffer& buffer, AccessScope::Mode mode)
+    : m_buffer(buffer)
+    , m_mode(mode)
+{
+    ASSERT(m_buffer.isMapped());
+    m_buffer.performDMABufSyncSystemCall({ DMABufSyncFlag::Start, m_mode == AccessScope::Mode::Read ? DMABufSyncFlag::Read : DMABufSyncFlag::Write });
+}
+
+MemoryMappedGPUBuffer::AccessScope::~AccessScope()
+{
+    m_buffer.performDMABufSyncSystemCall({ DMABufSyncFlag::End, m_mode == AccessScope::Mode::Read ? DMABufSyncFlag::Read : DMABufSyncFlag::Write });
+}
+
+std::unique_ptr<MemoryMappedGPUBuffer::AccessScope> MemoryMappedGPUBuffer::AccessScope::create(MemoryMappedGPUBuffer& buffer, AccessScope::Mode mode)
+{
+    if (!buffer.mapIfNeeded())
+        return nullptr;
+    return std::unique_ptr<AccessScope>(new AccessScope(buffer, mode));
+}
+
+bool MemoryMappedGPUBuffer::performDMABufSyncSystemCall(OptionSet<DMABufSyncFlag> flags)
+{
+    constexpr unsigned maxRetries = 10;
+
+    struct dma_buf_sync sync;
+    zeroBytes(sync);
+
+    auto mapFlag = [&](auto ourFlag, auto theirFlag) {
+        if (flags.contains(ourFlag))
+            sync.flags |= theirFlag;
+    };
+
+    mapFlag(DMABufSyncFlag::Start, DMA_BUF_SYNC_START);
+    mapFlag(DMABufSyncFlag::End, DMA_BUF_SYNC_END);
+    mapFlag(DMABufSyncFlag::Read, DMA_BUF_SYNC_READ);
+    mapFlag(DMABufSyncFlag::Write, DMA_BUF_SYNC_WRITE);
+
+    auto fd = primaryPlaneDmaBufFD();
+
+    unsigned counter = 0;
+    int result;
+    do {
+        result = ioctl(fd, DMA_BUF_IOCTL_SYNC, &sync);
+    } while (result == -1 && (errno == EAGAIN || errno == EINTR) && (counter++) < maxRetries);
+
+    if (result < 0) {
+        LOG_ERROR("MemoryMappedGPUBuffer::performDMABufSyncSystemCall(), DMA_BUF_SYNC_IOCTL failed - may result in visual artifacts.");
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2024, 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(GBM)
+#include "DMABufBuffer.h"
+#include "GLDisplay.h"
+#include "IntSize.h"
+#include <wtf/OptionSet.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+struct gbm_bo;
+struct gbm_device;
+typedef void* EGLImage;
+typedef intptr_t EGLAttrib;
+
+namespace WebCore {
+
+class IntRect;
+
+// Use MemoryMappedGPUBuffer to create a OpenGL texture, that's baked by a dma-buf.
+class MemoryMappedGPUBuffer {
+    WTF_MAKE_NONCOPYABLE(MemoryMappedGPUBuffer);
+    WTF_MAKE_FAST_ALLOCATED();
+public:
+    ~MemoryMappedGPUBuffer();
+
+    enum class BufferFlag : uint8_t {
+        ForceLinear = 1 << 0
+    };
+
+    // Will only return a MemoryMappedGPUBuffer, if gbm_bo allocation + mapping to userland + EGLImage creation succeeded.
+    static std::unique_ptr<MemoryMappedGPUBuffer> create(const IntSize&, OptionSet<BufferFlag>);
+
+    const IntSize& size() const { return m_size; }
+    const OptionSet<BufferFlag>& flags() const { return m_flags; }
+
+    // Map dma-buf into memory, if not yet mapped.
+    bool mapIfNeeded();
+    void unmapIfNeeded();
+
+    // Export gbm_bo buffer as dma-buf and wrap in EGLImage.
+    EGLImage createEGLImageFromDMABuf();
+
+    // Update the underlying data of the dma-buf, as often as desired.
+    // You need to obtain an AccessScope, fencing the write operation.
+    class AccessScope;
+    void updateContents(AccessScope&, const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
+    void updateContents(AccessScope&, const MemoryMappedGPUBuffer& srcBuffer, const IntRect& targetRect);
+
+    // You need to obtain an AccessScope, fencing the read operation.
+    std::span<uint32_t> mappedDataSpan(AccessScope&) const;
+
+    class AccessScope {
+        WTF_MAKE_NONCOPYABLE(AccessScope);
+        WTF_MAKE_FAST_ALLOCATED();
+    public:
+        ~AccessScope();
+
+        enum class Mode : bool {
+            Read,
+            Write
+        };
+
+        static std::unique_ptr<AccessScope> create(MemoryMappedGPUBuffer&, Mode);
+
+        const Mode& mode() const { return m_mode; }
+        const MemoryMappedGPUBuffer& buffer() const { return m_buffer; }
+
+    private:
+        AccessScope(MemoryMappedGPUBuffer&, Mode);
+
+        MemoryMappedGPUBuffer& m_buffer;
+        Mode m_mode { Mode::Read };
+    };
+
+    bool isMapped() const { return !!m_mappedData; }
+    bool isLinear() const;
+
+private:
+    MemoryMappedGPUBuffer(const IntSize&, OptionSet<BufferFlag>);
+
+    enum class DMABufSyncFlag : uint8_t {
+        Start = 1 << 0,
+        End   = 1 << 1,
+        Read  = 1 << 2,
+        Write = 1 << 3
+    };
+
+    bool performDMABufSyncSystemCall(OptionSet<DMABufSyncFlag> flags);
+    bool allocate(struct gbm_device*, const GLDisplay::DMABufFormat&);
+    bool createDMABufFromGBMBufferObject();
+    UnixFileDescriptor exportGBMBufferObjectAsDMABuf(unsigned planeIndex);
+
+    int primaryPlaneDmaBufFD() const;
+    uint32_t primaryPlaneDmaBufStride() const;
+
+    IntSize m_size;
+    OptionSet<BufferFlag> m_flags;
+    bool m_isLocked { false };
+    struct gbm_bo* m_bo { nullptr };
+    uint64_t m_modifier { 0 };
+    Vector<EGLAttrib> m_eglAttributes;
+    RefPtr<DMABufBuffer> m_dmaBuf;
+
+    void* m_mappedData { nullptr };
+    uint32_t m_mappedLength { 0 };
+};
+
+inline std::unique_ptr<MemoryMappedGPUBuffer::AccessScope> makeGPUBufferReadScope(MemoryMappedGPUBuffer& buffer)
+{
+    return MemoryMappedGPUBuffer::AccessScope::create(buffer, MemoryMappedGPUBuffer::AccessScope::Mode::Read);
+}
+
+inline std::unique_ptr<MemoryMappedGPUBuffer::AccessScope> makeGPUBufferWriteScope(MemoryMappedGPUBuffer& buffer)
+{
+    return MemoryMappedGPUBuffer::AccessScope::create(buffer, MemoryMappedGPUBuffer::AccessScope::Mode::Write);
+}
+
+} // namespace WebCore
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -410,6 +410,22 @@ SkiaPaintingEngine::HybridPaintingStrategy SkiaPaintingEngine::hybridPaintingStr
     return strategy;
 }
 
+bool SkiaPaintingEngine::shouldUseLinearTileTextures()
+{
+    static std::once_flag onceFlag;
+    static bool shouldUseLinearTextures = false;
+
+    std::call_once(onceFlag, [] {
+        if (const char* envString = getenv("WEBKIT_SKIA_USE_LINEAR_TILE_TEXTURES")) {
+            auto envStringView = StringView::fromLatin1(envString);
+            if (envStringView == "1"_s)
+                shouldUseLinearTextures = true;
+        }
+    });
+
+    return shouldUseLinearTextures;
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -64,6 +64,7 @@ public:
     static unsigned minimumAreaForGPUPainting();
     static float minimumFractionOfTasksUsingGPUPainting();
     static HybridPaintingStrategy hybridPaintingStrategy();
+    static bool shouldUseLinearTileTextures();
 
     bool useThreadedRendering() const { return m_cpuWorkerPool || m_gpuWorkerPool; }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -37,6 +37,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
+#if USE(GBM)
+#include "MemoryMappedGPUBuffer.h"
+#endif
+
 typedef void *EGLImage;
 
 namespace WebCore {
@@ -51,6 +55,11 @@ public:
     enum class Flags : uint8_t {
         SupportsAlpha = 1 << 0,
         DepthBuffer = 1 << 1,
+#if USE(GBM)
+        BackedByDMABuf = 1 << 2,
+        ForceLinearBuffer = 1 << 3,
+#endif
+        UseNearestTextureFilter = 1 << 4
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -94,6 +103,10 @@ public:
 
     OptionSet<TextureMapperFlags> colorConvertFlags() const;
 
+#if USE(GBM)
+    MemoryMappedGPUBuffer* memoryMappedGPUBuffer() const { return m_memoryMappedGPUBuffer.get(); }
+#endif
+
 private:
     BitmapTexture(const IntSize&, OptionSet<Flags>);
 #if USE(GBM)
@@ -102,6 +115,12 @@ private:
 
     void clearIfNeeded();
     void createFboIfNeeded();
+
+    void createTexture();
+    void allocateTexture();
+#if USE(GBM)
+    bool allocateTextureFromMemoryMappedGPUBuffer();
+#endif
 
     OptionSet<Flags> m_flags;
     IntSize m_size;
@@ -114,6 +133,10 @@ private:
     ClipStack m_clipStack;
     RefPtr<const FilterOperation> m_filterOperation;
     PixelFormat m_pixelFormat { PixelFormat::RGBA8 };
+
+#if USE(GBM)
+    std::unique_ptr<MemoryMappedGPUBuffer> m_memoryMappedGPUBuffer;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 49ef3002488aa8b83b2f1975816d4172863f1554
<pre>
[GTK][WPE] Add support for memory-mapped GPU buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290800">https://bugs.webkit.org/show_bug.cgi?id=290800</a>

Reviewed by Carlos Garcia Campos.

When using CPU rendering we produce pixel data that has to be uploaded
into a GL texture for composition - usually using glTexSubImage2D().

In order to save precious memory bandwidth on embedded devices, explore an
alternative mechanism, where buffer uploading happens out of the scope of
OpenGL to avoid overhead, such as copying the pixel data into a staging
buffer in Mesa etc.

The idea is to create a GBM buffer object, export it as a dma-buf, wrap
the dma-buf in an EGLImage and use it as backing for a regular OpenGL
texture, using glEGLImageTargetTexture2DOES(). Later on to update the
texture, one can mmap() the dma-buf fd, to gain write access to the
dma-buf. All memory operations have to be fenced using DMA_BUF_SYNC_*
system calls to ensure that the data is properly synchronized between
CPU and GPU (on shared memory systems, that are common in embedded).

Optimize BitmapTexture::updateContents() for the case when we want
to update a linear, mappable texture (backed by a dma-buf). Avoid
using glCopyTexSubImage2D, and use memcpy() instead on the mapped
memory region -- that avoids driver pitfalls, giving more control
about when synchronization happens.

Allocate tile textures always using GL_NEAREST instead of GL_LINEAR
filter -- GL_NEAREST is less expensive than GL_LINEAR, consuming
less bandwidth. However, it can only be used for textures that are
not scaled/filtered/... to avoid quality loss.

Add WEBKIT_SKIA_USE_LINEAR_TILE_TEXTURES environment variable,
only when set to 1 linear textures are used for the tiles. Off by
default, since the benefit is highly platform dependant.

Canonical link: <a href="https://commits.webkit.org/294962@main">https://commits.webkit.org/294962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a08583846541b08d505b5094945d065bc52d59ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78747 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59082 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25128 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36013 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30501 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->