### PR TITLE
AX: Make accessibility/mac/basic-embed-pdf-accessibility.html more resilient to unimportant PDFKit behavior differences

### DIFF
--- a/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt
+++ b/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt
@@ -10,7 +10,7 @@ PASS: pdfAxObject.parentElement().domIdentifier === 'pdfEmbed'
 PASS: pdfPageObject.role === 'AXRole: AXPage'
 PASS: pdfTextNode.stringAttributeValue('AXRole') === 'AXStaticText'
 PASS: pdfTextNode.stringValue.split(' ')[1] === 'Welcome'
-PASS: hitTestResult.stringAttributeValue('AXRole') === 'AXGroup'
+PASS: Hit test role was an expected value
 PASS: pdfTextNode.stringAttributeValue('AXRole') === 'AXStaticText'
 PASS: pdfTextNode.stringValue.split(' ')[1] === 'Welcome'
 PASS: searchResultElement.stringAttributeValue('AXSubrole') === 'AXPDFPluginSubrole'

--- a/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
+++ b/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
@@ -63,7 +63,14 @@ if (window.accessibilityController) {
             domPdfEmbedElement.offsetLeft + (domPdfEmbedElement.offsetWidth / 2),
             domPdfEmbedElement.offsetTop + (domPdfEmbedElement.offsetHeight / 2),
         );
-        output += expect("hitTestResult.stringAttributeValue('AXRole')", "'AXGroup'");
+        let hitTestRole = hitTestResult.stringAttributeValue("AXRole");
+        if (hitTestRole == "AXGroup" || hitTestRole == "AXStaticText") {
+            // Depending on the PDFKit version, we may get a group or static text at the point we hit test.
+            // It doesn't matter much either way -- as long as it's something inside the PDF, we know hit testing works.
+            output += "PASS: Hit test role was an expected value\n";
+        } else
+            output += `FAIL: Hit test role was an unexpected value (${hitTestRole})\n`;
+
         await waitFor(() => {
             pdfTextNode = traverseChildrenToFirstStaticText(hitTestResult);
             return pdfTextNode;


### PR DESCRIPTION
#### 554ab0ff24963f2e8e148c0224a4188461cb2b56
<pre>
AX: Make accessibility/mac/basic-embed-pdf-accessibility.html more resilient to unimportant PDFKit behavior differences
<a href="https://bugs.webkit.org/show_bug.cgi?id=290893">https://bugs.webkit.org/show_bug.cgi?id=290893</a>
<a href="https://rdar.apple.com/148388354">rdar://148388354</a>

Reviewed by Chris Fleizach.

* LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt:
* LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html:

Canonical link: <a href="https://commits.webkit.org/293109@main">https://commits.webkit.org/293109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35b076910a02bc07bedb779e869bd70a11ffe0e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31688 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105343 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18157 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83523 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82959 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24892 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->