### PR TITLE
[WGSL] Should not unpack values from pointers to non-resources

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -593,7 +593,10 @@ Packing RewriteGlobalVariables::getPacking(AST::UnaryExpression& expression)
         // of the operand (since we can't pack/unpack pointers) and return the
         // packing of the resulting type from dereferencing
         pack(Packing::Either, expression.expression());
-        return expression.inferredType()->packing();
+        auto* pointer = std::get_if<Types::Pointer>(expression.expression().inferredType());
+        if (pointer->addressSpace == AddressSpace::Storage || pointer->addressSpace == AddressSpace::Uniform)
+            return expression.inferredType()->packing();
+        return Packing::Unpacked;
     }
     return pack(Packing::Unpacked, expression.expression());
 }

--- a/Source/WebGPU/WGSL/tests/packing-pointer-arguments.wgsl
+++ b/Source/WebGPU/WGSL/tests/packing-pointer-arguments.wgsl
@@ -1,6 +1,7 @@
 // RUN: %metal-compile main
 
 @group(0) @binding(0) var<storage, read_write> buf: vec3u;
+var<private> buf2: vec3u;
 
 fn bar(a: ptr<storage, vec3u, read_write>) {
 }
@@ -13,8 +14,19 @@ fn foo(a: ptr<storage, vec3u, read_write>) {
   baz(*a);
 }
 
+fn f(b: ptr<function, vec3u>) {
+  var b2 = *b;
+}
+
+fn f2(b: ptr<private, vec3u>) {
+  var b2 = *b;
+}
+
 @compute @workgroup_size(1)
 fn main() {
   foo(&buf);
+  var b = buf;
+  f(&b);
+  f2(&buf2);
 }
 


### PR DESCRIPTION
#### ccbe541039b44cef37dd2fa6a765c369e3376c9b
<pre>
[WGSL] Should not unpack values from pointers to non-resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=290951">https://bugs.webkit.org/show_bug.cgi?id=290951</a>
<a href="https://rdar.apple.com/148463455">rdar://148463455</a>

Reviewed by Mike Wyrzykowski.

In 292751@main I fixed a bug where we weren&apos;t correctly unpacking the result from
dereferencing pointers. However, I missed that only pointers to resources should
be unpacked, as private, workgroup and function variables must already have been
unpacked at the time of assignment.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/packing-pointer-arguments.wgsl:

Canonical link: <a href="https://commits.webkit.org/293154@main">https://commits.webkit.org/293154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9626bfbe8d49f3602147eb4b36a37a4dc331e86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48522 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100997 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13572 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13352 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83594 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30212 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->