### PR TITLE
[JSC] Add convertUInt32ToDouble / convertUInt32ToFloat

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -37,8 +37,6 @@
 
 namespace JSC {
 
-const double MacroAssembler::twoToThe32 = (double)0x100000000ull;
-
 void MacroAssembler::jitAssert(const ScopedLambda<Jump(void)>& functor)
 {
     if (Options::useJITDebugAssertions()) {

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -207,8 +207,6 @@ public:
         return value == static_cast<int32_t>(value);
     }
 
-    static const double twoToThe32; // This is super useful for some double code.
-
     // Utilities used by the DFG JIT.
     using AbstractMacroAssemblerBase::invert;
     using MacroAssemblerBase::invert;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2881,7 +2881,17 @@ public:
     {
         m_assembler.scvtf<32, 32>(dest, src);
     }
-    
+
+    void convertUInt32ToDouble(RegisterID src, FPRegisterID dest)
+    {
+        m_assembler.ucvtf<64, 32>(dest, src);
+    }
+
+    void convertUInt32ToFloat(RegisterID src, FPRegisterID dest)
+    {
+        m_assembler.ucvtf<32, 32>(dest, src);
+    }
+
     void convertInt64ToDouble(RegisterID src, FPRegisterID dest)
     {
         m_assembler.scvtf<64, 64>(dest, src);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2334,6 +2334,18 @@ public:
             m_assembler.cvtsi2ss_mr(src.offset, src.base, dest);
     }
 
+    void convertUInt32ToDouble(RegisterID src, FPRegisterID dest)
+    {
+        zeroExtend32ToWord(src, scratchRegister());
+        convertInt64ToDouble(scratchRegister(), dest);
+    }
+
+    void convertUInt32ToFloat(RegisterID src, FPRegisterID dest)
+    {
+        zeroExtend32ToWord(src, scratchRegister());
+        convertInt64ToFloat(scratchRegister(), dest);
+    }
+
     Jump branchDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right)
     {
         if (cond & DoubleConditionBitInvert) {

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4827,11 +4827,53 @@ private:
         }
 
         case IToD: {
+            auto tryAppendUToD = [&](Value* value) {
+                if (!isValidForm(ConvertUInt32ToDouble, Arg::Tmp, Arg::Tmp))
+                    return false;
+
+                if (value->child(0)->type() != Int64)
+                    return false;
+
+                if (value->child(0)->opcode() != ZExt32)
+                    return false;
+
+                if (!canBeInternal(m_value->child(0)))
+                    return false;
+
+                append(ConvertUInt32ToDouble, tmp(value->child(0)->child(0)), tmp(value));
+                commitInternal(m_value->child(0));
+                return true;
+            };
+
+            if (tryAppendUToD(m_value))
+                return;
+
             appendUnOp<ConvertInt32ToDouble, ConvertInt64ToDouble>(m_value->child(0));
             return;
         }
 
         case IToF: {
+            auto tryAppendUToF = [&](Value* value) {
+                if (!isValidForm(ConvertUInt32ToFloat, Arg::Tmp, Arg::Tmp))
+                    return false;
+
+                if (value->child(0)->type() != Int64)
+                    return false;
+
+                if (value->child(0)->opcode() != ZExt32)
+                    return false;
+
+                if (!canBeInternal(m_value->child(0)))
+                    return false;
+
+                append(ConvertUInt32ToFloat, tmp(value->child(0)->child(0)), tmp(value));
+                commitInternal(m_value->child(0));
+                return true;
+            };
+
+            if (tryAppendUToF(m_value))
+                return;
+
             appendUnOp<ConvertInt32ToFloat, ConvertInt64ToFloat>(m_value->child(0));
             return;
         }

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -688,6 +688,12 @@ ConvertInt32ToFloat U:G:32, D:F:32
     Tmp, Tmp
     x86_64: Addr, Tmp
 
+arm64: ConvertUInt32ToDouble U:G:32, D:F:64
+    Tmp, Tmp
+
+arm64: ConvertUInt32ToFloat U:G:32, D:F:32
+    Tmp, Tmp
+
 CountLeadingZeros32 U:G:32, ZD:G:32
     Tmp, Tmp
     x86: Addr, Tmp

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -872,6 +872,8 @@ void testIToD64Arg();
 void testIToF64Arg();
 void testIToD32Arg();
 void testIToF32Arg();
+void testIToDU32Arg();
+void testIToFU32Arg();
 void testIToD64Mem();
 void testIToF64Mem();
 void testIToD32Mem();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -352,6 +352,8 @@ void run(const TestConfig* config)
     RUN(testIToF64Arg());
     RUN(testIToD32Arg());
     RUN(testIToF32Arg());
+    RUN(testIToDU32Arg());
+    RUN(testIToFU32Arg());
     RUN(testIToD64Mem());
     RUN(testIToF64Mem());
     RUN(testIToD32Mem());

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -3403,6 +3403,34 @@ void testIToF32Arg()
         CHECK(isIdentical(invoke<float>(*code, testValue.value), static_cast<float>(testValue.value)));
 }
 
+void testIToDU32Arg()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+    Value* src = arguments[0];
+    Value* srcAsDouble = root->appendNew<Value>(proc, IToD, Origin(), root->appendNew<Value>(proc, ZExt32, Origin(), src));
+    root->appendNewControlValue(proc, Return, Origin(), srcAsDouble);
+
+    auto code = compileProc(proc);
+    for (auto testValue : int32Operands())
+        CHECK(isIdentical(invoke<double>(*code, static_cast<uint32_t>(testValue.value)), static_cast<double>(static_cast<uint32_t>(testValue.value))));
+}
+
+void testIToFU32Arg()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t>(proc, root);
+    Value* src = arguments[0];
+    Value* srcAsFloat = root->appendNew<Value>(proc, IToF, Origin(), root->appendNew<Value>(proc, ZExt32, Origin(), src));
+    root->appendNewControlValue(proc, Return, Origin(), srcAsFloat);
+
+    auto code = compileProc(proc);
+    for (auto testValue : int32Operands())
+        CHECK(isIdentical(invoke<float>(*code, static_cast<uint32_t>(testValue.value)), static_cast<float>(static_cast<uint32_t>(testValue.value))));
+}
+
 void testIToD64Mem()
 {
     Procedure proc;

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2208,8 +2208,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
                     RELEASE_ASSERT(m_scratchFPR != InvalidFPRReg);
                     auto canBeInt = jit.branch32(CCallHelpers::GreaterThanOrEqual, valueRegs.payloadGPR(), CCallHelpers::TrustedImm32(0));
 
-                    jit.convertInt32ToDouble(valueRegs.payloadGPR(), m_scratchFPR);
-                    jit.addDouble(CCallHelpers::AbsoluteAddress(&CCallHelpers::twoToThe32), m_scratchFPR);
+                    jit.convertUInt32ToDouble(valueRegs.payloadGPR(), m_scratchFPR);
                     jit.boxDouble(m_scratchFPR, valueRegs);
                     done = jit.jump();
                     canBeInt.link(&jit);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2873,16 +2873,9 @@ void SpeculativeJIT::compileUInt32ToNumber(Node* node)
         }
         SpeculateInt32Operand op1(this, node->child1());
         FPRTemporary result(this);
-            
         GPRReg inputGPR = op1.gpr();
         FPRReg outputFPR = result.fpr();
-            
-        convertInt32ToDouble(inputGPR, outputFPR);
-            
-        Jump positive = branch32(GreaterThanOrEqual, inputGPR, TrustedImm32(0));
-        addDouble(AbsoluteAddress(&twoToThe32), outputFPR);
-        positive.link(this);
-            
+        convertUInt32ToDouble(inputGPR, outputFPR);
         doubleResult(outputFPR, node);
         return;
     }
@@ -3290,10 +3283,7 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
 
     if (shouldBox) {
         if (isUInt32) {
-            convertInt32ToDouble(resultReg, resultFPR);
-            Jump positive = branch32(GreaterThanOrEqual, resultReg, TrustedImm32(0));
-            addDouble(AbsoluteAddress(&twoToThe32), resultFPR);
-            positive.link(this);
+            convertUInt32ToDouble(resultReg, resultFPR);
             boxDouble(resultFPR, resultRegs);
         } else
             boxInt32(resultRegs.payloadGPR(), resultRegs);
@@ -3323,11 +3313,8 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
         return;
     }
 #endif
-    
-    convertInt32ToDouble(resultReg, resultFPR);
-    Jump positive = branch32(GreaterThanOrEqual, resultReg, TrustedImm32(0));
-    addDouble(AbsoluteAddress(&twoToThe32), resultFPR);
-    positive.link(this);
+
+    convertUInt32ToDouble(resultReg, resultFPR);
     doubleResult(resultFPR, node);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2741,14 +2741,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32ConvertUI32(Value operand, Value&
         "F32ConvertUI32", TypeKind::F32,
         BLOCK(Value::fromF32(static_cast<uint32_t>(operand.asI32()))),
         BLOCK(
-#if CPU(X86_64)
-            ScratchScope<1, 0> scratches(*this);
-            m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
-            m_jit.convertUInt64ToFloat(wasmScratchGPR, resultLocation.asFPR(), scratches.gpr(0));
-#else
-            m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
-            m_jit.convertUInt64ToFloat(wasmScratchGPR, resultLocation.asFPR());
-#endif
+            m_jit.convertUInt32ToFloat(operandLocation.asGPR(), resultLocation.asFPR());
         )
     )
 }
@@ -2785,14 +2778,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64ConvertUI32(Value operand, Value&
         "F64ConvertUI32", TypeKind::F64,
         BLOCK(Value::fromF64(static_cast<uint32_t>(operand.asI32()))),
         BLOCK(
-#if CPU(X86_64)
-            ScratchScope<1, 0> scratches(*this);
-            m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
-            m_jit.convertUInt64ToDouble(wasmScratchGPR, resultLocation.asFPR(), scratches.gpr(0));
-#else
-            m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
-            m_jit.convertUInt64ToDouble(wasmScratchGPR, resultLocation.asFPR());
-#endif
+            m_jit.convertUInt32ToDouble(operandLocation.asGPR(), resultLocation.asFPR());
         )
     )
 }


### PR DESCRIPTION
#### 382880c901fb12783b357ac17e04256f4e04f0df
<pre>
[JSC] Add convertUInt32ToDouble / convertUInt32ToFloat
<a href="https://bugs.webkit.org/show_bug.cgi?id=290905">https://bugs.webkit.org/show_bug.cgi?id=290905</a>
<a href="https://rdar.apple.com/148407575">rdar://148407575</a>

Reviewed by Yijia Huang.

This patch adds convertUInt32ToDouble / convertUInt32ToFloat. They are
efficiently implemented in x64 and ARM64. We leverage this in both JS
and wasm. And we introduce ConvertUInt32ToDouble / ConvertUInt32ToFloat
lowering rule for ARM64.

* Source/JavaScriptCore/assembler/MacroAssembler.cpp:
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::convertUInt32ToDouble):
(JSC::MacroAssemblerARM64::convertUInt32ToFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::convertUInt32ToDouble):
(JSC::MacroAssemblerX86_64::convertUInt32ToFloat):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testIToDU32Arg):
(testIToFU32Arg):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileUInt32ToNumber):
(JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI32):

Canonical link: <a href="https://commits.webkit.org/293108@main">https://commits.webkit.org/293108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d8e13a9776afcb5c4df79a103b12e4f26a36a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26008 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100933 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/54926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/6431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47902 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90606 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105422 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96553 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25010 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25382 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/83003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/27642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18634 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15859 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24971 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120178 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24793 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33701 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->