### PR TITLE
ASSERTION FAILED: Unsafe to ref/deref from different threads : m_isOwnedByMainThread == isMainThread() :  under WebCore::JSTrustedTypePolicy::visitAdditionalChildren<JSC::SlotVisitor>

### DIFF
--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateHTMLCallback : public RefCounted<CreateHTMLCallback>, public ActiveDOMCallback {
+class CreateHTMLCallback : public ThreadSafeRefCounted<CreateHTMLCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateScriptCallback : public RefCounted<CreateScriptCallback>, public ActiveDOMCallback {
+class CreateScriptCallback : public ThreadSafeRefCounted<CreateScriptCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateScriptURLCallback : public RefCounted<CreateScriptURLCallback>, public ActiveDOMCallback {
+class CreateScriptURLCallback : public ThreadSafeRefCounted<CreateScriptURLCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 


### PR DESCRIPTION
#### 59b9ac30c4c6720e636f724a6a5fd789cb55a51b
<pre>
ASSERTION FAILED: Unsafe to ref/deref from different threads : m_isOwnedByMainThread == isMainThread() :  under WebCore::JSTrustedTypePolicy::visitAdditionalChildren&lt;JSC::SlotVisitor&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=290826">https://bugs.webkit.org/show_bug.cgi?id=290826</a>
<a href="https://rdar.apple.com/148400517">rdar://148400517</a>

Reviewed by Chris Dumez.

Use ThreadSafeRefCounted in these callbacks.

* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.h:

Canonical link: <a href="https://commits.webkit.org/293145@main">https://commits.webkit.org/293145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9b10a50c23b386e546287e4c3841faab53325ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31817 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6510 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/47997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83618 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83072 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18735 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15884 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30245 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->