### PR TITLE
Reduce use of memcpy in CryptoAlgorithmRSA_OAEPOpenSSL.cpp

### DIFF
--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmRsaOaepParams.h"
 #include "CryptoKeyRSA.h"
 #include "OpenSSLUtilities.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -58,8 +59,8 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformEncrypt(const Cryp
     if (!parameters.labelVector().isEmpty()) {
         size_t labelSize = parameters.labelVector().size();
         // The library takes ownership of the label so the caller should not free the original memory pointed to by label.
-        auto label = OPENSSL_malloc(labelSize);
-        memcpy(label, parameters.labelVector().data(), labelSize);
+        auto label = static_cast<uint8_t*>(OPENSSL_malloc(labelSize));
+        memcpySpan(std::span(label, labelSize), parameters.labelVector().span());
         if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), label, labelSize) <= 0) {
             OPENSSL_free(label);
             return Exception { ExceptionCode::OperationError };
@@ -107,8 +108,8 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformDecrypt(const Cryp
     if (!parameters.labelVector().isEmpty()) {
         size_t labelSize = parameters.labelVector().size();
         // The library takes ownership of the label so the caller should not free the original memory pointed to by label.
-        auto label = OPENSSL_malloc(labelSize);
-        memcpy(label, parameters.labelVector().data(), labelSize);
+        auto label = static_cast<uint8_t*>(OPENSSL_malloc(labelSize));
+        memcpySpan(std::span(label, labelSize), parameters.labelVector().span());
         if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), label, labelSize) <= 0) {
             OPENSSL_free(label);
             return Exception { ExceptionCode::OperationError };


### PR DESCRIPTION
#### b0f5593c2f193fb118c923a887d43dbe0aadf0e3
<pre>
Reduce use of memcpy in CryptoAlgorithmRSA_OAEPOpenSSL.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=290881">https://bugs.webkit.org/show_bug.cgi?id=290881</a>
<a href="https://rdar.apple.com/problem/148379351">rdar://problem/148379351</a>

Reviewed by Chris Dumez.

Reduce use of memcpy.

* Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp:
(WebCore::CryptoAlgorithmRSA_OAEP::platformEncrypt):
(WebCore::CryptoAlgorithmRSA_OAEP::platformDecrypt):

Canonical link: <a href="https://commits.webkit.org/293164@main">https://commits.webkit.org/293164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31b4e2b3bf9119278ddc1e2b1ac46679ffeaaecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74494 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31670 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105319 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20994 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5238 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18514 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->