### PR TITLE
Use explicit line-height in recently added grid test.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations.html
@@ -15,7 +15,7 @@
   grid-template-rows: 50px;
   height: 50px;
   outline: 1px solid blue;
-  font: 10px Ahem;
+  font: 10px/1 Ahem;
 }
 
 .alignStart {


### PR DESCRIPTION
#### 3a5922f06951bd8b7d7bc2ae1f291cc7b7cd98a4
<pre>
Use explicit line-height in recently added grid test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290932">https://bugs.webkit.org/show_bug.cgi?id=290932</a>
<a href="https://rdar.apple.com/148444528">rdar://148444528</a>

Reviewed by Vitor Roriz.

I recently added a test for extrinsically sized grids that validated
the content was laid out correctly in the  presence of different
types of style and content mutations.  In this test I used font: 10px Ahem,
but it looks like I should also  be specifying an explicit line-height as per:

<a href="https://web-platform-tests.org/writing-tests/ahem.html#usage">https://web-platform-tests.org/writing-tests/ahem.html#usage</a>

This change addresses that by changing it to font: 10px/1 Ahem.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-extrinsically-sized-mutations.html:

Canonical link: <a href="https://commits.webkit.org/293125@main">https://commits.webkit.org/293125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4deb07a4c92170961993e827e1d10508d9180549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48480 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25030 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83020 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24991 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->