### PR TITLE
When skipping a ViewTransition the global object can be null. That results in a crash when trying to call the update callback.

### DIFF
--- a/LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject-expected.txt
+++ b/LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash
+
+PASS

--- a/LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject.html
+++ b/LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject.html
@@ -1,0 +1,22 @@
+<body>
+    <p>This test passes if WebKit does not crash</p>
+    <div id="result"></div>
+    <script>
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
+        async function test() {
+            const frame = document.createElement('iframe');
+            document.body.appendChild(frame);
+            const win = frame.contentWindow;
+            const doc = frame.contentDocument;
+            let z = doc.startViewTransition(() => {});
+            z.skipTransition();
+            frame.remove();
+            setTimeout(() => {
+                result.textContent = 'PASS';
+                window.testRunner?.notifyDone();
+            }, 10);
+        }
+        test();
+    </script>
+</body>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -177,7 +177,7 @@ void ViewTransition::skipViewTransition(ExceptionOr<JSC::JSValue>&& reason)
     if (m_phase < ViewTransitionPhase::UpdateCallbackCalled) {
         protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [this, weakThis = WeakPtr { *this }] {
             RefPtr protectedThis = weakThis.get();
-            if (protectedThis)
+            if (protectedThis && protectedThis->protectedDocument()->globalObject())
                 callUpdateCallback();
         });
 


### PR DESCRIPTION
#### 46ebeb960729df7e3c2072e74ae7d82dad19a48f
<pre>
When skipping a ViewTransition the global object can be null. That results in a crash when trying to call the update callback.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290930">https://bugs.webkit.org/show_bug.cgi?id=290930</a>
<a href="https://rdar.apple.com/147936177">rdar://147936177</a>

Reviewed by Ryosuke Niwa.

This fixes the issue by checking that the global object on the document
is not null before calling the callback that updates the DOM.

* LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject-expected.txt: Added.
* LayoutTests/fast/dom/skipviewtransition-callback-with-no-globalobject.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::skipViewTransition):

Canonical link: <a href="https://commits.webkit.org/293262@main">https://commits.webkit.org/293262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb82299fbb106acae8b08db771d5bdc1f14dff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74742 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6648 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83188 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27831 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5514 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18906 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30399 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->