### PR TITLE
    Adopt Portal Crossing Component when Dragging Model

### DIFF
--- a/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
@@ -78,6 +78,9 @@ RetainPtr<UIView> ModelPresentationManagerProxy::startDragForModel(const WebCore
 #if PLATFORM(VISION)
     CGRect frame = [modelView frame];
     [modelView _setAssumedNoncoplanarHostedContentSize:SPSize3DMake(CGRectGetWidth(frame), CGRectGetHeight(frame), 100)];
+
+    auto hostedView = modelPresentation->pageHostedModelView;
+    [hostedView setPortalCrossing:YES];
 #endif
 
     m_activelyDraggedModelLayerIDs.add(layerIdentifier);
@@ -87,6 +90,16 @@ RetainPtr<UIView> ModelPresentationManagerProxy::startDragForModel(const WebCore
 
 void ModelPresentationManagerProxy::doneWithCurrentDragSession()
 {
+    for (WebCore::PlatformLayerIdentifier layerIdentifier : m_activelyDraggedModelLayerIDs) {
+        auto iterator = m_modelPresentations.find(layerIdentifier);
+        if (iterator == m_modelPresentations.end())
+            continue;
+
+        auto& modelPresentation = iterator->value;
+        if (auto pageHostedModelView = modelPresentation->pageHostedModelView)
+            [modelPresentation->pageHostedModelView setPortalCrossing:NO];
+    }
+
     m_activelyDraggedModelLayerIDs.clear();
 }
 

--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, retain) UIView *remoteModelView;
 @property (nonatomic) BOOL shouldDisablePortal;
 - (void)applyBackgroundColor:(std::optional<WebCore::Color>)backgroundColor;
+- (void)setPortalCrossing:(BOOL)enabled;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm
@@ -109,7 +109,8 @@
         REEntityAddComponentByClass(_stereoContentEntity.get(), RENetworkComponentGetComponentType());
         REPtr<REComponentRef> stereoContentComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REEmbeddedStereoContentComponentGetComponentType());
         REPtr<REComponentRef> worldRootComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REWorldRootComponentGetComponentType());
-        if (stereoContentComponent && worldRootComponent) {
+        REPtr<REComponentRef> portalCrossingComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType());
+        if (stereoContentComponent && worldRootComponent && portalCrossingComponent) {
             REPtr<REWorldRootRef> worldRoot = adoptRE(RECreateWorldRoot());
             REEmbeddedStereoContentComponentSetWorldRoot(stereoContentComponent.get(), worldRoot.get());
             REWorldRootComponentSetWorldRoot(worldRootComponent.get(), worldRoot.get());
@@ -120,6 +121,12 @@
             REEmbeddedStereoContentComponentSetAllowsCrossing(stereoContentComponent.get(), true);
             REEmbeddedStereoContentComponentSetIsStereo(stereoContentComponent.get(), true);
             REEmbeddedStereoContentComponentSetEnableClipping(stereoContentComponent.get(), true);
+
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=290950
+            REEmbeddedStereoContentComponentSetLightingBlendDistance(stereoContentComponent.get(), 0.0);
+
+            REPortalCrossingFlagsComponentSetEnabled(portalCrossingComponent.get(), false);
+            REPortalCrossingFlagsComponentSetInherited(portalCrossingComponent.get(), false);
 
             REEntitySetParent(_stereoContentEntity.get(), _rootEntity.get());
 
@@ -290,6 +297,17 @@
     [_stereoContentLayer setFrame:self.bounds];
 }
 #endif
+
+- (void)setPortalCrossing:(BOOL)enabled
+{
+#if HAVE(RE_STEREO_CONTENT_SUPPORT)
+    if (REPtr<REComponentRef> portalCrossingComponent = REEntityGetOrAddComponentByClass(_stereoContentEntity.get(), REPortalCrossingFlagsComponentGetComponentType())) {
+        REPortalCrossingFlagsComponentSetEnabled(portalCrossingComponent.get(), enabled);
+        REPortalCrossingFlagsComponentSetInherited(portalCrossingComponent.get(), enabled);
+        RENetworkMarkComponentDirty(portalCrossingComponent.get());
+    }
+#endif
+}
 
 @end
 

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -325,7 +325,8 @@ public final class WKSRKEntity: NSObject {
                 let environment = try await EnvironmentResource(cube: textureResource, options: .init())
 
                 await MainActor.run {
-                    entity.components[ImageBasedLightComponent.self] = .init(source: .single(environment))
+                    entity.components[VirtualEnvironmentProbeComponent.self] = .init(source: .single(.init(environment: environment)))
+                    entity.components[ImageBasedLightComponent.self] = .init(source: .none)
                     entity.components[ImageBasedLightReceiverComponent.self] = .init(imageBasedLight: entity)
                     Logger.realityKitEntity.info("Successfully applied IBL to entity")
                     completion(true)
@@ -346,7 +347,8 @@ public final class WKSRKEntity: NSObject {
 #if canImport(RealityFoundation, _version: 380)
                 let environment = await EnvironmentResource.defaultObject()
                 await MainActor.run {
-                    entity.components[ImageBasedLightComponent.self] = .init(source: .single(environment))
+                    entity.components[VirtualEnvironmentProbeComponent.self] = .init(source: .single(.init(environment: environment)))
+                    entity.components[ImageBasedLightComponent.self] = .init(source: .none)
                     entity.components[ImageBasedLightReceiverComponent.self] = .init(imageBasedLight: entity)
                 }
 #else


### PR DESCRIPTION
#### b048497cedd9e7cde785648c11562f9192b7c829
<pre>
    Adopt Portal Crossing Component when Dragging Model
    <a href="https://bugs.webkit.org/show_bug.cgi?id=290949">https://bugs.webkit.org/show_bug.cgi?id=290949</a>
    <a href="https://rdar.apple.com/146805867">rdar://146805867</a>

    Reviewed by Ada Chan.

    This PR adds a portal crossing component to the model view such that when a drag is detected
    we enable it to prevent the model from clipping as it lifts off the page. We also add a
    virtual environment probe component such that lighting can blend as the model crosses the
    portal on lift.

    * Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm:
    (WebKit::ModelPresentationManagerProxy::setUpModelView):
    - Adds portal crossing to the view
    (WebKit::ModelPresentationManagerProxy::startDragForModel):
    - Added call to enable portal crossing before the drag starts
    (WebKit::ModelPresentationManagerProxy::doneWithCurrentDragSession):
    - Disables portal crossing after drag ends
    * Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
    (-[WKContentView dragInteraction:previewForLiftingItem:session:]):
    * Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm:
    (-[WKPageHostedModelView init]):
    (-[WKPageHostedModelView setPortalCrossing:]):
    - New API for toggling portal crossing component for the entity
    * Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
    (WKSRKEntity.applyIBL(_:completion:)):
    - Uses virtual environment probe for lighting

Canonical link: <a href="https://commits.webkit.org/293508@main">https://commits.webkit.org/293508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68e06a76c6e1e29615a309528947f19c37a4a05d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49656 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75411 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14446 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14237 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49032 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19085 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84369 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6264 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19897 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31306 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->