### PR TITLE
[JSC] `Array#indexOf` / `Array#includes` should treat +0 and -0 are the same value

### DIFF
--- a/JSTests/stress/array-prototype-includes-untyped-int32-neg-zero.js
+++ b/JSTests/stress/array-prototype-includes-untyped-int32-neg-zero.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.includes(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = 0;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? -0 : {};
+    shouldBe(test(array, searchElement), odd ? true : false);
+}
+

--- a/JSTests/stress/array-prototype-indexOf-untyped-int32-neg-zero.js
+++ b/JSTests/stress/array-prototype-indexOf-untyped-int32-neg-zero.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(array, searchElement) {
+    return array.indexOf(searchElement);
+}
+noInline(test);
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    array[i] = 0;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const odd = i % 2 === 0;
+    const searchElement = odd ? -0 : {};
+    shouldBe(test(array, searchElement), odd ? 0 : -1);
+}
+

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3969,10 +3969,16 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSG
     if (searchElement.isUndefined() && containsHole(data, length))
         OPERATION_RETURN(scope, toUCPUStrictInt32(1));
 
-    if (!searchElement.isInt32AsAnyInt())
-        OPERATION_RETURN(scope, toUCPUStrictInt32(0));
+    int32_t int32Value = 0;
+    if (searchElement.isInt32AsAnyInt())
+        int32Value = searchElement.asInt32AsAnyInt();
+    else {
+        if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
+            OPERATION_RETURN(scope, toUCPUStrictInt32(0));
+        int32Value = 0;
+    }
 
-    EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(searchElement.asInt32AsAnyInt()));
+    EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(int32Value));
     auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::find64(std::bit_cast<const uint64_t*>(data + index), encodedSearchElement, length - index));
     if (result)
         OPERATION_RETURN(scope, toUCPUStrictInt32(1));
@@ -4148,10 +4154,16 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSGl
 
     JSValue searchElement = JSValue::decode(encodedValue);
 
-    if (!searchElement.isInt32AsAnyInt())
-        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    int32_t int32Value = 0;
+    if (searchElement.isInt32AsAnyInt())
+        int32Value = searchElement.asInt32AsAnyInt();
+    else {
+        if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
+            OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+        int32Value = 0;
+    }
 
-    EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(searchElement.asInt32AsAnyInt()));
+    EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(int32Value));
     auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::find64(std::bit_cast<const uint64_t*>(data + index), encodedSearchElement, length - index));
     if (result)
         OPERATION_RETURN(scope, toUCPUStrictInt32(result - data));


### PR DESCRIPTION
#### 2f856d3a253c3ad7d4d0d1ba21e8ec78772c9e26
<pre>
[JSC] `Array#indexOf` / `Array#includes` should treat +0 and -0 are the same value
<a href="https://bugs.webkit.org/show_bug.cgi?id=290889">https://bugs.webkit.org/show_bug.cgi?id=290889</a>

Reviewed by Yusuke Suzuki.

<a href="https://commits.webkit.org/292999@main">https://commits.webkit.org/292999@main</a> optimized searching untyped
element from int32 array.

However, due to this optimization, a bug occurred where searching
for -0 would fail to match 0. This patch fixes that bug.

* JSTests/stress/array-prototype-includes-untyped-int32-neg-zero.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-indexOf-untyped-int32-neg-zero.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/293134@main">https://commits.webkit.org/293134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78ccfb144eaff5de3c6d054f4fdc7e638df478ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97899 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74542 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13494 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88471 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47871 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90575 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105391 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18601 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30109 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120147 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24762 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33697 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->