### PR TITLE
Unreviewed non-unified source build fix 2025-04 (part 1)

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -29,6 +29,7 @@
 #include "JSCConfig.h"
 #include "MarkedBlock.h"
 #include "StructureID.h"
+#include <wtf/BitVector.h>
 
 #if CPU(ADDRESS64) && !ENABLE(STRUCTURE_ID_WITH_SHIFT)
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/css/CSSBorderImage.h
+++ b/Source/WebCore/css/CSSBorderImage.h
@@ -25,6 +25,7 @@
 namespace WebCore {
 
 class CSSValue;
+class CSSValueList;
 
 namespace CSS {
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -35,6 +35,7 @@
 #include "RuleSet.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
+#include "StyleSheetContents.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -27,6 +27,8 @@
 #include "DOMMatrixReadOnly.h"
 
 #include "CSSParser.h"
+#include "CSSParserContext.h"
+#include "CSSParserMode.h"
 #include "CSSPropertyParserConsumer+Transform.h"
 #include "CSSToLengthConversionData.h"
 #include "DOMMatrix.h"

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -40,6 +40,7 @@
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "CSSPropertyParserConsumer+Color.h"
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
 #include "CSSTransformListValue.h"

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -38,6 +38,7 @@
 #include "CSSKeyframesRule.h"
 #include "CSSParser.h"
 #include "CSSParserEnum.h"
+#include "CSSParserFastPaths.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserObserver.h"
 #include "CSSParserObserverWrapper.h"

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2015,16 +2015,6 @@ static inline CSSValueID mapFromColumnRegionOrPageBreakInside(CSSValueID value)
     return CSSValueInvalid;
 }
 
-static inline CSSPropertyID mapFromLegacyBreakProperty(CSSPropertyID property)
-{
-    if (property == CSSPropertyPageBreakAfter || property == CSSPropertyWebkitColumnBreakAfter)
-        return CSSPropertyBreakAfter;
-    if (property == CSSPropertyPageBreakBefore || property == CSSPropertyWebkitColumnBreakBefore)
-        return CSSPropertyBreakBefore;
-    ASSERT(property == CSSPropertyPageBreakInside || property == CSSPropertyWebkitColumnBreakInside);
-    return CSSPropertyBreakInside;
-}
-
 bool CSSPropertyParser::consumePageBreakAfterShorthand(CSS::PropertyParserState& state)
 {
     auto keyword = consumeIdentRaw(m_range);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class CSSParserTokenRange;
 class CSSValue;
 enum CSSValueID : uint16_t;
+struct CSSParserContext;
 
 namespace CSS {
 struct PropertyParserState;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h
@@ -33,6 +33,7 @@ class CSSParserTokenRange;
 class CSSToLengthConversionData;
 class CSSValue;
 class TimingFunction;
+struct CSSParserContext;
 
 namespace CSS {
 struct PropertyParserState;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -48,6 +48,8 @@ enum CSSValueID : uint16_t;
 
 enum class FontTechnology : uint8_t;
 
+struct CSSParserContext;
+
 namespace CSS {
 struct PropertyParserState;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "CSSProperty.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserState.h"

--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -30,6 +30,8 @@
 #include "CanvasStyle.h"
 
 #include "CSSParser.h"
+#include "CSSParserContext.h"
+#include "CSSParserMode.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+ColorInlines.h"
 #include "CanvasGradient.h"

--- a/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp
+++ b/Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp
@@ -27,6 +27,7 @@
 #include "DropShadowFilterOperationWithStyleColor.h"
 
 #include "ColorBlending.h"
+#include "RenderStyle.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "SVGAnimatedProperty.h"
 #include "SVGSharedPrimitiveProperty.h"
 


### PR DESCRIPTION
#### 5ad70d151d7cd74e181d577151b5c3775625fc83
<pre>
Unreviewed non-unified source build fix 2025-04 (part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290868">https://bugs.webkit.org/show_bug.cgi?id=290868</a>

Added missing #include. Removed an unused function.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
* Source/WebCore/css/CSSBorderImage.h:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::mapFromLegacyBreakProperty): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h:
* Source/WebCore/html/canvas/CanvasStyle.cpp:
* Source/WebCore/rendering/style/DropShadowFilterOperationWithStyleColor.cpp:
* Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h:

Canonical link: <a href="https://commits.webkit.org/293051@main">https://commits.webkit.org/293051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68069d23e86d46020dd5d5840a74b0c9465a059b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102927 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/48344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25893 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/48344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100818 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54846 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6326 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47787 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90491 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96438 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24895 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/105307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84574 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/105307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27545 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15824 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24856 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120063 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/24678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33678 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/27992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->