### PR TITLE
[Navigation API] Fix crash in Navigation::innerDispatchNavigateEvent

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -887,7 +887,6 @@ page/LocalDOMWindow.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/Location.cpp
-page/Navigation.cpp
 page/NavigationDestination.cpp
 page/NavigationDestination.h
 page/NavigationHistoryEntry.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -90,7 +90,6 @@ loader/NetscapePlugInStreamLoader.cpp
 page/EventSource.cpp
 page/ImageAnalysisQueue.cpp
 page/LocalDOMWindow.cpp
-page/Navigation.cpp
 page/Quirks.cpp
 page/ScreenOrientation.cpp
 page/ShareDataReader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -489,7 +489,6 @@ page/LocalDOMWindow.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/Location.cpp
-page/Navigation.cpp
 page/Navigator.cpp
 page/OpportunisticTaskScheduler.cpp
 page/PageColorSampler.cpp

--- a/Source/WebCore/page/LocalDOMWindowProperty.h
+++ b/Source/WebCore/page/LocalDOMWindowProperty.h
@@ -36,6 +36,7 @@ class LocalDOMWindowProperty {
 public:
     WEBCORE_EXPORT LocalFrame* frame() const;
     LocalDOMWindow* window() const;
+    RefPtr<LocalDOMWindow> protectedWindow() const { return window(); }
 
 protected:
     explicit LocalDOMWindowProperty(LocalDOMWindow*);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -139,7 +139,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
             if (navigationType == NavigationNavigationType::Traverse) {
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
                 if (m_currentEntryIndex) {
-                    updateForActivation(frame()->loader().history().previousItem(), navigationType);
+                    updateForActivation(frame()->loader().history().protectedPreviousItem().get(), navigationType);
                     return;
                 }
                 // We are doing a cross document subframe traversal, we can't rely on previous window, so clear
@@ -168,7 +168,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
     auto rawEntries = page->checkedBackForward()->allItems();
     auto startingIndex = rawEntries.find(*currentItem);
     if (startingIndex != notFound) {
-        Ref startingOrigin = SecurityOrigin::create(rawEntries[startingIndex]->url());
+        Ref startingOrigin = SecurityOrigin::create(Ref { rawEntries[startingIndex] }->url());
 
         for (size_t i = 0; i < startingIndex; i++) {
             Ref item = rawEntries[i];
@@ -195,7 +195,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
         m_entries.append(NavigationHistoryEntry::create(*this, WTFMove(item)));
 
     m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem, start);
-    updateForActivation(frame()->loader().history().previousItem(), navigationType);
+    updateForActivation(frame()->loader().history().protectedPreviousItem().get(), navigationType);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation
@@ -206,7 +206,7 @@ void Navigation::updateForActivation(HistoryItem* previousItem, std::optional<Na
         return;
 
     ASSERT(m_currentEntryIndex);
-    if (currentEntry()->associatedHistoryItem().url().isAboutBlank())
+    if (currentEntry()->protectedAssociatedHistoryItem()->url().isAboutBlank())
         return;
 
     bool wasAboutBlank = previousItem && previousItem->url().isAboutBlank(); // FIXME: *Initial* about:blank
@@ -235,7 +235,7 @@ RefPtr<NavigationActivation> Navigation::createForPageswapEvent(HistoryItem* new
         return nullptr;
 
     // Skip cross-origin requests, or if any cross-origin redirects have been made.
-    bool isSameOrigin = SecurityOrigin::create(documentLoader->documentURL())->isSameOriginAs(window()->protectedDocument()->protectedSecurityOrigin());
+    bool isSameOrigin = SecurityOrigin::create(documentLoader->documentURL())->isSameOriginAs(protectedWindow()->protectedDocument()->protectedSecurityOrigin());
     if (!isSameOrigin || (!documentLoader->request().isSameSite() && !fromBackForwardCache))
         return nullptr;
 
@@ -350,7 +350,7 @@ RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTrack
 {
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(WTFMove(committed), WTFMove(finished), WTFMove(info), WTFMove(serializedState));
 
-    apiMethodTracker->finishedPromise->markAsHandled();
+    Ref { apiMethodTracker->finishedPromise }->markAsHandled();
 
     // FIXME: We should be able to assert m_upcomingNonTraverseMethodTracker is empty.
     if (!hasEntriesAndEventsDisabled())
@@ -365,7 +365,7 @@ RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTrack
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(WTFMove(committed), WTFMove(finished), WTFMove(info), nullptr);
     apiMethodTracker->key = key;
 
-    apiMethodTracker->finishedPromise->markAsHandled();
+    Ref { apiMethodTracker->finishedPromise }->markAsHandled();
 
     m_upcomingTraverseMethodTrackers.add(key, *apiMethodTracker);
 
@@ -391,20 +391,23 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
     if (!state && currentEntry())
         state = currentEntry()->associatedHistoryItem().navigationAPIStateObject();
 
-    if (!window()->protectedDocument()->isFullyActive() || window()->document()->unloadCounter())
+    RefPtr window = this->window();
+    if (!window->protectedDocument()->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
     RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTFMove(committed), WTFMove(finished), WTFMove(options.info), WTFMove(state));
 
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
-    ResourceRequest resourceRequest { frame()->protectedDocument()->url(), frame()->protectedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
-    FrameLoadRequest frameLoadRequest { *frame()->document(), frame()->protectedDocument()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
+    RefPtr frame = this->frame();
+    RefPtr document = frame->document();
+    ResourceRequest resourceRequest { document->url(), frame->protectedLoader()->outgoingReferrer(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
+    FrameLoadRequest frameLoadRequest { *document, document->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
     frameLoadRequest.setLockHistory(LockHistory::Yes);
     frameLoadRequest.setLockBackForwardList(LockBackForwardList::Yes);
-    frameLoadRequest.setShouldOpenExternalURLsPolicy(frame()->protectedDocument()->shouldOpenExternalURLsPolicyToPropagate());
+    frameLoadRequest.setShouldOpenExternalURLsPolicy(document->shouldOpenExternalURLsPolicyToPropagate());
 
-    frame()->protectedLoader()->changeLocation(WTFMove(frameLoadRequest));
+    frame->protectedLoader()->changeLocation(WTFMove(frameLoadRequest));
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
 }
@@ -412,8 +415,9 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
 Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    auto newURL = window()->document()->completeURL(url, ScriptExecutionContext::ForceUTF8::Yes);
-    const URL& currentURL = scriptExecutionContext()->url();
+    RefPtr window = this->window();
+    auto newURL = window->protectedDocument()->completeURL(url, ScriptExecutionContext::ForceUTF8::Yes);
+    const URL& currentURL = protectedScriptExecutionContext()->url();
 
     if (!newURL.isValid())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::SyntaxError, "Invalid URL"_s);
@@ -428,7 +432,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
     if (serializedState.hasException())
         return createErrorResult(WTFMove(committed), WTFMove(finished), serializedState.releaseException());
 
-    if (!window()->protectedDocument()->isFullyActive() || window()->document()->unloadCounter())
+    if (!window->protectedDocument()->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
     RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTFMove(committed), WTFMove(finished), WTFMove(options.info), serializedState.releaseReturnValue());
@@ -450,14 +454,16 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal
 Navigation::Result Navigation::performTraversal(const String& key, Navigation::Options options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    if (!window()->protectedDocument()->isFullyActive() || window()->document()->unloadCounter())
+    RefPtr window = this->window();
+    if (!window->protectedDocument()->isFullyActive() || window->document()->unloadCounter())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
     auto entry = findEntryByKey(key);
     if (!entry)
         createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::AbortError, "Navigation aborted"_s);
 
-    if (!frame()->isMainFrame() && window()->protectedDocument()->canNavigate(&frame()->page()->mainFrame()) != CanNavigateState::Able)
+    RefPtr frame = this->frame();
+    if (!frame->isMainFrame() && window->protectedDocument()->canNavigate(&frame->protectedPage()->protectedMainFrame().get()) != CanNavigateState::Able)
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::SecurityError, "Invalid state"_s);
 
     RefPtr current = currentEntry();
@@ -473,7 +479,7 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
     RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(WTFMove(committed), WTFMove(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
-    frame()->protectedNavigationScheduler()->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
+    frame->protectedNavigationScheduler()->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
         if (result == ScheduleHistoryNavigationResult::Aborted)
             createErrorResult(WTFMove(apiMethodTracker->committedPromise), WTFMove(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
     });
@@ -551,12 +557,13 @@ ExceptionOr<void> Navigation::updateCurrentEntry(UpdateCurrentEntryOptions&& opt
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#has-entries-and-events-disabled
 bool Navigation::hasEntriesAndEventsDisabled() const
 {
-    RefPtr document = window()->document();
+    RefPtr window = this->window();
+    RefPtr document = window->document();
     if (!document || !document->isFullyActive())
         return true;
     if (document->loader() && document->loader()->isInitialAboutBlank())
         return true;
-    if (window()->securityOrigin() && window()->securityOrigin()->isOpaque())
+    if (window->securityOrigin() && window->securityOrigin()->isOpaque())
         return true;
     return false;
 }
@@ -564,13 +571,14 @@ bool Navigation::hasEntriesAndEventsDisabled() const
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#resolve-the-finished-promise
 void Navigation::resolveFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker)
 {
-    if (!apiMethodTracker->committedToEntry) {
+    RefPtr committedToEntry = apiMethodTracker->committedToEntry;
+    if (!committedToEntry) {
         apiMethodTracker->finishedBeforeCommit = true;
         return;
     }
 
-    apiMethodTracker->committedPromise->resolve<IDLInterface<NavigationHistoryEntry>>(*apiMethodTracker->committedToEntry);
-    apiMethodTracker->finishedPromise->resolve<IDLInterface<NavigationHistoryEntry>>(*apiMethodTracker->committedToEntry);
+    Ref { apiMethodTracker->committedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
+    Ref { apiMethodTracker->finishedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
     cleanupAPIMethodTracker(apiMethodTracker);
 }
 
@@ -578,8 +586,8 @@ void Navigation::resolveFinishedPromise(NavigationAPIMethodTracker* apiMethodTra
 void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker, const Exception& exception, JSC::JSValue exceptionObject)
 {
     // finished is already marked as handled at this point so don't overwrite that.
-    apiMethodTracker->finishedPromise->reject(exception, RejectAsHandled::Yes, exceptionObject);
-    apiMethodTracker->committedPromise->reject(exception, RejectAsHandled::No, exceptionObject);
+    Ref { apiMethodTracker->finishedPromise }->reject(exception, RejectAsHandled::Yes, exceptionObject);
+    Ref { apiMethodTracker->committedPromise }->reject(exception, RejectAsHandled::No, exceptionObject);
     cleanupAPIMethodTracker(apiMethodTracker);
 }
 
@@ -588,7 +596,7 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
     if (!apiMethodTracker)
         return;
 
-    auto* globalObject = scriptExecutionContext()->globalObject();
+    auto* globalObject = protectedScriptExecutionContext()->globalObject();
     if (!globalObject && apiMethodTracker)
         globalObject = apiMethodTracker->committedPromise->globalObject();
     if (!globalObject)
@@ -607,13 +615,13 @@ void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTra
     apiMethodTracker->committedToEntry = entry;
     if (navigationType != NavigationNavigationType::Traverse) {
         if (apiMethodTracker->serializedState)
-            apiMethodTracker->committedToEntry->setState(WTFMove(apiMethodTracker->serializedState));
+            RefPtr { apiMethodTracker->committedToEntry }->setState(WTFMove(apiMethodTracker->serializedState));
     }
 
     if (apiMethodTracker->finishedBeforeCommit)
         resolveFinishedPromise(apiMethodTracker);
     else
-        apiMethodTracker->committedPromise->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
+        Ref { apiMethodTracker->committedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
@@ -650,11 +658,11 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
     if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
         m_entries[*m_currentEntryIndex] = NavigationHistoryEntry::create(*this, WTFMove(item));
         if (shouldCopyStateObjectFromCurrentEntry == ShouldCopyStateObjectFromCurrentEntry::Yes)
-            m_entries[*m_currentEntryIndex]->setState(oldCurrentEntry->state());
+            Ref { m_entries[*m_currentEntryIndex] }->setState(oldCurrentEntry->state());
     }
 
     if (m_ongoingAPIMethodTracker)
-        notifyCommittedToEntry(m_ongoingAPIMethodTracker.get(), currentEntry(), navigationType);
+        notifyCommittedToEntry(m_ongoingAPIMethodTracker.get(), protectedCurrentEntry().get(), navigationType);
 
     auto currentEntryChangeEvent = NavigationCurrentEntryChangeEvent::create(eventNames().currententrychangeEvent, {
         { false, false, false }, navigationType, oldCurrentEntry
@@ -703,10 +711,10 @@ void Navigation::updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems
 static bool documentCanHaveURLRewritten(const Document& document, const URL& targetURL)
 {
     const URL& documentURL = document.url();
-    auto& documentOrigin = document.securityOrigin();
+    Ref documentOrigin = document.securityOrigin();
     auto targetOrigin = SecurityOrigin::create(targetURL);
 
-    if (!documentOrigin.isSameSiteAs(targetOrigin))
+    if (!documentOrigin->isSameSiteAs(targetOrigin))
         return false;
 
     if (targetURL.protocolIsInHTTPFamily())
@@ -758,7 +766,8 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
         abortHandler.markAsAborted();
     });
 
-    auto* globalObject = scriptExecutionContext()->globalObject();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    auto* globalObject = scriptExecutionContext->globalObject();
     if (!globalObject && m_ongoingAPIMethodTracker)
         globalObject = m_ongoingAPIMethodTracker->committedPromise->globalObject();
     if (!globalObject)
@@ -782,7 +791,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
             errorInformation = WTFMove(*result);
         // Default to document url if extractErrorInformationFromErrorInstance was not able to determine sourceURL.
         if (errorInformation.sourceURL.isEmpty())
-            errorInformation.sourceURL = scriptExecutionContext()->url().string();
+            errorInformation.sourceURL = scriptExecutionContext->url().string();
     }
 
     if (RefPtr signal = event.signal())
@@ -795,8 +804,8 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     if (m_ongoingAPIMethodTracker)
         rejectFinishedPromise(m_ongoingAPIMethodTracker.get(), exception, domException);
 
-    if (m_transition) {
-        m_transition->rejectPromise(exception, domException);
+    if (RefPtr transition = m_transition) {
+        transition->rejectPromise(exception, domException);
         m_transition = nullptr;
     }
 }
@@ -873,7 +882,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     promoteUpcomingAPIMethodTracker(destination->key());
 
-    RefPtr document = window()->protectedDocument();
+    RefPtr document = protectedWindow()->protectedDocument();
 
     RefPtr apiMethodTracker = m_ongoingAPIMethodTracker;
     // FIXME: this should not be needed, we should pass it into FrameLoader.
@@ -886,14 +895,15 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
     auto info = apiMethodTracker ? apiMethodTracker->info : JSC::jsUndefined();
 
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
     RefPtr<DOMFormData> formData = nullptr;
     if (formState && (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace)) {
         // FIXME: Set submitter element.
-        if (auto domFormData = DOMFormData::create(*scriptExecutionContext(), &formState->form(), nullptr); !domFormData.hasException())
+        if (auto domFormData = DOMFormData::create(*scriptExecutionContext, Ref { formState->form() }.ptr(), nullptr); !domFormData.hasException())
             formData = domFormData.releaseReturnValue();
     }
 
-    RefPtr abortController = AbortController::create(*scriptExecutionContext());
+    RefPtr abortController = AbortController::create(*scriptExecutionContext);
 
     auto init = NavigateEvent::Init {
         { false, canBeCanceled, false },
@@ -945,7 +955,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         ASSERT(fromNavigationHistoryEntry);
 
         {
-            auto& domGlobalObject = *jsCast<JSDOMGlobalObject*>(scriptExecutionContext()->globalObject());
+            auto& domGlobalObject = *jsCast<JSDOMGlobalObject*>(scriptExecutionContext->globalObject());
             JSC::JSLockHolder locker(domGlobalObject.vm());
             m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull());
         }
@@ -972,14 +982,14 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
             else if (callbackResult.type() == CallbackResultType::ExceptionThrown) {
                 // FIXME: We need to keep around the failure reason but the generated handleEvent() catches and consumes it.
                 auto promiseAndWrapper = createPromiseAndWrapper(*document);
-                promiseAndWrapper.second->reject(ExceptionCode::TypeError);
+                Ref { promiseAndWrapper.second }->reject(ExceptionCode::TypeError);
                 promiseList.append(WTFMove(promiseAndWrapper.first));
             }
         }
 
         if (promiseList.isEmpty()) {
             auto promiseAndWrapper = createPromiseAndWrapper(*document);
-            promiseAndWrapper.second->resolveWithCallback([](JSDOMGlobalObject&) {
+            Ref { promiseAndWrapper.second }->resolveWithCallback([](JSDOMGlobalObject&) {
                 return JSC::jsUndefined();
             });
             promiseList.append(WTFMove(promiseAndWrapper.first));
@@ -987,54 +997,52 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
         // FIXME: this emulates the behavior of a Promise wrapped around waitForAll, but we may want the real
         // thing if the ordering-and-transition tests show timing related issues related to this.
-        protectedScriptExecutionContext()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [this, promiseList, abortController, document, apiMethodTracker]() {
-            waitForAllPromises(promiseList, [abortController, document, apiMethodTracker, weakThis = WeakPtr { *this }]() mutable {
-                if (!weakThis || abortController->signal().aborted() || !document->isFullyActive() || !weakThis->m_ongoingNavigateEvent)
+        protectedScriptExecutionContext()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController, document, apiMethodTracker]() {
+            waitForAllPromises(promiseList, [abortController, document, apiMethodTracker, weakThis]() mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
                     return;
 
-                RefPtr strongThis = weakThis.get();
+                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+                protectedThis->protectedOngoingNavigateEvent()->finish(*document, InterceptionHandlersDidFulfill::Yes, focusChanged);
+                protectedThis->m_ongoingNavigateEvent = nullptr;
 
-                auto focusChanged = std::exchange(strongThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-                strongThis->m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::Yes, focusChanged);
-                strongThis->m_ongoingNavigateEvent = nullptr;
-
-                strongThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
+                protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
 
                 if (apiMethodTracker)
-                    strongThis->resolveFinishedPromise(apiMethodTracker.get());
+                    protectedThis->resolveFinishedPromise(apiMethodTracker.get());
 
-                if (RefPtr transition = std::exchange(strongThis->m_transition, nullptr))
+                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
                     transition->resolvePromise();
 
-                strongThis->m_ongoingNavigateEvent = nullptr;
+                protectedThis->m_ongoingNavigateEvent = nullptr;
 
-            }, [abortController, document, apiMethodTracker, weakThis = WeakPtr { *this }](JSC::JSValue result) mutable {
-                if (!weakThis || abortController->signal().aborted() || !document->isFullyActive() || !weakThis->m_ongoingNavigateEvent)
+            }, [abortController, document, apiMethodTracker, weakThis](JSC::JSValue result) mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
                     return;
 
-                RefPtr strongThis = weakThis.get();
-
-                auto focusChanged = std::exchange(strongThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-                strongThis->m_ongoingNavigateEvent->finish(*document, InterceptionHandlersDidFulfill::No, focusChanged);
-                strongThis->m_ongoingNavigateEvent = nullptr;
+                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+                protectedThis->protectedOngoingNavigateEvent()->finish(*document, InterceptionHandlersDidFulfill::No, focusChanged);
+                protectedThis->m_ongoingNavigateEvent = nullptr;
 
                 ErrorInformation errorInformation;
                 String errorMessage;
                 if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
-                    if (auto result = extractErrorInformationFromErrorInstance(strongThis->protectedScriptExecutionContext()->globalObject(), *errorInstance)) {
+                    if (auto result = extractErrorInformationFromErrorInstance(protectedThis->protectedScriptExecutionContext()->globalObject(), *errorInstance)) {
                         errorInformation = WTFMove(*result);
                         errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
                     }
                 }
                 auto exception = Exception(ExceptionCode::UnknownError, errorMessage);
-                auto domException = createDOMException(*strongThis->protectedScriptExecutionContext()->globalObject(), exception.isolatedCopy());
+                auto domException = createDOMException(*protectedThis->protectedScriptExecutionContext()->globalObject(), exception.isolatedCopy());
 
-                strongThis->dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { strongThis->protectedScriptExecutionContext()->globalObject()->vm(), result }));
+                protectedThis->dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { protectedThis->protectedScriptExecutionContext()->globalObject()->vm(), result }));
 
                 if (apiMethodTracker)
-                    apiMethodTracker->finishedPromise->reject<IDLAny>(result, RejectAsHandled::Yes);
+                    Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
 
-                if (RefPtr transition = std::exchange(strongThis->m_transition, nullptr))
+                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
                     transition->rejectPromise(exception, domException);
             });
         });
@@ -1059,7 +1067,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
 Navigation::DispatchResult Navigation::dispatchTraversalNavigateEvent(HistoryItem& historyItem)
 {
-    auto* currentItem = frame() ? frame()->loader().history().currentItem() : nullptr;
+    RefPtr currentItem = frame() ? frame()->loader().history().currentItem() : nullptr;
     bool isSameDocument = currentItem && currentItem->documentSequenceNumber() == historyItem.documentSequenceNumber();
 
     RefPtr<NavigationHistoryEntry> destinationEntry;
@@ -1094,9 +1102,8 @@ bool Navigation::dispatchDownloadNavigateEvent(const URL& url, const String& dow
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-aborting-navigation
 void Navigation::abortOngoingNavigationIfNeeded()
 {
-    if (!m_ongoingNavigateEvent)
-        return;
-    abortOngoingNavigation(*m_ongoingNavigateEvent);
+    if (RefPtr ongoingNavigateEvent = m_ongoingNavigateEvent)
+        abortOngoingNavigation(*ongoingNavigateEvent);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -41,7 +41,6 @@ namespace WebCore {
 class FormState;
 class HistoryItem;
 class SerializedScriptValue;
-class NavigateEvent;
 class NavigationActivation;
 class NavigationDestination;
 
@@ -124,6 +123,7 @@ public:
 
     const Vector<Ref<NavigationHistoryEntry>>& entries() const;
     NavigationHistoryEntry* currentEntry() const;
+    RefPtr<NavigationHistoryEntry> protectedCurrentEntry() const { return currentEntry(); }
     NavigationTransition* transition() { return m_transition.get(); };
     NavigationActivation* activation() { return m_activation.get(); };
 
@@ -180,6 +180,8 @@ public:
         bool m_wasAborted { false };
     };
     Ref<AbortHandler> registerAbortHandler();
+
+    RefPtr<NavigateEvent> protectedOngoingNavigateEvent() { return m_ongoingNavigateEvent; }
 
 private:
     explicit Navigation(LocalDOMWindow&);

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -61,6 +61,8 @@ public:
     SerializedScriptValue* state() const { return m_state.get(); }
 
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
+    Ref<HistoryItem> protectedAssociatedHistoryItem() const { return m_associatedHistoryItem; }
+
     void dispatchDisposeEvent();
 
 private:


### PR DESCRIPTION
#### b893a8215898616634689660baa52009d3b176f8
<pre>
[Navigation API] Fix crash in Navigation::innerDispatchNavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=290956">https://bugs.webkit.org/show_bug.cgi?id=290956</a>
<a href="https://rdar.apple.com/148398107">rdar://148398107</a>

Reviewed by Chris Dumez.

Fix potential crashes (including the one in the radar) via
smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/LocalDOMWindowProperty.h:
(WebCore::LocalDOMWindowProperty::protectedWindow const):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::updateForActivation):
(WebCore::Navigation::createForPageswapEvent):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker):
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::hasEntriesAndEventsDisabled const):
(WebCore::Navigation::resolveFinishedPromise):
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::notifyCommittedToEntry):
(WebCore::Navigation::updateForNavigation):
(WebCore::documentCanHaveURLRewritten):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchTraversalNavigateEvent):
(WebCore::Navigation::abortOngoingNavigationIfNeeded):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/293201@main">https://commits.webkit.org/293201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9e5fe1b08deddb300ff06bf5a68b8c318b6143c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88660 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55064 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6594 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83144 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5469 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18845 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15908 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30338 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->