### PR TITLE
WebDriver Bidi: add initial implementations for `script` and `browsingContext` commands.

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -954,6 +954,7 @@ set(WebKit_WEBDRIVER_BIDI_PROTOCOL_GENERATOR_INPUTS
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowser.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowsingContext.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiLog.json
+    ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiScript.json
 )
 
 add_custom_command(

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -506,6 +506,7 @@ $(PROJECT_DIR)/UIProcess/Automation/WebAutomationSession.messages.in
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowser.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowsingContext.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiLog.json
+$(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json
 $(PROJECT_DIR)/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -518,6 +518,7 @@ WEBDRIVER_BIDI_PROTOCOL_INPUT_FILES = \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowser.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowsingContext.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiLog.json \
+    $(WebKit2)/UIProcess/Automation/protocol/BidiScript.json \
 #
 
 WEBDRIVER_BIDI_PROTOCOL_OUTPUT_FILES = \

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,5 @@
 AutomationProtocolObjects.h
+WebDriverBidiProtocolObjects.h
 Shared/API/c/cf/WKStringCF.mm
 Shared/API/c/cf/WKURLCF.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -88,6 +88,7 @@ UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
 WebDriverBidiBackendDispatchers.cpp
 WebDriverBidiFrontendDispatchers.cpp
+WebDriverBidiProtocolObjects.h
 WebProcess/ApplePay/WebPaymentCoordinator.cpp
 WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
 WebProcess/Cache/WebCacheStorageConnection.cpp

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -117,6 +117,11 @@ class WebAutomationSession final : public API::ObjectImpl<API::Object::Type::Aut
     , public SimulatedInputDispatcher::Client
 #endif
 {
+
+#if ENABLE(WEBDRIVER_BIDI)
+friend class WebDriverBidiProcessor;
+#endif
+
 public:
     WebAutomationSession();
     ~WebAutomationSession() override;
@@ -280,9 +285,10 @@ public:
 
     void didDestroyFrame(WebCore::FrameIdentifier);
 
-private:
     RefPtr<WebPageProxy> webPageProxyForHandle(const String&);
     String handleForWebPageProxy(const WebPageProxy&);
+
+private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
@@ -47,6 +47,13 @@ do { \
     return makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName)); \
 } while (false)
 
+#define SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(condition, errorName) \
+do { \
+    if (condition) { \
+        return makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName)); \
+    } \
+} while (false)
+
 #define SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(errorName, detailsString) \
 do { \
     return makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString)); \
@@ -56,6 +63,14 @@ do { \
 do { \
     callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName))); \
     return; \
+} while (false)
+
+#define ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(condition, errorName) \
+do { \
+    if (condition) { \
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName))); \
+        return; \
+    } \
 } while (false)
 
 #define ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(errorName, detailsString) \

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -31,20 +31,25 @@
 // For AutomationError codes.
 #include "AutomationProtocolObjects.h"
 #include "Logging.h"
+#include "PageLoadState.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
 #include "WebDriverBidiBackendDispatchers.h"
 #include "WebDriverBidiFrontendDispatchers.h"
 #include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include "WebProcessPool.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebKit {
 
 using namespace Inspector;
 using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContext;
+using ReadinessState = Inspector::Protocol::BidiBrowsingContext::ReadinessState;
+using PageLoadStrategy = Inspector::Protocol::Automation::PageLoadStrategy;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDriverBidiProcessor);
 
@@ -54,6 +59,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_browserDomainDispatcher(BidiBrowserBackendDispatcher::create(m_backendDispatcher, this))
     , m_browsingContextDomainDispatcher(BidiBrowsingContextBackendDispatcher::create(m_backendDispatcher, this))
+    , m_scriptDomainDispatcher(BidiScriptBackendDispatcher::create(m_backendDispatcher, this))
     , m_logDomainNotifier(makeUnique<BidiLogFrontendDispatcher>(m_frontendRouter))
 {
     protectedFrontendRouter()->connectFrontend(*this);
@@ -111,34 +117,248 @@ void WebDriverBidiProcessor::sendMessageToFrontend(const String& message)
 }
 
 
-// MARK: Inspector::BrowsingContextDispatcherHandler methods.
+// MARK: Inspector::BidiBrowsingContextDispatcherHandler methods.
 
-void WebDriverBidiProcessor::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, CommandCallbackOf<String, String>&& callback)
+void WebDriverBidiProcessor::activate(const BrowsingContext& browsingContext, CommandCallback<void>&& callback)
 {
     RefPtr session = m_session.get();
-    if (!session)
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR(NotImplemented);
+    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+
+    // FIXME: detect non-top level browsing contexts, returning `invalid argument`.
+    session->switchToBrowsingContext(browsingContext, emptyString(), [callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        callback({ });
+    });
 }
 
+void WebDriverBidiProcessor::close(const BrowsingContext& browsingContext, std::optional<bool>&& optionalPromptUnload, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-// MARK: Inspector::BrowserDispatcherHandler methods.
+    // FIXME: implement `promptUnload` option.
+    // FIXME: raise `invalid argument` if `browsingContext` is not a top-level traversable.
+
+    session->closeBrowsingContext(browsingContext);
+
+    callback({ });
+}
+
+static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
+
+static Inspector::Protocol::Automation::BrowsingContextPresentation browsingContextPresentationFromCreateType(Inspector::Protocol::BidiBrowsingContext::CreateType createType)
+{
+    switch (createType) {
+    case Inspector::Protocol::BidiBrowsingContext::CreateType::Tab:
+        return Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
+    case Inspector::Protocol::BidiBrowsingContext::CreateType::Window:
+        return Inspector::Protocol::Automation::BrowsingContextPresentation::Window;
+    }
+
+    ASSERT_NOT_REACHED();
+    return defaultBrowsingContextPresentation;
+}
+
+void WebDriverBidiProcessor::create(Inspector::Protocol::BidiBrowsingContext::CreateType createType, const BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, CommandCallback<BrowsingContext>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `referenceContext` option.
+    // FIXME: implement `background` option.
+    // FIXME: implement `userContext` option.
+
+    session->createBrowsingContext(browsingContextPresentationFromCreateType(createType), [callback = WTFMove(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        auto [resultContext, resultPresentation] = WTFMove(result.value());
+        callback(WTFMove(resultContext));
+    });
+}
+
+void WebDriverBidiProcessor::getTree(const BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `root` option.
+    // FIXME: implement `maxDepth` option.
+
+    auto infos = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
+    for (Ref process : session->protectedProcessPool()->processes()) {
+        for (Ref page : process->pages()) {
+            if (!page->isControlledByAutomation())
+                continue;
+
+            // FIXME: implement `parent` field.
+            // FIXME: implement `children` field.
+            // FIXME: implement `originalOpener` field.
+            // FIXME: implement `clientWindow` field.
+            // FIXME: implement `userContext` field.
+            infos->addItem(Inspector::Protocol::BidiBrowsingContext::Info::create()
+                .setContext(session->handleForWebPageProxy(page))
+                .setUrl(page->currentURL())
+                .setClientWindow("placeholder_window"_s)
+                .setUserContext("placeholder_context"_s)
+                .release());
+        }
+    }
+
+    callback({ { WTFMove(infos) } });
+}
+
+// https://www.w3.org/TR/webdriver/#dfn-session-page-load-timeout
+static constexpr Seconds defaultPageLoadTimeout = 300_s;
+static constexpr ReadinessState defaultReadinessState = ReadinessState::None;
+
+static PageLoadStrategy pageLoadStrategyFromReadinessState(ReadinessState state)
+{
+    switch (state) {
+    case ReadinessState::None:
+        return PageLoadStrategy::None;
+    case ReadinessState::Interactive:
+        return PageLoadStrategy::Eager;
+    case ReadinessState::Complete:
+        return PageLoadStrategy::Normal;
+    }
+
+    ASSERT_NOT_REACHED();
+    return PageLoadStrategy::Normal;
+}
+
+void WebDriverBidiProcessor::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
+    session->navigateBrowsingContext(browsingContext, url, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [url, callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        // FIXME: keep track of navigation IDs that we hand out.
+        callback({ { url, "placeholder_navigation"_s } });
+    });
+}
+
+void WebDriverBidiProcessor::reload(const BrowsingContext& browsingContext, std::optional<bool>&& optionalIgnoreCache, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::Navigation>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: implement `ignoreCache` option.
+
+    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
+    session->reloadBrowsingContext(browsingContext, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [session = WTFMove(session), browsingContext, callback = WTFMove(callback)](CommandResult<void>&& result) {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+        RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+
+        // FIXME: keep track of navigation IDs that we hand out.
+        callback({ { webPageProxy->currentURL(), "placeholder_navigation"_s } });
+    });
+}
+
+// MARK: Inspector::BidiBrowserDispatcherHandler methods.
 
 Inspector::Protocol::ErrorStringOr<void> WebDriverBidiProcessor::close()
 {
     RefPtr session = m_session.get();
-    if (!session)
-        SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
     session->terminate();
 
     return { };
 }
 
+// MARK: Log domain.
+
 void WebDriverBidiProcessor::logEntryAdded(const String& level, const String& source, const String& message, double timestamp, const String& type, const String& method)
 {
     m_logDomainNotifier->entryAdded(level, source, message, timestamp, type, method);
+}
+
+// MARK: Inspector::BidiScriptDispatcherHandler methods.
+
+void WebDriverBidiProcessor::callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& arguments, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: handle non-BrowsingContext obtained from `Target`.
+    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
+
+    // FIXME: handle `awaitPromise` option.
+    // FIXME: handle `resultOwnership` option.
+    // FIXME: handle `serializationOptions` option.
+    // FIXME: handle custom `this` option.
+    // FIXME: handle `userActivation` option.
+
+    Ref<JSON::Array> argumentsArray = arguments ? arguments.releaseNonNull() : JSON::Array::create();
+
+    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, WTFMove(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
+        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
+        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
+            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
+            .release();
+
+        // FIXME: handle serializing different RemoteValue types as JSON.
+        if (result)
+            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
+
+        // FIXME: keep track of realm IDs that we hand out.
+        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
+    });
+}
+
+void WebDriverBidiProcessor::evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Protocol::BidiScript::EvaluateResultType, String, RefPtr<Protocol::BidiScript::RemoteValue>, RefPtr<Protocol::BidiScript::ExceptionDetails>>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    // FIXME: handle non-BrowsingContext obtained from `Target`.
+    std::optional<BrowsingContext> browsingContext = target->getString("context"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!browsingContext, InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->webPageProxyForHandle(*browsingContext), WindowNotFound);
+
+    // FIXME: handle `awaitPromise` option.
+    // FIXME: handle `resultOwnership` option.
+    // FIXME: handle `serializationOptions` option.
+
+    String functionDeclaration = makeString("function() {\n return "_s, expression, "; \n}"_s);
+    session->evaluateJavaScriptFunction(*browsingContext, emptyString(), functionDeclaration, JSON::Array::create(), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTFMove(callback)](Inspector::CommandResult<String>&& result) {
+        auto evaluateResultType = result.has_value() ? Inspector::Protocol::BidiScript::EvaluateResultType::Success : Inspector::Protocol::BidiScript::EvaluateResultType::Exception;
+        auto resultObject = Inspector::Protocol::BidiScript::RemoteValue::create()
+            .setType(Inspector::Protocol::BidiScript::RemoteValueType::Object)
+            .release();
+
+        // FIXME: handle serializing different RemoteValue types as JSON here.
+        if (result)
+            resultObject->setValue(JSON::Value::create(WTFMove(result.value())));
+
+        // FIXME: keep track of realm IDs that we hand out.
+        callback({ { evaluateResultType, "placeholder_realm"_s, WTFMove(resultObject), nullptr } });
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json
@@ -1,12 +1,29 @@
 {
     "domain": "BidiBrowser",
     "exposedAs": "browser",
-    "description": "The browser module contains commands for managing the remote end browser process.",
     "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The browser module contains commands for managing the remote end browser process.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-browser",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browser",
+    "types": [
+        {
+            "id": "ClientWindow",
+            "description": "String uniquely identifying a client window.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browser-ClientWindow",
+            "type": "string"
+        },
+        {
+            "id": "UserContext",
+            "description": "Unique string identifying a user context with separate storage.",
+            "spec": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browser",
+            "type": "string"
+        }
+    ],
     "commands": [
         {
             "name": "close",
-            "description": "Terminates the WebDriver session to which it is sent."
+            "description": "Terminates the WebDriver session to which it is sent and cleans up remote end automation state.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browser-close"
         }
     ]
 }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -1,40 +1,136 @@
 {
     "domain": "BidiBrowsingContext",
     "exposedAs": "browsingContext",
-    "description": "The browsingContext module contains commands and events relating to navigables.",
     "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The browsingContext module contains commands and events relating to navigables.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-browsingContext",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context",
     "types": [
         {
             "id": "BrowsingContext",
+            "description": "A unique identifier for a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-Browsingcontext",
+            "type": "string"
+        },
+        {
+            "id": "CreateType",
+            "description": "The type of browsing context to be created.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-create",
             "type": "string",
-            "description": "A unique identifier for a navigable."
+            "enum": [ "tab", "window" ]
+        },
+        {
+            "id": "Info",
+            "description": "Information about a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-Info",
+            "type": "object",
+            "properties": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The navigable being described." },
+                { "name": "url", "type": "string" },
+                { "name": "originalOpener", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
+                { "name": "parent", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
+                { "name": "children", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "optional": true },
+                { "name": "clientWindow", "$ref": "BidiBrowser.ClientWindow" },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext" }
+            ]
         },
         {
             "id": "Navigation",
-            "type": "string",
-            "description": "Unique string identifying an ongoing navigation."
+            "description": "Unique string identifying an ongoing navigation.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-Navigation",
+            "type": "string"
         },
         {
             "id": "ReadinessState",
-            "type": "string",
             "description": "Represents the stage of document loading at which a navigation command will return.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-ReadinessState",
+            "type": "string",
             "enum": ["none", "interactive", "complete"]
         }
     ],
     "commands": [
         {
+            "name": "activate",
+            "description": "Activates and focuses the given top-level traversable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-activate",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/activate",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to activate.  It is an error to pass a non-top level traversable." }
+            ]
+        },
+        {
+            "name": "close",
+            "description": "Closes the given top-level traversable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-close",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/close",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to close.  It is an error to pass a non-top level traversable." },
+                { "name": "promptUnload", "type": "boolean", "optional": true, "description": "Whether to permit prompting the user from beforeunload event." }
+            ]
+        },
+        {
+            "name": "create",
+            "description": "Creates a new navigable, either in a new tab or in a new window, and returns its navigable id (<code>BidiBrowsingContext.BrowsingContext</code>).",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-create",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/create",
+            "async": true,
+            "parameters": [
+                { "name": "type", "$ref": "BidiBrowsingContext.CreateType" },
+                { "name": "referenceContext", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
+                { "name": "background", "type": "boolean", "optional": true },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "optional": true }
+            ],
+            "returns": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to close. It is an error to pass a non-top level traversable." }
+            ]
+        },
+        {
+            "name": "getTree",
+            "description": "Describes the frame tree at a particular moment in time. Returns a tree of all descendant navigables including the given parent itself, or all top-level contexts when no parent is provided.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-getTree",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/get_tree",
+            "async": true,
+            "parameters": [
+                { "name": "root", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
+                { "name": "maxDepth", "type": "number", "optional": true }
+            ],
+            "returns": [
+                { "name": "contexts", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "description": "Information about the matching browsing contexts." }
+            ]
+        },
+        {
             "name": "navigate",
             "description": "Navigates a navigable to the given URL.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-navigate",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/navigate",
+            "async": true,
             "parameters": [
-                { "name": "context", "$ref": "BrowsingContext", "description": "The identifier of the browsing context to navigate." },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to navigate." },
                 { "name": "url", "type": "string", "description": "The URL to navigate to." },
-                { "name": "wait", "$ref": "ReadinessState", "optional": true, "description": "The readiness state at which the command will return (default is 'none')." }
+                { "name": "wait", "$ref": "BidiBrowsingContext.ReadinessState", "optional": true, "description": "The readiness state at which the command will return (default is 'none')." }
             ],
             "returns": [
                 { "name": "url", "type": "string", "description": "The URL the browsing context navigated to." },
-                { "name": "navigation", "$ref": "Navigation", "optional": true, "description": "The navigation ID, or null if not applicable." }
+                { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "optional": true, "description": "The navigation ID, or null if not applicable." }
+            ]
+        },
+        {
+            "name": "reload",
+            "description": "Reloads a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/reload",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to reload." },
+                { "name": "ignoreCache", "type": "boolean", "optional": true },
+                { "name": "wait", "$ref": "BidiBrowsingContext.ReadinessState", "optional": true }
             ],
-            "async": true
+            "returns": [
+                { "name": "url", "type": "string", "description": "The URL the browsing context navigated to." },
+                { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "optional": true, "description": "The navigation ID, or null if not applicable." }
+            ]
         }
     ]
 }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiLog.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiLog.json
@@ -1,12 +1,16 @@
 {
     "domain": "BidiLog",
     "exposedAs": "log",
-    "description": "The log module contains commands and events relating to logging.",
     "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The log module contains commands and events relating to logging.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-log",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/log",
     "events": [
         {
             "name": "entryAdded",
             "description": "Fired when a new log entry is added.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-log-entryAdded",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/log/entry_added",
             "parameters": [
                 { "name": "level", "type": "string", "description": "The log entry level." },
                 { "name": "source", "type": "string", "description": "The source script information" },

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -1,0 +1,207 @@
+{
+    "domain": "BidiScript",
+    "exposedAs": "script",
+    "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The script module contains commands and events relating to script realms and execution.",
+    "spec": "https://w3c.github.io/webdriver-bidi/#module-script",
+    "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/script",
+    "types": [
+        {
+            "id": "EvaluateResultType",
+            "description": "Whether a script evaluation was successful or had thrown an exception.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-EvaluateResult",
+            "type": "string",
+            "enum": [ "success", "exception" ]
+        },
+        {
+            "id": "ExceptionDetails",
+            "description": "Represents the details of a JavaScript exception.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-ExceptionDetails",
+            "type": "object",
+            "properties": [
+                { "name": "lineNumber", "type": "number" },
+                { "name": "columnNumber", "type": "number" },
+                { "name": "text", "type": "string" },
+                { "name": "exception", "$ref": "BidiScript.RemoteValue" },
+                { "name": "stackTrace", "$ref": "BidiScript.StackTrace" }
+            ]
+        },
+        {
+            "id": "Handle",
+            "description": "Represents a handle to an object owned by the ECMAScript runtime. The handle is only valid in a specific <code>BidiScript.Realm</code>.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Handle",
+            "type": "string"
+        },
+        {
+            "id": "InternalId",
+            "description": "Represents the id of a previously serialized <code>BidiScript.RemoteValue</code> during serialization.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-InternalId",
+            "type": "string"
+        },
+        {
+            "id": "LocalValue",
+            "description": "Represents a value which can be deserialized into ECMAScript. This includes both primitive and non-primitive values as well as remote references (<code>BidiScript.RemoteReference</code>) and channels (<code>BidiScript.Channel</code>).",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-LocalValue",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "BidiScript.LocalValueType" },
+                { "name": "value", "type": "any" }
+            ]
+        },
+        {
+            "id": "LocalValueType",
+            "description": "Represents the concrete type of a <code>BidiScript.LocalValue</code>",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-LocalValue",
+            "type": "string",
+            "enum": [
+                "array",
+                "date",
+                "map",
+                "object",
+                "set"
+            ]
+        },
+        {
+            "id": "Realm",
+            "description": "Unique identifier for a script realm as defined at <https://tc39.es/ecma262/#realm>.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Realm",
+            "type": "string"
+        },
+        {
+            "id": "RemoteValue",
+            "description": "A mirror object that is used to introspect values accessible from the ECMAScript runtime. The fields used and their semantics depends on the value's type (<cod>BidiScript.RemoteValueType</code>)",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "BidiScript.RemoteValueType" },
+                { "name": "value", "type": "any", "optional": true },
+                { "name": "handle", "$ref": "BidiScript.Handle", "optional": true, "description": "Represents a reference to a remote Node. Applicable if `type` property is `node`, `nodelist`, `htmlcollection`." },
+                { "name": "internalId", "$ref": "BidiScript.InternalId", "optional": true, "description": "Represents a reference to a remote script value. If both `handle` and `internalId` are specified, `internalId` takes precedence." }
+            ]
+        },
+        {
+            "id": "RemoteValueType",
+            "description": "The type of a mirror object that represents a value accessible from the ECMAScript runtime.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue",
+            "type": "string",
+            "enum": [
+                "array",
+                "arraybuffer",
+                "date",
+                "error",
+                "function",
+                "generator",
+                "htmlcollection",
+                "map",
+                "node",
+                "nodelist",
+                "object",
+                "promise",
+                "proxy",
+                "regexp",
+                "set",
+                "symbol",
+                "typedarray",
+                "weakmap",
+                "weakset",
+                "window"
+            ]
+        },
+        {
+            "id": "ResultOwnership",
+            "description": "Specifies whether a serialized value will be treated as a global root (and therefore except from garbage collection).",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-ResultOwnership",
+            "type": "string",
+            "enum": [ "root", "none" ]
+        },
+        {
+            "id": "SerializationOptions",
+            "description": "Describes options to be used when serializing JavaScript objects.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-SerializationOptions",
+            "type": "object",
+            "properties": [
+                { "name": "maxDomDepth", "type": "number", "optional": true },
+                { "name": "maxObjectDepth", "type": "number", "optional": true },
+                { "name": "includesShadowTree", "type": "string", "enum": ["none", "open", "all"], "optional": true }
+            ]
+        },
+        {
+            "id": "StackFrame",
+            "description": "Represents a single call frame within a <code>BidiScript.StackTrace</code>.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-StackFrame",
+            "type": "object",
+            "properties": [
+                { "name": "lineNumber", "type": "number" },
+                { "name": "columnNumber", "type": "number" },
+                { "name": "functionName", "type": "string" },
+                { "name": "url", "type": "string" }
+            ]
+        },
+        {
+            "id": "StackTrace",
+            "description": "Represents the JavaScript stack at a point in script execution.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-StackTrace",
+            "type": "object",
+            "properties": [
+                { "name": "callFrames", "type": "array", "items": { "$ref": "BidiScript.StackFrame" }, "description": "An array of stack frames on the JavaScript call stack, beginning with the most recent caller." }
+            ]
+        },
+        {
+            "id": "Target",
+            "description": "A type that represents a place to evaluate JavaScript. It is either a <code>BidiBrowsingContext.BrowsingContext</code> or a <code>BidiScript.Realm</code>.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-Target",
+            "type": "object",
+            "properties": [
+                { "name": "realm", "$ref": "BidiScript.Realm", "optional": true },
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
+                { "name": "sandbox", "type": "string", "optional": true }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "callFunction",
+            "description": "Calls a provided function with given arguments in a given realm.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-callFunction",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/script/call_function",
+            "async": true,
+            "parameters": [
+                { "name": "functionDeclaration", "type": "string" },
+                { "name": "awaitPromise", "type": "boolean" },
+                { "name": "target", "$ref": "BidiScript.Target" },
+                { "name": "arguments", "type": "array", "items": { "$ref": "BidiScript.LocalValue" }, "optional": true },
+                { "name": "resultOwnership", "$ref": "BidiScript.ResultOwnership", "optional": true },
+                { "name": "serializationOptions", "$ref": "BidiScript.SerializationOptions", "optional": true },
+                { "name": "this", "$ref": "BidiScript.LocalValue", "optional": true },
+                { "name": "userActivation", "type": "boolean", "optional": true }
+            ],
+            "returns": [
+                { "name": "type", "$ref": "BidiScript.EvaluateResultType" },
+                { "name": "realm", "$ref": "BidiScript.Realm" },
+                { "name": "result", "$ref": "BidiScript.RemoteValue", "optional": true },
+                { "name": "exceptionDetails", "$ref": "BidiScript.ExceptionDetails", "optional": true }
+            ]
+        },
+        {
+            "name": "evaluate",
+            "description": "Evaluates a provided expression with given arguments in a given realm.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-evaluate",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/script/evaluate",
+            "async": true,
+            "parameters": [
+                { "name": "expression", "type": "string" },
+                { "name": "awaitPromise", "type": "boolean" },
+                { "name": "target", "$ref": "BidiScript.Target" },
+                { "name": "resultOwnership", "$ref": "BidiScript.ResultOwnership", "optional": true },
+                { "name": "serializationOptions", "$ref": "BidiScript.SerializationOptions", "optional": true },
+                { "name": "userActivation", "type": "boolean", "optional": true }
+            ],
+            "returns": [
+                { "name": "type", "$ref": "BidiScript.EvaluateResultType" },
+                { "name": "realm", "$ref": "BidiScript.Realm" },
+                { "name": "result", "$ref": "BidiScript.RemoteValue", "optional": true },
+                { "name": "exceptionDetails", "$ref": "BidiScript.ExceptionDetails", "optional": true }
+            ]
+        }
+    ]
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7089,6 +7089,11 @@
 		996B2B9C25E257EE00719379 /* InspectorExtensionDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorExtensionDelegate.h; sourceTree = "<group>"; };
 		996B2B9E25E2582C00719379 /* APIInspectorExtensionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInspectorExtensionClient.h; sourceTree = "<group>"; };
 		996B2BA025E2591100719379 /* _WKInspectorExtensionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorExtensionDelegate.h; sourceTree = "<group>"; };
+		996D00402D7AA0CD0049C7D8 /* BidiBrowser.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiBrowser.json; sourceTree = "<group>"; };
+		996D00412D7AA0CD0049C7D8 /* BidiBrowsingContext.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiBrowsingContext.json; sourceTree = "<group>"; };
+		996D00422D7AA0CD0049C7D8 /* BidiLog.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiLog.json; sourceTree = "<group>"; };
+		996D00432D7AA0CD0049C7D8 /* BidiScript.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiScript.json; sourceTree = "<group>"; };
+		996D00452D7AA0FD0049C7D8 /* CombinedWebDriverBidiDomains.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CombinedWebDriverBidiDomains.json; sourceTree = "<group>"; };
 		99788AC91F421DCA00C08000 /* _WKAutomationSessionConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAutomationSessionConfiguration.h; sourceTree = "<group>"; };
 		99788ACA1F421DCA00C08000 /* _WKAutomationSessionConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKAutomationSessionConfiguration.mm; sourceTree = "<group>"; };
 		9979659A25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUIExtensionControllerMessages.h; sourceTree = "<group>"; };
@@ -13889,6 +13894,7 @@
 				99C3AE251DAD946700AF5C16 /* cocoa */,
 				9946EF821E7B023D00541E79 /* ios */,
 				99C3AE221DAD8E1400AF5C16 /* mac */,
+				996D00442D7AA0CD0049C7D8 /* protocol */,
 				9955A6E91C7980BB00EB6A93 /* Automation.json */,
 				995226D5207D184600F78420 /* SimulatedInputDispatcher.cpp */,
 				995226D4207D184500F78420 /* SimulatedInputDispatcher.h */,
@@ -13900,6 +13906,17 @@
 				99A5144E2D5AB7D500937177 /* WebDriverBidiProcessor.h */,
 			);
 			path = Automation;
+			sourceTree = "<group>";
+		};
+		996D00442D7AA0CD0049C7D8 /* protocol */ = {
+			isa = PBXGroup;
+			children = (
+				996D00402D7AA0CD0049C7D8 /* BidiBrowser.json */,
+				996D00412D7AA0CD0049C7D8 /* BidiBrowsingContext.json */,
+				996D00422D7AA0CD0049C7D8 /* BidiLog.json */,
+				996D00432D7AA0CD0049C7D8 /* BidiScript.json */,
+			);
+			path = protocol;
 			sourceTree = "<group>";
 		};
 		99C3AE221DAD8E1400AF5C16 /* mac */ = {
@@ -15537,6 +15554,7 @@
 				EB7D252A27B31B3F009CB586 /* com.apple.WebKit.webpushd.mac.sb */,
 				51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */,
 				E1967E37150AB5E200C73169 /* com.apple.WebProcess.sb */,
+				996D00452D7AA0FD0049C7D8 /* CombinedWebDriverBidiDomains.json */,
 				1AB7D6171288B9D900CFD08C /* DownloadProxyMessageReceiver.cpp */,
 				1AB7D6181288B9D900CFD08C /* DownloadProxyMessages.h */,
 				1A64229712DD029200CAAE2C /* DrawingAreaMessageReceiver.cpp */,


### PR DESCRIPTION
#### fe32a3d1f71f9c7594351773210691982a496514
<pre>
WebDriver Bidi: add initial implementations for `script` and `browsingContext` commands.
<a href="https://bugs.webkit.org/show_bug.cgi?id=281943">https://bugs.webkit.org/show_bug.cgi?id=281943</a>
&lt;<a href="https://rdar.apple.com/problem/138880813">rdar://problem/138880813</a>&gt;

Reviewed by Devin Rousso.

In order to unblock more testing, implement simplified versions of core commands that are
used by most tests. This includes script evaluation, navigation, activate, create, close, and getTree.
We use the strategy of calling existing WebAutomationSession methods where possible and bridging
the results as necessary. Add FIXMEs for known missing pieces of argument and result handling.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
Add BidiScript.json.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
Give the Bidi processor access to protected session methods like `handleForWebPageProxy`.
We might figure out a better way to do this in the future once frame handle support is added.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
(WebKit::WebDriverBidiProcessor::activate): Added.
(WebKit::WebDriverBidiProcessor::close): Added.
(WebKit::browsingContextPresentationFromCreateType): Added.
(WebKit::WebDriverBidiProcessor::create): Added.
(WebKit::WebDriverBidiProcessor::getTree): Added.
Instead of calling `page-&gt;getWindowFrameWithCallback()` repeatedly, we can just iterate pages and frames.

(WebKit::pageLoadStrategyFromReadinessState): Added.
(WebKit::WebDriverBidiProcessor::navigate): Added.
(WebKit::WebDriverBidiProcessor::reload): Added.
(WebKit::WebDriverBidiProcessor::callFunction): Added.
(WebKit::WebDriverBidiProcessor::evaluate): Added.

* Source/WebKit/UIProcess/Automation/protocol/BidiBrowser.json:
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json: Added.
Add links to specification and tests where applicable. Add better descriptions. Add new types and commands.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Drive-by, add BiDi domain input files and generated combined file to the Xcode project.
This makes it easier to refer back to the input file while working in Xcode.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
Add baseline expectation for existing SaferCPP failure related to generated protocol code. This matches
the expectations for AutomationProtocolObjects.h. Improving this is to be addressed as a separate fix.

Canonical link: <a href="https://commits.webkit.org/293479@main">https://commits.webkit.org/293479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b954ff4f29787920827832661ae2602172723d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49615 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27109 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102026 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14207 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48991 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106517 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19047 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21266 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/28524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19856 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31258 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->