### PR TITLE
Drop unnecessary operator!=() for some classes

### DIFF
--- a/Source/WebCore/platform/ContentType.h
+++ b/Source/WebCore/platform/ContentType.h
@@ -57,7 +57,6 @@ public:
 
     WEBCORE_EXPORT String toJSONString() const;
     bool operator==(const ContentType& other) const { return raw() == other.raw(); }
-    bool operator!=(const ContentType& other) const { return !(*this == other); }
 
     ContentType isolatedCopy() const & { return { m_type.isolatedCopy(), m_typeWasInferredFromExtension }; }
     ContentType isolatedCopy() && { return { WTFMove(m_type).isolatedCopy(), m_typeWasInferredFromExtension }; }

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -53,7 +53,6 @@ public:
     WEBCORE_EXPORT unsigned hash() const;
 
     bool operator==(const Site&) const = default;
-    bool operator!=(const Site&) const = default;
 
     struct Hash {
         static unsigned hash(const Site& site) { return site.hash(); }

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -75,7 +75,6 @@ private:
         bool isHashTableEmptyValue() const { return !m_hashAndLength; }
 
         friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
-        friend bool operator!=(const SmallStringKey&, const SmallStringKey&) = default;
 
     private:
         static constexpr unsigned s_capacity = 16;

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -103,8 +103,7 @@ public:
 
         void operator++() { ++m_logicalIndex; }
         T& operator*() { return m_range.m_data[index()]; }
-        bool operator==(const Iterator& other) { return m_logicalIndex == other.m_logicalIndex; }
-        bool operator!=(const Iterator& other) { return m_logicalIndex != other.m_logicalIndex; }
+        bool operator==(const Iterator& other) const { return m_logicalIndex == other.m_logicalIndex; }
         unsigned index()
         {
             ASSERT(m_logicalIndex < m_range.m_length);


### PR DESCRIPTION
#### 41fa127633d929f1b9bfc6585d921baafb9e6a78
<pre>
Drop unnecessary operator!=() for some classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=290975">https://bugs.webkit.org/show_bug.cgi?id=290975</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/ContentType.h:
(WebCore::ContentType::operator== const):
(WebCore::ContentType::operator!= const): Deleted.
* Source/WebCore/platform/Site.h:
* Source/WebCore/platform/graphics/WidthCache.h:
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::BidiRange::Iterator::operator==):
(WebCore::BidiRange::Iterator::operator!=): Deleted.

Canonical link: <a href="https://commits.webkit.org/293184@main">https://commits.webkit.org/293184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7d6c425a5f418713a9fbe382a542a1421734fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74694 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101103 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13658 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83419 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6655 "Found 2 new test failures: fullscreen/full-screen-request-removed-with-raf.html imported/w3c/web-platform-tests/service-workers/service-worker/postmessage-to-client-message-queue.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105592 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18346 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83680 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83134 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18825 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15897 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30318 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->