### PR TITLE
[WGSL] Validate that function call expressions must return a value

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -911,8 +911,6 @@ void TypeChecker::visit(AST::IfStatement& statement)
 void TypeChecker::visit(AST::PhonyAssignmentStatement& statement)
 {
     infer(statement.rhs(), Evaluation::Runtime);
-    // There is nothing to unify with since result of the right-hand side is
-    // discarded.
 }
 
 void TypeChecker::visit(AST::ReturnStatement& statement)
@@ -1352,6 +1350,8 @@ void TypeChecker::visit(AST::CallExpression& call)
 
             if (m_discardResult == DiscardResult::Yes && functionType.mustUse)
                 typeError(InferBottom::No, call.span(), "ignoring return value of function '"_s, targetName, "' annotated with @must_use"_s);
+            else if (m_discardResult == DiscardResult::No && isPrimitive(functionType.result, Types::Primitive::Void))
+                typeError(InferBottom::No, call.span(), "function '"_s, targetName, "' does not return a value"_s);
 
             for (unsigned i = 0; i < numberOfArguments; ++i) {
                 auto& argument = call.arguments()[i];

--- a/Source/WebGPU/WGSL/tests/aliases.wgsl
+++ b/Source/WebGPU/WGSL/tests/aliases.wgsl
@@ -46,23 +46,23 @@ fn main() {
     let x = v(0);
     let y = s(0);
 
-    _ = f1(vec2f(vec2(0u)));
-    _ = f2(vec2i(vec2(0f)));
-    _ = f3(vec2u(vec2(0f)));
-    _ = f4(vec3f(vec3(0u)));
-    _ = f5(vec3i(vec3(0f)));
-    _ = f6(vec3u(vec3(0f)));
-    _ = f7(vec4f(vec4(0u)));
-    _ = f8(vec4i(vec4(0f)));
-    _ = f9(vec4u(vec4(0f)));
+    f1(vec2f(vec2(0u)));
+    f2(vec2i(vec2(0f)));
+    f3(vec2u(vec2(0f)));
+    f4(vec3f(vec3(0u)));
+    f5(vec3i(vec3(0f)));
+    f6(vec3u(vec3(0f)));
+    f7(vec4f(vec4(0u)));
+    f8(vec4i(vec4(0f)));
+    f9(vec4u(vec4(0f)));
 
-    _ = m1(mat2x2f(mat2x2(0, 0, 0, 0)));
-    _ = m2(mat2x3f(mat2x3(0, 0, 0, 0, 0, 0)));
-    _ = m3(mat2x4f(mat2x4(0, 0, 0, 0, 0, 0, 0, 0)));
-    _ = m4(mat3x2f(mat3x2(0, 0, 0, 0, 0, 0)));
-    _ = m5(mat3x3f(mat3x3(0, 0, 0, 0, 0, 0, 0, 0, 0)));
-    _ = m6(mat3x4f(mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
-    _ = m7(mat4x2f(mat4x2(0, 0, 0, 0, 0, 0, 0, 0)));
-    _ = m8(mat4x3f(mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
-    _ = m9(mat4x4f(mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    m1(mat2x2f(mat2x2(0, 0, 0, 0)));
+    m2(mat2x3f(mat2x3(0, 0, 0, 0, 0, 0)));
+    m3(mat2x4f(mat2x4(0, 0, 0, 0, 0, 0, 0, 0)));
+    m4(mat3x2f(mat3x2(0, 0, 0, 0, 0, 0)));
+    m5(mat3x3f(mat3x3(0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    m6(mat3x4f(mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    m7(mat4x2f(mat4x2(0, 0, 0, 0, 0, 0, 0, 0)));
+    m8(mat4x3f(mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    m9(mat4x4f(mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
 }

--- a/Source/WebGPU/WGSL/tests/phony-assignment.wgsl
+++ b/Source/WebGPU/WGSL/tests/phony-assignment.wgsl
@@ -1,0 +1,9 @@
+// RUN: %not %wgslc | %check
+
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK-L: function 'f' does not return a value
+  _ = f();
+}
+
+fn f() { }

--- a/Source/WebGPU/WGSL/tests/var-initialization-with-var.wgsl
+++ b/Source/WebGPU/WGSL/tests/var-initialization-with-var.wgsl
@@ -11,5 +11,5 @@ fn main() {
   // CHECK: local\d+ = 0
   b = 0.0;
   // CHECK: function\d\(local\d+\)
-  _ = f(b);
+  f(b);
 }


### PR DESCRIPTION
#### 3040c8aae462d09dc8dbc25590bc9e8a960d332a
<pre>
[WGSL] Validate that function call expressions must return a value
<a href="https://bugs.webkit.org/show_bug.cgi?id=290938">https://bugs.webkit.org/show_bug.cgi?id=290938</a>
<a href="https://rdar.apple.com/148106269">rdar://148106269</a>

Reviewed by Mike Wyrzykowski.

The spec[1] says that a function call expression should only be used for
functions that return a value, and call statements should be used instead
for void functions.

[1]: <a href="https://www.w3.org/TR/WGSL/#function-call-expr">https://www.w3.org/TR/WGSL/#function-call-expr</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/phony-assignment.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/aliases.wgsl:
* Source/WebGPU/WGSL/tests/valid/var-initialization-with-var.wgsl:

Canonical link: <a href="https://commits.webkit.org/293152@main">https://commits.webkit.org/293152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e01f2e5f7b20173d2f08939c1dd28586204f28f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48524 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74610 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31793 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13354 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105488 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25081 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18271 "Found 1 new test failure: pdf/fullscreen.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27686 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30214 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->