### PR TITLE
[GStreamer][Quirks] Add quirk supporting instant rate change with custom event

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -33,6 +33,7 @@ public:
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+    bool needsCustomInstantRateChange() const final { return true; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
@@ -39,6 +39,7 @@ public:
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-audio"); }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
+    bool needsCustomInstantRateChange() const final { return true; }
 
 private:
     Vector<String> m_disallowedWebAudioDecoders;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -36,6 +36,7 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
+    bool needsCustomInstantRateChange() const final { return true; }
 
 private:
     Vector<String> m_disallowedWebAudioDecoders;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -42,6 +42,7 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("native-audio") | getGstPlayFlag("native-video"); }
+    bool needsCustomInstantRateChange() const final { return true; }
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -34,6 +34,7 @@ public:
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
+    bool needsCustomInstantRateChange() const final { return true; }
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "GStreamerQuirks.h"
+#include <optional>
 
 #if USE(GSTREAMER)
 
@@ -348,6 +349,94 @@ void GStreamerQuirksManager::processWebAudioSilentBuffer(GstBuffer* buffer) cons
         if (quirk->processWebAudioSilentBuffer(buffer))
             break;
     }
+}
+
+bool GStreamerQuirksManager::needsCustomInstantRateChange() const
+{
+    for (auto& quirk : m_quirks) {
+        if (quirk->needsCustomInstantRateChange())
+            return true;
+    }
+    return false;
+}
+
+// Returning processed and didInstantRateChange.
+std::pair<bool, bool> GStreamerQuirksManager::applyCustomInstantRateChange(
+    bool isPipelinePlaying, bool isPipelineWaitingPreroll, float playbackRate, bool mute, GstElement* pipeline) const
+{
+    for (auto& quirk : m_quirks) {
+        if (quirk->needsCustomInstantRateChange()) {
+            return quirk->applyCustomInstantRateChange(isPipelinePlaying, isPipelineWaitingPreroll, playbackRate,
+                mute, pipeline);
+        }
+    }
+    return { false, false };
+}
+
+// Returning forwardToAllPads.
+bool GStreamerQuirksManager::analyzeWebKitMediaSrcCustomEvent(GRefPtr<GstEvent> event) const
+{
+    for (auto& quirk : m_quirks) {
+        if (quirk->needsCustomInstantRateChange())
+            return quirk->analyzeWebKitMediaSrcCustomEvent(event);
+    }
+    return false;
+}
+
+// Returning rate.
+std::optional<double> GStreamerQuirksManager::processWebKitMediaSrcCustomEvent(GRefPtr<GstEvent> event, bool handledByAnyStream,
+    bool handledByAllStreams) const
+{
+    for (auto& quirk : m_quirks) {
+        if (quirk->needsCustomInstantRateChange())
+            return quirk->processWebKitMediaSrcCustomEvent(event, handledByAnyStream, handledByAllStreams);
+    }
+    return std::nullopt;
+}
+
+// Returning processed and didInstantRateChange.
+std::pair<bool, bool> GStreamerQuirk::applyCustomInstantRateChange(
+    bool isPipelinePlaying, bool isPipelineWaitingPreroll, float playbackRate, bool mute, GstElement* pipeline) const
+{
+    // This check allows to implement a common behaviour for this instant rate change family of methods
+    // in the superclass, but ensure that the code will only run on subclasses actually supporting
+    // instant rate change. This is better than copypasting the code to all the subclasses, and better
+    // than creating a common base class. Common base classes for features instead of for platforms
+    // is a strategy that would quickly become unmaintainable.
+    if (!needsCustomInstantRateChange())
+        return std::pair<bool, bool>(false, false);
+
+    bool didInstantRateChange = false;
+    if (isPipelinePlaying && !isPipelineWaitingPreroll) {
+        GstStructure* s = gst_structure_new("custom-instant-rate-change",
+            "rate", G_TYPE_DOUBLE, playbackRate, nullptr);
+        didInstantRateChange = gst_element_send_event(
+            pipeline, gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, s));
+        if (didInstantRateChange)
+            g_object_set(pipeline, "mute", mute, nullptr);
+    }
+
+    return { true, didInstantRateChange };
+}
+
+// Returning forwardToAllPads.
+bool GStreamerQuirk::analyzeWebKitMediaSrcCustomEvent(GRefPtr<GstEvent> event) const
+{
+    return needsCustomInstantRateChange() && gst_event_has_name(event.get(), "custom-instant-rate-change");
+}
+
+// Returning rate.
+std::optional<double> GStreamerQuirk::processWebKitMediaSrcCustomEvent(GRefPtr<GstEvent> event, bool,
+    bool handledByAllStreams) const
+{
+    if (!needsCustomInstantRateChange())
+        return std::nullopt;
+    if (gst_event_has_name(event.get(), "custom-instant-rate-change") && handledByAllStreams) {
+        auto eventRate = gstStructureGet<double>(gst_event_get_structure(event.get()), "rate"_s);
+        if (eventRate.has_value())
+            return eventRate.value();
+    }
+    return std::nullopt;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -87,6 +87,16 @@ public:
     virtual int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const { return originalBufferingPercentage; }
     virtual void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int) const { };
     virtual void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState, GstState, GRefPtr<GstElement>&&) const { }
+    virtual bool needsCustomInstantRateChange() const { return false; }
+    // Note: Change these pairs and single return types as needed, or even use a struct, if more return fields
+    // have to be added in the future.
+    // Returning processed and didInstantRateChange.
+    virtual std::pair<bool, bool> applyCustomInstantRateChange(
+        bool isPipelinePlaying, bool isPipelineWaitingPreroll, float playbackRate, bool mute, GstElement* pipeline) const;
+    // Returning forwardToAllPads.
+    virtual bool analyzeWebKitMediaSrcCustomEvent(GRefPtr<GstEvent>) const;
+    // Returning rate.
+    virtual std::optional<double> processWebKitMediaSrcCustomEvent(GRefPtr<GstEvent>, bool handledByAnyStream, bool handledByAllTheStreams) const;
 
     // Subclass must return true if it wants to override the default behaviour of sibling platforms.
     virtual bool processWebAudioSilentBuffer(GstBuffer* buffer) const
@@ -148,6 +158,17 @@ public:
     void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
 
     void processWebAudioSilentBuffer(GstBuffer*) const;
+
+    bool needsCustomInstantRateChange() const;
+    // Returning processed and didInstantRateChange.
+    std::pair<bool, bool> applyCustomInstantRateChange(
+        bool isPipelinePlaying, bool isPipelineWaitingPreroll, float playbackRate, bool mute, GstElement* pipeline) const;
+    bool processCustomInstantRateChangeEvent() const;
+    // Returning forwardToAllPads.
+    bool analyzeWebKitMediaSrcCustomEvent(GRefPtr<GstEvent>) const;
+    // Returning rate.
+    std::optional<double> processWebKitMediaSrcCustomEvent(GRefPtr<GstEvent>, bool handledByAnyStream, bool handledByAllStreams) const;
+
 private:
     GStreamerQuirksManager(bool, bool);
 


### PR DESCRIPTION
#### 14cb80d8a004ff61c5550db2b35f7c0d66771313
<pre>
[GStreamer][Quirks] Add quirk supporting instant rate change with custom event
<a href="https://bugs.webkit.org/show_bug.cgi?id=290933">https://bugs.webkit.org/show_bug.cgi?id=290933</a>

Reviewed by Xabier Rodriguez-Calvar.

Some downstream platforms don&apos;t use GstClock for audio/video
synchronization, don&apos;t support existing
GST_SEEK_FLAG_INSTANT_RATE_CHANGE, or it doesn&apos;t work well in all use
cases.

This patch uses a &quot;custom-instant-rate-change&quot; custom OOB downstream
event sent by MediaPlayerPrivateGStreamer to the pipeline. That event is
then processed by WebKitMediaSrcGStreamer, who forwards it to all its
src pads and checks that it has been processed in all the streams. If
that happens, the rate field is updated in the GstSegment and regular
media processing continues.

As this is platform-specific behaviour, both MediaPlayerPrivateGStreamer
and WebKitMediaSrc delegate part of the implementation to the GStreamer
Quirks system. The custom event added in this patch needs to be
forwarded to all the pads, instead of just to the first one processing
it. This needs a behaviour change in webKitMediaSrcSendEvent(), but only
for specific cases (the regular case is to forward it to the first pad
attending it), and that&apos;s why the analyzeWebKitMediaSrcCustomEvent()
method is needed in the Quirks.

As a style choice, the quirk functions that need to return one or more
meaningful values do that directly (as a direct return type), optionally,
or by means of an std::pair. In all those cases, the &quot;meaning&quot; of each
value is named in a /* comment */ after the type. If this scheme evolves
in the future and the methods need to return more fields, and std::pair
or even a specific struct with the field names should be used. Ideally,
we might have used structs in this patch, but creating a struct to hold
a single value doesn&apos;t seem sensible at this point.

This patch is co-authored by Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1475">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1475</a>

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::updatePlaybackRate): Apply (by delegating to the Quirks) custom instant rate change in those platforms that need, instead of doing a seek to change it. Update the last playback rate if the change succeeded.
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin): Don&apos;t use the scaletempo element on platforms that rely on instant rate change.
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcStreamFlush): Update the GstSegment rate to the one currently configured in WebKitMediaSrcGStreamer (which might have been set when processing the &quot;custom-instant-rate-change&quot; event)
(webKitMediaSrcSendEvent): Added code to process OOB custom events (in general), by delegating in the Quirks. The Quirks can now decide if the event has to be propagated to all the pads or only to the first one processing it (default behaviour). In the specific case of the &quot;custom-instant-rate-change&quot; event, the Quirks will decide to propagate to all the pads, and the result of the propagation will be communicated to the Quirks, which will then decide to update the rate stored by WebKitMediaSourceGStreamer if the propagation was successful.in that case
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h: Override default behaviour and enable custom instant rate change on this platform.
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::needsCustomInstantRateChange const): True if any registered quirk needs instant rate change. Evaluated in short-circuit (if one quirk is true, evaluation stops).
(WebCore::GStreamerQuirksManager::applyCustomInstantRateChange const): Returns a pair with a first field indicating that the request to apply the instant rate has been processed (acknowledged by the first quirk that needs instant rate change), and a second field indicating if the instant rate change succeeded (was actually performed). Look at the GStreamerQuirk implementation for an explanation of what this method does.
(WebCore::GStreamerQuirksManager::analyzeWebKitMediaSrcCustomEvent const): Returns true if the first quirk that needs instant rate change indicates that the OOB event needs to be forwarded by all the src pads.
(WebCore::GStreamerQuirksManager::processWebKitMediaSrcCustomEvent const): Returns an optional new rate if the the first quirk that needs instant rate change has been able to retrieve a rate from the event (the event is of the &quot;custom-instant-rate-change&quot; kind and has a rate).
(WebCore::GStreamerQuirk::applyCustomInstantRateChange const): Default implementation (to be inherited/reused by the subclasses) to perform instant rate change on already playing pipelines. A &quot;custom-instant-rate-change&quot; event is sent to the pipeline, and the pipeline mute status is updated accordingly. This implementation is guarded, so it won&apos;t run in case of the method being called by mistake on platforms not supporting custom instant rate changes.
(WebCore::GStreamerQuirk::analyzeWebKitMediaSrcCustomEvent const): Default guarded implementation to determine if the custom event must be forwarded to all the streams/pads (required for &quot;custom-instant-rate-change&quot; on platforms supporting it) or only to the first one successfully processing it (default behaviour for the rest of the events).
(WebCore::GStreamerQuirk::processWebKitMediaSrcCustomEvent const): Default guarded implementation to extract the rate from the &quot;custom-instant-rate-change&quot; event, so that WebKitMediaSrcGStreamer can update its stored rate with that parsed value. This is a method with a parameter passed by reference (to store the result there), instead of returned as a method result, because that&apos;s the common way to do it in GStreamer parse functions (this operation is similar to a parsing). This design can better accept future evolution, where other fields may need to be provided by the analysis performed in this method.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::needsCustomInstantRateChange const): False by default, meaning that custom instant rate change isn&apos;t required on the platforms that don&apos;t override this method.

Canonical link: <a href="https://commits.webkit.org/293255@main">https://commits.webkit.org/293255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7028e4febb353743d18c737b91c58c87cc628128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26433 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6787 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48322 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25438 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25397 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->