### PR TITLE
[WGSL] Structs containing runtime-sized arrays should not be nested

### DIFF
--- a/LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt
+++ b/LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt
@@ -1,9 +1,6 @@
 PASS output[0] is 13
-PASS output[1] is 42
-PASS output[2] is 1
-PASS output[3] is 2
-PASS output[4] is 3
-PASS output[5] is 4
-PASS output[6] is 5
-PASS output[7] is 6
+PASS output[1] is 1
+PASS output[2] is 2
+PASS output[3] is 3
+PASS output[4] is 4
 

--- a/LayoutTests/fast/webgpu/array-length-pointer-parameter.html
+++ b/LayoutTests/fast/webgpu/array-length-pointer-parameter.html
@@ -11,37 +11,25 @@
     let code = `
 struct ad {
     c: u32,
-    af: ae,
-}
-
-struct ae {
-  c: u32,
-  af: array<u32>,
+    af: array<u32>,
 }
 
 @group(0) @binding(0) var<storage, read_write> ac: ad;
 
-fn z(t: ptr<storage, array<u32>, read_write>) {
+fn y(t: ptr<storage, array<u32>, read_write>) {
     t[0] = 1;
-    ac.af.af[1] = 2;
-}
-
-fn y(t: ptr<storage, ae, read_write>) {
-    t.af[2] = 3;
-    ac.af.af[3] = 4;
-    z(&t.af);
+    ac.af[1] = 2;
 }
 
 fn x(t: ptr<storage, ad, read_write>) {
-    t.af.af[4] = 5;
-    ac.af.af[5] = 6;
+    t.af[2] = 3;
+    ac.af[3] = 4;
     y(&t.af);
 }
 
 fn f()
 {
     ac.c = 13;
-    ac.af.c = 42;
     x(&ac);
 }
 
@@ -81,13 +69,10 @@ fn main()
     await outputBuffer0.mapAsync(GPUMapMode.READ);
     output = [...new Uint32Array(outputBuffer0.getMappedRange())]
     shouldBe('output[0]', '13');
-    shouldBe('output[1]', '42');
-    shouldBe('output[2]', '1');
-    shouldBe('output[3]', '2');
-    shouldBe('output[4]', '3');
-    shouldBe('output[5]', '4');
-    shouldBe('output[6]', '5');
-    shouldBe('output[7]', '6');
+    shouldBe('output[1]', '1');
+    shouldBe('output[2]', '2');
+    shouldBe('output[3]', '3');
+    shouldBe('output[4]', '4');
     outputBuffer0.unmap();
     let error = await device.popErrorScope();
     if (error) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -477,6 +477,12 @@ void TypeChecker::visit(AST::Structure& structure)
                 return;
             }
 
+            if (!std::holds_alternative<Types::Array>(*memberType)) {
+                typeError(InferBottom::No, member.span(), "a struct that contains a runtime array cannot be nested inside another struct"_s);
+                introduceType(structure.name(), m_types.bottomType());
+                return;
+            }
+
             if (i != structure.members().size() - 1) {
                 typeError(InferBottom::No, member.span(), "runtime arrays may only appear as the last member of a struct"_s);
                 introduceType(structure.name(), m_types.bottomType());

--- a/Source/WebGPU/WGSL/tests/array-length-pointer2.wgsl
+++ b/Source/WebGPU/WGSL/tests/array-length-pointer2.wgsl
@@ -2,30 +2,19 @@
 
 struct ad {
     c: u32,
-    af: ae,
-}
-
-struct ae {
-  c: u32,
-  af: array<u32>,
+    af: array<u32>,
 }
 
 @group(0) @binding(94) var<storage, read_write> ac: ad;
 
-fn z(t: ptr<storage, array<u32>, read_write>) {
+fn y(t: ptr<storage, array<u32>, read_write>) {
     t[2083] = 9;
-    ac.af.af[2083] = 9;
-}
-
-fn y(t: ptr<storage, ae, read_write>) {
-    t.af[2083] = 9;
-    ac.af.af[2083] = 9;
-    z(&t.af);
+    ac.af[2083] = 9;
 }
 
 fn x(t: ptr<storage, ad, read_write>) {
-    t.af.af[2083] = 9;
-    ac.af.af[2083] = 9;
+    t.af[2083] = 9;
+    ac.af[2083] = 9;
     y(&t.af);
 }
 

--- a/Source/WebGPU/WGSL/tests/struct-errors.wgsl
+++ b/Source/WebGPU/WGSL/tests/struct-errors.wgsl
@@ -1,5 +1,18 @@
 // RUN: %not %wgslc | %check
 
+struct T {
+    x: u32,
+    // CHECK-L: a struct that contains a runtime array cannot be nested inside another struct
+    y: U,
+}
+
+struct U {
+    x: u32,
+    y: array<u32>,
+}
+
+// --
+
 struct S {
     x: f32,
     y: i32,


### PR DESCRIPTION
#### a16768b5797d97d57c56a47466d6abc6c060a177
<pre>
[WGSL] Structs containing runtime-sized arrays should not be nested
<a href="https://bugs.webkit.org/show_bug.cgi?id=290937">https://bugs.webkit.org/show_bug.cgi?id=290937</a>
<a href="https://rdar.apple.com/148035899">rdar://148035899</a>

Reviewed by Mike Wyrzykowski.

The spec[1] says that all struct members should either have creation-fixed
footprint or the last member may be a runtime-sized array. However, a struct
that contains a runtime-sized array doesn&apos;t have creation-fixed footprint,
so it can&apos;t be used as a member of another struct.

[1]: <a href="https://www.w3.org/TR/WGSL/#struct-types">https://www.w3.org/TR/WGSL/#struct-types</a>

* LayoutTests/fast/webgpu/array-length-pointer-parameter-expected.txt:
* LayoutTests/fast/webgpu/array-length-pointer-parameter.html:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/struct.wgsl:
* Source/WebGPU/WGSL/tests/valid/array-length-pointer2.wgsl:

Canonical link: <a href="https://commits.webkit.org/293151@main">https://commits.webkit.org/293151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7faeb1fc19d2a1c242fc437348cb3ed3f48792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48523 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105487 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5376 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->