### PR TITLE
Implement request methods content blocker trigger field

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionError.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionError.cpp
@@ -78,6 +78,8 @@ const std::error_category& contentExtensionErrorCategory()
                 return "Invalid list of if-domain, unless-domain, if-top-url, or unless-top-url conditions.";
             case ContentExtensionError::JSONTooManyRules:
                 return "Too many rules in JSON array.";
+            case ContentExtensionError::JSONInvalidRequestMethod:
+                return "The request-method string must be \"get\", \"head\", \"options\", \"trace\", \"put\", \"delete\", \"post\", \"patch\", or \"connect\".";
             case ContentExtensionError::JSONDomainNotLowerCaseASCII:
                 return "Domains must be lower case ASCII. Use punycode to encode non-ASCII characters.";
             case ContentExtensionError::JSONMultipleConditions:

--- a/Source/WebCore/contentextensions/ContentExtensionError.h
+++ b/Source/WebCore/contentextensions/ContentExtensionError.h
@@ -52,6 +52,7 @@ enum class ContentExtensionError {
     JSONDomainNotLowerCaseASCII,
     JSONMultipleConditions,
     JSONTooManyRules,
+    JSONInvalidRequestMethod,
     
     JSONInvalidAction,
     JSONInvalidActionType,

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -166,6 +166,15 @@ static Expected<Trigger, std::error_code> loadTrigger(const JSON::Object& ruleOb
             return makeUnexpected(error);
     }
 
+    if (auto requestMethodValue = triggerObject->getValue("request-method"_s)) {
+        auto requestMethod = readRequestMethod(requestMethodValue->asString());
+
+        if (!requestMethod.has_value())
+            return makeUnexpected(ContentExtensionError::JSONInvalidRequestMethod);
+
+        trigger.flags |= static_cast<ResourceFlags>(requestMethod.value());
+    }
+
     auto checkCondition = [&] (ASCIILiteral key, Expected<Vector<String>, std::error_code> (*listReader)(const JSON::Array&), ActionCondition actionCondition) -> std::error_code {
         if (auto value = triggerObject->getValue(key)) {
             if (trigger.flags & ActionConditionMask)

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -235,6 +235,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     URL mainDocumentURL;
     URL frameURL;
     bool mainFrameContext = false;
+    RequestMethod requestMethod = readRequestMethod(initiatingDocumentLoader.request().httpMethod()).value_or(RequestMethod::None);
 
     if (auto* frame = initiatingDocumentLoader.frame()) {
         mainFrameContext = frame->isMainFrame();
@@ -252,7 +253,7 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     else
         frameURL = url;
 
-    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, resourceType, mainFrameContext };
+    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, resourceType, mainFrameContext, requestMethod };
     auto actions = actionsForResourceLoad(resourceLoadInfo, ruleListFilter);
 
     ContentRuleListResults results;
@@ -338,9 +339,10 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     return results;
 }
 
-ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForPingLoad(const URL& url, const URL& mainDocumentURL, const URL& frameURL)
+ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForPingLoad(const URL& url, const URL& mainDocumentURL, const URL& frameURL, const String& httpMethod)
 {
-    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, ResourceType::Ping };
+    RequestMethod requestMethod = readRequestMethod(httpMethod).value_or(RequestMethod::None);
+    ResourceLoadInfo resourceLoadInfo { url, mainDocumentURL, frameURL, ResourceType::Ping, false, requestMethod };
     auto actions = actionsForResourceLoad(resourceLoadInfo);
 
     ContentRuleListResults results;

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -76,7 +76,7 @@ public:
     WEBCORE_EXPORT StyleSheetContents* globalDisplayNoneStyleSheet(const String& identifier) const;
 
     ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter&);
-    WEBCORE_EXPORT ContentRuleListResults processContentRuleListsForPingLoad(const URL&, const URL& mainDocumentURL, const URL& frameURL);
+    WEBCORE_EXPORT ContentRuleListResults processContentRuleListsForPingLoad(const URL&, const URL& mainDocumentURL, const URL& frameURL, const String& httpMethod);
     bool processContentRuleListsForResourceMonitoring(const URL&, const URL& mainDocumentURL, const URL& frameURL, OptionSet<ResourceType>);
 
     static const String& displayNoneCSSRule();

--- a/Source/WebCore/contentextensions/DFABytecode.h
+++ b/Source/WebCore/contentextensions/DFABytecode.h
@@ -88,6 +88,7 @@ enum class DFABytecodeFlagsSize : uint8_t {
     UInt8 = 0x00,
     UInt16 = 0x10,
     UInt24 = 0x20,
+    UInt32 = 0x30
 };
 enum class DFABytecodeActionSize : uint8_t {
     UInt8 = 0x00,

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -81,8 +81,9 @@ static DFABytecodeFlagsSize bytecodeFlagsSize(ResourceFlags flags)
         return DFABytecodeFlagsSize::UInt8;
     if (flags <= std::numeric_limits<uint16_t>::max())
         return DFABytecodeFlagsSize::UInt16;
-    RELEASE_ASSERT(flags <= UInt24Max);
-    return DFABytecodeFlagsSize::UInt24;
+    if (flags <= UInt24Max)
+        return DFABytecodeFlagsSize::UInt24;
+    return DFABytecodeFlagsSize::UInt32;
 }
 
 static DFABytecodeActionSize bytecodeActionSize(uint32_t actionWithoutFlags)
@@ -105,6 +106,8 @@ static size_t toSizeT(DFABytecodeFlagsSize size)
         return sizeof(uint16_t);
     case DFABytecodeFlagsSize::UInt24:
         return UInt24Size;
+    case DFABytecodeFlagsSize::UInt32:
+        return sizeof(uint32_t);
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -127,6 +127,8 @@ static ResourceFlags consumeResourceFlagsAndInstruction(std::span<const uint8_t>
         return consumeInteger<uint16_t>(bytecode, programCounter);
     case DFABytecodeFlagsSize::UInt24:
         return consume24BitUnsignedInteger(bytecode, programCounter);
+    case DFABytecodeFlagsSize::UInt32:
+        return consumeInteger<uint32_t>(bytecode, programCounter);
     }
     ASSERT_NOT_REACHED();
     return 0;
@@ -190,13 +192,15 @@ void DFABytecodeInterpreter::interpretTestFlagsAndAppendAction(uint32_t& program
     ResourceFlags loadTypeFlags = flagsToCheck & LoadTypeMask;
     ResourceFlags loadContextFlags = flagsToCheck & LoadContextMask;
     ResourceFlags resourceTypeFlags = flagsToCheck & ResourceTypeMask;
+    ResourceFlags requestMethodFlags = flagsToCheck & RequestMethodMask;
 
     bool loadTypeMatches = loadTypeFlags ? (loadTypeFlags & flags) : true;
     bool loadContextMatches = loadContextFlags ? (loadContextFlags & flags) : true;
     bool resourceTypeMatches = resourceTypeFlags ? (resourceTypeFlags & flags) : true;
-    
+    bool requestMethodMatches = requestMethodFlags ? (requestMethodFlags == (flags & RequestMethodMask)) : true;
+
     auto actionWithoutFlags = consumeAction(m_bytecode, programCounter, instructionLocation);
-    if (loadTypeMatches && loadContextMatches && resourceTypeMatches) {
+    if (loadTypeMatches && loadContextMatches && resourceTypeMatches && requestMethodMatches) {
         uint64_t actionAndFlags = (static_cast<uint64_t>(flagsToCheck) << 32) | static_cast<uint64_t>(actionWithoutFlags);
         actions.add(actionAndFlags);
     }

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -152,11 +152,34 @@ std::optional<OptionSet<LoadContext>> readLoadContext(StringView name)
     return std::nullopt;
 }
 
+std::optional<RequestMethod> readRequestMethod(StringView name)
+{
+    if (equalIgnoringASCIICase(name, "get"_s))
+        return RequestMethod::Get;
+    if (equalIgnoringASCIICase(name, "head"_s))
+        return RequestMethod::Head;
+    if (equalIgnoringASCIICase(name, "options"_s))
+        return RequestMethod::Options;
+    if (equalIgnoringASCIICase(name, "trace"_s))
+        return RequestMethod::Trace;
+    if (equalIgnoringASCIICase(name, "put"_s))
+        return RequestMethod::Put;
+    if (equalIgnoringASCIICase(name, "delete"_s))
+        return RequestMethod::Delete;
+    if (equalIgnoringASCIICase(name, "post"_s))
+        return RequestMethod::Post;
+    if (equalIgnoringASCIICase(name, "patch"_s))
+        return RequestMethod::Patch;
+    if (equalIgnoringASCIICase(name, "connect"_s))
+        return RequestMethod::Connect;
+    return std::nullopt;
+}
+
 bool ResourceLoadInfo::isThirdParty() const
 {
     return !RegistrableDomain(mainDocumentURL).matches(resourceURL);
 }
-    
+
 ResourceFlags ResourceLoadInfo::getResourceFlags() const
 {
     ResourceFlags flags = 0;
@@ -164,6 +187,7 @@ ResourceFlags ResourceLoadInfo::getResourceFlags() const
     flags |= type.toRaw();
     flags |= isThirdParty() ? static_cast<ResourceFlags>(LoadType::ThirdParty) : static_cast<ResourceFlags>(LoadType::FirstParty);
     flags |= mainFrameContext ? static_cast<ResourceFlags>(LoadContext::TopFrame) : static_cast<ResourceFlags>(LoadContext::ChildFrame);
+    flags |= static_cast<ResourceFlags>(requestMethod);
     return flags;
 }
 

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -72,19 +72,34 @@ enum class LoadContext : uint32_t {
 };
 static constexpr uint32_t LoadContextMask = 0x30000;
 
+enum class RequestMethod : uint32_t {
+    None = 0x0000000,
+    Get = 0x200000,
+    Head = 0x400000,
+    Options = 0x600000,
+    Trace = 0x800000,
+    Put = 0xA00000,
+    Delete = 0xC00000,
+    Post = 0xE00000,
+    Patch = 0x1000000,
+    Connect = 0x1200000,
+};
+static constexpr uint32_t RequestMethodMask = 0x1E00000;
+
 using ResourceFlags = uint32_t;
 
-constexpr ResourceFlags AllResourceFlags = LoadTypeMask | ResourceTypeMask | LoadContextMask | ActionConditionMask;
+constexpr ResourceFlags AllResourceFlags = LoadTypeMask | ResourceTypeMask | LoadContextMask | ActionConditionMask | RequestMethodMask;
 
 // The first 32 bits of a uint64_t action are used for the action location.
-// The next 21 bits are used for the flags (ResourceType, LoadType, LoadContext, ActionCondition).
+// The next 25 bits are used for the flags (ResourceType, LoadType, LoadContext, ActionCondition, RequestMethod).
 // The values -1 and -2 are used for removed and empty values in HashTables.
-static constexpr uint64_t ActionFlagMask = 0x001FFFFF00000000;
+static constexpr uint64_t ActionFlagMask = 0x01FFFFFF00000000;
 
 OptionSet<ResourceType> toResourceType(CachedResource::Type, ResourceRequestRequester, bool isMainFrame);
 std::optional<OptionSet<ResourceType>> readResourceType(StringView);
 std::optional<OptionSet<LoadType>> readLoadType(StringView);
 std::optional<OptionSet<LoadContext>> readLoadContext(StringView);
+std::optional<RequestMethod> readRequestMethod(StringView);
 
 ASCIILiteral resourceTypeToString(OptionSet<ResourceType>);
 
@@ -94,11 +109,12 @@ struct ResourceLoadInfo {
     URL frameURL;
     OptionSet<ResourceType> type;
     bool mainFrameContext { false };
+    RequestMethod requestMethod { RequestMethod::None };
 
     bool isThirdParty() const;
     ResourceFlags getResourceFlags() const;
-    ResourceLoadInfo isolatedCopy() const & { return { resourceURL.isolatedCopy(), mainDocumentURL.isolatedCopy(), frameURL.isolatedCopy(), type, mainFrameContext }; }
-    ResourceLoadInfo isolatedCopy() && { return { WTFMove(resourceURL).isolatedCopy(), WTFMove(mainDocumentURL).isolatedCopy(), WTFMove(frameURL).isolatedCopy(), type, mainFrameContext }; }
+    ResourceLoadInfo isolatedCopy() const & { return { resourceURL.isolatedCopy(), mainDocumentURL.isolatedCopy(), frameURL.isolatedCopy(), type, mainFrameContext, requestMethod }; }
+    ResourceLoadInfo isolatedCopy() && { return { WTFMove(resourceURL).isolatedCopy(), WTFMove(mainDocumentURL).isolatedCopy(), WTFMove(frameURL).isolatedCopy(), type, mainFrameContext, requestMethod }; }
 };
 
 } // namespace WebCore::ContentExtensions

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -561,7 +561,7 @@ void NetworkLoadChecker::processContentRuleListsForLoad(ResourceRequest&& reques
             return;
         }
 
-        auto results = backend.processContentRuleListsForPingLoad(request.url(), protectedThis->m_mainDocumentURL, protectedThis->m_frameURL);
+        auto results = backend.processContentRuleListsForPingLoad(request.url(), protectedThis->m_mainDocumentURL, protectedThis->m_frameURL, request.httpMethod());
         WebCore::ContentExtensions::applyResultsToRequest(ContentRuleListResults { results }, nullptr, request);
         callback(ContentExtensionResult { WTFMove(request), results });
     });


### PR DESCRIPTION
#### 301771c71cc7b6b56aa1e2567926fc71d927d459
<pre>
Implement request methods content blocker trigger field
<a href="https://bugs.webkit.org/show_bug.cgi?id=290962">https://bugs.webkit.org/show_bug.cgi?id=290962</a>
<a href="https://rdar.apple.com/148474901">rdar://148474901</a>

Reviewed by Alex Christensen.

This patch introduces a new trigger field, request-method, to perform an action
only if the HTTP request method matches the specified HTTP request method. This
field has a string value, which can be any of the HTTP methods (lowercased) as
defined by:

<a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods">https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods</a>

We chose to use a string value, rather than an array of strings, because making
the request methods mutually exclusive saves more space (4 bits instead of 9).
Although this pattern deviates from the trigger field norm, it&apos;s better to save
the bits since we&apos;re running out of room.

The motivation behind this change is that we need to support requestMethods and
excludedRequestMethods in dNR, which isn&apos;t possible without this change.

* Source/WebCore/contentextensions/ContentExtensionError.cpp:
(WebCore::ContentExtensions::contentExtensionErrorCategory):
* Source/WebCore/contentextensions/ContentExtensionError.h:
Introduce a new error for invalid request-method field.

* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadTrigger):
Parse the request-method into the trigger flags, raising an error as needed.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForPingLoad):
Parse the HTTP request method of the load and include it in the resource load
info.

* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
Make the method for processing content rule lists for ping loads take in an HTTP
method parameter.

* Source/WebCore/contentextensions/DFABytecode.h:
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::bytecodeFlagsSize):
(WebCore::ContentExtensions::toSizeT):
* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::consumeResourceFlagsAndInstruction):
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpretTestFlagsAndAppendAction):
Introduce a 32 bit flags size. With the introduction of request methods, the
flags can be up to 25 bits in size.

* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::readRequestMethod):
(WebCore::ContentExtensions::ResourceLoadInfo::getResourceFlags const):
* Source/WebCore/loader/ResourceLoadInfo.h:
(WebCore::ContentExtensions::ResourceLoadInfo::isolatedCopy const):
(WebCore::ContentExtensions::ResourceLoadInfo::isolatedCopy):
Introduce the request methods enum, and modify the byte code as necessary.

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::processContentRuleListsForLoad):
Pass in the HTTP method when processing content rule lists for ping load.

* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, RequestMethod)):
Write a new test for validating the behavior of the request-method field.

(TestWebKitAPI::TEST_F(ContentExtensionTest, InvalidJSON)):
Add assertions for validating the request-method field in the JSON.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm:
(TEST(ContentRuleList, RequestMethods)):
Write a new test for validating the behavior of the request-method field.

Canonical link: <a href="https://commits.webkit.org/293746@main">https://commits.webkit.org/293746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f313f23d9b7981162cc8e0ea302257006a99ecf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29102 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20694 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32034 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->