### PR TITLE
WebPage::getPlatformEditorStateCommon can be slow, flushing layout for computed styles and parsing string.

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -489,7 +489,7 @@ RefPtr<HTMLElement> ApplyStyleCommand::splitAncestorsWithUnicodeBidi(Node* node,
     RefPtr<HTMLElement> unsplitAncestor;
 
     if (allowedDirection != WritingDirection::Natural && highestAncestorUnicodeBidi != CSSValueBidiOverride && is<HTMLElement>(*highestAncestorWithUnicodeBidi)) {
-        auto highestAncestorDirection = EditingStyle::create(highestAncestorWithUnicodeBidi.get(), EditingStyle::AllProperties)->textDirection();
+        auto highestAncestorDirection = EditingStyle::create(highestAncestorWithUnicodeBidi.get(), EditingStyle::PropertiesToInclude::AllProperties)->textDirection();
         if (highestAncestorDirection && *highestAncestorDirection == allowedDirection) {
             if (!nextHighestAncestorWithUnicodeBidi)
                 return static_pointer_cast<HTMLElement>(WTFMove(highestAncestorWithUnicodeBidi));

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -429,7 +429,7 @@ void DeleteSelectionCommand::saveTypingStyleState()
         return;
 
     // Figure out the typing style in effect before the delete is done.
-    m_typingStyle = EditingStyle::create(m_selectionToDelete.start(), EditingStyle::EditingPropertiesInEffect);
+    m_typingStyle = EditingStyle::create(m_selectionToDelete.start(), EditingStyle::PropertiesToInclude::EditingPropertiesInEffect);
     m_typingStyle->removeStyleAddedByNode(enclosingAnchorElement(m_selectionToDelete.start()).get());
 
     // If we're deleting into a Mail blockquote, save the style at end() instead of start()

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -66,7 +66,7 @@ enum class StandardFontFamilySerializationMode : uint8_t { Keep, Strip };
 class EditingStyle : public RefCounted<EditingStyle> {
 public:
 
-    enum PropertiesToInclude { AllProperties, OnlyEditingInheritableProperties, EditingPropertiesInEffect };
+    enum class PropertiesToInclude { AllProperties, OnlyEditingInheritableProperties, EditingPropertiesInEffect, PostLayoutProperties };
 
     enum ShouldPreserveWritingDirection { PreserveWritingDirection, DoNotPreserveWritingDirection };
     enum ShouldExtractMatchingStyle { ExtractMatchingStyle, DoNotExtractMatchingStyle };
@@ -77,12 +77,12 @@ public:
         return adoptRef(*new EditingStyle);
     }
 
-    static Ref<EditingStyle> create(Node* node, PropertiesToInclude propertiesToInclude = OnlyEditingInheritableProperties)
+    static Ref<EditingStyle> create(Node* node, PropertiesToInclude propertiesToInclude = PropertiesToInclude::OnlyEditingInheritableProperties)
     {
         return adoptRef(*new EditingStyle(node, propertiesToInclude));
     }
 
-    static Ref<EditingStyle> create(const Position& position, PropertiesToInclude propertiesToInclude = OnlyEditingInheritableProperties)
+    static Ref<EditingStyle> create(const Position& position, PropertiesToInclude propertiesToInclude = PropertiesToInclude::OnlyEditingInheritableProperties)
     {
         return adoptRef(*new EditingStyle(position, propertiesToInclude));
     }
@@ -144,7 +144,7 @@ public:
     void prepareToApplyAt(const Position&, ShouldPreserveWritingDirection = DoNotPreserveWritingDirection);
     void mergeTypingStyle(Document&);
     enum CSSPropertyOverrideMode { OverrideValues, DoNotOverrideValues };
-    void mergeInlineStyleOfElement(StyledElement&, CSSPropertyOverrideMode, PropertiesToInclude = AllProperties);
+    void mergeInlineStyleOfElement(StyledElement&, CSSPropertyOverrideMode, PropertiesToInclude = PropertiesToInclude::AllProperties);
     static Ref<EditingStyle> wrappingStyleForSerialization(Node& context, bool shouldAnnotate, StandardFontFamilySerializationMode);
     void mergeStyleFromRules(StyledElement&);
     void mergeStyleFromRulesForSerialization(StyledElement&, StandardFontFamilySerializationMode);
@@ -166,7 +166,10 @@ public:
     TextDecorationChange strikeThroughChange() const { return static_cast<TextDecorationChange>(m_strikeThroughChange); }
 
     WEBCORE_EXPORT bool hasStyle(CSSPropertyID, const String& value);
-    WEBCORE_EXPORT static RefPtr<EditingStyle> styleAtSelectionStart(const VisibleSelection&, bool shouldUseBackgroundColorInEffect = false);
+    WEBCORE_EXPORT bool fontWeightIsBold();
+    WEBCORE_EXPORT bool fontStyleIsItalic();
+    WEBCORE_EXPORT bool webkitTextDecorationsInEffectIsUnderline();
+    WEBCORE_EXPORT static RefPtr<EditingStyle> styleAtSelectionStart(const VisibleSelection&, bool shouldUseBackgroundColorInEffect = false, PropertiesToInclude = PropertiesToInclude::AllProperties);
     static WritingDirection textDirectionForSelection(const VisibleSelection&, EditingStyle* typingStyle, bool& hasNestedOrMultipleEmbeddings);
     static bool isEmbedOrIsolate(CSSValueID unicodeBidi) { return unicodeBidi == CSSValueID::CSSValueIsolate || unicodeBidi == CSSValueID::CSSValueWebkitIsolate || unicodeBidi == CSSValueID::CSSValueEmbed; }
 

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -82,7 +82,7 @@ void InsertParagraphSeparatorCommand::calculateStyleBeforeInsertion(const Positi
     if (!isStartOfParagraph(visiblePosition) && !isEndOfParagraph(visiblePosition))
         return;
 
-    m_style = EditingStyle::create(position, EditingStyle::EditingPropertiesInEffect);
+    m_style = EditingStyle::create(position, EditingStyle::PropertiesToInclude::EditingPropertiesInEffect);
     protectedStyle()->mergeTypingStyle(*position.document());
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -637,14 +637,14 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
     auto& postLayoutData = *result.postLayoutData;
 
     if (result.isContentEditable) {
-        if (auto editingStyle = EditingStyle::styleAtSelectionStart(selection)) {
-            if (editingStyle->hasStyle(CSSPropertyFontWeight, "bold"_s))
+        if (auto editingStyle = EditingStyle::styleAtSelectionStart(selection, false, EditingStyle::PropertiesToInclude::PostLayoutProperties)) {
+            if (editingStyle->fontWeightIsBold())
                 postLayoutData.typingAttributes.add(TypingAttribute::Bold);
 
-            if (editingStyle->hasStyle(CSSPropertyFontStyle, "italic"_s) || editingStyle->hasStyle(CSSPropertyFontStyle, "oblique"_s))
+            if (editingStyle->fontStyleIsItalic())
                 postLayoutData.typingAttributes.add(TypingAttribute::Italics);
 
-            if (editingStyle->hasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s))
+            if (editingStyle->webkitTextDecorationsInEffectIsUnderline())
                 postLayoutData.typingAttributes.add(TypingAttribute::Underline);
 
             if (RefPtr styleProperties = editingStyle->style()) {


### PR DESCRIPTION
#### 25f27158a9b49429c8b10ece629fcab48e385851
<pre>
WebPage::getPlatformEditorStateCommon can be slow, flushing layout for computed styles and parsing string.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290955">https://bugs.webkit.org/show_bug.cgi?id=290955</a>
&lt;<a href="https://rdar.apple.com/148468929">rdar://148468929</a>&gt;

Reviewed by Wenson Hsieh.

Converts EditingPropertiesToInclude and PropertiesToInclude to enum classes to
ensure there&apos;s never any type confusion on these very similar enums.

Adds a new enum value so that getPlatformEditorStateCommon&apos;s call to
styleAtSelectionStart can only copy the subset of properties that it will read.
This prevents copying lots of unrelated properties, some of which can trigger
layout flushes.

Adds new getters for checking some specific styles (like bold, italic etc) to
EditorStyle. This avoids allocating a new EditorStyle, parsing strings into
computed values, and then diffing the two computed styles and instead allows a
fast, direct lookup.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::splitAncestorsWithUnicodeBidi):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::saveTypingStyleState):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::copyEditingProperties):
(WebCore::copyPropertiesFromComputedStyle):
(WebCore::EditingStyle::init):
(WebCore::EditingStyle::removeStyleAddedByNode):
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
(WebCore::EditingStyle::prepareToApplyAt):
(WebCore::EditingStyle::mergeInlineStyleOfElement):
(WebCore::extractEditingProperties):
(WebCore::EditingStyle::wrappingStyleForSerialization):
(WebCore::EditingStyle::removeStyleFromRulesAndContext):
(WebCore::fontWeightIsBold):
(WebCore::EditingStyle::fontWeightIsBold):
(WebCore::EditingStyle::fontStyleIsItalic):
(WebCore::EditingStyle::webkitTextDecorationsInEffectIsUnderline):
(WebCore::EditingStyle::styleAtSelectionStart):
* Source/WebCore/editing/EditingStyle.h:
(WebCore::EditingStyle::create):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::calculateStyleBeforeInsertion):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):

Canonical link: <a href="https://commits.webkit.org/293414@main">https://commits.webkit.org/293414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f9e21da946c606be1fac2e7b12df7c2a9dcb29a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31801 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54978 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105499 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83057 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18715 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->