### PR TITLE
Vimeo web app videos reset to beginning when brought back from background the first time

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -195,6 +195,7 @@ private:
     bool isEnabledVideoTrackID(TrackID) const;
     bool requiresFlush() const;
     void flushVideo();
+    void setLayerRequiresFlush();
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     RetainPtr<AVSampleBufferAudioRenderer> audioRendererForTrackID(TrackID) const;
     void flushAudio(AVSampleBufferAudioRenderer *);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -228,9 +228,7 @@ private:
     void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, TrackID);
 
     void flush();
-#if PLATFORM(IOS_FAMILY)
     void flushIfNeeded();
-#endif
     void flushTrack(TrackID);
     void flushVideo();
     void flushAudio(AVSampleBufferAudioRenderer*);
@@ -304,6 +302,7 @@ private:
         StagedLayer
     };
     AcceleratedVideoMode acceleratedVideoMode() const;
+    void setLayerRequiresFlush();
 
     const Logger& logger() const final { return m_logger.get(); }
     Ref<const Logger> protectedLogger() const { return logger(); }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -812,7 +812,7 @@ void MediaPlayerPrivateWebM::setReadyState(MediaPlayer::ReadyState state)
 
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_readyState = state;
-    
+
     if (auto player = m_player.get())
         player->readyStateChanged();
 }
@@ -1168,7 +1168,7 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
         updateDisplayLayer();
         return;
     }
-    
+
     if (isEnabledVideoTrackID(trackId)) {
         m_enabledVideoTrackID.reset();
         m_readyForMoreSamplesMap.erase(trackId);
@@ -1343,13 +1343,15 @@ void MediaPlayerPrivateWebM::flush()
     }
 }
 
-#if PLATFORM(IOS_FAMILY)
 void MediaPlayerPrivateWebM::flushIfNeeded()
 {
+#if PLATFORM(IOS_FAMILY)
     if (!m_displayLayerWasInterrupted)
         return;
 
     m_displayLayerWasInterrupted = false;
+#endif
+
     if (m_videoTracks.size())
         flushVideo();
 
@@ -1362,7 +1364,6 @@ void MediaPlayerPrivateWebM::flushIfNeeded()
     if (m_enabledVideoTrackID)
         reenqueSamples(*m_enabledVideoTrackID);
 }
-#endif
 
 void MediaPlayerPrivateWebM::flushTrack(TrackID trackId)
 {
@@ -1900,6 +1901,7 @@ void MediaPlayerPrivateWebM::invalidateVideoRenderer(VideoMediaSampleRenderer& v
 {
     videoRenderer.flush();
     videoRenderer.stopRequestingMediaData();
+    videoRenderer.notifyWhenVideoRendererRequiresFlushToResumeDecoding({ });
     if (auto renderer = videoRenderer.renderer())
         m_listener->stopObservingVideoRenderer(renderer);
 }
@@ -1945,6 +1947,10 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
         protectedThis->setHasAvailableVideoFrame(true);
         if (protectedThis->m_isGatheringVideoFrameMetadata)
             protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
+    });
+    videoRenderer->notifyWhenVideoRendererRequiresFlushToResumeDecoding([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setLayerRequiresFlush();
     });
     configureVideoRenderer(*videoRenderer);
 }
@@ -2033,6 +2039,16 @@ void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFu
 #else
     UNUSED_PARAM(isInFullscreenOrPictureInPicture);
 #endif
+}
+
+void MediaPlayerPrivateWebM::setLayerRequiresFlush()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+#if PLATFORM(IOS_FAMILY)
+    m_displayLayerWasInterrupted = true;
+#endif
+    // FIXME: Do not immediately flush the layer if the process is now backgrounded on iOS.
+    flushIfNeeded();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateWebM::videoPlaybackQualityMetrics()

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -74,6 +74,7 @@ public:
 
     void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&);
     void notifyWhenDecodingErrorOccurred(Function<void(OSStatus)>&&);
+    void notifyWhenVideoRendererRequiresFlushToResumeDecoding(Function<void()>&&);
 
     void flush();
 
@@ -140,6 +141,7 @@ private:
 
     void notifyHasAvailableVideoFrame(const MediaTime&, double, FlushId);
     void notifyErrorHasOccurred(OSStatus);
+    void notifyVideoRendererRequiresFlushToResumeDecoding();
 
     Ref<GuaranteedSerialFunctionDispatcher> dispatcher() const;
     void ensureOnDispatcher(Function<void()>&&) const;
@@ -172,6 +174,7 @@ private:
     bool m_prefersDecompressionSession WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     std::optional<uint32_t> m_currentCodec;
     std::atomic<bool> m_gotDecodingError { false };
+    bool m_needsFlushing WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 
     // Playback Statistics
     std::atomic<unsigned> m_totalVideoFrames { 0 };
@@ -182,6 +185,7 @@ private:
 
     Function<void(const MediaTime&, double)> m_hasAvailableFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
     Function<void(OSStatus)> m_errorOccurredFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
+    Function<void()> m_rendererNeedsFlushFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
     ProcessIdentity m_resourceOwner;
     MonotonicTime m_startupTime;
 };

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -30,6 +30,7 @@
 #include "ProcessIdentity.h"
 #include <CoreMedia/CMTime.h>
 #include <atomic>
+#include <wtf/Expected.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
@@ -73,7 +74,7 @@ private:
     };
     WEBCORE_EXPORT explicit WebCoreDecompressionSession(Mode);
 
-    RetainPtr<VTDecompressionSessionRef> ensureDecompressionSessionForSample(CMSampleBufferRef);
+    Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> ensureDecompressionSessionForSample(CMSampleBufferRef);
 
     Ref<DecodingPromise> decodeSampleInternal(CMSampleBufferRef, bool displaying);
     void handleDecompressionOutput(bool displaying, OSStatus, VTDecodeInfoFlags, CVImageBufferRef, CMTime presentationTimeStamp, CMTime presentationDuration);


### PR DESCRIPTION
#### ebca0eca47d9d85b228679df6e88dfe21d5e636b
<pre>
Vimeo web app videos reset to beginning when brought back from background the first time
<a href="https://bugs.webkit.org/show_bug.cgi?id=290900">https://bugs.webkit.org/show_bug.cgi?id=290900</a>
<a href="https://rdar.apple.com/148397123">rdar://148397123</a>

Reviewed by Jer Noble and Youenn Fablet.

When the web process goes into the background, the AVSampleBufferDisplayLayer
will send a notification that to resume playback we need to flush, all while
playback is paused. Existing VT session are also invalidated and can no longer
be used to further decode content.
From time to time, the SourceBufferPrivateAVFObjC will continue to attempt
to decode current content before playback is paused. This could lead the current
WebCoreDecompressionSession with its now invalidated VT session to attempt
to decode which would error.

Detect when the VTDecompressionSession got invalidated and signal that to
continue decoding we need to flush the video track and recreate the
WebCoreDecompressionSession.
If the switch to a new VT session can be done transparently (that is the change
occurred on a keyframe) we will do so and immediately recreate the VT session
without the need for a flush.

In a follow-up change we will handle when/how to flush the VideoMediaSampleRenderer
when the process is now in the background.

Manually tested. The current testing infrastructure is using iOS simulator
which doesn&apos;t use a videocodecd process, VT session aren&apos;t invalidated when
the webview goes into the background and we can&apos;t replicate the condition
that would have triggered this bug.
Work to add a regression test will be considered in webkit.org/b/291072

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setLayerRequiresFlush):
(WebCore::SourceBufferPrivateAVFObjC::configureVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::invalidateVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setReadyState):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::invalidateVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setLayerRequiresFlush):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::notifyWhenVideoRendererRequiresFlushToResumeDecoding):
(WebCore::VideoMediaSampleRenderer::notifyVideoRendererRequiresFlushToResumeDecoding):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::ensureDecompressionSessionForSample):
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
(WebCore::WebCoreDecompressionSession::decodeSampleSync):

Canonical link: <a href="https://commits.webkit.org/293396@main">https://commits.webkit.org/293396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d4b7ef1ee176b493c23d66355c57eaa720c742f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75237 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48798 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85451 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83700 "Found 1 new API test failure: /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21201 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28352 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25879 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->