### PR TITLE
[text-wrap-style] Do not apply text-wrap-style when text indentation is larger than width constraints.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-3-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-3-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-3.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-pretty-line-break-crash-3.html
@@ -1,0 +1,38 @@
+<style></style>
+<script>
+   nodes = new Map([['n0', new WeakRef(document.documentElement)]]);
+   function storeNode(key, node) {
+   weak = new WeakRef(node);
+   nodes.set(key, weak);
+   }
+   function getNodeSafe(key) {
+   weak = nodes.get(key);
+   node = weak.deref();
+   return node;
+   }
+   (async => {
+   (() => {
+   })();
+   let ss0 = document.styleSheets[0];
+   let sr0 = ss0.rules;
+   try { let = (()=> {
+   ss0?.insertRule(`& { text-wrap-style: pretty; text-indent: hanging 679ic; }`);
+   })(); } catch {}
+   try { (() => {
+   n1 = document.createElement('a'); getNodeSafe('n0').prepend(n1);
+   storeNode('n1', n1);
+   })(); } catch {}
+   try { (() => {
+   n2 = document.createElement('b'); getNodeSafe('n1').appendChild(n2);
+   storeNode('n2', n2);
+   })(); } catch {}
+   try { (() => {
+   n22 = document.createElement('c'); n22.id = getNodeSafe('n2').append(n22);
+   storeNode('n22', n22);
+   })(); } catch {}
+   try { getNodeSafe('n22').before("This test passes if it doesn't crash."); } catch {}
+   })();
+   if (window.testRunner) {
+      testRunner.dumpAsText();
+   }
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -72,6 +72,7 @@ private:
     bool shouldTrimTrailing(size_t inlineItemIndex, bool useFirstLineStyle) const;
     Vector<size_t> computeBreakOpportunities(InlineItemRange) const;
     Vector<LayoutUnit> computeLineWidthsFromBreaks(InlineItemRange, const Vector<size_t>& breaks, bool isFirstChunk) const;
+    InlineLayoutUnit computeMaxTextIndent() const;
     InlineLayoutUnit computeTextIndent(std::optional<bool> previousLineEndsWithLineBreak) const;
 
     InlineFormattingContext& m_inlineFormattingContext;


### PR DESCRIPTION
#### 2fa995c95765e88a758ba77105d72e95fd44971b
<pre>
[text-wrap-style] Do not apply text-wrap-style when text indentation is larger than width constraints.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290870">https://bugs.webkit.org/show_bug.cgi?id=290870</a>
&lt;<a href="https://rdar.apple.com/148250987">rdar://148250987</a>&gt;

Reviewed by Alan Baradlay.

We should not try to constrain inline content when the available space between available bounds
and indentation is not enough to make meaningful breaking decisions.

In this situation, we should fall back to auto layout.

Canonical link: <a href="https://commits.webkit.org/293124@main">https://commits.webkit.org/293124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6f221a36bda233175f495fc8264d44faac6301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74600 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47949 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83040 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27677 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25024 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->