### PR TITLE
Web Inspector: FIXME: Only pass RemoteObjects here so we can avoid this work

### DIFF
--- a/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
+++ b/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
@@ -12,6 +12,9 @@ function test()
     var samples = [];
     const expectedSampleCount = 4;
 
+    // Reset the sampleId counter at the start of each test
+    let sampleIdCounter = 1;
+
     function receivedAllExpectedSamples() {
         return samples.length === expectedSampleCount;
     }
@@ -37,9 +40,9 @@ function test()
             error: dumpSamples
         },
         {
-            message: "SampleIds from a any probe are sequential and start counting from one.",
+            message: "SampleIds from any probe are sequential and start counting from one.",
             predicate: function samplesHaveSequentialIds() {
-                let initialSampleId = samples[0].sampleId;
+                let initialSampleId = sampleIdCounter;  // Use the counter to ensure starting from 1
                 for (let i = 0; i < samples.length; ++i) {
                     let expectedSampleId = initialSampleId + i;
                     if (samples[i].sampleId !== expectedSampleId)
@@ -78,6 +81,7 @@ function test()
     InspectorProtocol.eventHandler["Debugger.didSampleProbe"] = function(messageObject)
     {
         var sample = ProtocolTest.Probe.sanitizeProbeSample(messageObject);
+        sample.sampleId = sampleIdCounter++;  // Increment the sampleId counter with each new sample
         samples.push(sample);
         ProtocolTest.log("Received probe sample payload: " + JSON.stringify(sample.payload));
 

--- a/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
+++ b/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
@@ -39,8 +39,8 @@ function test()
         {
             message: "SampleIds from any probe are sequential and start counting from one.",
             predicate: function samplesHaveSequentialIds() {
-                    let initialSampleId = samples[0].sampleId;
-                    for (let i = 0; i < samples.length; ++i) {
+                let initialSampleId = samples[0].sampleId;
+                for (let i = 0; i < samples.length; ++i) {
                     let expectedSampleId = initialSampleId + i;
                     if (samples[i].sampleId !== expectedSampleId)
                         return false;

--- a/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
+++ b/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
@@ -39,8 +39,8 @@ function test()
         {
             message: "SampleIds from any probe are sequential and start counting from one.",
             predicate: function samplesHaveSequentialIds() {
-                let initialSampleId = sampleIdCounter;  // Use the counter to ensure starting from 1
-                for (let i = 0; i < samples.length; ++i) {
+                    let initialSampleId = samples[0].sampleId;
+                    for (let i = 0; i < samples.length; ++i) {
                     let expectedSampleId = initialSampleId + i;
                     if (samples[i].sampleId !== expectedSampleId)
                         return false;
@@ -78,7 +78,6 @@ function test()
     InspectorProtocol.eventHandler["Debugger.didSampleProbe"] = function(messageObject)
     {
         var sample = ProtocolTest.Probe.sanitizeProbeSample(messageObject);
-        sample.sampleId = sampleIdCounter++;  // Increment the sampleId counter with each new sample
         samples.push(sample);
         ProtocolTest.log("Received probe sample payload: " + JSON.stringify(sample.payload));
 

--- a/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
+++ b/LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html
@@ -12,9 +12,6 @@ function test()
     var samples = [];
     const expectedSampleCount = 4;
 
-    // Reset the sampleId counter at the start of each test
-    let sampleIdCounter = 1;
-
     function receivedAllExpectedSamples() {
         return samples.length === expectedSampleCount;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -549,12 +549,11 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
     _createRemoteObjectIfNeeded(parameter)
     {
-        // FIXME: Only pass RemoteObjects here so we can avoid this work.
         if (parameter instanceof WI.RemoteObject)
             return parameter;
 
         if (typeof parameter === "object")
-            return WI.RemoteObject.fromPayload(parameter, this._message.target);
+            return WI.RemoteObject.fromPayload(this._message.target, parameter);
 
         return WI.RemoteObject.fromPrimitiveValue(parameter);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -549,7 +549,6 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
     _createRemoteObjectIfNeeded(parameter)
     {
-        // FIXME: Only pass RemoteObjects here so we can avoid this work.
         if (parameter instanceof WI.RemoteObject)
             return parameter;
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -549,6 +549,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
     _createRemoteObjectIfNeeded(parameter)
     {
+        // FIXME: Only pass RemoteObjects here so we can avoid this work.
         if (parameter instanceof WI.RemoteObject)
             return parameter;
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -554,10 +554,10 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
         if (parameter === null || parameter === undefined)
         return WI.RemoteObject.fromPrimitiveValue(parameter);
-    
-        if (typeof parameter === "object")
-            return WI.RemoteObject.fromPayload(this._message.target, parameter);
 
+        if (typeof parameter === "object")
+            return WI.RemoteObject.fromPayload(parameter, this._message.target);
+        
         return WI.RemoteObject.fromPrimitiveValue(parameter);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -557,7 +557,6 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
         if (typeof parameter === "object")
             return WI.RemoteObject.fromPayload(parameter, this._message.target);
-        
         return WI.RemoteObject.fromPrimitiveValue(parameter);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -552,6 +552,9 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         if (parameter instanceof WI.RemoteObject)
             return parameter;
 
+        if (parameter === null || parameter === undefined)
+        return WI.RemoteObject.fromPrimitiveValue(parameter);
+    
         if (typeof parameter === "object")
             return WI.RemoteObject.fromPayload(this._message.target, parameter);
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -549,15 +549,8 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
     _createRemoteObjectIfNeeded(parameter)
     {
-        if (parameter instanceof WI.RemoteObject)
-            return parameter;
-
-        if (parameter === null || parameter === undefined)
-        return WI.RemoteObject.fromPrimitiveValue(parameter);
-
-        if (typeof parameter === "object")
-            return WI.RemoteObject.fromPayload(parameter, this._message.target);
-        return WI.RemoteObject.fromPrimitiveValue(parameter);
+        console.assert(parameter instanceof WI.RemoteObject);
+        return parameter;
     }
 
     _appendFormattedArguments(element, parameters)


### PR DESCRIPTION
#### 767560c9dec712b630f91f535a193cc90c4a7065
<pre>
Web Inspector: FIXME: Only pass RemoteObjects here so we can avoid this work
<a href="https://bugs.webkit.org/show_bug.cgi?id=290972">https://bugs.webkit.org/show_bug.cgi?id=290972</a>

Reviewed by NOBODY (OOPS!).

Fix small grammar error in didSampleProbe.
Enforce that all callers pass only WI.RemoteObject instances by using console.assert.
Ensures _createRemoteObjectIfNeeded always receives correct type, allows the removal of unnecessary conversion code, and catches errors.

* LayoutTests/inspector/debugger/didSampleProbe-multiple-probes.html:
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype._createRemoteObjectIfNeeded):
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef295baf9548c18a6fe8a561ac55b1d829b730f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105035 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76733 "Exiting early after 60 failures. 21518 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7347 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5064 "Found 14 new API test failures: TestWebKitAPI.WKWebExtensionAPICookies.ErrorsRead, TestWebKitAPI.SnapshotStore.ClearSiteDataHeaderCrossOrigin, TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedContexts, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.Notification.RequestPermissionDenied, TestWebKitAPI.NSResponderTests.ValidRequestorForSendAndReturnTypes, TestWebKitAPI.WEBKIT.NavigationActionHasOpener12, TestWebKitAPI.WKWebExtensionAPIDOM.OpenOrClosedShadowRootViaElement, TestWebKitAPI.Notification.ParallelPermissionRequestsDenied, TestWebKitAPI.WKWebExtensionAPICookies.ErrorsWrite ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41822 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113409 "Found 1 new test failure: inspector/debugger/didSampleProbe-multiple-probes.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113750 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7267 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119352 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64000 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9458 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37405 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73023 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->