### PR TITLE
GPUP: Frequent StrokeLine* spends time in PathDataLine serialization

### DIFF
--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -107,8 +107,8 @@ inline void PathImpl::addSegment(PathSegment segment)
             add(WTFMove(segment));
         },
         [&](PathDataLine segment) {
-            add(PathMoveTo { segment.start });
-            add(PathLineTo { segment.end });
+            add(PathMoveTo { segment.start() });
+            add(PathLineTo { segment.end() });
         },
         [&](PathDataQuadCurve segment) {
             add(PathMoveTo { segment.start });

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -651,8 +651,8 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathContinuousRoundedRect
 
 FloatPoint PathDataLine::calculateEndPoint(const FloatPoint&, FloatPoint& lastMoveToPoint) const
 {
-    lastMoveToPoint = start;
-    return end;
+    lastMoveToPoint = start();
+    return end();
 }
 
 std::optional<FloatPoint> PathDataLine::tryGetEndPointWithoutContext() const
@@ -668,27 +668,27 @@ void PathDataLine::extendFastBoundingRect(const FloatPoint& currentPoint, const 
 
 void PathDataLine::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
 {
-    boundingRect.extend(start);
-    boundingRect.extend(end);
+    boundingRect.extend(start());
+    boundingRect.extend(end());
 }
 
 void PathDataLine::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::MoveToPoint, { start } });
-    applier({ PathElement::Type::AddLineToPoint, { end } });
+    applier({ PathElement::Type::MoveToPoint, { start() } });
+    applier({ PathElement::Type::AddLineToPoint, { end() } });
 }
 
 void PathDataLine::transform(const AffineTransform& transform)
 {
-    start = transform.mapPoint(start);
-    end = transform.mapPoint(end);
+    setStart(transform.mapPoint(start()));
+    setEnd(transform.mapPoint(end()));
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataLine& data)
 {
-    ts << "move to "_s << data.start;
+    ts << "move to "_s << data.start();
     ts << ", "_s;
-    ts << "add line to "_s << data.end;
+    ts << "add line to "_s << data.end();
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -288,9 +288,20 @@ struct PathContinuousRoundedRect {
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathContinuousRoundedRect&);
 
 struct PathDataLine {
-    FloatPoint start;
-    FloatPoint end;
+    PathDataLine(FloatPoint start, FloatPoint end)
+        : m_values { { start.x(), start.y(), end.x(), end.y() } }
+    {
+    }
+    PathDataLine(std::span<const float, 4> values)
+        : m_values { values[0], values[1], values[2], values[3] }
+    {
+    }
 
+    FloatPoint start() const { return { m_values[0], m_values[1] }; }
+    void setStart(FloatPoint p) { m_values[0] = p.x(); m_values[1] = p.y(); }
+    FloatPoint end() const { return { m_values[2], m_values[3] }; }
+    void setEnd(FloatPoint p) { m_values[2] = p.x(); m_values[3] = p.y(); }
+    std::span<const float, 4> span() const LIFETIME_BOUND { return m_values; }
     static constexpr bool canApplyElements = true;
     static constexpr bool canTransform = true;
 
@@ -305,6 +316,8 @@ struct PathDataLine {
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
+private:
+    std::array<float, 4> m_values { };
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataLine&);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -805,7 +805,7 @@ void GraphicsContextCG::strokePath(const Path& path)
 
 #if USE(CG_CONTEXT_STROKE_LINE_SEGMENTS_WHEN_STROKING_PATH)
     if (auto line = path.singleDataLine()) {
-        CGPoint cgPoints[2] { line->start, line->end };
+        CGPoint cgPoints[2] { line->start(), line->end() };
         CGContextStrokeLineSegments(context, cgPoints, 2);
         return;
     }

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -549,8 +549,8 @@ FloatRect PathCG::strokeBoundingRect(NOESCAPE const Function<void(GraphicsContex
 
 static inline void addToCGContextPath(CGContextRef context, PathDataLine segment)
 {
-    addToCGContextPath(context, PathMoveTo { segment.start });
-    addToCGContextPath(context, PathLineTo { segment.end });
+    addToCGContextPath(context, PathMoveTo { segment.start() });
+    addToCGContextPath(context, PathLineTo { segment.end() });
 }
 
 static inline void addToCGContextPath(CGContextRef context, PathDataQuadCurve segment)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1241,8 +1241,8 @@ public:
 
 #if ENABLE(INLINE_PATH_DATA)
     StrokeLine(const PathDataLine& line)
-        : m_start(line.start)
-        , m_end(line.end)
+        : m_start(line.start())
+        , m_end(line.end())
     {
     }
 #endif

--- a/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
@@ -93,8 +93,7 @@ header: <WebCore/PathSegmentData.h>
 };
 
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataLine {
-    WebCore::FloatPoint start;
-    WebCore::FloatPoint end;
+    std::span<const float, 4> span();
 };
 
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataQuadCurve {

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -561,7 +561,7 @@ void RemoteDisplayListRecorder::strokeRect(const FloatRect& rect, float lineWidt
 void RemoteDisplayListRecorder::strokeLine(const PathDataLine& line)
 {
 #if ENABLE(INLINE_PATH_DATA)
-    auto path = Path({ PathSegment { PathDataLine { { line.start }, { line.end } } } });
+    auto path = Path({ PathSegment { PathDataLine { { line.start() }, { line.end() } } } });
 #else
     Path path;
     path.moveTo(line.start);


### PR DESCRIPTION
#### 036aaba87e27465f52e7f83ff872dc09281bfcd4
<pre>
GPUP: Frequent StrokeLine* spends time in PathDataLine serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=290988">https://bugs.webkit.org/show_bug.cgi?id=290988</a>
<a href="https://rdar.apple.com/148507518">rdar://148507518</a>

Reviewed by Simon Fraser.

IPC encoding is showing up as a bottleneck in StrokeLine* messages.

Fix by storing the float values in std::array, so that encoding can
encode them in one go as std::span&lt;const float, 4&gt;.

* Source/WebCore/platform/graphics/PathImpl.h:
(WebCore::PathImpl::addSegment):
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathDataLine::calculateEndPoint const):
(WebCore::PathDataLine::extendBoundingRect const):
(WebCore::PathDataLine::applyElements const):
(WebCore::PathDataLine::transform):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PathSegmentData.h:
(WebCore::PathDataLine::PathDataLine):
(WebCore::PathDataLine::start const):
(WebCore::PathDataLine::setStart):
(WebCore::PathDataLine::end const):
(WebCore::PathDataLine::setEnd):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::strokePath):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::addToCGContextPath):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::StrokeLine::StrokeLine):
* Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::strokeLine):

Canonical link: <a href="https://commits.webkit.org/293457@main">https://commits.webkit.org/293457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcd135b2f1e015c844e109f0161e3d3088ae4a05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27083 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75365 "Build is in progress. Recent messages:") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32491 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102000 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14392 "Build is in progress. Recent messages:Running configuration; Running run-layout-tests-in-stress-mode; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89407 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/55726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7457 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106491 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26093 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19023 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Skipped layout-tests; Running layout-tests; Uploaded test results") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85604 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/83830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19827 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26046 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31232 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25866 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->