### PR TITLE
[HDR] Use the ImageSource properties to detect whether an image has gain map or not

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -97,7 +97,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     auto sizeForDrawing = expandedIntSize(sourceSize * scaleFactorForDrawing);
     auto subsamplingLevel =  m_source->subsamplingLevelForScaleFactor(context, scaleFactorForDrawing, options.allowImageSubsampling());
 
-    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), sizeForDrawing });
+    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), m_source->shouldDecodeToHDR(), sizeForDrawing });
 
     if (!nativeImage) {
         if (nativeImage.error() != DecodingStatus::Decoding)

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -72,7 +72,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
-    bool hasHDRContent() const final { return hasHDRContentForTesting() || m_source->headroom() > Headroom::None; }
+    bool hasHDRContent() const final { return hasHDRContentForTesting() || m_source->hasHDRContent(); }
     ImageOrientation orientation() const final { return m_source->orientation(); }
     unsigned frameCount() const final { return m_source->frameCount(); }
 #if ASSERT_ENABLED

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -168,6 +168,11 @@ Headroom BitmapImageDescriptor::headroom() const
     return primaryImageFrameMetadata(m_headroom, CachedFlag::Headroom, &ImageFrame::headroom);
 }
 
+bool BitmapImageDescriptor::hasHDRGainMap() const
+{
+    return imageMetadata(m_hasHDRGainMap, false, CachedFlag::HasHDRGainMap, &ImageDecoder::hasHDRGainMap);
+}
+
 String BitmapImageDescriptor::uti() const
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -58,6 +58,7 @@ public:
     DestinationColorSpace colorSpace() const;
     std::optional<Color> singlePixelSolidColor() const;
     Headroom headroom() const;
+    bool hasHDRGainMap() const;
 
     String uti() const;
     String filenameExtension() const;
@@ -88,12 +89,13 @@ private:
         ColorSpace                  = 1 << 7,
         SinglePixelSolidColor       = 1 << 8,
         Headroom                    = 1 << 9,
+        HasHDRGainMap               = 1 << 10,
 
-        UTI                         = 1 << 10,
-        FilenameExtension           = 1 << 11,
-        AccessibilityDescription    = 1 << 12,
-        HotSpot                     = 1 << 13,
-        MaximumSubsamplingLevel     = 1 << 14,
+        UTI                         = 1 << 11,
+        FilenameExtension           = 1 << 12,
+        AccessibilityDescription    = 1 << 13,
+        HotSpot                     = 1 << 14,
+        MaximumSubsamplingLevel     = 1 << 15,
     };
 
     template<typename MetadataType>
@@ -117,6 +119,7 @@ private:
     mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
     mutable std::optional<Color> m_singlePixelSolidColor;
     mutable Headroom m_headroom { Headroom::None };
+    mutable bool m_hasHDRGainMap { false };
 
     mutable String m_uti;
     mutable String m_filenameExtension;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -362,7 +362,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
         return;
     }
 
-    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, DecodingMode::Asynchronous);
+    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, shouldDecodeToHDR() });
     RefPtr frameAnimator = this->frameAnimator();
 
     if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
@@ -376,7 +376,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
 
     if (!isCompatibleNativeImage) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
-        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous });
+        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, shouldDecodeToHDR() });
         return;
     }
 
@@ -563,7 +563,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     }
 
     if (!isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options)) {
-        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, DecodingMode::Synchronous);
+        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, { DecodingMode::Synchronous, shouldDecodeToHDR() });
 
         RefPtr nativeImage = NativeImage::create(WTFMove(platformImage));
         if (!nativeImage)
@@ -613,7 +613,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::currentNativeImage
     // If frame0 is displayed for the first time, startAnimation() has to request decoding frame1
     // asynchronously. A flicker will occur if we request decoding frame0 also asynchronously.
     if (options.decodingMode() == DecodingMode::Asynchronous && isAnimated() && !hasEverAnimated())
-        effectiveOptions = { DecodingMode::Synchronous, options.sizeForDrawing() };
+        effectiveOptions = { DecodingMode::Synchronous, shouldDecodeToHDR(), options.sizeForDrawing() };
 
     return nativeImageAtIndexForDrawing(currentFrameIndex(), subsamplingLevel, effectiveOptions);
 }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -160,7 +160,8 @@ private:
     ImageOrientation orientation() const final { return m_descriptor.orientation(); }
     DestinationColorSpace colorSpace() const final { return m_descriptor.colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_descriptor.singlePixelSolidColor(); }
-    Headroom headroom() const final { return m_descriptor.headroom(); }
+    bool hasHDRGainMap() const { return m_descriptor.hasHDRGainMap(); }
+    bool hasHDRContent() const final { return m_descriptor.hasHDRGainMap() || m_descriptor.headroom() > Headroom::None; }
 
     String uti() const final { return m_descriptor.uti(); }
     String filenameExtension() const final { return m_descriptor.filenameExtension(); }

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -36,10 +36,16 @@ enum class DecodingMode : uint8_t {
     Asynchronous
 };
 
+enum class ShouldDecodeToHDR : bool {
+    No,
+    Yes
+};
+
 class DecodingOptions {
 public:
-    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
+    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, ShouldDecodeToHDR shouldDecodeToHDR = ShouldDecodeToHDR::No, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
         : m_decodingMode(decodingMode)
+        , m_shouldDecodeToHDR(shouldDecodeToHDR)
         , m_sizeForDrawing(sizeForDrawing)
     {
     }
@@ -51,12 +57,17 @@ public:
     bool isSynchronous() const { return m_decodingMode == DecodingMode::Synchronous; }
     bool isAsynchronous() const { return m_decodingMode == DecodingMode::Asynchronous; }
 
+    ShouldDecodeToHDR shouldDecodeToHDR() const { return m_shouldDecodeToHDR; }
+
     std::optional<IntSize> sizeForDrawing() const { return m_sizeForDrawing; }
     bool hasFullSize() const { return !m_sizeForDrawing; }
     bool hasSizeForDrawing() const { return !!m_sizeForDrawing; }
 
     bool isCompatibleWith(const DecodingOptions& other) const
     {
+        if (shouldDecodeToHDR() != other.shouldDecodeToHDR())
+            return false;
+
         if (isAuto() || other.isAuto())
             return false;
 
@@ -71,6 +82,7 @@ public:
 
 private:
     DecodingMode m_decodingMode;
+    ShouldDecodeToHDR m_shouldDecodeToHDR;
     std::optional<IntSize> m_sizeForDrawing;
 };
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -82,6 +82,7 @@ public:
     virtual EncodedDataStatus encodedDataStatus() const = 0;
     virtual void setEncodedDataStatusChangeCallback(Function<void(EncodedDataStatus)>&&) { }
     virtual bool isSizeAvailable() const { return encodedDataStatus() >= EncodedDataStatus::SizeAvailable; }
+    virtual bool hasHDRGainMap() const { return false; }
     virtual IntSize size() const = 0;
     virtual size_t frameCount() const = 0;
     virtual size_t primaryFrameIndex() const { return 0; }

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -80,8 +80,9 @@ public:
     virtual unsigned frameCount() const { return 1; }
     virtual DestinationColorSpace colorSpace() const = 0;
     virtual std::optional<Color> singlePixelSolidColor() const = 0;
-    virtual Headroom headroom() const = 0;
+    virtual bool hasHDRContent() const = 0;
 
+    ShouldDecodeToHDR shouldDecodeToHDR() const { return hasHDRContent() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No; }
     bool hasSolidColor() const;
 
     virtual String uti() const { return String(); }

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -39,7 +39,7 @@ private:
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_frame.size(); }
     DestinationColorSpace colorSpace() const final { return m_frame.nativeImage()->colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage()->singlePixelSolidColor(); }
-    Headroom headroom() const final { return m_frame.nativeImage()->headroom(); }
+    bool hasHDRContent() const final { return m_frame.nativeImage()->headroom() > Headroom::None; }
 
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) final { return m_frame; }
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -51,6 +51,7 @@ public:
     size_t bytesDecodedToDetermineProperties() const final;
 
     EncodedDataStatus encodedDataStatus() const final;
+    bool hasHDRGainMap() const final;
     IntSize size() const final { return IntSize(); }
     size_t frameCount() const final;
     size_t primaryFrameIndex() const final;


### PR DESCRIPTION
#### e419179f6f32cb9e195e789e64abc2aaf33fbd20
<pre>
[HDR] Use the ImageSource properties to detect whether an image has gain map or not
<a href="https://bugs.webkit.org/show_bug.cgi?id=291765">https://bugs.webkit.org/show_bug.cgi?id=291765</a>
<a href="https://rdar.apple.com/149565322">rdar://149565322</a>

Reviewed by Simon Fraser.

CGImageSource properties will be checked to know whether an image has gain
map or not. If the image has a gain map, the key { kCGImageSourceDecodeRequest,
kCGImageSourceDecodeToHDR } will be sent to ImageIO to decode the gain-map image.
Without it ImageIO will decode the SDR image only.

* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::hasHDRGainMap const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::currentNativeImageForDrawing):
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::DecodingOptions):
(WebCore::DecodingOptions::shouldDecodeToHDR const):
(WebCore::DecodingOptions::isCompatibleWith const):
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::hasHDRGainMap const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::shouldDecodeToHDR const):
* Source/WebCore/platform/graphics/NativeImageSource.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::appendImageSourceOptions):
(WebCore::appendImageSourceOption):
(WebCore::imageSourceOptions):
(WebCore::imageSourceThumbnailOptions):
(WebCore::ImageDecoderCG::hasHDRGainMap const):
(WebCore::ImageDecoderCG::createFrameImageAtIndex):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:

Canonical link: <a href="https://commits.webkit.org/293871@main">https://commits.webkit.org/293871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74a68593bc776fc02ebfb27d11a66019dc62148

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50098 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107636 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27260 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85194 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29405 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->