### PR TITLE
[Android] Build WebDriver as a library

### DIFF
--- a/Source/WebDriver/CMakeLists.txt
+++ b/Source/WebDriver/CMakeLists.txt
@@ -66,13 +66,19 @@ MAKE_JS_FILE_ARRAYS(
 )
 list(APPEND WebDriver_SOURCES ${WebDriver_DERIVED_SOURCES_DIR}/WebDriverAtoms.cpp)
 
-WEBKIT_EXECUTABLE_DECLARE(WebDriver)
+if (ANDROID AND (PORT STREQUAL WPE))
+    set(WebDriver_TARGET_TYPE LIBRARY)
+else ()
+    set(WebDriver_TARGET_TYPE EXECUTABLE)
+endif ()
+
+cmake_language(CALL "WEBKIT_${WebDriver_TARGET_TYPE}_DECLARE" WebDriver)
 
 add_dependencies(WebDriver JavaScriptCoreSharedScripts)
 
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
-WEBKIT_EXECUTABLE(WebDriver)
+cmake_language(CALL "WEBKIT_${WebDriver_TARGET_TYPE}" WebDriver)
 
 install(TARGETS WebDriver
     RUNTIME DESTINATION "${EXEC_INSTALL_DIR}"

--- a/Source/WebDriver/WebDriverMain.cpp
+++ b/Source/WebDriver/WebDriverMain.cpp
@@ -30,7 +30,18 @@
 #include <wtf/MainThread.h>
 #include <wtf/Threading.h>
 
+//
+// On Android, WebDriver is built as a shared library, and the process is spawned
+// from the Java side, which calls into a C++ function using JNI, and that in turn
+// jumps into the entry point. The mangled name is used directly, from the code at
+// https://github.com/Igalia/wpe-android/blob/b918e3f8b86eda406436cb251c2e7b10a529008c/wpeview/src/main/cpp/Service/EntryPoint.cpp#L55
+//
+#if OS(ANDROID)
+__attribute__((visibility("default")))
+int WebKit::WebDriverProcessMain(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
     WebDriver::WebDriverService::platformInit();
 


### PR DESCRIPTION
#### 9c5b417a5187923c8e929e025e497bc371566388
<pre>
[Android] Build WebDriver as a library
<a href="https://bugs.webkit.org/show_bug.cgi?id=290921">https://bugs.webkit.org/show_bug.cgi?id=290921</a>

Reviewed by Michael Catanzaro.

On Android processes are spawned from the Java side, which dynamically
loads the libWebDriver.so shared object and calls into its entry point
from Java through JNI. Therefore, setup the CMake build to build a
shared library, and rename the entry point to WebKit::WebDriverProcessMain.

* Source/WebDriver/CMakeLists.txt: Arrange to compile the WebDriver
target as a shared library when building the WPE port for Android.
* Source/WebDriver/WebDriverMain.cpp:
(main): Use WebKit::WebDriverProcessMain as entry point name under OS(ANDROID).

Canonical link: <a href="https://commits.webkit.org/293601@main">https://commits.webkit.org/293601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad5a88cd2a4a51db142b51c727f277eab8e2e4e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49974 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75629 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102380 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14682 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26487 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84102 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21330 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20230 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16175 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31628 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->