### PR TITLE
[Page color sampling] hulu.com: bottom fixed container is incorrectly treated as fixed container edge

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt
@@ -1,23 +1,23 @@
 Headline
 Headline
 
-PASS colors.top is null
+PASS colors.top is "multiple"
 PASS colors.left is null
 PASS colors.right is null
 PASS colors.bottom is "rgb(211, 211, 211)"
-PASS colors.top is null
+PASS colors.top is "multiple"
 PASS colors.left is null
 PASS colors.right is null
 PASS colors.bottom is "rgb(211, 211, 211)"
-PASS colors.top is null
+PASS colors.top is "multiple"
 PASS colors.left is null
 PASS colors.right is null
 PASS colors.bottom is "rgb(211, 211, 211)"
-PASS colors.top is null
+PASS colors.top is "multiple"
 PASS colors.left is null
 PASS colors.right is null
 PASS colors.bottom is "rgb(211, 211, 211)"
-PASS colors.top is null
+PASS colors.top is "multiple"
 PASS colors.left is null
 PASS colors.right is null
 PASS colors.bottom is "rgb(211, 211, 211)"

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
@@ -62,7 +62,7 @@
         }
 
         for (colors of sampledColors) {
-            shouldBeNull("colors.top");
+            shouldBeEqualToString("colors.top", "multiple");
             shouldBeNull("colors.left");
             shouldBeNull("colors.right");
             shouldBeEqualToString("colors.bottom", "rgb(211, 211, 211)");

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container-expected.txt
@@ -1,0 +1,8 @@
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Sign up for free

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+            height: 200vh;
+        }
+
+        footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 100px;
+            color: white;
+            text-align: center;
+            z-index: 1000;
+        }
+
+        button {
+            background: rgb(52, 199, 89);
+            width: 80%;
+            height: 40px;
+            border-radius: 4px;
+            border: none;
+            font-size: 16px;
+            color: white;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 0, 50, 0);
+        await UIHelper.ensurePresentationUpdate();
+        colors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("colors.top");
+        shouldBeNull("colors.left");
+        shouldBeNull("colors.right");
+        shouldBeNull("colors.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="tall"></div>
+<pre id="console"></pre>
+<pre id="description"></pre>
+<footer><button>Sign up for free</button></footer>
+</body>
+</html>

--- a/Source/WebCore/page/PageColorSampler.h
+++ b/Source/WebCore/page/PageColorSampler.h
@@ -33,10 +33,12 @@ namespace WebCore {
 class LayoutRect;
 class Page;
 
+enum class PredominantColorType : uint8_t;
+
 class PageColorSampler {
 public:
     static std::optional<Color> sampleTop(Page&);
-    static Color predominantColor(Page&, const LayoutRect&);
+    static std::variant<PredominantColorType, Color> predominantColor(Page&, const LayoutRect&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -92,6 +92,22 @@ constexpr std::array<BoxSide, 4> allBoxSides = {
     BoxSide::Left
 };
 
+constexpr BoxSide boxSideFromFlag(BoxSideFlag flag)
+{
+    switch (flag) {
+    case BoxSideFlag::Top:
+        return BoxSide::Top;
+    case BoxSideFlag::Right:
+        return BoxSide::Right;
+    case BoxSideFlag::Bottom:
+        return BoxSide::Bottom;
+    case BoxSideFlag::Left:
+        return BoxSide::Left;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return BoxSide::Left;
+}
+
 using BoxSideSet = OptionSet<BoxSideFlag>;
 
 constexpr BoxSide mapSideLogicalToPhysical(const WritingMode, const LogicalBoxSide);

--- a/Source/WebCore/platform/FixedContainerEdges.h
+++ b/Source/WebCore/platform/FixedContainerEdges.h
@@ -30,9 +30,33 @@
 
 namespace WebCore {
 
+enum class PredominantColorType : uint8_t {
+    None,
+    Multiple,
+};
+
+using FixedContainerEdge = std::variant<WebCore::PredominantColorType, WebCore::Color>;
+
 struct FixedContainerEdges {
-    RectEdges<Color> predominantColors;
-    RectEdges<bool> fixedEdges;
+    RectEdges<FixedContainerEdge> colors { PredominantColorType::None, PredominantColorType::None, PredominantColorType::None, PredominantColorType::None };
+
+    bool hasFixedEdge(BoxSide side) const
+    {
+        return std::visit(WTF::makeVisitor([&](PredominantColorType type) {
+            return type != PredominantColorType::None;
+        }, [&](const Color&) {
+            return true;
+        }), colors.at(side));
+    }
+
+    Color predominantColor(BoxSide side) const
+    {
+        return std::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {
+            return { };
+        }, [&](const Color& color) {
+            return color;
+        }), colors.at(side));
+    }
 
     bool operator==(const FixedContainerEdges&) const = default;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9087,9 +9087,24 @@ header: <WebCore/StageModeOperations.h>
 enum class WebCore::StageModeOperation : bool;
 #endif
 
+header: <WebCore/FixedContainerEdges.h>
+enum class WebCore::PredominantColorType : uint8_t {
+    None,
+    Multiple
+};
+
+using WebCore::FixedContainerEdge = std::variant<WebCore::PredominantColorType, WebCore::Color>;
+
+header: <WebCore/FixedContainerEdges.h>
+[Nested] class WebCore::RectEdges<WebCore::FixedContainerEdge> {
+    WebCore::FixedContainerEdge top();
+    WebCore::FixedContainerEdge right();
+    WebCore::FixedContainerEdge bottom();
+    WebCore::FixedContainerEdge left();
+};
+
 struct WebCore::FixedContainerEdges {
-    WebCore::RectEdges<WebCore::Color> predominantColors;
-    WebCore::RectEdges<bool> fixedEdges;
+    WebCore::RectEdges<WebCore::FixedContainerEdge> colors;
 };
 
 header: <WebCore/LocalFrameLoaderClient.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -402,17 +402,10 @@ for this property.
 
 @property (nonatomic, readonly) BOOL _isSuspended;
 
-@property (nonatomic, readonly) _WKRectEdge _fixedContainerEdges WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) UIColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) UIColor *_sampledLeftFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) UIColor *_sampledBottomFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) UIColor *_sampledRightFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 #else
 @property (nonatomic, readonly) NSColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, readonly) NSColor *_sampledLeftFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, readonly) NSColor *_sampledBottomFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, readonly) NSColor *_sampledRightFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
 #endif
 
 @property (nonatomic, readonly) BOOL _canTogglePictureInPicture;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -31,6 +31,8 @@
 #import <WebKit/WKWebViewPrivateForTestingMac.h>
 #endif
 
+#import <WebKit/_WKRectEdge.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef enum {
@@ -153,6 +155,17 @@ struct WKAppPrivacyReportTestingData {
 @property (nonatomic, readonly) BOOL _hasAccessibilityActivityForTesting;
 
 - (void)_setMediaVolumeForTesting:(float)volume;
+
+@property (nonatomic, readonly) _WKRectEdge _fixedContainerEdges;
+#if TARGET_OS_IPHONE
+@property (nonatomic, readonly) UIColor *_sampledLeftFixedPositionContentColor;
+@property (nonatomic, readonly) UIColor *_sampledBottomFixedPositionContentColor;
+@property (nonatomic, readonly) UIColor *_sampledRightFixedPositionContentColor;
+#else
+@property (nonatomic, readonly) NSColor *_sampledLeftFixedPositionContentColor;
+@property (nonatomic, readonly) NSColor *_sampledBottomFixedPositionContentColor;
+@property (nonatomic, readonly) NSColor *_sampledRightFixedPositionContentColor;
+#endif
 
 @end
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -396,17 +396,19 @@ void UIScriptControllerCocoa::resetVisibilityAdjustments(JSValueRef callback)
 
 JSObjectRef UIScriptControllerCocoa::fixedContainerEdgeColors() const
 {
-    auto nsColorOrNSNull = [](WebCore::CocoaColor *color) -> id {
+    auto colorDescriptionOrNull = [fixedEdges = webView()._fixedContainerEdges](WebCore::CocoaColor *color, _WKRectEdge edge) -> id {
         if (color)
             return (NSString *)WebCoreTestSupport::serializationForCSS(color);
+        if (fixedEdges & edge)
+            return @"multiple";
         return NSNull.null;
     };
 
     RetainPtr jsValue = [JSValue valueWithObject:@{
-        @"top": nsColorOrNSNull(webView()._sampledTopFixedPositionContentColor),
-        @"left": nsColorOrNSNull(webView()._sampledLeftFixedPositionContentColor),
-        @"bottom": nsColorOrNSNull(webView()._sampledBottomFixedPositionContentColor),
-        @"right": nsColorOrNSNull(webView()._sampledRightFixedPositionContentColor)
+        @"top": colorDescriptionOrNull(webView()._sampledTopFixedPositionContentColor, _WKRectEdgeTop),
+        @"left": colorDescriptionOrNull(webView()._sampledLeftFixedPositionContentColor, _WKRectEdgeLeft),
+        @"bottom": colorDescriptionOrNull(webView()._sampledBottomFixedPositionContentColor, _WKRectEdgeBottom),
+        @"right": colorDescriptionOrNull(webView()._sampledRightFixedPositionContentColor, _WKRectEdgeRight)
     } inContext:[JSContext contextWithJSGlobalContextRef:m_context->jsContext()]];
     return JSValueToObject(m_context->jsContext(), [jsValue JSValueRef], nullptr);
 }


### PR DESCRIPTION
#### 25a957aaa1f78387b1f0eaac63d3c3f56e4ecc26
<pre>
[Page color sampling] hulu.com: bottom fixed container is incorrectly treated as fixed container edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=290963">https://bugs.webkit.org/show_bug.cgi?id=290963</a>
<a href="https://rdar.apple.com/146925724">rdar://146925724</a>

Reviewed by Aditya Keerthi.

Currently, the `FixedContainerEdges` struct consists of two pieces of data:

1.  A flag on each rect edge, denoting whether there&apos;s a fixed container docked to that rect edge.
2.  A color on each rect edge, representing the primary color for that edge (or an invalid color in
    the case of either multiple colors, or if there is no visible color).

In the case where there&apos;s a fixed-position container docked to a viewport edge, hit-testing will
find the container and set the fixed edge flag on that edge. However, if the container doesn&apos;t
actually render any visible content near that edge (e.g. if it&apos;s completely transparent, with no
background and no children), we end up returning the invalid color from `predominantColor`, which
we then handle in the same way as having multiple visible colors — by filling the inset area with
the page background color.

Instead, we should simply treat this scenario has not having a fixed edge in the first place. To
achieve this, we add an early return in `PageColorSampler::predominantColor` if `colorDistribution`
is empty (i.e. there&apos;s no visible pixels).

We also refactor this code, to tighten `FixedContainerEdges` state: instead of using separate rect
edges representing the presence of fixed objects and the predominant color along each edge, we use
a single variant per edge that contains one of:

-   A `PredominantColorType` enum, which is either `None` (representing no fixed edge) or `Multiple`
    (representing a fixed edge with multiple colors).

-   A `Color` representing a single, solid predominant color along a fixed edge.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html:

Adjust an existing layout test to account for the fact that multiple colors are now represented by
the string `&quot;multiple&quot;`.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

Refactor this entire method to reduce code duplication, by pulling all rect-edge-specific logic out
into separate lambdas, and then simply iterating over all requested `BoxSideFlag`s to set fixed
container edge data.

* Source/WebCore/page/PageColorSampler.h:

Make `predominantColor` return a variant of `PredominantColorType, Color`.

* Source/WebCore/platform/BoxSides.h:
(WebCore::boxSideFromFlag):

Add a `constexpr` helper to convert from `BoxSideFlag` to `BoxSide`.

* Source/WebCore/platform/FixedContainerEdges.h:
(WebCore::FixedContainerEdges::hasFixedEdge const):
(WebCore::FixedContainerEdges::predominantColor const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _fixedContainerEdges]):
(sampledFixedPositionContentColor):
(-[WKWebView _sampledBottomFixedPositionContentColor]):
(-[WKWebView _sampledLeftFixedPositionContentColor]):
(-[WKWebView _sampledTopFixedPositionContentColor]):
(-[WKWebView _sampledRightFixedPositionContentColor]):
(-[WKWebView _updateFixedContainerEdges:]):
(-[WKWebView _updateFixedColorExtensionViews]):
(-[WKWebView _sampledBottomFixedPositionContentColor:]): Deleted.
(-[WKWebView _sampledLeftFixedPositionContentColor:]): Deleted.
(-[WKWebView _sampledTopFixedPositionContentColor:]): Deleted.
(-[WKWebView _sampledRightFixedPositionContentColor:]): Deleted.

Move several SPI methods that are no longer needed by internal clients into the testing-only
`WKWebView` category.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::fixedContainerEdgeColors const):

Make a slight adjustment to the testing helpers, to differentiate the &quot;no fixed edge&quot; case from the
&quot;multiple colors&quot; case. Multiple colors are now represented by the string &quot;multiple&quot;, while not
having any fixed edge is represented with `null`.

Canonical link: <a href="https://commits.webkit.org/293146@main">https://commits.webkit.org/293146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3f388aa1c5205f078b1d63f88c6e5b913d73de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31832 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101053 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13611 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48020 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105542 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25135 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30268 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->