### PR TITLE
filter-test-logs should signal failure when the scripts fail partway through

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -24,6 +24,7 @@
 import os
 import argparse
 import sys
+from collections import deque
 
 
 def parser():
@@ -41,7 +42,6 @@ def parser():
 
     return parser.parse_args()
 
-
 def filter_jsc_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
     with open(log_file, 'w') as f:
@@ -53,10 +53,9 @@ def filter_jsc_tests(log_file_name):
             elif line.startswith('** The following JSC') or line.startswith('Results'):
                 print_line = True
                 print(line, end='')
+    return print_line
 
-
-def filter_layout_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
+def filter_layout_tests(log_file):
     with open(log_file, 'w') as f:
         print_line = False
         for line in sys.stdin:
@@ -66,10 +65,9 @@ def filter_layout_tests(log_file_name):
             elif line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line:
                 print_line = True
                 print(line, end='')
+    return print_line
 
-
-def filter_scan_build(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
+def filter_scan_build(log_file):
     with open(log_file, 'w') as f:
         print_all_lines = False
         for line in sys.stdin:
@@ -82,9 +80,9 @@ def filter_scan_build(log_file_name):
             if line.startswith('**'):
                 print_all_lines = True
                 print(line, end='')
+    return print_all_lines
 
-def filter_webdriver_tests(log_file_name):
-    log_file = os.path.abspath(f'{log_file_name}')
+def filter_webdriver_tests(log_file):
     with open(log_file, 'w') as f:
         print_line = False
         for line in sys.stdin:
@@ -94,18 +92,24 @@ def filter_webdriver_tests(log_file_name):
             if 'tests ran as expected' in line:
                 print_line = True
                 print(line, end='')
+    return print_line
 
 def main():
     args = parser()
+    log_file = os.path.abspath(f'{args.output}')
     if args.filter_type == 'jsc':
-        filter_jsc_tests(args.output)
+        printed_results = filter_jsc_tests(log_file)
     elif args.filter_type == 'layout':
-        filter_layout_tests(args.output)
+        printed_results = filter_layout_tests(log_file)
     elif args.filter_type == 'scan-build':
-        filter_scan_build(args.output)
+        printed_results = filter_scan_build(log_file)
     elif args.filter_type == 'webdriver':
-        filter_webdriver_tests(args.output)
-
+        printed_results = filter_webdriver_tests(args.output)
+    if not printed_results:
+        with open(log_file, 'r') as raw_output:
+            for l in iter(deque(raw_output, maxlen=500)):
+                sys.stdout.write(l)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
#### 059ca9174a00318789bd8eb92b3531c412a4a24a
<pre>
filter-test-logs should signal failure when the scripts fail partway through
<a href="https://bugs.webkit.org/show_bug.cgi?id=290911">https://bugs.webkit.org/show_bug.cgi?id=290911</a>

Reviewed by NOBODY (OOPS!).

run-jsc-stress-tests or run-javascriptcore-tests may run into an
exception and fail to print the results. In that case, filter-test-logs
should raise the alarm.

Change filter-test-logs to both exit with a non-zero status
and pass-through the whole output when that happens.

* Tools/Scripts/filter-test-logs:
(filter_jsc_tests):
(filter_layout_tests):
(filter_scan_build):
(filter_webdriver_tests):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b1e89fd0a7cc2f0a4f68ea1f230a4e82dc61e8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31854 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83653 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83107 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18795 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24940 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->