### PR TITLE
REGRESSION(289811@main): media/ios/video-volume-ios-quirk.html is a constant failure on iPadOS

### DIFF
--- a/LayoutTests/media/ios/video-volume-ios-quirk.html
+++ b/LayoutTests/media/ios/video-volume-ios-quirk.html
@@ -12,8 +12,8 @@
     testDOMException("video.volume = -0.5", "DOMException.INDEX_SIZE_ERR");
     video.src = findMediaFile("video", "content/test");
 
-	setTimeout(function() { 
-	    testExpected("video.volume", 1.0);
+    setTimeout(function() {
+        consoleWrite(`LOG video.volume 100ms later: ${video.volume}`);
         endTest();
-	} , 100);
+    }, 100);
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7794,8 +7794,6 @@ webkit.org/b/290794 fast/viewport/ios/content-visibility-layout-viewport-during-
 
 webkit.org/b/290796 fast/events/ios/keyboard-scrolling-distance.html [ Failure ]
 
-webkit.org/b/290799 media/ios/video-volume-ios-quirk.html [ Failure ]
-
 webkit.org/b/290804 [ Debug ] editing/caret/caret-position-vertical-rl.html [ Failure ]
 
 webkit.org/b/290804 [ Release ] editing/caret/caret-position-vertical-rl.html [ Pass Failure ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -19,6 +19,7 @@ fast/forms/ios/zoom-after-input-tap-wide-input.html [ Skip ]
 fast/forms/ios/zoom-after-input-tap.html [ Skip ]
 
 media/video-background-playback.html [ Pass Crash ]
+media/video-volume.html [ Pass ]
 fast/forms/ios/scroll-to-reveal-focused-select.html [ Crash Failure ]
 fast/forms/ios/time-picker-value-change.html [ Failure ]
 [ Debug ] fast/forms/ios/form-control-refresh/select/focus-select-in-touchend.html [ Timeout ]

--- a/LayoutTests/platform/ipad/media/ios/video-volume-ios-quirk-expected.txt
+++ b/LayoutTests/platform/ipad/media/ios/video-volume-ios-quirk-expected.txt
@@ -8,6 +8,6 @@ RUN(video.volume = 0)
 EXPECTED (video.volume == '0') OK
 TEST(video.volume = 1.5) THROWS(DOMException.INDEX_SIZE_ERR) OK
 TEST(video.volume = -0.5) THROWS(DOMException.INDEX_SIZE_ERR) OK
-LOG video.volume 100ms later: 1
+LOG video.volume 100ms later: 0
 END OF TEST
 


### PR DESCRIPTION
#### 4615b1cca18617c349abd4b5d90d1225dec266d3
<pre>
REGRESSION(289811@main): media/ios/video-volume-ios-quirk.html is a constant failure on iPadOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=290799">https://bugs.webkit.org/show_bug.cgi?id=290799</a>
<a href="https://rdar.apple.com/148280360">rdar://148280360</a>

Reviewed by Eric Carlson.

Make the test log video.volume instead so we can more cleanly
differentiate iOS and iPadOS.

And while here also enable the main volume test on iPadOS as it is now
passing.

* LayoutTests/media/ios/video-volume-ios-quirk-expected.txt:
* LayoutTests/media/ios/video-volume-ios-quirk.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/media/ios/video-volume-ios-quirk-expected.txt: Copied from LayoutTests/media/ios/video-volume-ios-quirk-expected.txt.

Canonical link: <a href="https://commits.webkit.org/293215@main">https://commits.webkit.org/293215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791d8b2e4be37710a02f35cfa53855179f34b293

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48643 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105607 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83140 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18840 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15917 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25159 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->