### PR TITLE
Factor match result cache into a class

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3102,6 +3102,7 @@ style/IdChangeInvalidation.cpp
 style/InlineTextBoxStyle.cpp
 style/InspectorCSSOMWrappers.cpp
 style/MatchedDeclarationsCache.cpp
+style/MatchResultCache.cpp
 style/PageRuleCollector.cpp
 style/PropertyAllowlist.cpp
 style/PropertyCascade.cpp

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MatchResultCache.h"
+
+#include "MatchResult.h"
+#include "StyleProperties.h"
+#include "StyledElement.h"
+
+namespace WebCore {
+namespace Style {
+
+MatchResultCache::MatchResultCache() = default;
+MatchResultCache::~MatchResultCache() = default;
+
+const MatchResult* MatchResultCache::get(const Element& element)
+{
+    auto it = m_cachedMatchResults.find(element);
+    if (it == m_cachedMatchResults.end())
+        return { };
+
+    auto& matchResult = *it->value;
+
+    auto inlineStyleMatches = [&] {
+        auto* styledElement = dynamicDowncast<StyledElement>(element);
+        if (!styledElement || !styledElement->inlineStyle())
+            return false;
+
+        auto& inlineStyle = *styledElement->inlineStyle();
+
+        for (auto& declaration : matchResult.authorDeclarations) {
+            if (&declaration.properties.get() == &inlineStyle)
+                return true;
+        }
+        return false;
+    }();
+
+    if (!inlineStyleMatches) {
+        m_cachedMatchResults.remove(it);
+        return { };
+    }
+
+    return &matchResult;
+}
+
+void MatchResultCache::update(const Element& element, const MatchResult& matchResult)
+{
+    // For now we cache match results if there is mutable inline style. This way we can avoid
+    // selector matching when it gets mutated again.
+    auto* styledElement = dynamicDowncast<StyledElement>(element);
+    if (styledElement && styledElement->inlineStyle() && styledElement->inlineStyle()->isMutable())
+        m_cachedMatchResults.set(element, makeUniqueRef<MatchResult>(matchResult));
+    else
+        m_cachedMatchResults.remove(element);
+}
+
+}
+}

--- a/Source/WebCore/style/MatchResultCache.h
+++ b/Source/WebCore/style/MatchResultCache.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/WeakHashMap.h>
+
+namespace WebCore {
+
+class Element;
+
+namespace Style {
+
+struct MatchResult;
+
+class MatchResultCache {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    MatchResultCache();
+    ~MatchResultCache();
+
+    const MatchResult* get(const Element&);
+    void update(const Element&, const MatchResult&);
+
+private:
+    WeakHashMap<const Element, UniqueRef<MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
+};
+
+}
+}

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -66,6 +66,7 @@ class WeakPtrImplWithEventTargetData;
 namespace Style {
 
 class CustomPropertyRegistry;
+class MatchResultCache;
 class Resolver;
 class RuleSet;
 struct MatchResult;
@@ -136,8 +137,7 @@ public:
 
     void clearViewTransitionStyles();
 
-    const MatchResult* cachedMatchResult(const Element&);
-    void updateCachedMatchResult(const Element&, const MatchResult&);
+    MatchResultCache& matchResultCache();
 
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
@@ -257,7 +257,7 @@ private:
 
     SingleThreadWeakHashMap<const RenderBoxModelObject, LayoutRect> m_anchorRectsOnLastUpdate;
 
-    mutable WeakHashMap<const Element, UniqueRef<MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
+    std::unique_ptr<MatchResultCache> m_matchResultCache;
 
     UniqueRef<CustomPropertyRegistry> m_customPropertyRegistry;
     UniqueRef<CSSCounterStyleRegistry> m_counterStyleRegistry;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -44,6 +44,7 @@
 #include "HTMLSlotElement.h"
 #include "LoaderStrategy.h"
 #include "LocalFrame.h"
+#include "MatchResultCache.h"
 #include "NodeRenderStyle.h"
 #include "Page.h"
 #include "PlatformStrategies.h"
@@ -177,7 +178,7 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
         return { WTFMove(style) };
 
     if (resolutionType == ResolutionType::FullWithMatchResultCache) {
-        if (auto cachedMatchResult = m_document->styleScope().cachedMatchResult(element))
+        if (auto cachedMatchResult = m_document->styleScope().matchResultCache().get(element))
             return scope().resolver->styleForElementWithCachedMatchResult(element, resolutionContext, *cachedMatchResult, *existingStyle);
     }
 
@@ -186,7 +187,7 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
     if (elementStyle.relations)
         commitRelations(WTFMove(elementStyle.relations), *m_update);
 
-    m_document->styleScope().updateCachedMatchResult(element, *elementStyle.matchResult);
+    m_document->styleScope().matchResultCache().update(element, *elementStyle.matchResult);
 
     return elementStyle;
 }


### PR DESCRIPTION
#### 5e9ecf10680f2f3d1b50789c7e58c72b71af0467
<pre>
Factor match result cache into a class
<a href="https://bugs.webkit.org/show_bug.cgi?id=290908">https://bugs.webkit.org/show_bug.cgi?id=290908</a>
<a href="https://rdar.apple.com/148418249">rdar://148418249</a>

Reviewed by Alan Baradlay.

Move out from Style::Scope.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/MatchResultCache.cpp: Added.
(WebCore::Style::MatchResultCache::get):
(WebCore::Style::MatchResultCache::update):
* Source/WebCore/style/MatchResultCache.h: Added.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::releaseMemory):
(WebCore::Style::Scope::scheduleUpdate):
(WebCore::Style::Scope::matchResultCache):
(WebCore::Style::Scope::cachedMatchResult): Deleted.
(WebCore::Style::Scope::updateCachedMatchResult): Deleted.
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):

Canonical link: <a href="https://commits.webkit.org/293095@main">https://commits.webkit.org/293095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d97dbfc61e9dc57d0ac58aba64848a8bd1cee19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100903 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13495 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6405 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47872 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6478 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105392 "Failed to checkout and rebase branch from PR 43455") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/105392 "Failed to checkout and rebase branch from PR 43455") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84654 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/105392 "Failed to checkout and rebase branch from PR 43455") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24941 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->