### PR TITLE
Some clients decide to unconditionally load window.open requests in the main frame

### DIFF
--- a/JSTests/stress/enumerator-put-by-val-should-respect-readonly.js
+++ b/JSTests/stress/enumerator-put-by-val-should-respect-readonly.js
@@ -1,0 +1,56 @@
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function sloppy() {
+    var object = {};
+    Object.defineProperty(object, 'test', {
+        writable: false,
+        enumerable: true,
+        configurable: true,
+        value: 42,
+    });
+    for (const name in object)
+        object[name] = 0x1234;
+    shouldBe(object.test, 42);
+}
+noInline(sloppy);
+
+function strict() {
+    "use strict";
+    var object = {};
+    Object.defineProperty(object, 'test', {
+        writable: false,
+        enumerable: true,
+        configurable: true,
+        value: 42,
+    });
+    shouldThrow(() => {
+        for (const name in object)
+            object[name] = 0x1234;
+    }, `TypeError: Attempted to assign to readonly property.`);
+}
+noInline(strict);
+
+for (var i = 0; i < 1e4; ++i) {
+    sloppy();
+    strict();
+}
+

--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -176,25 +176,26 @@ testRegExp(/(?<A>abc)x|(?<A>abc)y|abcz/, "abcz", ["abcz", undefined, undefined],
 // Test 11
 testRegExp(/(?<A>abc)x|(?<B>abc)y|abcz/, "abcz", ["abcz", undefined, undefined], { A: undefined, B: undefined });
 testRegExp(/(?<x>a)|(?<x>b)/, "ba", ["b", undefined, "b"], { x: "b"});
+testRegExp(/(?<=(?:\k<x>{0}(?<x>a)))b/, "ab", ["b", "a"], { x: "a" });
 testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<x>(?<x>a)))b/, "aab", ["b", undefined, "a"], { x: "a" });
 testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<x>))b/, "aab", ["b", undefined], { x: undefined });
 testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<y>(?<y>a)))b/, "aab", ["b", undefined, "a"], { x: undefined, y: "a" });
 
-// Test 16
+// Test 17
 testRegExp(/^(?:(?<a>x)|(?<a>y)|z)\k<a>$/, "z", ["z", undefined, undefined]);
 testRegExp(/^(?:(?<a>x)|(?<a>y)|z){2}\k<a>$/, "xz", ["xz", undefined, undefined]);
 testRegExp(/(?<a>x)|(?:zy\k<a>)/, "zy", ["zy", undefined]);
 testRegExpSyntaxError("(?<A>123)(?<A>456)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?<A>123)(?:(?<A>456)|(?<A>789))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 
-// Test 21
+// Test 22
 testRegExpSyntaxError("(?<=\\k<a>a)x", "u", "SyntaxError: Invalid regular expression: invalid \\k<> named backreference");
 testRegExp(/(?<b>.).\k<b>/u, "bab", ["bab", "b"]);
 testRegExp(/(?<b>.).\k<b>/u, "baa", null, null);
 testRegExp(/(?<a>\k<a>\w)../u, "bab", ["bab", "b"], { a: "b" });
 testRegExp(/(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/, "abc", ["abc", undefined, "a", "b", "c", undefined], { x: "b", y: "a", z: "c" });
 
-// Test 26
+// Test 27
 testRegExp(/(?<=(?:\1|b)(aa))./, "aaaax", ["x", "aa"]);
 testRegExp(/(?<=(?:\2|b)(?<=\1(a))(aa))./, "aaaax", ["x", "a", "aa"]);
 testRegExp(/(?<=((?:\3|b))(?<=\2(a))(aa))./, "aaaax", ["x", "aa", "a", "aa"]);
@@ -202,14 +203,14 @@ testRegExpSyntaxError("((?:(?<f>\w))(?<f>.)(a*c)?)*", "", "SyntaxError: Invalid 
 //  &&&&  testRegExp(/((?:(?<f>\w))(?<f>.)(a*c)?)*/, "aabbbccc", ["aabbbcc","bcc","b","c","c"], { f: "c" });
 testRegExp(/(?<A>)|(?<A>)*\k<A>/, "", ["", "", undefined], { A: "" });
 
-// Test 31
+// Test 32
 testRegExp(/(?:(?<A>a)|(?<A>b)*)\k<A>/, "bb", ["bb",undefined,"b"], { A: "b" });
 testRegExp(/((?<A>A+)(?<B>B+)(?<C>C+)(?<D>D+))+|((?<B>B+)(?<C>C+)(?<D>D+))+|((?<A>A+)(?<C>C+)(?<D>D+))+|((?<C>C+)(?<D>D+))+|((?<B>B+)(?<D>D+))+|((?<A>A+)(?<D>D+))+|((?<D>D+))/, "AAD", ["AAD", undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, "AAD", "AA", "D", undefined, undefined], { A: "AA", B: undefined, C: undefined, D: "D" });
 testRegExpSyntaxError("(?<x>c)(?:(?<x>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<x>a)|(?<x>b))(?<x>c)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<x>c)x)(?:(?<x>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 
-// Test 36
+// Test 37
 testRegExpSyntaxError("(?:(?<x>a)|(?<x>b))(?:(?<x>c)x)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<x>c)x|(?<y>d))(?:(?<y>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<y>a)|(?<x>b))(?:(?<x>c)x|(?<y>d))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");

--- a/LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request-expected.txt
+++ b/LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request-expected.txt
@@ -1,0 +1,33 @@
+Document.getCSSCanvasContext() should return null if the context was created with a different type.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Creating CSSCanvasContext with type = 2d
+PASS context != null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+Creating CSSCanvasContext with type = bitmaprenderer
+PASS context != null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+Creating CSSCanvasContext with type = webgl
+PASS context != null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+Creating CSSCanvasContext with type = webgl2
+PASS context != null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS type == type2 ? context2 == context : context2 == null is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request.html
+++ b/LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request.html
@@ -1,0 +1,18 @@
+<script src="../../resources/js-test.js"></script>
+<body>
+    <script>
+        description('Document.getCSSCanvasContext() should return null if the context was created with a different type.');
+
+        let types = ['2d', 'bitmaprenderer', 'webgl', 'webgl2'];
+        for (var type of types) {
+            debug("Creating CSSCanvasContext with type = " + type);
+            let name = type;
+            var context = document.getCSSCanvasContext(type, name, 0, 0);
+            shouldBeTrue("context != null");
+            for (var type2 of types) {
+                var context2 = document.getCSSCanvasContext(type2, name, 0, 0);
+                shouldBeTrue("type == type2 ? context2 == context : context2 == null");
+            }
+        }
+    </script>
+</body>

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -774,6 +774,14 @@ private:
                         Edge(child));
                 };
                 
+                // AI already concluded this was a constant so we're safe to do so as well.
+                if (AbstractValue constantResult = m_state.forNode(node); constantResult.value()) {
+                    addFilterStatus();
+                    m_graph.convertToConstant(node, constantResult.value());
+                    changed = true;
+                    break;
+                }
+
                 if (status.numVariants() == 1) {
                     unsigned identifierNumber = m_graph.identifiers().ensure(uid);
                     addFilterStatus();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -8209,7 +8209,7 @@ void SpeculativeJIT::compileEnumeratorPutByVal(Node* node)
 
             genericOrRecoverCase.append(branch32(NotEqual, scratchGPR, Address(enumeratorGPR, JSPropertyNameEnumerator::cachedStructureIDOffset())));
             emitNonNullDecodeZeroExtendedStructureID(scratchGPR, scratchGPR);
-            genericOrRecoverCase.append(branchTest32(NonZero, Address(scratchGPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_isWatchingReplacementBits)));
+            genericOrRecoverCase.append(branchTest32(NonZero, Address(scratchGPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_hasReadOnlyOrGetterSetterPropertiesExcludingProtoBits | Structure::s_isWatchingReplacementBits)));
 
             // Compute the offset
             // If index is less than the enumerator's cached inline storage, then it's an inline access

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16335,7 +16335,7 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(checkReplacementSensitiveStructure);
         LValue structureValue = decodeNonNullStructure(structureID);
-        LValue hasReplacementSensitiveStructure = m_out.testNonZero32(m_out.constInt32(Structure::s_isWatchingReplacementBits), m_out.load32(structureValue, m_heaps.Structure_bitField));
+        LValue hasReplacementSensitiveStructure = m_out.testNonZero32(m_out.constInt32(Structure::s_hasReadOnlyOrGetterSetterPropertiesExcludingProtoBits | Structure::s_isWatchingReplacementBits), m_out.load32(structureValue, m_heaps.Structure_bitField));
         m_out.branch(hasReplacementSensitiveStructure, rarely(genericOrRecover), usually(checkInlineOrOutOfLineBlock));
 
         m_out.appendTo(checkInlineOrOutOfLineBlock);

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -2171,7 +2171,7 @@ void JIT::emit_op_enumerator_put_by_val(const JSInstruction* currentInstruction)
     load32(Address(baseGPR, JSCell::structureIDOffset()), scratch2GPR);
     structureMismatch.append(branch32(NotEqual, scratch2GPR, Address(scratch1GPR, JSPropertyNameEnumerator::cachedStructureIDOffset())));
     emitNonNullDecodeZeroExtendedStructureID(scratch2GPR, scratch2GPR);
-    structureMismatch.append(branchTest32(NonZero, Address(scratch2GPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_isWatchingReplacementBits)));
+    structureMismatch.append(branchTest32(NonZero, Address(scratch2GPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_hasReadOnlyOrGetterSetterPropertiesExcludingProtoBits | Structure::s_isWatchingReplacementBits)));
 
     // Compute the offset.
     emitGetVirtualRegister(index, scratch2GPR);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3570,7 +3570,7 @@ llintOpWithMetadata(op_enumerator_put_by_val, OpEnumeratorPutByVal, macro (size,
     bineq t2, JSCell::m_structureID[t0], .putSlowPath
 
     structureIDToStructureWithScratch(t2, t3)
-    btinz Structure::m_bitField[t2], (constexpr Structure::s_isWatchingReplacementBits), .putSlowPath
+    btinz Structure::m_bitField[t2], ((constexpr Structure::s_hasReadOnlyOrGetterSetterPropertiesExcludingProtoBits) | (constexpr Structure::s_isWatchingReplacementBits)), .putSlowPath
 
     get(m_value, t2)
     loadConstantOrVariable(size, t2, t3)

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -208,12 +208,16 @@ inline void opEnumeratorPutByVal(JSGlobalObject* globalObject, JSValue baseValue
         return;
     }
     case JSPropertyNameEnumerator::OwnStructureMode: {
-        if (LIKELY(baseValue.isCell()) && baseValue.asCell()->structureID() == enumerator->cachedStructureID() && !baseValue.asCell()->structure()->isWatchingReplacement()) {
-            // We'll only match the structure ID if the base is an object.
-            ASSERT(index < enumerator->endStructurePropertyIndex());
-            scope.release();
-            asObject(baseValue)->putDirectOffset(vm, index < enumerator->cachedInlineCapacity() ? index : index - enumerator->cachedInlineCapacity() + firstOutOfLineOffset, value);
-            return;
+        if (LIKELY(baseValue.isCell())) {
+            auto* baseCell = baseValue.asCell();
+            auto* structure = baseCell->structure();
+            if (structure->id() == enumerator->cachedStructureID() && !structure->isWatchingReplacement() && !structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto()) {
+                // We'll only match the structure ID if the base is an object.
+                ASSERT(index < enumerator->endStructurePropertyIndex());
+                scope.release();
+                asObject(baseValue)->putDirectOffset(vm, index < enumerator->cachedInlineCapacity() ? index : index - enumerator->cachedInlineCapacity() + firstOutOfLineOffset, value);
+                return;
+            }
         }
         if (enumeratorMetadata)
             *enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1624,6 +1624,12 @@ public:
         ASSERT(m_alternative->m_terms.size());
 
         if (!max) {
+            // If we're removing a ForwardReference, we need to remove the corresponding references in
+            // m_forwardReferencesInLookbehind, or else we have a bad pointer.
+            // We know that the ForwardReference is the atom we just pushed, so it has to be at the end
+            // of m_forwardReferencesInLookbehind.
+            if (parenthesisMatchDirection() == Backward && m_alternative->m_terms.last().type == PatternTerm::Type::ForwardReference)
+                m_forwardReferencesInLookbehind.removeLast();
             m_alternative->removeLastTerm();
             return;
         }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -385,12 +385,9 @@ CanvasRenderingContext2D* HTMLCanvasElement::getContext2d(const String& type, Ca
 {
     ASSERT_UNUSED(HTMLCanvasElement::is2dType(type), type);
 
-    if (m_context && !m_context->is2d())
-        return nullptr;
-
     if (!m_context)
         return createContext2d(type, WTFMove(settings));
-    return downcast<CanvasRenderingContext2D>(m_context.get());
+    return dynamicDowncast<CanvasRenderingContext2D>(m_context.get());
 }
 
 #if ENABLE(WEBGL)
@@ -479,18 +476,17 @@ WebGLRenderingContextBase* HTMLCanvasElement::getContextWebGL(WebGLVersion type,
     if (!shouldEnableWebGL(document().settings()))
         return nullptr;
 
-    if (m_context) {
-        auto* glContext = dynamicDowncast<WebGLRenderingContextBase>(*m_context);
-        if (!glContext)
-            return nullptr;
+    if (!m_context)
+        return createContextWebGL(type, WTFMove(attrs));
 
-        if ((type == WebGLVersion::WebGL1) != glContext->isWebGL1())
-            return nullptr;
+    auto* glContext = dynamicDowncast<WebGLRenderingContextBase>(*m_context);
+    if (!glContext)
+        return nullptr;
 
-        return glContext;
-    }
+    if ((type == WebGLVersion::WebGL1) != glContext->isWebGL1())
+        return nullptr;
 
-    return createContextWebGL(type, WTFMove(attrs));
+    return glContext;
 }
 
 #endif // ENABLE(WEBGL)
@@ -521,6 +517,7 @@ ImageBitmapRenderingContext* HTMLCanvasElement::createContextBitmapRenderer(cons
 ImageBitmapRenderingContext* HTMLCanvasElement::getContextBitmapRenderer(const String& type, ImageBitmapRenderingContextSettings&& settings)
 {
     ASSERT_UNUSED(type, HTMLCanvasElement::isBitmapRendererType(type));
+
     if (!m_context)
         return createContextBitmapRenderer(type, WTFMove(settings));
     return dynamicDowncast<ImageBitmapRenderingContext>(m_context.get());
@@ -556,13 +553,10 @@ GPUCanvasContext* HTMLCanvasElement::getContextWebGPU(const String& type, GPU* g
     if (!document().settings().webGPUEnabled())
         return nullptr;
 
-    if (m_context && !m_context->isWebGPU())
-        return nullptr;
-
     if (!m_context)
         return createContextWebGPU(type, gpu);
 
-    return downcast<GPUCanvasContext>(m_context.get());
+    return dynamicDowncast<GPUCanvasContext>(m_context.get());
 }
 
 void HTMLCanvasElement::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3403,6 +3403,8 @@ private:
     String m_failingProvisionalLoadURL;
     bool m_isLoadingAlternateHTMLStringForFailingProvisionalLoad { false };
 
+    bool m_isCallingCreateNewPage { false };
+
     std::unique_ptr<WebPageLoadTiming> m_pageLoadTiming;
     HashSet<WebCore::FrameIdentifier> m_framesWithSubresourceLoadingForPageLoadTiming;
     RunLoop::Timer m_generatePageLoadTimingTimer;


### PR DESCRIPTION
#### 609e8c7a932f28b700a00eebc26ca034468746de
<pre>
Some clients decide to unconditionally load window.open requests in the main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=286381">https://bugs.webkit.org/show_bug.cgi?id=286381</a>
<a href="https://rdar.apple.com/142278116">rdar://142278116</a>

Reviewed by Alex Christensen and Charlie Wolfe.

Some clients of WKWebView decide to uncoditionally load the request from window.open and
return nil during their createWebViewWithConfiguration UI delegate call. This is okay in
most situations if you want to replace what is in the main frame, but is an issue whenever
the url passed to window.open is a javascript url. In this case, any i-frame can use this
to run script as the main frame.

To fix this, we ignore javascript scheme load requests that are made during the short time
we are calling the createNewPage UI delegate. The normal flow is to make a request after this
delegate has completed and it&apos;s unusual for apps to make one while they are processing this delegate,
so I think this won&apos;t break any apps.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.h:

Originally-landed-as: 283286.627@safari-7620-branch (c08948bfe20e). <a href="https://rdar.apple.com/148114319">rdar://148114319</a>
Canonical link: <a href="https://commits.webkit.org/293176@main">https://commits.webkit.org/293176@main</a>
</pre>
----------------------------------------------------------------------
#### 4c5c78c66372522f90ad0478a887337262ab00c9
<pre>
getCSSCanvasContext() unconditionally casts the context to ImageBitmapRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=286105">https://bugs.webkit.org/show_bug.cgi?id=286105</a>
<a href="https://rdar.apple.com/142779827">rdar://142779827</a>

Reviewed by Dan Glastonbury.

Like what we do in similar functions, getContextBitmapRenderer() should return
nullptr if the type of m_context is not `bitmaprenderer`. It should check
m_context.isBitmapRenderer() before casting m_context to ImageBitmapRenderingContext
Alternatively we can use dynamicDowncast&lt;ImageBitmapRenderingContext&gt; instead.

* LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request-expected.txt: Added.
* LayoutTests/fast/canvas/getCSSCanvasContext-create-and-request.html: Added.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext2d):
(WebCore::HTMLCanvasElement::getContextWebGL):
(WebCore::HTMLCanvasElement::getContextBitmapRenderer):
(WebCore::HTMLCanvasElement::getContextWebGPU):

Originally-landed-as: 283286.625@safari-7620-branch (ea954231fc42). <a href="https://rdar.apple.com/148114504">rdar://148114504</a>
Canonical link: <a href="https://commits.webkit.org/293175@main">https://commits.webkit.org/293175@main</a>
</pre>
----------------------------------------------------------------------
#### 4036cbb6b4f0b1b420a9576cc890552ce5a4135a
<pre>
Removing zero-count repeats of a forward reference should remove the associated m_forwardReferencesInLookbehind entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=286315">https://bugs.webkit.org/show_bug.cgi?id=286315</a>
<a href="https://rdar.apple.com/143118888">rdar://143118888</a>

Reviewed by Yusuke Suzuki.

Currently, Yarr tries to convert forward references to backreferences if possible. If
a forward reference is elided because it is quantified with a zero repeat count, it can
be removed. However, we do not remove bookkeeping data for backreference conversion,
meaning that we hold a stale index in this data.

* JSTests/stress/regexp-duplicate-named-captures.js:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::quantifyAtom):

Originally-landed-as: 283286.624@safari-7620-branch (f17564aaeeb2). <a href="https://rdar.apple.com/148114858">rdar://148114858</a>
Canonical link: <a href="https://commits.webkit.org/293174@main">https://commits.webkit.org/293174@main</a>
</pre>
----------------------------------------------------------------------
#### edcbf4c6ddc6102acf3ea5c11bddb05d21c4db04
<pre>
[JSC] enumerator_put_by_val should respect ReadOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=286325">https://bugs.webkit.org/show_bug.cgi?id=286325</a>
<a href="https://rdar.apple.com/143136742">rdar://143136742</a>

Reviewed by Keith Miller.

For EnumeratorPutByVal, we should check hasReadOnlyOrGetterSetterPropertiesExcludingProto bit too
since enumerated names may have ReadOnly properties.

* JSTests/stress/enumerator-put-by-val-should-respect-readonly.js: Added.
(shouldBe):
(shouldThrow):
(strict):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileEnumeratorPutByVal):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_enumerator_put_by_val):
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h:
(JSC::CommonSlowPaths::opEnumeratorPutByVal):

Originally-landed-as: 283286.623@safari-7620-branch (0e91bfa1a4ef). <a href="https://rdar.apple.com/148115516">rdar://148115516</a>
Canonical link: <a href="https://commits.webkit.org/293173@main">https://commits.webkit.org/293173@main</a>
</pre>
----------------------------------------------------------------------
#### ade1f961a450dfec519507fae4793c4901033b64
<pre>
GetById constant folding should use the results of AI
<a href="https://bugs.webkit.org/show_bug.cgi?id=286145">https://bugs.webkit.org/show_bug.cgi?id=286145</a>
<a href="https://rdar.apple.com/141582168">rdar://141582168</a>

Reviewed by Yusuke Suzuki and Yijia Huang.

Right now ConstantFolding tries to recompute the same information that AI does.
However since compilation is concurrent this information could be outdated on the
mutator. This can cause problems, instead ConstantFolding should just trust AI.

This isn&apos;t really the right long term fix for this. Instead ConstantFolding
should just be part of AI (conditionally enabled) but we should fix that in a
follow up patch.

* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Originally-landed-as: 283286.621@safari-7620-branch (cf19ad9af78c). <a href="https://rdar.apple.com/148115691">rdar://148115691</a>
Canonical link: <a href="https://commits.webkit.org/293172@main">https://commits.webkit.org/293172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093c5ca6d24e76d5040dd12ab60c949774721b2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31838 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13616 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88601 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48027 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90737 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105549 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96682 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83090 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18775 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15894 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30275 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120303 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24921 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33715 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->