### PR TITLE
[WebDriver][win] separate AutomationSessionClient and AutomationClient into different files

### DIFF
--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -53,6 +53,7 @@ list(APPEND WebKit_SOURCES
     UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
 
     UIProcess/win/AutomationClientWin.cpp
+    UIProcess/win/AutomationSessionClientWin.cpp
     UIProcess/win/PageClientImpl.cpp
     UIProcess/win/WebContextMenuProxyWin.cpp
     UIProcess/win/WebPageProxyWin.cpp


### PR DESCRIPTION
#### 796a2794b625da267fda8f7cac76c923a2619a29
<pre>
[WebDriver][win] separate AutomationSessionClient and AutomationClient into different files
<a href="https://bugs.webkit.org/show_bug.cgi?id=290982">https://bugs.webkit.org/show_bug.cgi?id=290982</a>

Reviewed by Fujii Hironori.

Currently, `AutomationSessionClient` and `AutomationClient` are
implemented in the same file on the win port.
They should be separated into different files.

* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/UIProcess/win/AutomationClientWin.cpp:
(WebKit::AutomationSessionClient::AutomationSessionClient): Deleted.
(WebKit::AutomationSessionClient::close): Deleted.
(WebKit::AutomationSessionClient::didReceiveAuthenticationChallenge): Deleted.
(WebKit::AutomationSessionClient::requestNewPageWithOptions): Deleted.
(WebKit::AutomationSessionClient::didDisconnectFromRemote): Deleted.
(WebKit::AutomationSessionClient::retainWebView): Deleted.
(WebKit::AutomationSessionClient::releaseWebView): Deleted.
* Source/WebKit/UIProcess/win/AutomationClientWin.h:
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp: Copied from Source\WebKit\UIProcess\win\AutomationClientWin.cpp.
(WebKit::AutomationSessionClient::AutomationSessionClient):
(WebKit::AutomationSessionClient::close):
(WebKit::AutomationSessionClient::didReceiveAuthenticationChallenge):
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
(WebKit::AutomationSessionClient::didDisconnectFromRemote):
(WebKit::AutomationSessionClient::retainWebView):
(WebKit::AutomationSessionClient::releaseWebView):
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.h: Copied from Source\WebKit\UIProcess\win\AutomationClientWin.h.

Canonical link: <a href="https://commits.webkit.org/293149@main">https://commits.webkit.org/293149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/431ef0cc630dfa6edc4bfd3d2d4ea21d2c6aa99b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48600 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/17994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26153 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13630 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/88613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55025 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83391 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105564 "Hash 431ef0cc for PR 43529 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/105564 "Hash 431ef0cc for PR 43529 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25530 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/84794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/105564 "Hash 431ef0cc for PR 43529 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27745 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18791 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15886 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->