### PR TITLE
run-jsc-stress-tests --treat-failing-as-flaky should also limit total runtime

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -301,10 +301,11 @@ Usage: $programName [options] [options to pass to build system]
 
   --report-execution-time       Print execution time for each stress test.
   --treat-failing-as-flaky      Treat failing stress tests as flaky.
-                                Expects 3 comma-separated values: passPercentage,maxTries,maxFailing
+                                Expects 3 or 4 comma-separated values: passPercentage,maxTries,maxFailing[,maxRetrySeconds]
                                 If less than maxFailing tests failed, run them again (up to maxTries)
                                 until we can tell whether they pass more than passPercentage of the
-                                time (in which case the test is counted as a pass).
+                                time (in which case the test is counted as a pass). Do not start a new iteration
+                                if we've spent more than maxRetrySeconds retrying.
 
   --filter                      Only run tests whose name matches the given regular expression.
   --env-vars                    Pass a list of environment variables to set before running tests.

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -317,9 +317,9 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
     when '--test-writer'
         $testWriter = arg
     when '--treat-failing-as-flaky'
-        md = /^([^,]+),(\d+),(\d+)$/.match(arg)
+        md = /^([^,]+),(\d+),(\d+)(,(\d+))?$/.match(arg)
         if md.nil?
-            $stderr.puts("Could not parse argument to `--treat-failing-as-flaky`; expected `passPercentage,maxTries,maxFailing`")
+            $stderr.puts("Could not parse argument to `--treat-failing-as-flaky`; expected `passPercentage,maxTries,maxFailing[,maxRetrySeconds]`")
             exit(1)
         end
         passPercentage = md[1].to_f
@@ -337,9 +337,18 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
             $stderr.puts("Invalid maxFailing `#{md[3]}`")
             exit(1)
         end
+        maxRetrySeconds = nil
+        if not md[5].nil?
+           maxRetrySeconds = md[5].to_i
+           if maxRetrySeconds == 0
+               $stderr.puts("Invalid maxRetrySeconds")
+               exit(1)
+           end
+        end
         $treatFailingAsFlaky = OpenStruct.new(:passPercentage => passPercentage,
                                               :maxTries => maxTries,
-                                              :maxFailing => maxFailing)
+                                              :maxFailing => maxFailing,
+                                              :maxRetrySeconds => maxRetrySeconds)
     when '--remote'
         $copyVM = true
         $tarball = true
@@ -3412,7 +3421,7 @@ end
 ExecutorSelfTests.run
 TestResultEvaluatorSelfTests.run
 
-class NonRemoteTestsExecutor < BaseTestsExecutor
+class NonRemoteTestsExecutor < BasicTestsExecutor
     def initialize(runlist, serialPlans, maxIterationsBounds, treatFailingAsFlaky, testRunner)
         super(runlist, serialPlans,
               nil,
@@ -3462,7 +3471,7 @@ class BundleTestsExecutor < NonRemoteTestsExecutor
     end
 end
 
-class BaseRemoteTestsExecutor < BaseTestsExecutor
+class BaseRemoteTestsExecutor < BasicTestsExecutor
     def initialize(runlist, serialPlans, remoteHosts, iterationLimits,
                    treatFailingAsFlaky, testRunner)
         super(runlist, serialPlans, remoteHosts, iterationLimits, treatFailingAsFlaky)


### PR DESCRIPTION
#### 4777f045be98e46519905adaffccaf1e081d0856
<pre>
run-jsc-stress-tests --treat-failing-as-flaky should also limit total runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=290906">https://bugs.webkit.org/show_bug.cgi?id=290906</a>

Reviewed by Justin Michaud.

When we treat failing tests as flaky we retry them up to a
user-specified number of iterations, until it&apos;s clear whether they can
make the pass percentage. This works well for tests that finish quickly
but gets us in pathological behavior when a test hangs. We then run it
until it hits the timeout multiple times, needlessly prolonguing the
time it tests to run tests in the buildbot.

Add a cap on the number of seconds we can spend retrying and refuse to
start a new iteration if it has been exceeded.

* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test/executor.rb:

Canonical link: <a href="https://commits.webkit.org/294423@main">https://commits.webkit.org/294423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f39120f90236454464abb0eb13baca6a7f314db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75996 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49789 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92494 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107325 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98445 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84476 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21895 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26886 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/122071 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26697 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34081 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->