### PR TITLE
Add support for ImageCapture.grabFrame

### DIFF
--- a/LayoutTests/fast/mediastream/image-capture-grabFrame-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-grabFrame-expected.txt
@@ -1,0 +1,10 @@
+
+
+PASS 'grabFrame()' on an 'ended' track should reject "InvalidStateError"
+PASS "grabFrame" should reject if the track ends before the 'grabFrame()' promise resolves
+PASS The image returned by 'grabFrame()' should have the same size as track settings
+PASS Validate 0 rotated frame
+PASS Validate 90 rotated frame
+PASS Validate 180 rotated frame
+PASS Validate 270 rotated frame
+

--- a/LayoutTests/fast/mediastream/image-capture-grabFrame.html
+++ b/LayoutTests/fast/mediastream/image-capture-grabFrame.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>ImageCapture grabFrame</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <video id=video autoplay playsinline></video>
+    <br>
+    <canvas id=canvas1></canvas>
+    <canvas id=canvas2></canvas>
+    <script>
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+    const [track] = stream.getVideoTracks();
+    test.add_cleanup(() => track.stop());
+
+    assert_equals(track.readyState, 'live');
+    track.stop();
+    assert_equals(track.readyState, 'ended');
+
+    const imageCapture = new ImageCapture(track);
+    const promise = imageCapture.grabFrame();
+
+    let result;
+    promise.then(
+        (value) => { result = value; },
+        (error) => { result = error; }
+    );
+
+    await Promise.resolve();
+    assert_equals(result['name'], 'InvalidStateError');
+    return promise_rejects_dom(test, 'InvalidStateError', promise);
+
+}, `'grabFrame()' on an 'ended' track should reject "InvalidStateError"`);
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+    const [track] = stream.getVideoTracks();
+    test.add_cleanup(() => track.stop());
+
+    assert_equals(track.readyState, 'live');
+
+    const imageCapture = new ImageCapture(track);
+    const promise = imageCapture.grabFrame();
+
+    track.stop();
+    assert_equals(track.readyState, 'ended');
+
+    return promise_rejects_dom(test, 'OperationError', promise);
+
+}, `"grabFrame" should reject if the track ends before the 'grabFrame()' promise resolves`);
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+    const [track] = stream.getVideoTracks();
+    test.add_cleanup(() => track.stop());
+
+    const imageCapture = new ImageCapture(track);
+    let settings = track.getSettings();
+    assert_equals(settings.width, 640);
+
+    let image = await imageCapture.grabFrame();
+    assert_equals(image.width, settings.width, "image width 1");
+    assert_equals(image.height, settings.height, "image height 1");
+
+    await track.applyConstraints({ width: 320 });
+    settings = track.getSettings();
+    assert_equals(settings.width, 320);
+
+    image = await imageCapture.grabFrame();
+    assert_equals(image.width, settings.width, "image width 2");
+    assert_equals(image.height, settings.height, "image height 2");
+}, `The image returned by 'grabFrame()' should have the same size as track settings`);
+
+async function validateImages(test, rotation)
+{
+    if (!window.testRunner)
+        return;
+    testRunner.setMockCameraOrientation(rotation);
+
+    let width = 640;
+    let height = 480;
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width, height, frameRate : 5 } });
+    const [track] = stream.getVideoTracks();
+    test.add_cleanup(() => track.stop());
+
+    video.srcObject = stream;
+    await video.play();
+
+    const imageCapture = new ImageCapture(track);
+    const imagePromise = imageCapture.grabFrame();
+    const videoFramePromise = new Promise(resolve => video.requestVideoFrameCallback(() => resolve(new VideoFrame(video))));
+
+    const image = await imagePromise;
+    const videoFrame = await videoFramePromise;
+    test.add_cleanup(() => videoFrame.close());
+
+    if (rotation === 90 || rotation === 270) {
+        width = 480;
+        height = 640;
+    }
+
+    canvas1.width = width;
+    canvas1.height = height;
+    canvas1.getContext('2d').drawImage(image, 0, 0, width, height);
+    const data1 = canvas1.getContext('2d').getImageData(0, 0, width, height).data;
+
+    canvas2.width = width;
+    canvas2.height = height;
+    if (rotation === 0) {
+       canvas2.getContext('2d').reset();
+       canvas2.getContext('2d').drawImage(videoFrame, 0, 0, 640, 480);
+    } else if (rotation === 90) {
+       canvas2.getContext('2d').reset();
+       canvas2.getContext('2d').translate(240, 320);
+       canvas2.getContext('2d').rotate(Math.PI / 2);
+       canvas2.getContext('2d').drawImage(videoFrame, -320, -240, 640, 480);
+    } else if (rotation === 180) {
+       canvas2.getContext('2d').reset();
+       canvas2.getContext('2d').translate(320, 240);
+       canvas2.getContext('2d').rotate(-Math.PI);
+       canvas2.getContext('2d').drawImage(videoFrame, -320, -240, 640, 480);
+    } else if (rotation === 270) {
+       canvas2.getContext('2d').reset();
+       canvas2.getContext('2d').translate(240, 320);
+       canvas2.getContext('2d').rotate(-Math.PI / 2);
+       canvas2.getContext('2d').drawImage(videoFrame, -320, -240, 640, 480);
+    }
+
+    const data2 = canvas2.getContext('2d').getImageData(0, 0, width, height).data;
+
+    let error = 10;
+    let checkRoughlyEqual = (a, b) => {
+       return Math.abs(a - b) < error;
+    };
+
+    let differenceCounter = 0;
+    for (let i = 0; i < data1.length; i = i + 4) {
+        if (!checkRoughlyEqual(data1[i], data2[i]) || !checkRoughlyEqual(data1[i + 1], data2[i + 1]) || !checkRoughlyEqual(data1[i + 2], data2[i + 2]))
+            differenceCounter++;
+    }
+
+    const threshold = canvas1.width * canvas1.height / 25;
+    assert_less_than(differenceCounter, threshold);
+}
+
+promise_test(async (test) => {
+    return validateImages(test, 0);
+}, "Validate 0 rotated frame");
+
+promise_test(async (test) => {
+    return validateImages(test, 90);
+}, "Validate 90 rotated frame");
+
+promise_test(async (test) => {
+    return validateImages(test, 180);
+}, "Validate 180 rotated frame");
+
+promise_test(async (test) => {
+    return validateImages(test, 270);
+}, "Validate 270 rotated frame");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2235,6 +2235,7 @@ webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
 webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
 fast/mediastream/video-rotation-clone.html [ Skip ]
+fast/mediastream/image-capture-grabFrame.html [ Failure ]
 
 # No AudioSession category handling in WPE/GTK ports.
 fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -28,11 +28,18 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "GraphicsContext.h"
+#include "ImageBitmapOptions.h"
+#include "ImageBuffer.h"
 #include "JSBlob.h"
+#include "JSImageBitmap.h"
 #include "JSPhotoCapabilities.h"
 #include "JSPhotoSettings.h"
 #include "Logging.h"
+#include "MediaStrategy.h"
+#include "PlatformStrategies.h"
 #include "TaskSource.h"
+#include "VideoFrame.h"
 #include <wtf/LoggerHelper.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -62,7 +69,10 @@ ImageCapture::ImageCapture(Document& document, Ref<MediaStreamTrack> track)
     ALWAYS_LOG(LOGIDENTIFIER);
 }
 
-ImageCapture::~ImageCapture() = default;
+ImageCapture::~ImageCapture()
+{
+    stop();
+}
 
 void ImageCapture::takePhoto(PhotoSettings&& settings, DOMPromiseDeferred<IDLInterface<Blob>>&& promise)
 {
@@ -93,6 +103,187 @@ void ImageCapture::takePhoto(PhotoSettings&& settings, DOMPromiseDeferred<IDLInt
             SUPPRESS_UNCOUNTED_ARG promise.resolve(Blob::create(capture.scriptExecutionContext(), WTFMove(get<0>(result.value())), WTFMove(get<1>(result.value()))));
         });
     });
+}
+
+// FIXME: Move this routine to VideoFrame.
+static ImageOrientation videoFrameOrientation(const VideoFrame& videoFrame)
+{
+    switch (videoFrame.rotation()) {
+    case VideoFrame::Rotation::None:
+        return videoFrame.isMirrored() ? ImageOrientation::Orientation::OriginTopRight : ImageOrientation::Orientation::OriginTopLeft;
+    case VideoFrame::Rotation::Right:
+        return videoFrame.isMirrored() ? ImageOrientation::Orientation::OriginRightBottom : ImageOrientation::Orientation::OriginRightTop;
+    case VideoFrame::Rotation::UpsideDown:
+        return videoFrame.isMirrored() ? ImageOrientation::Orientation::OriginBottomLeft : ImageOrientation::Orientation::OriginBottomRight;
+    case VideoFrame::Rotation::Left:
+        return videoFrame.isMirrored() ? ImageOrientation::Orientation::OriginLeftTop : ImageOrientation::Orientation::OriginLeftBottom;
+    }
+    ASSERT_NOT_REACHED();
+    return ImageOrientation::Orientation::OriginTopLeft;
+}
+
+static Ref<ImageBitmap> createImageBitmapViaDrawing(Ref<ImageBuffer>&& imageBuffer, VideoFrame& videoFrame)
+{
+    bool shouldDiscardAlpha = false;
+    imageBuffer->context().drawVideoFrame(videoFrame, { { }, imageBuffer->backendSize() }, videoFrameOrientation(videoFrame), shouldDiscardAlpha);
+
+    bool isOriginClean = true;
+    return ImageBitmap::create(WTFMove(imageBuffer), isOriginClean);
+}
+
+static Ref<ImageBitmap> createImageBitmapFromNativeImage(Ref<ImageBuffer>&& imageBuffer, NativeImage& nativeImage, ImageOrientation orientation)
+{
+    imageBuffer->context().drawNativeImage(nativeImage, { { }, imageBuffer->backendSize() }, { { }, imageBuffer->backendSize() }, ImagePaintingOptions { orientation });
+
+    bool isOriginClean = true;
+    return ImageBitmap::create(WTFMove(imageBuffer), isOriginClean);
+}
+
+static void createImageBitmap(VideoFrame& videoFrame, CompletionHandler<void(RefPtr<ImageBitmap>&&)>&& completionHandler)
+{
+    IntSize size { static_cast<int>(videoFrame.presentationSize().width()), static_cast<int>(videoFrame.presentationSize().height()) };
+    if (videoFrame.rotation() == VideoFrameRotation::Left || videoFrame.rotation() == VideoFrameRotation::Right)
+        size = { size.height(), size.width() };
+    auto imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8);
+    if (!imageBuffer) {
+        completionHandler({ });
+        return;
+    }
+
+    if (hasPlatformStrategies()) {
+        platformStrategies()->mediaStrategy().nativeImageFromVideoFrame(videoFrame, [videoFrame = Ref { videoFrame }, imageBuffer = imageBuffer.releaseNonNull(), completionHandler = WTFMove(completionHandler)](auto&& nativeImage) mutable {
+            if (!nativeImage) {
+                completionHandler(createImageBitmapViaDrawing(WTFMove(imageBuffer), videoFrame));
+                return;
+            }
+
+            RefPtr image = WTFMove(*nativeImage);
+            if (!image) {
+                completionHandler({ });
+                return;
+            }
+
+            completionHandler(createImageBitmapFromNativeImage(WTFMove(imageBuffer), *image, videoFrameOrientation(videoFrame)));
+        });
+        return;
+    }
+
+    completionHandler(createImageBitmapViaDrawing(imageBuffer.releaseNonNull(), videoFrame));
+}
+
+class ImageCaptureVideoFrameObserver : public RealtimeMediaSource::VideoFrameObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageCaptureVideoFrameObserver, WTF::DestructionThread::MainRunLoop> {
+public:
+    static Ref<ImageCaptureVideoFrameObserver> create(Ref<RealtimeMediaSource>&& source) { return adoptRef(*new ImageCaptureVideoFrameObserver(WTFMove(source))); }
+    ~ImageCaptureVideoFrameObserver()
+    {
+        ASSERT(m_callbacks.isEmpty());
+    }
+
+    using Callback = CompletionHandler<void(ExceptionOr<Ref<ImageBitmap>>&&)>;
+    void add(Callback&& callback)
+    {
+        if (m_callbacks.isEmpty())
+            m_source->addVideoFrameObserver(*this);
+
+        m_callbacks.append(WTFMove(callback));
+    }
+
+    void stop()
+    {
+        if (!m_callbacks.isEmpty())
+            m_source->removeVideoFrameObserver(*this);
+
+        while (!m_callbacks.isEmpty())
+            m_callbacks.takeFirst()(WebCore::Exception { WebCore::ExceptionCode::OperationError, "grabFrame is stopped"_s });
+    }
+
+private:
+    explicit ImageCaptureVideoFrameObserver(Ref<RealtimeMediaSource>&& source)
+        : m_source(WTFMove(source))
+    {
+    }
+
+    void videoFrameAvailable(VideoFrame& frame, VideoFrameTimeMetadata) final
+    {
+        {
+            Locker locker(m_frameLock);
+            m_frame = &frame;
+        }
+        callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            RefPtr<VideoFrame> frame;
+            {
+                Locker locker(protectedThis->m_frameLock);
+                frame = std::exchange(protectedThis->m_frame, { });
+            }
+
+            if (!frame)
+                return;
+
+            protectedThis->processVideoFrame(*frame);
+        });
+    }
+
+    void processVideoFrame(VideoFrame& frame)
+    {
+        ASSERT(isMainThread());
+        if (m_callbacks.isEmpty())
+            return;
+
+        createImageBitmap(frame, [callback = m_callbacks.takeFirst()](auto&& bitmap) mutable {
+            if (!bitmap) {
+                callback(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Unable to create ImageBitmap"_s });
+                return;
+            }
+            callback(bitmap.releaseNonNull());
+        });
+
+        if (m_callbacks.isEmpty())
+            m_source->removeVideoFrameObserver(*this);
+    }
+
+    Deque<Callback> m_callbacks;
+    const Ref<RealtimeMediaSource> m_source;
+    Lock m_frameLock;
+    RefPtr<VideoFrame> m_frame WTF_GUARDED_BY_LOCK(m_frameLock);
+};
+
+void ImageCapture::grabFrame(DOMPromiseDeferred<IDLInterface<ImageBitmap>>&& promise)
+{
+    auto identifier = LOGIDENTIFIER;
+    ALWAYS_LOG(identifier);
+
+    if (m_track->readyState() == MediaStreamTrack::State::Ended) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+        return;
+    }
+
+    if (!m_grabFrameObserver) {
+        m_grabFrameObserver = ImageCaptureVideoFrameObserver::create(m_track->source());
+        Ref { m_track->privateTrack() }->addObserver(*this);
+    }
+
+    Ref { *m_grabFrameObserver }->add([promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](auto&& result) mutable {
+        if (!pendingActivity->object().m_isStopped)
+            promise.settle(WTFMove(result));
+    });
+}
+
+void ImageCapture::stop()
+{
+    m_isStopped = true;
+    stopGrabFrameObserver();
+}
+
+void ImageCapture::stopGrabFrameObserver()
+{
+    if (auto grabFrameObserver = std::exchange(m_grabFrameObserver, { })) {
+        Ref { m_track->privateTrack() }->removeObserver(*this);
+        grabFrameObserver->stop();
+    }
 }
 
 void ImageCapture::getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&& promise)

--- a/Source/WebCore/Modules/mediastream/ImageCapture.idl
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.idl
@@ -37,6 +37,7 @@
     Promise<PhotoCapabilities> getPhotoCapabilities();
 
     Promise<Blob> takePhoto(optional PhotoSettings photoSettings = {});
+    Promise<ImageBitmap> grabFrame();
 
     Promise<PhotoSettings> getPhotoSettings();
 

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "NativeImage.h"
 #include "NowPlayingManager.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -36,6 +38,7 @@ class CDMFactory;
 class MediaRecorderPrivateWriter;
 class MediaRecorderPrivateWriterListener;
 class NowPlayingManager;
+class VideoFrame;
 
 struct AudioDestinationCreationOptions;
 
@@ -56,6 +59,10 @@ public:
     virtual std::unique_ptr<MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(const String&, MediaRecorderPrivateWriterListener&) const;
 #endif
 
+#if ENABLE(VIDEO)
+    virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
+#endif
+
     virtual bool isWebMediaStrategy() const { return false; }
 
 protected:
@@ -63,5 +70,10 @@ protected:
     virtual ~MediaStrategy();
     bool m_mockMediaSourceEnabled { false };
 };
+
+inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -734,6 +734,7 @@ void MockRealtimeVideoSource::orientationChanged(IntDegrees orientation)
         m_deviceOrientation = VideoFrame::Rotation::Right;
         break;
     case -90:
+    case 270:
         m_deviceOrientation = VideoFrame::Rotation::Left;
         break;
     case 180:

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -30,6 +30,7 @@
 #include "GPUProcessConnection.h"
 #include "RemoteAudioDestinationProxy.h"
 #include "RemoteCDMFactory.h"
+#include "RemoteVideoFrameObjectHeapProxy.h"
 #include "WebProcess.h"
 #include <WebCore/AudioDestination.h>
 #include <WebCore/AudioIOCallback.h>
@@ -135,4 +136,13 @@ std::unique_ptr<MediaRecorderPrivateWriter> WebMediaStrategy::createMediaRecorde
     return nullptr;
 }
 #endif
+
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
+{
+    // FIMXE: Move out of sync IPC.
+    completionHandler(WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -52,6 +52,9 @@ private:
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
     std::unique_ptr<WebCore::MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(const String&, WebCore::MediaRecorderPrivateWriterListener&) const final;
 #endif
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    void nativeImageFromVideoFrame(const WebCore::VideoFrame&, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&&) final;
+#endif
 
 #if ENABLE(GPU_PROCESS)
     std::atomic<bool> m_useGPUProcess { false };


### PR DESCRIPTION
#### ae6cd18d5eb77dd68e72c04b2b7c887567ba3cf8
<pre>
Add support for ImageCapture.grabFrame
<a href="https://rdar.apple.com/148425176">rdar://148425176</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290916">https://bugs.webkit.org/show_bug.cgi?id=290916</a>

Reviewed by Eric Carlson.

Add support of ImageCapture::grabFrame by doing the following:
- Introduce ImageCaptureVideoFrameObserver as a VideoFrameObserver on the ImageCapture track.
- Convert the VideoFrame into an ImageBitmap. We handle the rotation so that drawing the ImageBitmap is similar to rendering the track via a media element.
- The conversion requires conversion to RGB which is done in GPUProcess. For that purpose, we introduce a new MediaStrategy which uses an existing IPC call.

Marking as failing in glib since there is a lack of mock rotation support.

Covered by added test.

* LayoutTests/fast/mediastream/image-capture-grabFrame-expected.txt: Added.
* LayoutTests/fast/mediastream/image-capture-grabFrame.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::~ImageCapture):
(WebCore::videoFrameOrientation):
(WebCore::createImageBitmapViaDrawing):
(WebCore::createImageBitmapFromNativeImage):
(WebCore::createImageBitmap):
(WebCore::ImageCaptureVideoFrameObserver::create):
(WebCore::ImageCaptureVideoFrameObserver::~ImageCaptureVideoFrameObserver):
(WebCore::ImageCaptureVideoFrameObserver::add):
(WebCore::ImageCaptureVideoFrameObserver::stop):
(WebCore::ImageCaptureVideoFrameObserver::ImageCaptureVideoFrameObserver):
(WebCore::ImageCaptureVideoFrameObserver::processVideoFrame):
(WebCore::ImageCapture::grabFrame):
(WebCore::ImageCapture::stop):
(WebCore::ImageCapture::stopGrabFrameObserver):
* Source/WebCore/Modules/mediastream/ImageCapture.h:
* Source/WebCore/Modules/mediastream/ImageCapture.idl:
* Source/WebCore/platform/MediaStrategy.h:
(WebCore::MediaStrategy::nativeImageFromVideoFrame):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::orientationChanged):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:

Canonical link: <a href="https://commits.webkit.org/293243@main">https://commits.webkit.org/293243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab5f181a6779fccb743215e63fe6eb5589063066

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32016 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48308 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25424 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25382 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->