### PR TITLE
Make image creation not a flushing operation for IOSurface-backed ImageBuffers

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -296,9 +296,6 @@ void ImageBufferIOSurfaceBackend::prepareForExternalWrite()
 
 RetainPtr<CGImageRef> ImageBufferIOSurfaceBackend::createImage()
 {
-    // CGIOSurfaceContextCreateImage flushes, so clear the flush need.
-    if (m_context)
-        m_context->consumeHasDrawn();
     // Consumers may hold on to the image, so mark external writes needing the invalidation marker.
     m_mayHaveOutstandingBackingStoreReferences = true;
     return m_surface->createImage(ensurePlatformContext());
@@ -306,9 +303,6 @@ RetainPtr<CGImageRef> ImageBufferIOSurfaceBackend::createImage()
 
 RetainPtr<CGImageRef> ImageBufferIOSurfaceBackend::createImageReference()
 {
-    // CGIOSurfaceContextCreateImageReference flushes, so clear the flush need.
-    if (m_context)
-        m_context->consumeHasDrawn();
     // The reference is used only in synchronized manner, so after the use ends, we can update
     // externally without invalidation marker. Thus we do not set m_mayHaveOutstandingBackingStoreReferences.
     auto image = adoptCF(CGIOSurfaceContextCreateImageReference(ensurePlatformContext()));


### PR DESCRIPTION
#### 4170735ca04ab6e2649d5e7bde7177a9255fca0a
<pre>
Make image creation not a flushing operation for IOSurface-backed ImageBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=290989">https://bugs.webkit.org/show_bug.cgi?id=290989</a>
<a href="https://rdar.apple.com/148508050">rdar://148508050</a>

Reviewed by Simon Fraser.

<a href="https://rdar.apple.com/106141264">rdar://106141264</a> will make CGIOSurfaceCreateImage an asynchronous
flush operation instead of current synchronous flush.

Update ImageBufferIOSurfaceBackend to match the future behavior: avoid
clearing the &quot;needs flush&quot; flag when creating the NativeImage copies.

This change should not have a big perf impact without <a href="https://rdar.apple.com/106141264">rdar://106141264</a>.
The feature, flushing by creating an image, was not explicitly used. It
would also not be hit in normal operation, only in very specific edge
cases.

* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::createImage):
(WebCore::ImageBufferIOSurfaceBackend::createImageReference):

Canonical link: <a href="https://commits.webkit.org/293463@main">https://commits.webkit.org/293463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9bb9c996b38fcfd03225bd9ad88ebfc130b2e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98997 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18634 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8880 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104126 "Build is in progress. Recent messages:Printed configuration; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49589 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101042 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18929 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Compiled WebKit (warnings)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27084 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Compiled WebKit (warnings)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75364 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests; Uploaded test results; 13 flakes 80 failures; Running compile-webkit-without-change; 1 flakes 79 failures; Running analyze-layout-tests-results") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32492 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102001 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/18929 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Compiled WebKit (warnings)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55725 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98481 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7383 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48966 "Build is in progress. Recent messages:Running configuration; Checked out pull request; Compiled WebKit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/18929 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84328 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/98567 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83831 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21259 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28492 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6160 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 16 flakes") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19828 "Build is in progress. Recent messages:Running configuration; Running checkout-pull-request; Running compile-webkit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26047 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31233 "Build is in progress. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Running checkout-pull-request; Found 51914 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->