### PR TITLE
New Test(292677@main): [ iOS ] editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html is a constant failure.

### DIFF
--- a/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html
+++ b/LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html
@@ -29,7 +29,7 @@ addEventListener("load", async () => {
     for (const stringToType of ["\n", "One\n", "Two\n", "Three\n", "Four\n", "Five\n"]) {
         await UIHelper.typeCharacters(stringToType);
         await UIHelper.ensurePresentationUpdate();
-        caretRects.push(await UIHelper.getUICaretViewRect());
+        caretRects.push(UIHelper.roundRectToDevicePixel(await UIHelper.getUICaretViewRect()));
     }
 
     shouldBe("caretRects[0].height", "caretRects[1].height");

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7819,5 +7819,3 @@ webkit.org/b/290871 imported/w3c/web-platform-tests/navigation-api/scroll-behavi
 webkit.org/b/290876 imported/w3c/web-platform-tests/trusted-types/DedicatedWorker-constructor-from-SharedWorker.html [ Pass Failure ]
 
 webkit.org/b/290888 fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html [ Pass Failure ]
-
-webkit.org/b/290928 editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html [ Failure ]


### PR DESCRIPTION
#### 2ef03feecfd25b0d035f02cf9a34de6b32f1a0bd
<pre>
New Test(292677@main): [ iOS ] editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290928">https://bugs.webkit.org/show_bug.cgi?id=290928</a>
<a href="https://rdar.apple.com/148441297">rdar://148441297</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Use `roundRectToDevicePixel` here to fix the failing test on iPad, where the offset is nearly (but
not exactly) equal to 23, due to tiny floating point rounding errors: `22.999998807907104`.

* LayoutTests/editing/selection/ios/caret-rect-after-inserting-newlines-in-textarea.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/293127@main">https://commits.webkit.org/293127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63278587b0d255a1826fd3fecba00a54954a66b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74597 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100972 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47941 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105463 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25049 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20968 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18677 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25010 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->