### PR TITLE
Address more Safer CPP failures in WebKit/UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -93,10 +93,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-UIProcess/Downloads/DownloadProxy.cpp
-UIProcess/RemotePageDrawingAreaProxy.cpp
-UIProcess/WebsiteData/WebsiteDataStore.cpp
-UIProcess/mac/WebContextMenuProxyMac.mm
 WebDriverBidiBackendDispatchers.cpp
 WebDriverBidiFrontendDispatchers.cpp
 WebProcess/ApplePay/WebPaymentCoordinator.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -112,12 +112,6 @@ UIProcess/mac/WKPrintingView.mm
 UIProcess/mac/WKQuickLookPreviewController.mm
 UIProcess/mac/WKRevealItemPresenter.mm
 UIProcess/mac/WKSharingServicePickerDelegate.mm
-UIProcess/mac/WebColorPickerMac.mm
-UIProcess/mac/WebContextMenuProxyMac.mm
-UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
-UIProcess/mac/WebDateTimePickerMac.mm
-UIProcess/mac/WebPageProxyMac.mm
-UIProcess/mac/WebPopupMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
 WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp

--- a/Source/WebKit/Shared/WebContextMenuItemData.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItemData.cpp
@@ -86,6 +86,11 @@ API::Object* WebContextMenuItemData::userData() const
     return m_userData.get();
 }
 
+RefPtr<API::Object> WebContextMenuItemData::protectedUserData() const
+{
+    return m_userData;
+}
+
 void WebContextMenuItemData::setUserData(API::Object* userData)
 {
     m_userData = userData;

--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -54,6 +54,7 @@ public:
     WebCore::ContextMenuItem core() const;
     
     API::Object* userData() const;
+    RefPtr<API::Object> protectedUserData() const;
     void setUserData(API::Object*);
 
 private:

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1030,7 +1030,7 @@ NSDictionary *WebPageProxy::contentsOfUserInterfaceItem(NSString *userInterfaceI
 #if ENABLE(CONTEXT_MENUS)
     RefPtr activeContextMenu = m_activeContextMenu;
     if (activeContextMenu && [userInterfaceItem isEqualToString:@"mediaControlsContextMenu"])
-        return @{ userInterfaceItem: activeContextMenu->platformData() };
+        return @{ userInterfaceItem: activeContextMenu->platformData().get() };
 #endif // ENABLE(CONTEXT_MENUS)
 
     return nil;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -107,7 +107,7 @@ void DownloadProxy::invalidate()
 
 void DownloadProxy::processDidClose()
 {
-    m_client->processDidCrash(*this);
+    protectedClient()->processDidCrash(*this);
 }
 
 WebPageProxy* DownloadProxy::originatingPage() const
@@ -125,7 +125,7 @@ void DownloadProxy::didStart(const ResourceRequest& request, const String& sugge
 
     if (m_didStartCallback)
         m_didStartCallback(this);
-    m_client->legacyDidStart(*this);
+    protectedClient()->legacyDidStart(*this);
 }
 
 void DownloadProxy::didReceiveAuthenticationChallenge(AuthenticationChallenge&& authenticationChallenge, AuthenticationChallengeIdentifier challengeID)
@@ -148,7 +148,7 @@ void DownloadProxy::willSendRequest(ResourceRequest&& proposedRequest, const Res
 
 void DownloadProxy::didReceiveData(uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite)
 {
-    m_client->didReceiveData(*this, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
+    protectedClient()->didReceiveData(*this, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
 }
 
 void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::ResourceResponse& response, String&& suggestedFilename, DecideDestinationCallback&& completionHandler)
@@ -191,7 +191,7 @@ void DownloadProxy::decideDestinationWithSuggestedFilename(const WebCore::Resour
 
 void DownloadProxy::didCreateDestination(const String& path)
 {
-    m_client->didCreateDestination(*this, path);
+    protectedClient()->didCreateDestination(*this, path);
 }
 
 #if PLATFORM(MAC)
@@ -224,7 +224,7 @@ void DownloadProxy::didFinish()
 #if PLATFORM(MAC)
     updateQuarantinePropertiesIfPossible();
 #endif
-    m_client->didFinish(*this);
+    protectedClient()->didFinish(*this);
     if (m_downloadIsCancelled)
         return;
 
@@ -240,7 +240,7 @@ void DownloadProxy::didFail(const ResourceError& error, std::span<const uint8_t>
 
     m_legacyResumeData = createData(resumeData);
 
-    m_client->didFail(*this, error, m_legacyResumeData.get());
+    protectedClient()->didFail(*this, error, m_legacyResumeData.get());
 
     // This can cause the DownloadProxy object to be deleted.
     if (RefPtr downloadProxyMap = m_downloadProxyMap.get())

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -55,8 +55,8 @@ RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy()
 {
     for (auto& name : m_names)
         protectedProcess()->removeMessageReceiver(name, m_identifier);
-    if (m_drawingArea)
-        m_drawingArea->removeRemotePageDrawingAreaProxy(*this);
+    if (RefPtr drawingArea = m_drawingArea.get())
+        drawingArea->removeRemotePageDrawingAreaProxy(*this);
 }
 
 Ref<WebProcessProxy> RemotePageDrawingAreaProxy::protectedProcess()
@@ -66,14 +66,14 @@ Ref<WebProcessProxy> RemotePageDrawingAreaProxy::protectedProcess()
 
 void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    if (m_drawingArea)
-        m_drawingArea->didReceiveMessage(connection, decoder);
+    if (RefPtr drawingArea = m_drawingArea.get())
+        drawingArea->didReceiveMessage(connection, decoder);
 }
 
 bool RemotePageDrawingAreaProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (m_drawingArea)
-        return m_drawingArea->didReceiveSyncMessage(connection, decoder, encoder);
+    if (RefPtr drawingArea = m_drawingArea.get())
+        return drawingArea->didReceiveSyncMessage(connection, decoder, encoder);
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -55,7 +55,7 @@ public:
 
 #if PLATFORM(COCOA)
     virtual NSMenu *platformMenu() const = 0;
-    virtual NSArray *platformData() const = 0;
+    virtual RetainPtr<NSArray> platformData() const = 0;
 #endif // PLATFORM(COCOA)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2252,17 +2252,15 @@ void WebsiteDataStore::addSecKeyProxyStore(Ref<SecKeyProxyStore>&& store)
 #if ENABLE(WEB_AUTHN)
 void WebsiteDataStore::setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&& configuration)
 {
-    if (!m_authenticatorManager->isMock()) {
+    if (RefPtr manager = dynamicDowncast<MockAuthenticatorManager>(m_authenticatorManager))
+        manager->setTestConfiguration(WTFMove(configuration));
+    else
         m_authenticatorManager = MockAuthenticatorManager::create(WTFMove(configuration));
-        return;
-    }
-    Ref manager = downcast<MockAuthenticatorManager>(m_authenticatorManager);
-    manager->setTestConfiguration(WTFMove(configuration));
 }
 
 VirtualAuthenticatorManager& WebsiteDataStore::virtualAuthenticatorManager()
 {
-    if (!m_authenticatorManager->isVirtual())
+    if (!is<VirtualAuthenticatorManager>(m_authenticatorManager.get()))
         m_authenticatorManager = VirtualAuthenticatorManager::create();
     return downcast<VirtualAuthenticatorManager>(m_authenticatorManager.get());
 }

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -97,7 +97,7 @@ private:
 #endif
 
     NSMenu *platformMenu() const override;
-    NSArray *platformData() const override;
+    RetainPtr<NSArray> platformData() const override;
 
     RetainPtr<NSMenu> m_menu;
     RetainPtr<WKMenuDelegate> m_menuDelegate;

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -416,8 +416,8 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     [_table scrollRowToVisible:newSelection];
 
     // Notify accessibility clients of new selection.
-    NSString *currentSelectedString = [self currentSelectedString];
-    [self notifyAccessibilityClients:currentSelectedString];
+    RetainPtr currentSelectedString = [self currentSelectedString].createNSString();
+    [self notifyAccessibilityClients:currentSelectedString.get()];
 }
 
 - (void)invalidate
@@ -437,14 +437,14 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     _enclosingWindow = nil;
 
     // Notify accessibility clients that datalist went away.
-    NSString *info = WEB_UI_STRING("Suggestions list hidden.", "Accessibility announcement for the data list suggestions dropdown going away.");
-    [self notifyAccessibilityClients:info];
+    RetainPtr info = WEB_UI_STRING("Suggestions list hidden.", "Accessibility announcement for the data list suggestions dropdown going away.").createNSString();
+    [self notifyAccessibilityClients:info.get()];
 }
 
 - (NSRect)dropdownRectForElementRect:(const WebCore::IntRect&)rect
 {
-    NSWindow *presentingWindow = [_presentingView window];
-    NSRect screenRect = presentingWindow.screen.visibleFrame;
+    RetainPtr presentingWindow = [_presentingView window];
+    NSRect screenRect = presentingWindow.get().screen.visibleFrame;
     NSRect windowRect = [presentingWindow convertRectToScreen:[_presentingView convertRect:rect toView:nil]];
 
     windowRect = CGRectIntersection(windowRect, screenRect);
@@ -476,9 +476,9 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     [_scrollView flashScrollers];
 
     // Notify accessibility clients of datalist becoming visible.
-    NSString *currentSelectedString = [self currentSelectedString];
-    NSString *info = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Suggestions list visible, %@", "Accessibility announcement that the suggestions list became visible. The format argument is for the first option in the list."), currentSelectedString];
-    [self notifyAccessibilityClients:info];
+    RetainPtr currentSelectedString = [self currentSelectedString].createNSString();
+    RetainPtr info = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Suggestions list visible, %@", "Accessibility announcement that the suggestions list became visible. The format argument is for the first option in the list."), currentSelectedString.get()];
+    [self notifyAccessibilityClients:info.get()];
 }
 
 - (void)selectedRow:(NSTableView *)sender


### PR DESCRIPTION
#### d6e4ce712a4dea19dd82c6240ba4849ad67fb561
<pre>
Address more Safer CPP failures in WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=290945">https://bugs.webkit.org/show_bug.cgi?id=290945</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/Shared/WebContextMenuItemData.cpp:
(WebKit::WebContextMenuItemData::protectedUserData const):
* Source/WebKit/Shared/WebContextMenuItemData.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::contentsOfUserInterfaceItem):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::processDidClose):
(WebKit::DownloadProxy::didStart):
(WebKit::DownloadProxy::didReceiveData):
(WebKit::DownloadProxy::didCreateDestination):
(WebKit::DownloadProxy::didFinish):
(WebKit::DownloadProxy::didFail):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
(WebKit::RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy):
(WebKit::RemotePageDrawingAreaProxy::didReceiveMessage):
(WebKit::RemotePageDrawingAreaProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/WebContextMenuProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setMockWebAuthenticationConfiguration):
(WebKit::WebsiteDataStore::virtualAuthenticatorManager):
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKPopoverColorWell _showPopover]):
(-[WKColorPopoverMac invalidate]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(+[WKMenuTarget sharedMenuTarget]):
(-[WKMenuTarget forwardContextMenuAction:]):
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::createMenuActionItem):
(WebKit::contentsOfContextMenuItem):
(WebKit::WebContextMenuProxyMac::platformData const):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController moveSelectionByDirection:]):
(-[WKDataListSuggestionsController invalidate]):
(-[WKDataListSuggestionsController dropdownRectForElementRect:]):
(-[WKDataListSuggestionsController showSuggestionsDropdown:]):
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePickerBackdropView drawRect:]):
(-[WKDateTimePicker initWithParams:inView:]):
(-[WKDateTimePicker updatePicker:]):
(-[WKDateTimePicker initialDateForEmptyValue]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::searchTheWeb):
(WebKit::WebPageProxy::headerBannerHeight const):
(WebKit::WebPageProxy::footerBannerHeight const):
(WebKit::temporaryPDFDirectoryPath):
(WebKit::pathToPDFOnDisk):
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
(WebKit::WebPageProxy::showPDFContextMenu):
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
(WebKit::WebPageProxy::handleContextMenuCopySubject):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
(WebKit::WebPopupMenuProxyMac::showPopupMenu):

Canonical link: <a href="https://commits.webkit.org/293137@main">https://commits.webkit.org/293137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c4c6915e91069586fbb081d1e8f2d8970438bf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48502 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13340 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47944 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83588 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83038 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18680 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15881 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30192 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->