### PR TITLE
[JSC] Fix inverted condition in partial loop unrolling and clarify logic with shouldFullyUnroll()

### DIFF
--- a/JSTests/stress/loop-unrolling-variable-with-inverted-condition.js
+++ b/JSTests/stress/loop-unrolling-variable-with-inverted-condition.js
@@ -1,0 +1,21 @@
+//@ runDefault("--usePartialLoopUnrolling=1", "--useConcurrentJIT=1")
+function test(results, limit)
+{
+    var i = -2147483648 + 10;
+    do {
+        results.push(Math.abs(i));
+        --i;
+    } while (i !== limit);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    var results = [];
+    test(results, -2147483647);
+    if (results.length != 9)
+        throw "Wrong result length: " + results.length;
+    for (var j = 0; j < 9; ++j) {
+        if (results[j] !== 2147483638 + j)
+            throw "Wrong result, results[j] = " + results[j] + " at j = " + j;
+    }
+}


### PR DESCRIPTION
#### d6e8264d2a17461cc9cfac2def534d7fb18bbcb4
<pre>
[JSC] Fix inverted condition in partial loop unrolling and clarify logic with shouldFullyUnroll()
<a href="https://bugs.webkit.org/show_bug.cgi?id=290927">https://bugs.webkit.org/show_bug.cgi?id=290927</a>
<a href="https://rdar.apple.com/148439864">rdar://148439864</a>

Reviewed by Yusuke Suzuki.

This patch fixes an inverted condition bug that affected partial loop unrolling.
Previously, full unrolling handled the edge direction implicitly during constant
iteration computation. Therefore, for partial unrolling, we need to explicitly
swap the taken and notTaken edges at the terminal branch to maintain correct control flow.

To clarify the semantics, the helper method isOperandConstant() has been renamed
to shouldFullyUnroll() to make the distinction between full and partial unrolling
explicit. All related code paths have been updated accordingly.

* JSTests/stress/loop-unrolling-variable-with-inverted-condition.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::shouldFullyUnroll const):
(JSC::DFG::LoopUnrollingPhase::identifyInductionVariable):
(JSC::DFG::LoopUnrollingPhase::shouldUnrollLoop):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
(JSC::DFG::LoopUnrollingPhase::LoopData::dump const):
(JSC::DFG::LoopUnrollingPhase::LoopData::isOperandConstant const): Deleted.

Canonical link: <a href="https://commits.webkit.org/293123@main">https://commits.webkit.org/293123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78895ca99f2288957d1db3a85f77028ae04fbffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74580 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31765 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6445 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47919 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90623 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105441 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96570 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25027 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83574 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83019 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30157 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120195 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24810 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33705 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->