### PR TITLE
AX: Attachment elements don't emit an attachment character with ENABLE(AX_THREAD_TEXT_API)

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -45,7 +45,6 @@ accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Tim
 accessibility/content-editable-as-textarea.html [ Failure ]
 accessibility/full-size-kana-untransformed.html [ Failure ]
 accessibility/mac/aria-image-emits-object-replacement.html [ Failure ]
-accessibility/mac/attachment-element-replacement-character.html [ Failure ]
 accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html [ Failure ]
 accessibility/mac/attributed-string-includes-misspelled-with-selection.html [ Failure ]
 accessibility/mac/attributed-string-with-listitem-multiple-lines.html [ Failure ]

--- a/LayoutTests/accessibility/mac/attachment-element-replacement-character-expected.txt
+++ b/LayoutTests/accessibility/mac/attachment-element-replacement-character-expected.txt
@@ -1,15 +1,8 @@
-some  test
 This tests that attachment element replacements are present in strings.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 String:
 some [ATTACHMENT] test
-This tests that attachment element replacements are present in strings.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+some  test

--- a/LayoutTests/accessibility/mac/attachment-element-replacement-character.html
+++ b/LayoutTests/accessibility/mac/attachment-element-replacement-character.html
@@ -1,29 +1,28 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
-<body id="body">
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
 
 some
 <attachment id="attachment" title="title" subtitle="subtitle" action="action" progress="0.5"></attachment>
 test
 
-<p id="description"></p>
-<div id="console"></div>
-
-<script src="../../resources/js-test-pre.js"></script>
 <script>
+var output = "This tests that attachment element replacements are present in strings.\n\n";
 
-    description("This tests that attachment element replacements are present in strings.");
+if (window.accessibilityController) {
+    var body = accessibilityController.rootElement.childAtIndex(0);
+    var startMarker = body.startTextMarker;
+    var endMarker = body.endTextMarker;
+    var textMarkerRange = body.textMarkerRangeForMarkers(startMarker, endMarker);
+    output += `String: \n${body.stringForTextMarkerRange(textMarkerRange).replace(String.fromCharCode(65532), "[ATTACHMENT]")}`
 
-    if (window.accessibilityController) {
-        var body = accessibilityController.rootElement.childAtIndex(0);
-        var startMarker = body.startTextMarker;
-        var endMarker = body.endTextMarker;
-        var textMarkerRange = body.textMarkerRangeForMarkers(startMarker, endMarker);
-        debug("String: \n" + body.stringForTextMarkerRange(textMarkerRange).replace(String.fromCharCode(65532), "[ATTACHMENT]"));
-    }
-
+    debug(output);
+}
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>
+

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -48,6 +48,7 @@
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "HTMLAreaElement.h"
+#include "HTMLAttachmentElement.h"
 #include "HTMLBRElement.h"
 #include "HTMLDetailsElement.h"
 #include "HTMLFormElement.h"
@@ -1415,7 +1416,8 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         return { renderLineBreak->containingBlock(), { AXTextRun(box ? box->lineIndex() : 0, makeString('\n').isolatedCopy(), { lengthOneDomOffsets }, { 0 }, 0) } };
     }
 
-    if (is<HTMLImageElement>(node()) || is<HTMLMediaElement>(node())) {
+    RefPtr node = this->node();
+    if (is<HTMLImageElement>(node) || is<HTMLMediaElement>(node) || is<HTMLAttachmentElement>(node)) {
         auto* containingBlock = renderer ? renderer->containingBlock() : nullptr;
         FloatRect rect = frameRect();
         uint16_t width = static_cast<uint16_t>(rect.width());


### PR DESCRIPTION
#### 872078065dcbc16c745ce28a9f783bf3dc2f024c
<pre>
AX: Attachment elements don&apos;t emit an attachment character with ENABLE(AX_THREAD_TEXT_API)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290929">https://bugs.webkit.org/show_bug.cgi?id=290929</a>
<a href="https://rdar.apple.com/148442865">rdar://148442865</a>

Reviewed by Chris Fleizach.

Make AccessibilityRenderObject::textRuns() emit an attachment character for this element, and re-write the test
into a more modern style.

* LayoutTests/accessibility-isolated-tree/TestExpectations: Remove test failure.
* LayoutTests/accessibility/mac/attachment-element-replacement-character-expected.txt:
* LayoutTests/accessibility/mac/attachment-element-replacement-character.html:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/293122@main">https://commits.webkit.org/293122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f70fb5f1145885c6f28e36f26293b800dd3cfeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74575 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31758 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105433 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83010 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30149 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->