### PR TITLE
[JSC] Puts to private fields shouldn't generate property conditions

### DIFF
--- a/JSTests/stress/eval-call-should-update-top-frame.js
+++ b/JSTests/stress/eval-call-should-update-top-frame.js
@@ -1,0 +1,7 @@
+for (let i = 0; i < 10000; ++i) {
+    const v23 = (2 ** 31) - 1;
+    const v28 = (-1).toLocaleString(2, 31).padEnd(v23, "aa");
+    try {
+        eval(v28);
+    } catch { }
+}

--- a/JSTests/stress/static-private-fields-dont-need-property-conditions.js
+++ b/JSTests/stress/static-private-fields-dont-need-property-conditions.js
@@ -1,0 +1,28 @@
+function f0() {
+}
+const v3 = Object.getOwnPropertyNames(this);
+this / Object;
+const v7 = f0();
+try {
+    Object(f0, true);
+} catch(e11) {
+}
+for (const v12 of v3) {
+    const v14 = this[v12];
+    for (let i16 = 0;
+        (() => {
+            class C21 extends Object {
+                static #f = v14;
+                6 = Object;
+            }
+            new C21();
+            new C21();
+            new C21();
+            Object.__proto__ = v3;
+            new Float64Array(2887);
+            return i16 < 32;
+        })();
+        i16++) {
+    }
+    Object[v12] = this;
+}

--- a/LayoutTests/js/dom/resizable-array-buffer-do-not-crash-expected.txt
+++ b/LayoutTests/js/dom/resizable-array-buffer-do-not-crash-expected.txt
@@ -1,0 +1,9 @@
+Test for resizable ArrayBuffer crash
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/resizable-array-buffer-do-not-crash.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-do-not-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script src="script-tests/resizable-array-buffer-do-not-crash.js"></script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/js/dom/script-tests/resizable-array-buffer-do-not-crash.js
+++ b/LayoutTests/js/dom/script-tests/resizable-array-buffer-do-not-crash.js
@@ -1,0 +1,14 @@
+description(
+'Test for resizable ArrayBuffer crash'
+);
+
+function main() {
+    const buffer = new ArrayBuffer(0x2000, {maxByteLength: 0x2000});
+    const uint8Array = new Uint8Array(buffer, 0x1000, 0x1000);
+    buffer.resize(0);
+
+    IDBKeyRange.bound(uint8Array, '');
+}
+try {
+    main();
+} catch { }

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -497,6 +497,9 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 newCase = AccessCase::create(vm, codeBlock, AccessCase::IndexedProxyObjectLoad, nullptr);
                 break;
             }
+            case GetByKind::PrivateName:
+            case GetByKind::PrivateNameById:
+                RELEASE_ASSERT_NOT_REACHED();
             default:
                 break;
             }
@@ -635,6 +638,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
             else {
                 if (isPrivate) {
                     RELEASE_ASSERT(!slot.isUnset());
+                    RELEASE_ASSERT(conditionSet.isEmpty());
                     constexpr bool isGlobalProxy = false;
                     if (!slot.isCacheable())
                         return GiveUpOnCache;
@@ -1113,13 +1117,9 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                     break;
                 }
                 case PutByKind::DefinePrivateNameById:
-                case PutByKind::DefinePrivateNameByVal: {
+                case PutByKind::DefinePrivateNameByVal:
                     ASSERT(ident.isPrivateName());
-                    conditionSet = generateConditionsForPropertyMiss(vm, codeBlock, globalObject, newStructure, ident.impl());
-                    if (!conditionSet.isValid())
-                        return GiveUpOnCache;
                     break;
-                }
                 case PutByKind::ByIdDirectStrict:
                 case PutByKind::ByIdDirectSloppy:
                 case PutByKind::ByValDirectStrict:
@@ -1213,12 +1213,13 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
             }
             case PutByKind::DefinePrivateNameById:
             case PutByKind::DefinePrivateNameByVal:
+            case PutByKind::SetPrivateNameById:
+            case PutByKind::SetPrivateNameByVal:
+                RELEASE_ASSERT_NOT_REACHED();
             case PutByKind::ByIdDirectStrict:
             case PutByKind::ByIdDirectSloppy:
             case PutByKind::ByValDirectStrict:
             case PutByKind::ByValDirectSloppy:
-            case PutByKind::SetPrivateNameById:
-            case PutByKind::SetPrivateNameByVal:
                 return GiveUpOnCache;
             }
         }
@@ -1566,7 +1567,7 @@ static InlineCacheAction tryCacheInBy(
                 break;
             }
             default:
-                break;
+                RELEASE_ASSERT_NOT_REACHED();
             }
         } else if (wasFound) {
             if (!structure->propertyAccessesAreCacheable())

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2387,8 +2387,10 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValSetPrivateFieldGeneric, void, (JSGloba
 JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalSloppy, EncodedJSValue, (void* frame, JSScope* callerScopeChain, EncodedJSValue encodedThisValue))
 {
     CallFrame* calleeFrame = reinterpret_cast<CallFrame*>(frame);
+    CallFrame* callFrame = calleeFrame->callerFrame();
     // We can't trust our callee since it could be garbage but our caller's should be ok.
-    VM& vm = calleeFrame->callerFrame()->deprecatedVM();
+    VM& vm = callFrame->deprecatedVM();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     calleeFrame->setCodeBlock(nullptr);
 
@@ -2398,8 +2400,10 @@ JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalSloppy, EncodedJSValue, (void* f
 JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalStrict, EncodedJSValue, (void* frame, JSScope* callerScopeChain, EncodedJSValue encodedThisValue))
 {
     CallFrame* calleeFrame = reinterpret_cast<CallFrame*>(frame);
+    CallFrame* callFrame = calleeFrame->callerFrame();
     // We can't trust our callee since it could be garbage but our caller's should be ok.
-    VM& vm = calleeFrame->callerFrame()->deprecatedVM();
+    VM& vm = callFrame->deprecatedVM();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     calleeFrame->setCodeBlock(nullptr);
 
@@ -2409,8 +2413,10 @@ JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalStrict, EncodedJSValue, (void* f
 JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalSloppyTaintedByWithScope, EncodedJSValue, (void* frame, JSScope* callerScopeChain, EncodedJSValue encodedThisValue))
 {
     CallFrame* calleeFrame = reinterpret_cast<CallFrame*>(frame);
+    CallFrame* callFrame = calleeFrame->callerFrame();
     // We can't trust our callee since it could be garbage but our caller's should be ok.
-    VM& vm = calleeFrame->callerFrame()->deprecatedVM();
+    VM& vm = callFrame->deprecatedVM();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     calleeFrame->setCodeBlock(nullptr);
 
@@ -2420,8 +2426,10 @@ JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalSloppyTaintedByWithScope, Encode
 JSC_DEFINE_JIT_OPERATION(operationCallDirectEvalStrictTaintedByWithScope, EncodedJSValue, (void* frame, JSScope* callerScopeChain, EncodedJSValue encodedThisValue))
 {
     CallFrame* calleeFrame = reinterpret_cast<CallFrame*>(frame);
+    CallFrame* callFrame = calleeFrame->callerFrame();
     // We can't trust our callee since it could be garbage but our caller's should be ok.
-    VM& vm = calleeFrame->callerFrame()->deprecatedVM();
+    VM& vm = callFrame->deprecatedVM();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     calleeFrame->setCodeBlock(nullptr);
 

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -100,7 +100,7 @@ public:
             byteOffsetEnd = bufferByteLength;
         else
             byteOffsetEnd = byteOffsetStart + byteLengthRaw();
-        if (UNLIKELY(!(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength)))
+        if (UNLIKELY(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength))
             return 0;
         return byteOffsetRaw();
     }
@@ -122,7 +122,7 @@ public:
             byteOffsetEnd = bufferByteLength;
         else
             byteOffsetEnd = byteOffsetStart + byteLengthRaw();
-        if (UNLIKELY(!(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength)))
+        if (UNLIKELY(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength))
             return 0;
         if (!isAutoLength())
             return byteLengthRaw();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -27,6 +27,7 @@
 #import "CoreIPCError.h"
 
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/URL.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
@@ -61,6 +62,19 @@ bool CoreIPCError::hasValidUserInfo(const RetainPtr<CFDictionaryRef>& userInfo)
     if (RetainPtr<id> underlyingError = [info objectForKey:NSUnderlyingErrorKey]) {
         if (![underlyingError isKindOfClass:[NSError class]])
             return false;
+    }
+
+    if (id nsErrorFailingURL = [info objectForKey:@"NSErrorFailingURLKey"]) {
+        auto *failingURL = dynamic_objc_cast<NSURL>(nsErrorFailingURL);
+        if (!failingURL)
+            return false;
+        if (id nsErrorFailingURLString = [info objectForKey:@"NSErrorFailingURLStringKey"]) {
+            auto *failingURLString = dynamic_objc_cast<NSString>(nsErrorFailingURLString);
+            if (!failingURLString)
+                return false;
+            if (![failingURL isEqual:URL(failingURLString)])
+                return false;
+        }
     }
 
     return true;

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.h
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.h
@@ -55,7 +55,6 @@ struct WebProcessDataStoreParameters {
     SandboxExtension::Handle modelElementCacheDirectoryExtensionHandle;
 #endif
 #if PLATFORM(IOS_FAMILY)
-    std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> containerTemporaryDirectoryExtensionHandle;
 #endif

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
@@ -39,7 +39,6 @@
     WebKit::SandboxExtensionHandle modelElementCacheDirectoryExtensionHandle;
 #endif
 #if PLATFORM(IOS_FAMILY)
-    std::optional<WebKit::SandboxExtensionHandle> cookieStorageDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> containerCachesDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> containerTemporaryDirectoryExtensionHandle;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -886,9 +886,6 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
-    if (auto directory = websiteDataStore.resolvedCookieStorageDirectory(); !directory.isEmpty())
-        cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
     if (auto directory = websiteDataStore.resolvedContainerCachesWebContentDirectory(); !directory.isEmpty())
         containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
@@ -916,7 +913,6 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
         WTFMove(modelElementCacheDirectoryExtensionHandle),
 #endif
 #if PLATFORM(IOS_FAMILY)
-        WTFMove(cookieStorageDirectoryExtensionHandle),
         WTFMove(containerCachesDirectoryExtensionHandle),
         WTFMove(containerTemporaryDirectoryExtensionHandle),
 #endif

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -611,9 +611,6 @@ void WebProcess::platformSetWebsiteDataStoreParameters(WebProcessDataStoreParame
 #endif
 #endif
 #if PLATFORM(IOS_FAMILY)
-    // FIXME: Does the web process still need access to the cookie storage directory? Probably not.
-    if (auto& handle = parameters.cookieStorageDirectoryExtensionHandle)
-        SandboxExtension::consumePermanently(*handle);
     if (auto& handle = parameters.containerCachesDirectoryExtensionHandle)
         SandboxExtension::consumePermanently(*handle);
     if (auto& handle = parameters.containerTemporaryDirectoryExtensionHandle)


### PR DESCRIPTION
#### d7bd7d8f7cdf153da2bc16ed461eb3c72066b2d8
<pre>
[JSC] Puts to private fields shouldn&apos;t generate property conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=285643">https://bugs.webkit.org/show_bug.cgi?id=285643</a>
<a href="https://rdar.apple.com/142585218">rdar://142585218</a>

Reviewed by Yusuke Suzuki.

Private fields shouldn&apos;t generate property conditions this is because:

1) Private fields are always own properties so we should never walk the prototype chain.
2) Private names are constants in the function rather than part of the code block or IC.

We could solve (2) by having the CodeBlock&apos;s ICs reference the private name but that&apos;s not useful
anyway because we don&apos;t need to walk the prototype chain.

* JSTests/stress/static-private-fields-dont-need-property-conditions.js: Added.
(f0):
(catch):
(const.v12.of.v3.):
(const.v12.of.v3):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
(JSC::tryCachePutBy):
(JSC::tryCacheInBy):

Originally-landed-as: 283286.618@safari-7620-branch (222ba8af1970). <a href="https://rdar.apple.com/148116227">rdar://148116227</a>
Canonical link: <a href="https://commits.webkit.org/293171@main">https://commits.webkit.org/293171@main</a>
</pre>
----------------------------------------------------------------------
#### ab73d23c3e07779c07ddec0cb7653bd94271a867
<pre>
[IPC][Hardening] CoreIPCError should ensure NSErrorFailingURLKey and NSErrorFailingURLStringKey contain the same value
<a href="https://bugs.webkit.org/show_bug.cgi?id=285680">https://bugs.webkit.org/show_bug.cgi?id=285680</a>
<a href="https://rdar.apple.com/140567340">rdar://140567340</a>

Reviewed by Wenson Hsieh and Sihui Liu.

Treat NSError with deferring NSErrorFailingURLKey and NSErrorFailingURLStringKey as invalid.

* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::hasValidUserInfo):

Originally-landed-as: 283286.617@safari-7620-branch (22fa685170fe). <a href="https://rdar.apple.com/148116349">rdar://148116349</a>
Canonical link: <a href="https://commits.webkit.org/293170@main">https://commits.webkit.org/293170@main</a>
</pre>
----------------------------------------------------------------------
#### 71951f425f93be30777569a3c24cfed962f1985a
<pre>
[JSC] Eval call operations should update VM::topCallFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=285892">https://bugs.webkit.org/show_bug.cgi?id=285892</a>
<a href="https://rdar.apple.com/140795825">rdar://140795825</a>

Reviewed by Yijia Huang.

Eval operations should update VM::topCallFrame to prepare for throwing
an error for OOM of input string resolution.

* JSTests/stress/eval-call-should-update-top-frame.js: Added.
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):

Originally-landed-as: 283286.615@safari-7620-branch (2d42b44d8073). <a href="https://rdar.apple.com/148116678">rdar://148116678</a>
Canonical link: <a href="https://commits.webkit.org/293169@main">https://commits.webkit.org/293169@main</a>
</pre>
----------------------------------------------------------------------
#### a12f52cb55e9cb5edd32755633e1735b5e8ee9d8
<pre>
[JSC] Fix incorrect OOB condition for resizable ArrayBuffer in C++ wrapper code
<a href="https://bugs.webkit.org/show_bug.cgi?id=285876">https://bugs.webkit.org/show_bug.cgi?id=285876</a>
<a href="https://rdar.apple.com/141269480">rdar://141269480</a>

Reviewed by Yijia Huang and Keith Miller.

OOB checking condition is not correct for resizable ArrayBuffer when it
is used with C++ wrapper code. This patch fixes it.

* LayoutTests/js/dom/resizable-array-buffer-do-not-crash-expected.txt: Added.
* LayoutTests/js/dom/resizable-array-buffer-do-not-crash.html: Added.
* LayoutTests/js/dom/script-tests/resizable-array-buffer-do-not-crash.js: Added.
(main):
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::byteOffset const):
(JSC::ArrayBufferView::byteLength const):

Originally-landed-as: 283286.614@safari-7620-branch (604d4327862d). <a href="https://rdar.apple.com/148116771">rdar://148116771</a>
Canonical link: <a href="https://commits.webkit.org/293168@main">https://commits.webkit.org/293168@main</a>
</pre>
----------------------------------------------------------------------
#### eb40e825f8eead8459655be10537d314077547b6
<pre>
Remove sandbox access to cookie directory from web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=284993">https://bugs.webkit.org/show_bug.cgi?id=284993</a>
<a href="https://rdar.apple.com/141741137">rdar://141741137</a>

Reviewed by Charlie Wolfe.

In ye olden days, we used to do networking in the web content process.
Now we don&apos;t, so we don&apos;t need access to the cookie file any more.

* Source/WebKit/Shared/WebProcessDataStoreParameters.h:
* Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformSetWebsiteDataStoreParameters):

Originally-landed-as: 283286.612@safari-7620-branch (30bbe120cc59). <a href="https://rdar.apple.com/148117103">rdar://148117103</a>
Canonical link: <a href="https://commits.webkit.org/293167@main">https://commits.webkit.org/293167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/715e14afae9ca9aa8d74de7f5e961912badc57c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74650 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48026 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90736 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105548 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96681 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18305 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83639 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83093 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5409 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18773 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25100 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30274 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120302 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24920 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33714 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->