### PR TITLE
[SVG2] Sync `SVGSVGElement` interface to have `getElementById` nullable

### DIFF
--- a/Source/WebCore/svg/SVGSVGElement.idl
+++ b/Source/WebCore/svg/SVGSVGElement.idl
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2010 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -54,7 +54,7 @@
     [NewObject] SVGTransform createSVGTransform();
     [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
 
-    Element getElementById([RequiresExistingAtomString] DOMString elementId);
+    Element? getElementById([RequiresExistingAtomString] DOMString elementId);
 
     // SVG animations extensions
     // https://svgwg.org/specs/animations/#InterfaceSVGSVGElement


### PR DESCRIPTION
#### 2b979c172b8f9c43859629c0810ddb376616d370
<pre>
[SVG2] Sync `SVGSVGElement` interface to have `getElementById` nullable
<a href="https://bugs.webkit.org/show_bug.cgi?id=290973">https://bugs.webkit.org/show_bug.cgi?id=290973</a>
<a href="https://rdar.apple.com/148483297">rdar://148483297</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with recent change [1]:

[1] <a href="https://github.com/w3c/svgwg/commit/e02e2c64659238b6ea1434325579a88226e25d81">https://github.com/w3c/svgwg/commit/e02e2c64659238b6ea1434325579a88226e25d81</a>

The specification [2] was already clear to allow `null` but interface was
reflecting otherwise and this patch is to now align &apos;interface&apos; and make
`getElementById` nullable:

[2] <a href="https://www.w3.org/TR/SVG2/struct.html#__svg__SVGSVGElement__getElementById">https://www.w3.org/TR/SVG2/struct.html#__svg__SVGSVGElement__getElementById</a>

&quot;The getElementById method, must return the first element in tree order,
within the ‘svg’ element&apos;s descendants, whose ID is elementId, or null
if there is no such element.&quot;

In 252478@main, we already made necessary changes to align with specification
and handle `null` case.

* Source/WebCore/svg/SVGSVGElement.idl:

Canonical link: <a href="https://commits.webkit.org/293163@main">https://commits.webkit.org/293163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a10e8752173af1c2cf4c563a6f4a95e59cffd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74641 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83626 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83081 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30264 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->