### PR TITLE
REGRESSION(290563@main): [Unified PDF] [iOS] Find in page results look blurry when zooming in

### DIFF
--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -196,7 +196,7 @@ private:
     static bool gSystemAllowsAnimationControls;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, const Image&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Image&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -103,6 +103,19 @@ public:
         this->scale(scale, scale);
     }
 
+    constexpr IntSize scaled(float widthScale, float heightScale) const
+    {
+        return {
+            static_cast<int>(static_cast<float>(m_width) * widthScale),
+            static_cast<int>(static_cast<float>(m_height) * heightScale)
+        };
+    }
+
+    constexpr IntSize scaled(float s) const
+    {
+        return scaled(s, s);
+    }
+
     constexpr IntSize expandedTo(const IntSize& other) const
     {
         return IntSize(std::max(m_width, other.m_width), std::max(m_height, other.m_height));


### PR DESCRIPTION
#### ad6bac3e96733804da0ddf32b8987d09dd3e987e
<pre>
REGRESSION(290563@main): [Unified PDF] [iOS] Find in page results look blurry when zooming in
<a href="https://bugs.webkit.org/show_bug.cgi?id=290986">https://bugs.webkit.org/show_bug.cgi?id=290986</a>
<a href="https://rdar.apple.com/147420275">rdar://147420275</a>

Reviewed by Tim Horton and Megan Gardner.

In 290563@main, we made the plugin-to-root-view transform a no-op for
full main frame plugins that do not handle page scale gesture (i.e. iOS)
becauseflows driven externally from the plugin, such as text selections,
ended up double applying the page scale, first in the main frame&apos;s
handling of scale updates, and second in the aforementioned transform.

However, this had the subtle effect of dropping the page scale for flows
driven internally from the plugin, such as text indicator data creation.
To account for this under-application, we compute a correction factor
&quot;mainFrameScaleForTextIndicator&quot; and scale the text indicator image
buffer size appropriately. Note that this factor is 1 when the plugin
handles page scale factors because it is then included in the
plugin-to-root-view transform.

* Source/WebCore/platform/graphics/Image.h:
Export the textstream operator&lt;&lt; overload to log Image data from
UnifiedPDFPlugin.

* Source/WebCore/platform/graphics/IntSize.h:
(WebCore::IntSize::scaled const):
Port the namesake helper from FloatSize.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::textIndicatorForTextMatch):
Drive-by fix: OptionSet has a single case constructor, so an
initializer list is unnecessary.

(WebKit::UnifiedPDFPlugin::textIndicatorForSelection):
Drive-by fix: Using the enclosed IntRect representing the selection
bounds meant that we lost some precision in the rect size. This
manifested in some unexpected misalignment between the text indicator
image and the rest of the string, especially at higher scales. Plumbing
a FloatRect all the way through helped alleviate this issue.

Canonical link: <a href="https://commits.webkit.org/293180@main">https://commits.webkit.org/293180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/011fd6e2172d578a6b7c3ccb3af556d246dac7bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18326 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83659 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27753 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18804 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30299 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->