### PR TITLE
[web-animations] start time of animations created during a page rendering update should match that update's timeline time

### DIFF
--- a/LayoutTests/compositing/backing/backface-visibility-flip-expected.txt
+++ b/LayoutTests/compositing/backing/backface-visibility-flip-expected.txt
@@ -16,6 +16,7 @@ Front Back
               (position 10.00 10.00)
               (bounds 300.00 300.00)
               (preserves3D 1)
+              (transform [1.00 0.00 -0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
               (children 2
                 (GraphicsLayer
                   (bounds 300.00 300.00)

--- a/LayoutTests/compositing/backing/backface-visibility-flip.html
+++ b/LayoutTests/compositing/backing/backface-visibility-flip.html
@@ -29,7 +29,7 @@
             height: 100%;
         }
         .flipping {
-            -webkit-animation: flip 2s forwards;
+            -webkit-animation: flip 3600s forwards;
         }
         
         .front, .back {

--- a/LayoutTests/compositing/backing/transition-extent-expected.txt
+++ b/LayoutTests/compositing/backing/transition-extent-expected.txt
@@ -16,6 +16,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 1)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
         (GraphicsLayer
           (position 20.00 1500.00)
@@ -23,6 +24,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 0)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
       )
     )

--- a/LayoutTests/compositing/backing/transition-extent.html
+++ b/LayoutTests/compositing/backing/transition-extent.html
@@ -13,7 +13,7 @@
             width: 100px;
             height: 100px;
             background-color: silver;
-            transition: transform 2s;
+            transition: transform 3600s;
             transform: rotate3d(0, 0, 1, 0deg)
         }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
@@ -12,4 +12,5 @@ PASS Setting the start time of a play-pending animation applies a pending playba
 PASS Setting the start time of a playing animation applies a pending playback rate
 PASS Setting the start time on a running animation updates the play state
 PASS Setting the start time on a reverse running animation updates the play state
+PASS Checking the start time of animations started at various times between two page rendering updates
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
@@ -325,5 +325,58 @@ promise_test(async t => {
 }, 'Setting the start time on a reverse running animation updates the play '
    + 'state');
 
+promise_test(async t => {
+  const make_animation = () => createDiv(t).animate(null, 100 * MS_PER_SEC);
+
+  // Wait for a couple of page rendering updates to run and record the timeline time.
+  await waitForAnimationFrames(2);
+  const timelineTimeForFirstPageRenderingUpdate = document.timeline.currentTime;
+
+  // Create a first animation that is created during the page rendering update.
+  // This animation should have its start time set to the current timeline time.
+  const animStartedDuringPageRenderingUpdate = make_animation();
+
+  // Wait for a new JS call frame and start another animation. This animation
+  // should have its start time set to the timeline time of the next page
+  // rendering update.
+  await new Promise(setTimeout);
+  const animStartedAfterTimeout = make_animation();
+
+  // Wait for another new JS call frame and start another animation. This
+  // animation, like the previous one, should have its start time set to
+  // the timeline time of the next page rendering update.
+  await new Promise(setTimeout);
+  const animStartedAfterAnotherTimeout = make_animation();
+
+  // Now wait until the next page rendering update and record the timeline time.
+  await waitForAnimationFrames(1);
+  const timelineTimeForSecondPageRenderingUpdate = document.timeline.currentTime;
+
+  // Create an animation that is created during this second page rendering update.
+  // This animation should have its start time set to the new timeline time.
+  const animStartedDuringSecondPageRenderingUpdate = make_animation();
+
+  // All animations should be ready by the next animation frame.
+  await waitForAnimationFrames(1);
+
+  const assert_start_time = (animation, expected, description) => {
+    assert_approx_equals(animation.startTime, expected, 0.0001,
+      `Start time of animation started ${description}`);
+  };
+
+  assert_start_time(animStartedDuringPageRenderingUpdate,
+    timelineTimeForFirstPageRenderingUpdate,
+    "during the first page rendering update");
+  assert_start_time(animStartedAfterTimeout,
+    timelineTimeForSecondPageRenderingUpdate,
+    "after waiting for a new JS call frame");
+  assert_start_time(animStartedAfterAnotherTimeout,
+    timelineTimeForSecondPageRenderingUpdate,
+    "after waiting for another new JS call frame");
+  assert_start_time(animStartedDuringSecondPageRenderingUpdate,
+    timelineTimeForSecondPageRenderingUpdate,
+    "during the second page rendering update");
+}, 'Checking the start time of animations started at various times between two page rendering updates');
+
 </script>
 </body>

--- a/LayoutTests/platform/mac/compositing/visible-rect/animated-from-none-expected.txt
+++ b/LayoutTests/platform/mac/compositing/visible-rect/animated-from-none-expected.txt
@@ -35,6 +35,7 @@
                   (position -100.00 0.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
                   (visible rect 100.00, 0.00 100.00 x 200.00)
                   (coverage rect 100.00, 0.00 500.00 x 200.00)
                   (intersects coverage rect 1)

--- a/LayoutTests/webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html
+++ b/LayoutTests/webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html
@@ -27,6 +27,8 @@ promise_test(async test => {
     const target = document.body.appendChild(document.createElement("div"));
     target.classList.add("target");
 
+    assert_equals(target.getAnimations().length, 0, "There are no animations applied initially.");
+
     const getAnimation = () => {
         const animations = target.getAnimations();
         assert_equals(animations.length, 1, "There is one animation applied to the target.");
@@ -41,13 +43,16 @@ promise_test(async test => {
     let retargetedTransition;
 
     // Start the initial transition.
-    await new Promise(requestAnimationFrame);
     target.classList.add("in-flight");
     initialTransition = getAnimation();
     
     // Wait until the animation is complete and retarget the transition to the same value.
-    await(initialTransition.ready);
-    await(new Promise(resolve => setTimeout(resolve, 100)));
+    await initialTransition.ready;
+
+    const timeout = new Promise(resolve => setTimeout(resolve, 100));
+
+    await Promise.all([timeout, initialTransition.finished]);
+
     target.classList.add("retargeted");
     retargetedTransition = getAnimation();
 

--- a/LayoutTests/webanimations/custom-effect/custom-effect.html
+++ b/LayoutTests/webanimations/custom-effect/custom-effect.html
@@ -12,15 +12,15 @@ promise_test(async t => {
     let numberOfCalls = 0;
     let customEffectProgress = null;
 
+    await waitForAnimationFrames(1);
+    await new Promise(setTimeout);
+
     const animation = document.timeline.animate(progress => {
         customEffectProgress = progress;
         numberOfCalls++;
     }, { duration: 1 });
 
     assert_equals(customEffectProgress, null, "Callback does not fire upon creation.");
-
-    await waitForAnimationFrames(1);
-    assert_equals(customEffectProgress, 0, "Callback is first fired with progress = 0.");
 
     await animation.finished;
     const numberOfCallsAfterEffectEnded = numberOfCalls;

--- a/LayoutTests/webanimations/offset-anchor-animation-yields-compositing.html
+++ b/LayoutTests/webanimations/offset-anchor-animation-yields-compositing.html
@@ -6,7 +6,7 @@ testRunner.waitUntilDone();
 testRunner.dumpAsText();
 
 document.getElementById("target").animate({
-    offsetAnchor: ["0 0", "100% 100%"]
+    offsetAnchor: ["0 0", "0 0"]
 }, 1000 * 60).ready.then(() => {
     document.getElementById("results").innerText = internals.layerTreeAsText(document);
     testRunner.notifyDone();

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -77,7 +77,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     return timing;
 }
 
-AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optional<WebAnimationTime> startTime) const
+AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData() const
 {
     if (!m_animation)
         return { };
@@ -87,16 +87,16 @@ AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optio
     return {
         timeline ? timeline->currentTime() : std::nullopt,
         timeline ? timeline->duration() : std::nullopt,
-        startTime ? startTime : animation->startTime(),
-        animation->currentTime(startTime),
+        animation->startTime(),
+        animation->currentTime(),
         animation->playbackRate()
     };
 }
 
-BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<WebAnimationTime> startTime)
+BasicEffectTiming AnimationEffect::getBasicTiming()
 {
     updateComputedTimingPropertiesIfNeeded();
-    return m_timing.getBasicTiming(resolutionData(startTime));
+    return m_timing.getBasicTiming(resolutionData());
 }
 
 ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
@@ -106,11 +106,11 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<WebAnimationTime> startTime)
+ComputedEffectTiming AnimationEffect::getComputedTiming()
 {
     updateComputedTimingPropertiesIfNeeded();
 
-    auto data = resolutionData(startTime);
+    auto data = resolutionData();
     auto resolvedTiming = m_timing.resolve(data);
 
     // https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -56,9 +56,9 @@ public:
     virtual bool isKeyframeEffect() const { return false; }
 
     EffectTiming getBindingsTiming() const;
-    BasicEffectTiming getBasicTiming(std::optional<WebAnimationTime> = std::nullopt);
+    BasicEffectTiming getBasicTiming();
     ComputedEffectTiming getBindingsComputedTiming();
-    ComputedEffectTiming getComputedTiming(std::optional<WebAnimationTime> = std::nullopt);
+    ComputedEffectTiming getComputedTiming();
     ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
@@ -118,7 +118,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    AnimationEffectTiming::ResolutionData resolutionData(std::optional<WebAnimationTime>) const;
+    AnimationEffectTiming::ResolutionData resolutionData() const;
     void updateComputedTimingPropertiesIfNeeded();
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -47,6 +47,11 @@ void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
 {
     updateGlobalPosition(animation);
 
+    if (animation.pending()) {
+        if (CheckedPtr controller = this->controller())
+            controller->addPendingAnimation(animation);
+    }
+
     if (m_animations.add(animation)) {
         auto* timeline = animation.timeline();
         if (timeline && timeline != this)

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -83,10 +83,15 @@ void AnimationTimelinesController::removeTimeline(AnimationTimeline& timeline)
 
 void AnimationTimelinesController::detachFromDocument()
 {
-    m_currentTimeClearingTaskCancellationGroup.cancel();
+    m_pendingAnimationsProcessingTaskCancellationGroup.cancel();
 
     while (RefPtr timeline = m_timelines.takeAny())
         timeline->detachFromDocument();
+}
+
+void AnimationTimelinesController::addPendingAnimation(WebAnimation& animation)
+{
+    m_pendingAnimations.add(animation);
 }
 
 void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResolutionSeconds timestamp)
@@ -292,12 +297,13 @@ std::optional<Seconds> AnimationTimelinesController::currentTime()
 void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds newCurrentTime)
 {
     m_cachedCurrentTime = newCurrentTime;
+
     // We want to be sure to keep this time cached until we've both finished running JS and finished updating
     // animations, so we schedule the invalidation task and register a whenIdle callback on the VM, which will
     // fire syncronously if no JS is running.
     m_waitingOnVMIdle = true;
-    if (!m_currentTimeClearingTaskCancellationGroup.hasPendingTask()) {
-        CancellableTask task(m_currentTimeClearingTaskCancellationGroup, std::bind(&AnimationTimelinesController::maybeClearCachedCurrentTime, this));
+    if (!m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask()) {
+        CancellableTask task(m_pendingAnimationsProcessingTaskCancellationGroup, std::bind(&AnimationTimelinesController::maybeProcessPendingAnimations, this));
         m_document->eventLoop().queueTask(TaskSource::InternalAsyncTask, WTFMove(task));
     }
 
@@ -308,18 +314,24 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
             return;
 
         m_waitingOnVMIdle = false;
-        maybeClearCachedCurrentTime();
+        maybeProcessPendingAnimations();
     });
 }
 
-void AnimationTimelinesController::maybeClearCachedCurrentTime()
+void AnimationTimelinesController::maybeProcessPendingAnimations()
 {
-    // We want to make sure we only clear the cached current time if we're not currently running
+    // We want to make sure we only process pending animations if we're not currently running
     // JS or waiting on all current animation updating code to have completed. This is so that
     // we're guaranteed to have a consistent current time reported for all work happening in a given
     // JS frame or throughout updating animations in WebCore.
-    if (!m_isSuspended && !m_waitingOnVMIdle && !m_currentTimeClearingTaskCancellationGroup.hasPendingTask())
-        m_cachedCurrentTime = std::nullopt;
+    ASSERT(m_cachedCurrentTime);
+    if (!m_isSuspended && !m_waitingOnVMIdle && !m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask()) {
+        auto pendingAnimations = std::exchange(m_pendingAnimations, { });
+        for (Ref pendingAnimation : pendingAnimations) {
+            if (pendingAnimation->timeline() && pendingAnimation->timeline()->isMonotonic())
+                pendingAnimation->setPendingStartTime(*m_cachedCurrentTime);
+        }
+    }
 }
 
 bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimation& animation) const

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -57,6 +57,7 @@ public:
     void removeTimeline(AnimationTimeline&);
     void detachFromDocument();
     void updateAnimationsAndSendEvents(ReducedResolutionSeconds);
+    void addPendingAnimation(WebAnimation&);
 
     std::optional<Seconds> currentTime();
     std::optional<FramesPerSecond> maximumAnimationFrameRate() const { return m_frameRateAligner.maximumFrameRate(); }
@@ -75,7 +76,7 @@ private:
 
     ReducedResolutionSeconds liveCurrentTime() const;
     void cacheCurrentTime(ReducedResolutionSeconds);
-    void maybeClearCachedCurrentTime();
+    void maybeProcessPendingAnimations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
@@ -86,7 +87,8 @@ private:
 
     UncheckedKeyHashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;
-    TaskCancellationGroup m_currentTimeClearingTaskCancellationGroup;
+    WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_pendingAnimations;
+    TaskCancellationGroup m_pendingAnimationsProcessingTaskCancellationGroup;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     FrameRateAligner m_frameRateAligner;
     Markable<Seconds, Seconds::MarkableTraits> m_cachedCurrentTime;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -53,7 +53,6 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
     : StyleOriginatedAnimation(styleable, backingAnimation)
     , m_property(property)
     , m_generationTime(generationTime)
-    , m_timelineTimeAtCreation(styleable.element.document().timeline().currentTime())
     , m_targetStyle(RenderStyle::clonePtr(targetStyle))
     , m_currentStyle(RenderStyle::clonePtr(oldStyle))
     , m_reversingAdjustedStartStyle(RenderStyle::clonePtr(reversingAdjustedStartStyle))
@@ -63,9 +62,9 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 
 CSSTransition::~CSSTransition() = default;
 
-OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
+OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext)
 {
-    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, startTime);
+    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext);
     m_currentStyle = RenderStyle::clonePtr(targetStyle);
     return impact;
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -49,7 +49,6 @@ public:
     const AtomString transitionProperty() const;
     AnimatableCSSProperty property() const { return m_property; }
     MonotonicTime generationTime() const { return m_generationTime; }
-    std::optional<Seconds> timelineTimeAtCreation() const { return m_timelineTimeAtCreation; }
     const RenderStyle& targetStyle() const { return *m_targetStyle; }
     const RenderStyle& currentStyle() const { return *m_currentStyle; }
     const RenderStyle& reversingAdjustedStartStyle() const { return *m_reversingAdjustedStartStyle; }
@@ -59,13 +58,12 @@ private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
-    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
+    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 
     AnimatableCSSProperty m_property;
     MonotonicTime m_generationTime;
-    Markable<Seconds, Seconds::MarkableTraits> m_timelineTimeAtCreation;
     std::unique_ptr<RenderStyle> m_targetStyle;
     std::unique_ptr<RenderStyle> m_currentStyle;
     std::unique_ptr<RenderStyle> m_reversingAdjustedStartStyle;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1649,7 +1649,7 @@ void KeyframeEffect::didChangeTargetStyleable(const std::optional<const Styleabl
         newTargetStyleable->ensureKeyframeEffectStack().addEffect(*this);
 }
 
-OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
+OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext)
 {
     OptionSet<AnimationImpact> impact;
     if (!m_target)
@@ -1657,16 +1657,15 @@ OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const
 
     updateBlendingKeyframes(targetStyle, resolutionContext);
 
-    auto computedTiming = getComputedTiming(startTime);
-    if (!startTime) {
-        if (m_phaseAtLastApplication != computedTiming.phase) {
-            m_phaseAtLastApplication = computedTiming.phase;
-            impact.add(AnimationImpact::RequiresRecomposite);
-        }
+    auto computedTiming = getComputedTiming();
 
-        if (auto target = targetStyleable())
-            InspectorInstrumentation::willApplyKeyframeEffect(*target, *this, computedTiming);
+    if (m_phaseAtLastApplication != computedTiming.phase) {
+        m_phaseAtLastApplication = computedTiming.phase;
+        impact.add(AnimationImpact::RequiresRecomposite);
     }
+
+    if (auto target = targetStyleable())
+        InspectorInstrumentation::willApplyKeyframeEffect(*target, *this, computedTiming);
 
     if (!computedTiming.progress)
         return impact;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -133,7 +133,7 @@ public:
     void setBindingsComposite(CompositeOperation);
 
     void getAnimatedStyle(std::unique_ptr<RenderStyle>& animatedStyle);
-    OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
+    OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&);
     void invalidate();
 
     void animationRelevancyDidChange();

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -466,12 +466,12 @@ ExceptionOr<void> WebAnimation::setBindingsCurrentTime(const std::optional<WebAn
     return setCurrentTime(currentTime);
 }
 
-std::optional<WebAnimationTime> WebAnimation::currentTime(std::optional<WebAnimationTime> startTime) const
+std::optional<WebAnimationTime> WebAnimation::currentTime() const
 {
-    return currentTime(RespectHoldTime::Yes, startTime);
+    return currentTime(RespectHoldTime::Yes);
 }
 
-std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respectHoldTime, std::optional<WebAnimationTime> startTime) const
+std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respectHoldTime) const
 {
     // 3.4.4. The current time of an animation
     // https://drafts.csswg.org/web-animations-1/#the-current-time-of-an-animation
@@ -491,7 +491,7 @@ std::optional<WebAnimationTime> WebAnimation::currentTime(RespectHoldTime respec
         return std::nullopt;
 
     // Otherwise, current time = (timeline time - start time) * playback rate
-    return (*m_timeline->currentTime() - startTime.value_or(*m_startTime)) * m_playbackRate;
+    return (*m_timeline->currentTime() - *m_startTime) * m_playbackRate;
 }
 
 ExceptionOr<void> WebAnimation::silentlySetCurrentTime(std::optional<WebAnimationTime> seekTime)
@@ -1569,14 +1569,14 @@ void WebAnimation::markAsReady()
     m_pendingStartTime = std::nullopt;
 }
 
-OptionSet<AnimationImpact> WebAnimation::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
+OptionSet<AnimationImpact> WebAnimation::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext)
 {
     if (!m_shouldSkipUpdatingFinishedStateWhenResolving)
         updateFinishedState(DidSeek::No, SynchronouslyNotify::No);
     m_shouldSkipUpdatingFinishedStateWhenResolving = false;
 
     if (auto keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get()))
-        return keyframeEffect->apply(targetStyle, resolutionContext, startTime);
+        return keyframeEffect->apply(targetStyle, resolutionContext);
     return { };
 }
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1259,7 +1259,9 @@ void WebAnimation::runPendingPlayTask()
     ASSERT(m_startTime || m_holdTime);
 
     // 2. Let ready time be the time value of the timeline associated with animation at the moment when animation became ready.
-    auto readyTime = m_timeline->currentTime();
+    auto readyTime = m_pendingStartTime;
+    if (!readyTime)
+        readyTime = m_timeline->currentTime();
 
     // 3. Perform the steps corresponding to the first matching condition below, if any:
     if (m_holdTime) {
@@ -1426,7 +1428,10 @@ void WebAnimation::runPendingPauseTask()
 
     // 1. Let ready time be the time value of the timeline associated with animation at the moment when the user agent
     //    completed processing necessary to suspend playback of animation's target effect.
-    auto readyTime = m_timeline->currentTime();
+    auto readyTime = m_pendingStartTime;
+    if (!readyTime)
+        readyTime = m_timeline->currentTime();
+
     auto animationStartTime = m_startTime;
 
     // 2. If animation's start time is resolved and its hold time is not resolved, let animation's hold time be the result of
@@ -1522,10 +1527,18 @@ void WebAnimation::tick()
     if (m_timeline && m_timeline->isProgressBased())
         autoAlignStartTime();
 
+    markAsReady();
+
     m_hasScheduledEventsDuringTick = false;
     updateFinishedState(DidSeek::No, SynchronouslyNotify::Yes);
     m_shouldSkipUpdatingFinishedStateWhenResolving = true;
 
+    if (!isEffectInvalidationSuspended() && m_effect)
+        m_effect->animationDidTick();
+}
+
+void WebAnimation::markAsReady()
+{
     // https://drafts.csswg.org/web-animations-2/#ready
     // An animation is ready at the first moment where all of the following conditions are true:
     //     - the user agent has completed any setup required to begin the playback of each inclusive
@@ -1533,16 +1546,27 @@ void WebAnimation::tick()
     //       any keyframe effect or executing any custom effects associated with an animation effect.
     //     - the animation is associated with a timeline that is not inactive.
     //     - the animation’s hold time or start time is resolved.
-    auto isReady = m_timeline && m_timeline->currentTime() && (m_holdTime || m_startTime);
-    if (isReady && (!m_effect || !m_effect->preventsAnimationReadiness())) {
-        if (hasPendingPauseTask())
-            runPendingPauseTask();
-        if (hasPendingPlayTask())
-            runPendingPlayTask();
-    }
+    if (!pending())
+        return;
 
-    if (!isEffectInvalidationSuspended() && m_effect)
-        m_effect->animationDidTick();
+    auto isReady = m_timeline && m_timeline->currentTime() && (m_holdTime || m_startTime);
+    if (!isReady)
+        return;
+
+    // Monotonic animations also require a pending start time.
+    if (!m_pendingStartTime && m_timeline->isMonotonic())
+        return;
+
+    // The effect can also prevent readines.
+    if (m_effect && m_effect->preventsAnimationReadiness())
+        return;
+
+    if (hasPendingPauseTask())
+        runPendingPauseTask();
+    if (hasPendingPlayTask())
+        runPendingPlayTask();
+
+    m_pendingStartTime = std::nullopt;
 }
 
 OptionSet<AnimationImpact> WebAnimation::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -137,6 +137,8 @@ public:
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
     std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
 
+    void setPendingStartTime(WebAnimationTime pendingStartTime) { m_pendingStartTime = pendingStartTime; }
+
     virtual std::variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);
     std::optional<FramesPerSecond> frameRate() const { return m_effectiveFrameRate; }
@@ -177,6 +179,8 @@ public:
     std::optional<Seconds> convertAnimationTimeToTimelineTime(Seconds) const;
 
     void progressBasedTimelineSourceDidChangeMetrics();
+
+    void markAsReady();
 
     // ContextDestructionObserver.
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
@@ -240,6 +244,7 @@ private:
     UniqueRef<FinishedPromise> m_finishedPromise;
     std::optional<WebAnimationTime> m_previousCurrentTime;
     std::optional<WebAnimationTime> m_startTime;
+    std::optional<WebAnimationTime> m_pendingStartTime;
     std::optional<WebAnimationTime> m_holdTime;
     MarkableDouble m_pendingPlaybackRate;
     double m_playbackRate { 1 };

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -89,7 +89,7 @@ public:
     AnimationTimeline* timeline() const { return m_timeline.get(); }
     virtual void setTimeline(RefPtr<AnimationTimeline>&&);
 
-    std::optional<WebAnimationTime> currentTime(std::optional<WebAnimationTime> = std::nullopt) const;
+    std::optional<WebAnimationTime> currentTime() const;
     ExceptionOr<void> setCurrentTime(std::optional<WebAnimationTime>);
 
     double playbackRate() const { return m_playbackRate + 0; }
@@ -154,7 +154,7 @@ public:
     bool needsTick() const;
     virtual void tick();
     WEBCORE_EXPORT Seconds timeToNextTick() const;
-    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
+    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&);
     void effectTargetDidChange(const std::optional<const Styleable>& previousTarget, const std::optional<const Styleable>& newTarget);
     void acceleratedStateDidChange();
     void willChangeRenderer();
@@ -206,7 +206,7 @@ private:
     WebAnimationTime effectEndTime() const;
     WebAnimation& readyPromiseResolve();
     WebAnimation& finishedPromiseResolve();
-    std::optional<WebAnimationTime> currentTime(RespectHoldTime, std::optional<WebAnimationTime> = std::nullopt) const;
+    std::optional<WebAnimationTime> currentTime(RespectHoldTime) const;
     ExceptionOr<void> silentlySetCurrentTime(std::optional<WebAnimationTime>);
     void finishNotificationSteps();
     bool hasPendingPauseTask() const { return m_timeToRunPendingPauseTask != TimeToRunPendingTask::NotScheduled; }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -594,13 +594,8 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             auto style = RenderStyle::clone(*lastStyleChangeEventStyle);
             if (auto* keyframeEffectStack = styleable.keyframeEffectStack()) {
                 for (const auto& effect : keyframeEffectStack->sortedEffects()) {
-                    if (!effectTargetsProperty(*effect))
-                        continue;
-                    auto* effectAnimation = effect->animation();
-                    auto* cssTransition = dynamicDowncast<CSSTransition>(effectAnimation);
-                    ASSERT(document.timeline().currentTime());
-                    bool shouldUseTimelineTimeAtCreation = cssTransition && (!effectAnimation->startTime() || effectAnimation->startTime() == document.timeline().currentTime());
-                    effectAnimation->resolve(style, { nullptr }, shouldUseTimelineTimeAtCreation ? cssTransition->timelineTimeAtCreation() : std::nullopt);
+                    if (effectTargetsProperty(*effect))
+                        Ref { *effect->animation() }->resolve(style, { nullptr });
                 }
             }
             return style;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=290993<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa4b410ba12bf825e5cdd1d42e192f39efcaede5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26380 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74814 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-transitions/properties-value-implicit-001.html imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-002.html imported/w3c/web-platform-tests/css/css-transitions/pseudo-elements-001.html imported/w3c/web-platform-tests/web-animations/timing-model/timelines/timelines.html webanimations/offset-distance-animation-yields-compositing.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101302 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13791 "Found 1 new test failure: compositing/backing/transition-extent.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55173 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6735 "Found 1 new test failure: compositing/layer-creation/overlap-animation-container.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48269 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25385 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25758 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84977 "Exiting early after 10 failures. 144 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83268 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27909 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19024 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25343 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->