### PR TITLE
Fix up autofocus candidate appending steps

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/same-origin-autofocus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/same-origin-autofocus-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Blocked autofocusing on a form control in a cross-origin subframe.
 
 
-FAIL Autofocus should not work in the same origin grand child iframe assert_unreached: The grandchild iframe shouldn't get focus Reached unreachable code
+PASS Autofocus should not work in the same origin grand child iframe
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5948,9 +5948,7 @@ void Document::flushAutofocusCandidates()
 
     while (!m_autofocusCandidates.isEmpty()) {
         RefPtr element = m_autofocusCandidates.first().get();
-        Document* elementMainFrameDocument = element ? element->document().mainFrameDocument() : nullptr;
-        if (!elementMainFrameDocument)
-            LOG_ONCE(SiteIsolation, "Unable to fully perform Document::flushAutofocusCandidates() without access to the elements main frame document ");
+        RefPtr<Document> elementMainFrameDocument = element ? element->document().mainFrameDocument() : nullptr;
 
         if (!element || !element->document().isFullyActive() || (elementMainFrameDocument && elementMainFrameDocument != this)) {
             m_autofocusCandidates.removeFirst();


### PR DESCRIPTION
#### c797e4235b0271048db719f017d6a7bae6044eed
<pre>
Fix up autofocus candidate appending steps
<a href="https://rdar.apple.com/148464871">rdar://148464871</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290952">https://bugs.webkit.org/show_bug.cgi?id=290952</a>

Reviewed by Alex Christensen.

Before this change we only compared the Element&apos;s origin to the top origin before adding it to the autofocus candidate list.
According to the insertion steps from <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute">https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute</a>,
Elements should not be appended to the autofocus candidate list unless every navigable ancestor is of the same origin.

e.g. We need to walk the whole frame tree to the parent.

Also clean up some site isolation related code/error messages that don&apos;t actually apply *because* we have this same
origin - and therefore same process - guarantee.

This site isolation cleanup also happened to progress a WPT test for all configurations.

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/same-origin-autofocus-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushAutofocusCandidates):
* Source/WebCore/dom/Element.cpp:
(WebCore::shouldAutofocus):
(WebCore::Element::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/293147@main">https://commits.webkit.org/293147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99ce94bc884e2552238e1bbd2b7c0732212916df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74646 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13614 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25137 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30270 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->