### PR TITLE
The offsetLeft of rows should include border-spacing

### DIFF
--- a/LayoutTests/fast/table/031-expected.txt
+++ b/LayoutTests/fast/table/031-expected.txt
@@ -5,9 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 306x304
         RenderTableSection {TBODY} at (0,0) size 306x304
-          RenderTableRow {TR} at (0,2) size 306x300
+          RenderTableRow {TR} at (2,2) size 302x300
             RenderTableCell {TD} at (2,2) size 302x300 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 6x298
                 RenderTableSection {TBODY} at (0,0) size 6x298
-                  RenderTableRow {TR} at (0,2) size 6x294
+                  RenderTableRow {TR} at (2,2) size 2x294
                     RenderTableCell {TD} at (2,148) size 2x2 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/fast/table/032-expected.txt
+++ b/LayoutTests/fast/table/032-expected.txt
@@ -8,11 +8,11 @@ layer at (8,50) size 100x50
     RenderBlock (floating) {DIV} at (0,0) size 6x50 [bgcolor=#008000]
       RenderTable {TABLE} at (0,0) size 6x6
         RenderTableSection {TBODY} at (0,0) size 6x6
-          RenderTableRow {TR} at (0,2) size 6x2
+          RenderTableRow {TR} at (2,2) size 2x2
             RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=1 cs=1]
 layer at (8,100) size 6x50
   RenderBlock (positioned) {DIV} at (0,50) size 6x50 [bgcolor=#008000]
     RenderTable {TABLE} at (0,0) size 6x6
       RenderTableSection {TBODY} at (0,0) size 6x6
-        RenderTableRow {TR} at (0,2) size 6x2
+        RenderTableRow {TR} at (2,2) size 2x2
           RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/fast/table/fixed-with-auto-with-colspan-expected.txt
+++ b/LayoutTests/fast/table/fixed-with-auto-with-colspan-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 400x385
   RenderBlock (positioned) {DIV} at (0,0) size 400x385
     RenderTable {TABLE} at (0,5) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -18,7 +18,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,60) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -29,7 +29,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,115) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -40,7 +40,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,170) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -51,7 +51,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,225) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -62,7 +62,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,280) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -73,7 +73,7 @@ layer at (0,0) size 400x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,335) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -86,7 +86,7 @@ layer at (0,0) size 430x385
   RenderBlock (positioned) {DIV} at (0,0) size 430x385
     RenderTable {TABLE} at (0,5) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 50x2 [bgcolor=#008000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=1]
@@ -97,34 +97,34 @@ layer at (0,0) size 430x385
           RenderTableCell {TD} at (390,24) size 50x2 [bgcolor=#008000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (0,60) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 160x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=3]
           RenderTableCell {TD} at (170,24) size 270x2 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (0,115) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 105x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (115,24) size 50x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell {TD} at (170,24) size 270x2 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (0,170) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 105x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (115,24) size 325x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=6]
     RenderTable {TABLE} at (0,225) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 380x2 [bgcolor=#008000] [r=0 c=1 rs=1 cs=7]
     RenderTable {TABLE} at (0,280) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (60,24) size 105x2 [bgcolor=#008000] [r=0 c=1 rs=1 cs=2]
           RenderTableCell {TD} at (170,24) size 270x2 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (0,335) size 445x50
       RenderTableSection {TBODY} at (0,0) size 445x50
-        RenderTableRow {TR} at (0,0) size 445x50
+        RenderTableRow {TR} at (5,0) size 435x50
           RenderTableCell {TD} at (5,24) size 105x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (115,24) size 215x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=4]
           RenderTableCell {TD} at (335,24) size 50x2 [bgcolor=#008000] [r=0 c=6 rs=1 cs=1]

--- a/LayoutTests/fast/table/fixed-with-auto-with-colspan-vertical-expected.txt
+++ b/LayoutTests/fast/table/fixed-with-auto-with-colspan-vertical-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 385x400
   RenderBlock (positioned) {DIV} at (0,0) size 385x400
     RenderTable {TABLE} at (5,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -18,7 +18,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (60,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -29,7 +29,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (115,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -40,7 +40,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (170,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -51,7 +51,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (225,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -62,7 +62,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (280,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -73,7 +73,7 @@ layer at (0,0) size 385x400
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#FF0000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (335,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#FF0000] [r=0 c=2 rs=1 cs=1]
@@ -86,7 +86,7 @@ layer at (0,0) size 385x430
   RenderBlock (positioned) {DIV} at (0,0) size 385x430
     RenderTable {TABLE} at (5,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x2 [bgcolor=#008000] [r=0 c=1 rs=1 cs=1]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=1]
@@ -97,34 +97,34 @@ layer at (0,0) size 385x430
           RenderTableCell {TD} at (0,414) size 50x2 [bgcolor=#008000] [r=0 c=7 rs=1 cs=1]
     RenderTable {TABLE} at (60,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x112 [bgcolor=#008000] [r=0 c=0 rs=1 cs=3]
           RenderTableCell {TD} at (0,194) size 50x222 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (115,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x57 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (0,139) size 50x2 [bgcolor=#008000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell {TD} at (0,194) size 50x222 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (170,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x57 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (0,139) size 50x277 [bgcolor=#008000] [r=0 c=2 rs=1 cs=6]
     RenderTable {TABLE} at (225,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x332 [bgcolor=#008000] [r=0 c=1 rs=1 cs=7]
     RenderTable {TABLE} at (280,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x2 [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell {TD} at (0,84) size 50x57 [bgcolor=#008000] [r=0 c=1 rs=1 cs=2]
           RenderTableCell {TD} at (0,194) size 50x222 [bgcolor=#008000] [r=0 c=3 rs=1 cs=5]
     RenderTable {TABLE} at (335,0) size 50x445
       RenderTableSection {TBODY} at (0,0) size 50x445
-        RenderTableRow {TR} at (0,0) size 50x445
+        RenderTableRow {TR} at (0,5) size 50x435
           RenderTableCell {TD} at (0,29) size 50x57 [bgcolor=#008000] [r=0 c=0 rs=1 cs=2]
           RenderTableCell {TD} at (0,139) size 50x167 [bgcolor=#008000] [r=0 c=2 rs=1 cs=4]
           RenderTableCell {TD} at (0,359) size 50x2 [bgcolor=#008000] [r=0 c=6 rs=1 cs=1]

--- a/LayoutTests/fast/table/giantRowspan2-expected.txt
+++ b/LayoutTests/fast/table/giantRowspan2-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x78
         RenderTableSection {TBODY} at (0,0) size 784x78
-          RenderTableRow {TR} at (0,2) size 784x74
+          RenderTableRow {TR} at (2,2) size 780x74
             RenderTableCell {TD} at (2,2) size 780x74 [r=0 c=0 rs=65534 cs=1]
               RenderText {#text} at (1,1) size 771x72
                 text run at (1,1) width 687: "This test succeeds if it does not crash. We implemented a heuristic a while back to prevent giant rowspans. "

--- a/LayoutTests/fast/table/growCellForImageQuirk-expected.txt
+++ b/LayoutTests/fast/table/growCellForImageQuirk-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 156x56 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 156x56
-          RenderTableRow {TR} at (0,2) size 156x52
+          RenderTableRow {TR} at (2,2) size 152x52
             RenderTableCell {TD} at (2,2) size 152x52 [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 75x50 [bgcolor=#ADD8E6]
               RenderImage {IMG} at (76,1) size 75x50 [bgcolor=#ADD8E6]

--- a/LayoutTests/fast/table/growCellForImageQuirk-vertical-expected.txt
+++ b/LayoutTests/fast/table/growCellForImageQuirk-vertical-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 56x156 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 56x156
-          RenderTableRow {TR} at (2,0) size 52x156
+          RenderTableRow {TR} at (2,2) size 52x152
             RenderTableCell {TD} at (2,2) size 52x152 [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 50x75 [bgcolor=#ADD8E6]
               RenderImage {IMG} at (1,76) size 50x75 [bgcolor=#ADD8E6]

--- a/LayoutTests/fast/table/offset-top-includes-border-expected.txt
+++ b/LayoutTests/fast/table/offset-top-includes-border-expected.txt
@@ -1,3 +1,13 @@
 webkit.org/b/11582: The offsetTop of tbody, rows and cells should include the table's border. The tbody should include border-spacing in its offsetTop and offsetLeft too but that is a separate and more involved bug (webkit.org/b/119020) which when it's resolved should change the offsets from 14 to 19 for the tbody in this test. The offsetLeft for the row is also wrong (webkit.org/b/119021), fixing it will require a lot of rebaselining.
 
-PASS
+FAIL:
+Expected 14 for offsetLeft, but got 19.
+
+<table border="10">
+        <tbody data-offset-y="14" data-offset-x="14">
+            <tr data-offset-y="19" data-offset-x="14">
+                <td data-offset-y="19" data-offset-x="19">
+                </td>
+            </tr>
+        </tbody>
+    </table>

--- a/LayoutTests/fast/table/table-row-outline-paint-expected.txt
+++ b/LayoutTests/fast/table/table-row-outline-paint-expected.txt
@@ -5,9 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 114x106
         RenderTableSection {TBODY} at (0,0) size 114x106
-          RenderTableRow {TR} at (0,2) size 114x50
+          RenderTableRow {TR} at (2,2) size 110x50
             RenderTableCell {TD} at (2,25) size 54x4 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (58,25) size 54x4 [border: (1px solid #000000)] [r=0 c=1 rs=1 cs=1]
-          RenderTableRow {TR} at (0,54) size 114x50
+          RenderTableRow {TR} at (2,54) size 110x50
             RenderTableCell {TD} at (2,77) size 54x4 [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (58,77) size 54x4 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]

--- a/LayoutTests/fast/table/wide-colspan-expected.txt
+++ b/LayoutTests/fast/table/wide-colspan-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x569
       RenderTable {TABLE} at (0,0) size 1606x110
         RenderTableSection {TBODY} at (0,0) size 1606x110
-          RenderTableRow {TR} at (0,2) size 1606x52
+          RenderTableRow {TR} at (2,2) size 1602x52
             RenderTableCell {TD} at (2,2) size 1602x52 [r=0 c=0 rs=1 cs=2]
               RenderImage {IMG} at (1,1) size 1600x50
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,56) size 1606x52
+          RenderTableRow {TR} at (2,56) size 1602x52
             RenderTableCell {TD} at (2,56) size 800x52 [r=1 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 400x50
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/fast/table/wide-column-expected.txt
+++ b/LayoutTests/fast/table/wide-column-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x569
       RenderTable {TABLE} at (0,0) size 1606x56
         RenderTableSection {TBODY} at (0,0) size 1606x56
-          RenderTableRow {TR} at (0,2) size 1606x52
+          RenderTableRow {TR} at (2,2) size 1602x52
             RenderTableCell {TD} at (2,2) size 1602x52 [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 1600x50
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-spacing-included-in-sizes-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-spacing-included-in-sizes-001-expected.txt
@@ -28,10 +28,5 @@ FAIL tbody 3 assert_equals:
     </tr>
   </tbody>
 height expected 100 but got 110
-FAIL tfoot tr 4 assert_equals:
-<tr style="outline: 2px dashed black" data-expected-width="210" data-expected-height="100">
-      <td></td>
-      <td></td>
-    </tr>
-width expected 210 but got 230
+PASS tfoot tr 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/bounding-box-computation-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/bounding-box-computation-1-expected.txt
@@ -10,7 +10,7 @@ PASS Control test: Table width is 120px
 PASS Control test: Table height is 120px
 PASS Table-cell is 100px wide
 PASS Table-cell is 100px tall
-FAIL Table-row is 100px wide assert_equals: expected 100 but got 120
+PASS Table-row is 100px wide
 PASS Table-row is 100px tall
 FAIL Table-row-group is 100px wide assert_equals: expected 100 but got 120
 FAIL Table-row-group is 100px tall assert_equals: expected 100 but got 120

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-rows-with-zero-columns.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-rows-with-zero-columns.html
@@ -28,12 +28,12 @@
   </table>
 
   <table cellspacing="10">
-    <tr data-expected-width="60" data-expected-height="40"></tr>
+    <tr data-expected-width="40" data-expected-height="40"></tr>
   </table>
 
   <table cellspacing="10">
-    <tr data-expected-width="60" data-expected-height="15"></tr>
-    <tr data-expected-width="60" data-expected-height="15"></tr>
+    <tr data-expected-width="40" data-expected-height="15"></tr>
+    <tr data-expected-width="40" data-expected-height="15"></tr>
   </table>
 
   <table cellspacing="0" border="5">
@@ -46,12 +46,12 @@
   </table>
 
   <table cellspacing="10" border="5">
-    <tr data-expected-width="50" data-expected-height="30"></tr>
+    <tr data-expected-width="30" data-expected-height="30"></tr>
   </table>
 
   <table cellspacing="10" border="5">
-    <tr data-expected-width="50" data-expected-height="10"></tr>
-    <tr data-expected-width="50" data-expected-height="10"></tr>
+    <tr data-expected-width="30" data-expected-height="10"></tr>
+    <tr data-expected-width="30" data-expected-height="10"></tr>
   </table>
 </main>
 

--- a/LayoutTests/platform/mac/fast/table/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/001-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 42x24
   RenderTable {TABLE} at (0,0) size 42x24 [bgcolor=#000000]
     RenderTableSection {TBODY} at (0,0) size 42x24
-      RenderTableRow {TR} at (0,2) size 42x20
+      RenderTableRow {TR} at (2,2) size 38x20
         RenderTableCell {TD} at (2,2) size 38x20 [color=#FFFFFF] [r=0 c=0 rs=1 cs=1]
           RenderText {#text} at (1,1) size 36x18
             text run at (1,1) width 36: "Hello"

--- a/LayoutTests/platform/mac/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/003-expected.txt
@@ -5,47 +5,47 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x47
         RenderTableSection {TBODY} at (0,0) size 784x47
-          RenderTableRow {TR} at (0,2) size 784x21
+          RenderTableRow {TR} at (2,2) size 780x21
             RenderTableCell {TD} at (2,2) size 53x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 37x19
                 text run at (1,1) width 37: "URL:"
             RenderTableCell {TD} at (56,2) size 727x21 [r=0 c=1 rs=1 cs=1]
               RenderTextControl {INPUT} at (1,1) size 724x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-          RenderTableRow {TR} at (0,25) size 784x20
+          RenderTableRow {TR} at (2,25) size 780x20
             RenderTableCell {TD} at (2,25) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 257x18
                 text run at (1,1) width 257: "Alongwordtogiveyouanicebigminwidth."
       RenderTable {TABLE} at (0,47) size 100x100 [bgcolor=#FF0000] [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 96x96
-          RenderTableRow {TR} at (0,2) size 96x92
+          RenderTableRow {TR} at (2,2) size 92x92
             RenderTableCell {TD} at (2,46) size 92x4 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
       RenderTable {TABLE} at (0,147) size 173x120 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 169x116
-          RenderTableRow {TR} at (0,2) size 169x22
+          RenderTableRow {TR} at (2,2) size 165x22
             RenderTableCell {TD} at (2,2) size 165x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "hello"
-          RenderTableRow {TR} at (0,26) size 169x22
+          RenderTableRow {TR} at (2,26) size 165x22
             RenderTableCell {TD} at (2,26) size 165x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x18
                 text run at (2,2) width 69: "more hello"
-          RenderTableRow {TR} at (0,50) size 169x22
+          RenderTableRow {TR} at (2,50) size 165x22
             RenderTableCell {TD} at (2,50) size 165x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 38x18
                 text run at (2,2) width 38: "world"
-          RenderTableRow {TR} at (0,74) size 169x40
+          RenderTableRow {TR} at (2,74) size 165x40
             RenderTableCell {TD} at (2,74) size 165x40 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 0x0
       RenderTable {TABLE} at (0,267) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
-          RenderTableRow {TR} at (0,2) size 337x20
+          RenderTableRow {TR} at (2,2) size 333x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 331x18
                 text run at (1,1) width 234: "I should wrap and not have nowrap. "
                 text run at (234,1) width 98: "I really should."
       RenderTable {TABLE} at (0,291) size 337x24
         RenderTableSection {TBODY} at (0,0) size 337x24
-          RenderTableRow {TR} at (0,2) size 337x20
+          RenderTableRow {TR} at (2,2) size 333x20
             RenderTableCell {TD} at (2,2) size 333x20 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 331x18
                 RenderText {#text} at (0,0) size 331x18
@@ -53,7 +53,7 @@ layer at (0,0) size 800x600
                   text run at (233,0) width 98: "I really should."
       RenderTable {TABLE} at (0,315) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
-          RenderTableRow {TR} at (0,2) size 373x20
+          RenderTableRow {TR} at (2,2) size 369x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 367x18
                 text run at (1,1) width 147: "I should have nowrap. "
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
                 text run at (247,1) width 121: "Definitely. Should."
       RenderTable {TABLE} at (0,339) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
-          RenderTableRow {TR} at (0,2) size 373x20
+          RenderTableRow {TR} at (2,2) size 369x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 367x18
                 RenderText {#text} at (0,0) size 367x18

--- a/LayoutTests/platform/mac/fast/table/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/004-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 309x228 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 305x224
-          RenderTableRow {TR} at (0,2) size 305x220
+          RenderTableRow {TR} at (2,2) size 301x220
             RenderTableCell {TD} at (2,2) size 238x220 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (101,101) size 36x18
                 text run at (101,101) width 36: "Hello"

--- a/LayoutTests/platform/mac/fast/table/009-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/009-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
                 RenderBlock {DIV} at (82,1) size 634x54 [border: (2px solid #FF0000)]
                   RenderTable {TABLE} at (2,2) size 630x216 [bgcolor=#CCCCCC] [border: (2px outset #000000)]
                     RenderTableSection {TBODY} at (2,2) size 626x212
-                      RenderTableRow {TR} at (0,15) size 626x182
+                      RenderTableRow {TR} at (15,15) size 596x182
                         RenderTableCell {TD} at (15,15) size 596x182 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                           RenderTable {TABLE} at (249,1) size 98x180 [bgcolor=#CCCCCC]
                             RenderTableSection {TBODY} at (0,0) size 97x180

--- a/LayoutTests/platform/mac/fast/table/010-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/010-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x0
       RenderTable {TABLE} at (0,0) size 105x24
         RenderTableSection {TBODY} at (0,0) size 105x24
-          RenderTableRow {TR} at (0,2) size 105x20
+          RenderTableRow {TR} at (2,2) size 101x20
             RenderTableCell {TD} at (2,2) size 38x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 36x18
                 text run at (1,1) width 36: "Hello"

--- a/LayoutTests/platform/mac/fast/table/011-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/011-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x84
     RenderBody {BODY} at (8,8) size 784x68
       RenderTable {TABLE} at (0,0) size 67x68
         RenderTableSection {THEAD} at (0,0) size 67x24
-          RenderTableRow {TR} at (0,2) size 67x20
+          RenderTableRow {TR} at (2,2) size 63x20
             RenderTableCell {TH} at (2,2) size 15x20 [color=#FF0000] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 13x18
                 text run at (1,1) width 13: "H"
@@ -19,7 +19,7 @@ layer at (0,0) size 800x84
               RenderText {#text} at (1,1) size 12x18
                 text run at (1,1) width 12: "D"
         RenderTableSection {TFOOT} at (0,46) size 67x22
-          RenderTableRow {TR} at (0,0) size 67x20
+          RenderTableRow {TR} at (2,0) size 63x20
             RenderTableCell {TH} at (2,0) size 15x20 [color=#0000FF] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 11x18
                 text run at (2,1) width 11: "F"
@@ -33,7 +33,7 @@ layer at (0,0) size 800x84
               RenderText {#text} at (1,1) size 12x18
                 text run at (1,1) width 12: "T"
         RenderTableSection {TBODY} at (0,24) size 67x22
-          RenderTableRow {TR} at (0,0) size 67x20
+          RenderTableRow {TR} at (2,0) size 63x20
             RenderTableCell {TD} at (2,0) size 15x20 [color=#008000] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 8x18
                 text run at (1,1) width 8: "b"

--- a/LayoutTests/platform/mac/fast/table/015-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/015-expected.txt
@@ -5,13 +5,13 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 48x30 [border: (3px solid #000000)]
         RenderTableSection {TBODY} at (3,3) size 42x24
-          RenderTableRow {TR} at (0,2) size 42x20
+          RenderTableRow {TR} at (2,2) size 38x20
             RenderTableCell {TD} at (2,2) size 38x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 36x18
                 text run at (1,1) width 36: "Hello"
       RenderTable {TABLE} at (0,46) size 48x30 [border: (3px solid #000000)]
         RenderTableSection {TBODY} at (3,3) size 42x24
-          RenderTableRow {TR} at (0,2) size 42x20
+          RenderTableRow {TR} at (2,2) size 38x20
             RenderTableCell {TD} at (2,2) size 38x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 36x18
                 text run at (1,1) width 36: "Hello"

--- a/LayoutTests/platform/mac/fast/table/017-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/017-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 745x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 743x50
-          RenderTableRow {TR} at (0,2) size 743x46
+          RenderTableRow {TR} at (2,2) size 739x46
             RenderTableCell {TD} at (2,2) size 240x46 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,2) size 236x42
                 RenderTableSection {TBODY} at (0,0) size 236x42
-                  RenderTableRow {TR} at (0,2) size 236x38
+                  RenderTableRow {TR} at (2,2) size 232x38
                     RenderTableCell {TD} at (2,2) size 232x38 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 229x36
                         text run at (1,1) width 229: "This is the first column. It has some"
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (243,2) size 498x46 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (2,2) size 494x42
                 RenderTableSection {TBODY} at (0,0) size 494x42
-                  RenderTableRow {TR} at (0,2) size 494x38
+                  RenderTableRow {TR} at (2,2) size 490x38
                     RenderTableCell {TD} at (2,2) size 490x38 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 471x36
                         text run at (1,1) width 176: "This is the second column. "

--- a/LayoutTests/platform/mac/fast/table/018-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/018-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,86) size 784x64
         RenderTable {TABLE} at (0,0) size 784x64 [border: (1px outset #000000)]
           RenderTableSection {TBODY} at (1,1) size 782x62
-            RenderTableRow {TR} at (0,2) size 782x58
+            RenderTableRow {TR} at (2,2) size 778x58
               RenderTableCell {TD} at (2,2) size 778x58 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 128x18
                   text run at (2,2) width 128: "The following text: "

--- a/LayoutTests/platform/mac/fast/table/020-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/020-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 500x28 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 498x26
-          RenderTableRow {TR} at (0,2) size 498x22
+          RenderTableRow {TR} at (2,2) size 494x22
             RenderTableCell {TD} at (2,2) size 222x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 159x18
                 text run at (2,2) width 159: "Dell Inspiron Notebooks"

--- a/LayoutTests/platform/mac/fast/table/021-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/021-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 186x24
         RenderTableSection {TBODY} at (0,0) size 186x24
-          RenderTableRow {TR} at (0,2) size 186x20
+          RenderTableRow {TR} at (2,2) size 182x20
             RenderTableCell {TD} at (2,2) size 81x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 79x18
                 text run at (1,1) width 79: "first-column"

--- a/LayoutTests/platform/mac/fast/table/022-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/022-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 341x24
         RenderTableSection {TBODY} at (0,0) size 341x24
-          RenderTableRow {TR} at (0,2) size 341x2
+          RenderTableRow {TR} at (2,2) size 337x2
             RenderTableCell {TD} at (2,2) size 129x2 [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (132,2) size 207x2 [r=0 c=1 rs=1 cs=1]
-          RenderTableRow {TR} at (0,6) size 341x16
+          RenderTableRow {TR} at (2,6) size 337x16
             RenderTableCell {TD} at (2,6) size 129x16 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 127x14
                 text run at (1,1) width 127: "[this should not overlap]"
@@ -17,10 +17,10 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 205: "[with this, since the table is auto width]"
       RenderTable {TABLE} at (0,24) size 600x24
         RenderTableSection {TBODY} at (0,0) size 600x24
-          RenderTableRow {TR} at (0,2) size 600x2
+          RenderTableRow {TR} at (2,2) size 596x2
             RenderTableCell {TD} at (2,2) size 297x2 [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (301,2) size 297x2 [r=0 c=1 rs=1 cs=1]
-          RenderTableRow {TR} at (0,6) size 600x16
+          RenderTableRow {TR} at (2,6) size 596x16
             RenderTableCell {TD} at (2,6) size 297x16 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 127x14
                 text run at (1,1) width 127: "[this should not overlap]"

--- a/LayoutTests/platform/mac/fast/table/023-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/023-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 785x740
     RenderBody {BODY} at (8,8) size 769x716
       RenderTable {TABLE} at (0,0) size 769x80
         RenderTableSection {TBODY} at (0,0) size 769x80
-          RenderTableRow {TR} at (0,2) size 769x76
+          RenderTableRow {TR} at (2,2) size 765x76
             RenderTableCell {TD} at (2,29) size 688x22 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,29) size 8x18
                 text run at (2,2) width 8: "1"
@@ -21,11 +21,11 @@ layer at (0,0) size 785x740
       RenderBlock {P} at (0,96) size 769x0
       RenderTable {TABLE} at (0,96) size 769x196
         RenderTableSection {TBODY} at (0,0) size 769x196
-          RenderTableRow {TR} at (0,2) size 769x192
+          RenderTableRow {TR} at (2,2) size 765x192
             RenderTableCell {TD} at (2,2) size 765x192 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,2) size 761x188
                 RenderTableSection {TBODY} at (0,0) size 761x188
-                  RenderTableRow {TR} at (0,2) size 761x184
+                  RenderTableRow {TR} at (2,2) size 757x184
                     RenderTableCell {TD} at (2,83) size 680x22 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,83) size 8x18
                         text run at (2,2) width 8: "1"
@@ -47,11 +47,11 @@ layer at (0,0) size 785x740
       RenderBlock {P} at (0,308) size 769x0
       RenderTable {TABLE} at (0,308) size 527x196
         RenderTableSection {TBODY} at (0,0) size 527x196
-          RenderTableRow {TR} at (0,2) size 527x192
+          RenderTableRow {TR} at (2,2) size 523x192
             RenderTableCell {TD} at (2,2) size 523x192 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,2) size 519x188
                 RenderTableSection {TBODY} at (0,0) size 519x188
-                  RenderTableRow {TR} at (0,2) size 519x184
+                  RenderTableRow {TR} at (2,2) size 515x184
                     RenderTableCell {TD} at (2,83) size 437x22 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,83) size 8x18
                         text run at (2,2) width 8: "1"
@@ -73,12 +73,12 @@ layer at (0,0) size 785x740
       RenderBlock {P} at (0,520) size 769x0
       RenderTable {TABLE} at (0,520) size 527x196
         RenderTableSection {TBODY} at (0,0) size 527x196
-          RenderTableRow {TR} at (0,2) size 527x192
+          RenderTableRow {TR} at (2,2) size 523x192
             RenderTableCell {TD} at (2,2) size 523x192 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 519x188
                 RenderTable {TABLE} at (0,0) size 519x188
                   RenderTableSection {TBODY} at (0,0) size 519x188
-                    RenderTableRow {TR} at (0,2) size 519x184
+                    RenderTableRow {TR} at (2,2) size 515x184
                       RenderTableCell {TD} at (2,83) size 437x22 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (2,83) size 8x18
                           text run at (2,2) width 8: "1"

--- a/LayoutTests/platform/mac/fast/table/024-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/024-expected.txt
@@ -5,19 +5,19 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 356x40
         RenderTableSection {TBODY} at (0,0) size 356x40
-          RenderTableRow {TR} at (0,2) size 356x17
+          RenderTableRow {TR} at (2,2) size 352x17
             RenderTableCell {TD} at (2,2) size 353x17 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=2]
               RenderImage {IMG} at (1,1) size 350x15 [bgcolor=#FFFF00]
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,21) size 356x17
+          RenderTableRow {TR} at (2,21) size 352x17
             RenderTableCell {TD} at (2,22) size 132x15 [bgcolor=#0000FF] [r=1 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,2) size 130x13
                 RenderTableSection {TBODY} at (0,0) size 130x12
-                  RenderTableRow {TR} at (0,2) size 130x8
+                  RenderTableRow {TR} at (2,2) size 126x8
                     RenderTableCell {TD} at (2,2) size 126x8 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (1,1) size 124x6
                         RenderTableSection {TBODY} at (0,0) size 124x6
-                          RenderTableRow {TR} at (0,2) size 124x2
+                          RenderTableRow {TR} at (2,2) size 120x2
                             RenderTableCell {TD} at (2,2) size 57x2 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=1]
                             RenderTableCell {TD} at (60,2) size 3x2 [bgcolor=#0000FF] [r=0 c=1 rs=1 cs=1]
                             RenderTableCell {TD} at (64,2) size 58x2 [bgcolor=#0000FF] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/025-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/025-expected.txt
@@ -12,11 +12,11 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (207,0) size 342x43 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 333x35
                 RenderTableSection {TBODY} at (0,0) size 333x35
-                  RenderTableRow {TR} at (0,2) size 333x31
+                  RenderTableRow {TR} at (2,2) size 329x31
                     RenderTableCell {TD} at (2,2) size 329x31 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 325x27
                         RenderTableSection {TBODY} at (0,0) size 325x27
-                          RenderTableRow {TR} at (0,2) size 325x23
+                          RenderTableRow {TR} at (2,2) size 321x23
                             RenderTableCell {TD} at (2,11) size 41x5 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                             RenderTableCell {TD} at (44,2) size 236x23 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=1 rs=1 cs=2]
                               RenderImage {IMG} at (2,2) size 21x15 [bgcolor=#800080]
@@ -39,11 +39,11 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (548,0) size 237x43 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=2 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 228x35
                 RenderTableSection {TBODY} at (0,0) size 228x34
-                  RenderTableRow {TR} at (0,2) size 228x30
+                  RenderTableRow {TR} at (2,2) size 224x30
                     RenderTableCell {TD} at (2,2) size 224x30 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 220x26
                         RenderTableSection {TBODY} at (0,0) size 220x26
-                          RenderTableRow {TR} at (0,2) size 220x22
+                          RenderTableRow {TR} at (2,2) size 216x22
                             RenderTableCell {TD} at (2,2) size 216x22 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                               RenderImage {IMG} at (2,2) size 212x18 [bgcolor=#800080]
                               RenderText {#text} at (0,0) size 0x0
@@ -57,11 +57,11 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (219,0) size 329x43 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 321x35
                 RenderTableSection {TBODY} at (0,0) size 321x35
-                  RenderTableRow {TR} at (0,2) size 321x31
+                  RenderTableRow {TR} at (2,2) size 317x31
                     RenderTableCell {TD} at (2,2) size 317x31 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 313x27
                         RenderTableSection {TBODY} at (0,0) size 313x27
-                          RenderTableRow {TR} at (0,2) size 313x23
+                          RenderTableRow {TR} at (2,2) size 309x23
                             RenderTableCell {TD} at (2,11) size 35x5 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                             RenderTableCell {TD} at (38,2) size 236x23 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=1 rs=1 cs=2]
                               RenderImage {IMG} at (2,2) size 21x15 [bgcolor=#800080]
@@ -84,11 +84,11 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (548,0) size 236x43 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=2 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 228x35
                 RenderTableSection {TBODY} at (0,0) size 228x34
-                  RenderTableRow {TR} at (0,2) size 228x30
+                  RenderTableRow {TR} at (2,2) size 224x30
                     RenderTableCell {TD} at (2,2) size 224x30 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 220x26
                         RenderTableSection {TBODY} at (0,0) size 220x26
-                          RenderTableRow {TR} at (0,2) size 220x22
+                          RenderTableRow {TR} at (2,2) size 216x22
                             RenderTableCell {TD} at (2,2) size 216x22 [bgcolor=#FFA500] [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
                               RenderImage {IMG} at (2,2) size 212x18 [bgcolor=#800080]
                               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/table/026-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/026-expected.txt
@@ -5,12 +5,12 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (714,0) size 70x30
         RenderTableSection {TBODY} at (0,0) size 70x30
-          RenderTableRow {TR} at (0,2) size 70x26
+          RenderTableRow {TR} at (2,2) size 66x26
             RenderTableCell {TD} at (2,2) size 66x26 [r=0 c=0 rs=1 cs=1]
               RenderBlock (floating) {DIV} at (1,1) size 64x24
                 RenderTable {TABLE} at (0,0) size 64x24
                   RenderTableSection {TBODY} at (0,0) size 64x24
-                    RenderTableRow {TR} at (0,2) size 64x20
+                    RenderTableRow {TR} at (2,2) size 60x20
                       RenderTableCell {TD} at (2,2) size 10x20 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 8x18
                           text run at (1,1) width 8: "a"

--- a/LayoutTests/platform/mac/fast/table/027-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/027-expected.txt
@@ -42,11 +42,11 @@ layer at (0,0) size 800x585
             RenderTableCell {TD} at (222,26) size 350x312 [border: (1px solid #008000)] [r=1 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 342x304
                 RenderTableSection {TBODY} at (0,0) size 342x304
-                  RenderTableRow {TR} at (0,2) size 342x300
+                  RenderTableRow {TR} at (2,2) size 338x300
                     RenderTableCell {TD} at (2,2) size 338x300 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 334x296
                         RenderTableSection {TBODY} at (0,0) size 334x296
-                          RenderTableRow {TR} at (0,2) size 334x292
+                          RenderTableRow {TR} at (2,2) size 330x292
                             RenderTableCell {TD} at (2,146) size 127x4 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                             RenderTableCell {TD} at (130,2) size 73x292 [border: (1px solid #008000)] [r=0 c=1 rs=1 cs=1]
                               RenderText {#text} at (2,2) size 68x288

--- a/LayoutTests/platform/mac/fast/table/027-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/027-vertical-expected.txt
@@ -42,11 +42,11 @@ layer at (0,0) size 785x810
             RenderTableCell {TD} at (26,222) size 312x350 [border: (1px solid #008000)] [r=1 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (4,4) size 304x342
                 RenderTableSection {TBODY} at (0,0) size 304x342
-                  RenderTableRow {TR} at (2,0) size 300x342
+                  RenderTableRow {TR} at (2,2) size 300x338
                     RenderTableCell {TD} at (2,2) size 300x338 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (2,2) size 296x334
                         RenderTableSection {TBODY} at (0,0) size 296x334
-                          RenderTableRow {TR} at (2,0) size 292x334
+                          RenderTableRow {TR} at (2,2) size 292x330
                             RenderTableCell {TD} at (2,146) size 292x-161 [border: (1px solid #008000)] [r=0 c=0 rs=1 cs=1]
                             RenderTableCell {TD} at (2,130) size 292x73 [border: (1px solid #008000)] [r=0 c=1 rs=1 cs=1]
                               RenderText {#text} at (2,2) size 288x68

--- a/LayoutTests/platform/mac/fast/table/030-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/030-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 706x30 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 702x26
-          RenderTableRow {TR} at (0,2) size 702x22
+          RenderTableRow {TR} at (2,2) size 698x22
             RenderTableCell {TD} at (2,2) size 698x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 246x18
                 text run at (2,2) width 246: "I should be 90% of the window width."

--- a/LayoutTests/platform/mac/fast/table/033-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/033-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [color=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 400x30
         RenderTableSection {TBODY} at (0,0) size 400x30
-          RenderTableRow {TR} at (0,2) size 400x26
+          RenderTableRow {TR} at (2,2) size 396x26
             RenderTableCell {TD} at (2,2) size 396x26 [color=#800080] [bgcolor=#008000] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 351x24 [color=#FFFFFF]
                 RenderTableSection {TBODY} at (0,0) size 351x24
-                  RenderTableRow {TR} at (0,2) size 351x20
+                  RenderTableRow {TR} at (2,2) size 347x20
                     RenderTableCell {TD} at (2,2) size 347x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 345x18
                         text run at (1,1) width 345: "This text should be white, since we're in quirks mode."

--- a/LayoutTests/platform/mac/fast/table/034-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/034-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 785x1276
     RenderBody {BODY} at (8,8) size 769x1260
       RenderTable {TABLE} at (0,0) size 1056x1260
         RenderTableSection {TBODY} at (0,0) size 1056x1260
-          RenderTableRow {TR} at (0,2) size 1056x1256
+          RenderTableRow {TR} at (2,2) size 1052x1256
             RenderTableCell {TD} at (2,629) size 2x2 [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (6,2) size 1048x1256 [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 1046x1254 [bgcolor=#A9AFB8]

--- a/LayoutTests/platform/mac/fast/table/037-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/037-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x58
     RenderBody {body} at (8,8) size 784x42
       RenderTable {table} at (0,0) size 83x24
         RenderTableSection (anonymous) at (0,0) size 83x24
-          RenderTableRow {tr} at (0,2) size 83x20
+          RenderTableRow {tr} at (2,2) size 79x20
             RenderTableCell {td} at (2,2) size 79x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 77x18
                 text run at (1,1) width 77: "Hello world"

--- a/LayoutTests/platform/mac/fast/table/038-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/038-expected.txt
@@ -10,14 +10,14 @@ layer at (0,0) size 800x600
           text run at (0,18) width 258: "possible, while column 1 should be tiny."
       RenderTable {TABLE} at (0,36) size 784x54 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 780x50
-          RenderTableRow {TR} at (0,2) size 780x22
+          RenderTableRow {TR} at (2,2) size 776x22
             RenderTableCell {TD} at (2,2) size 12x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "1"
             RenderTableCell {TD} at (16,2) size 762x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (2,2) size 22x18
                 text run at (2,2) width 22: "2-3"
-          RenderTableRow {TR} at (0,26) size 780x22
+          RenderTableRow {TR} at (2,26) size 776x22
             RenderTableCell {TD} at (2,26) size 12x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "1"

--- a/LayoutTests/platform/mac/fast/table/038-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/038-vertical-expected.txt
@@ -10,14 +10,14 @@ layer at (0,0) size 785x636
           text run at (0,18) width 258: "possible, while column 1 should be tiny."
       RenderTable {TABLE} at (0,36) size 54x584 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 50x580
-          RenderTableRow {TR} at (2,0) size 22x580
+          RenderTableRow {TR} at (2,2) size 22x576
             RenderTableCell {TD} at (2,2) size 22x12 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 18x8
                 text run at (2,2) width 8: "1"
             RenderTableCell {TD} at (2,16) size 22x562 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (2,2) size 18x22
                 text run at (2,2) width 22: "2-3"
-          RenderTableRow {TR} at (26,0) size 22x580
+          RenderTableRow {TR} at (26,2) size 22x576
             RenderTableCell {TD} at (26,2) size 22x12 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 18x8
                 text run at (2,2) width 8: "1"

--- a/LayoutTests/platform/mac/fast/table/039-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/039-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderTable {TABLE} at (0,0) size 182x49 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 180x47
-          RenderTableRow {TR} at (0,1) size 180x22
+          RenderTableRow {TR} at (1,1) size 178x22
             RenderTableCell {TH} at (1,1) size 35x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18
                 text run at (2,2) width 31: "(1,1)"
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TH} at (143,1) size 36x22 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18
                 text run at (2,2) width 31: "(1,5)"
-          RenderTableRow {TR} at (0,24) size 180x22
+          RenderTableRow {TR} at (1,24) size 178x22
             RenderTableCell {TD} at (1,24) size 35x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18
                 text run at (2,2) width 31: "(2,1)"

--- a/LayoutTests/platform/mac/fast/table/041-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/041-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x327
           text run at (0,0) width 226: "ROWSPAN of 1024 - Works"
       RenderTable {TABLE} at (0,40) size 170x101 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 168x98
-          RenderTableRow {TR} at (0,2) size 168x22
+          RenderTableRow {TR} at (2,2) size 164x22
             RenderTableCell {TD} at (2,2) size 47x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 43x18
                 text run at (2,2) width 43: "header"
@@ -24,7 +24,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,2) size 47x22 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 43x18
                 text run at (2,2) width 43: "header"
-          RenderTableRow {TR} at (0,26) size 168x22
+          RenderTableRow {TR} at (2,26) size 164x22
             RenderTableCell {TD} at (2,26) size 47x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
@@ -34,7 +34,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,26) size 47x22 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
-          RenderTableRow {TR} at (0,50) size 168x22
+          RenderTableRow {TR} at (2,50) size 164x22
             RenderTableCell {TD} at (2,50) size 47x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
@@ -44,7 +44,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,50) size 47x22 [border: (1px inset #000000)] [r=2 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
-          RenderTableRow {TR} at (0,74) size 168x22
+          RenderTableRow {TR} at (2,74) size 164x22
             RenderTableCell {TD} at (2,74) size 47x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
@@ -59,7 +59,7 @@ layer at (0,0) size 800x327
           text run at (0,0) width 284: "ROWSPAN of 1025 - Doesn't Work"
       RenderTable {TABLE} at (0,200) size 170x101 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 168x98
-          RenderTableRow {TR} at (0,2) size 168x22
+          RenderTableRow {TR} at (2,2) size 164x22
             RenderTableCell {TD} at (2,2) size 47x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 43x18
                 text run at (2,2) width 43: "header"
@@ -75,7 +75,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,2) size 47x22 [border: (1px inset #000000)] [r=0 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 43x18
                 text run at (2,2) width 43: "header"
-          RenderTableRow {TR} at (0,26) size 168x22
+          RenderTableRow {TR} at (2,26) size 164x22
             RenderTableCell {TD} at (2,26) size 47x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
@@ -85,7 +85,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,26) size 47x22 [border: (1px inset #000000)] [r=1 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
-          RenderTableRow {TR} at (0,50) size 168x22
+          RenderTableRow {TR} at (2,50) size 164x22
             RenderTableCell {TD} at (2,50) size 47x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
@@ -95,7 +95,7 @@ layer at (0,0) size 800x327
             RenderTableCell {TD} at (119,50) size 47x22 [border: (1px inset #000000)] [r=2 c=4 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"
-          RenderTableRow {TR} at (0,74) size 168x22
+          RenderTableRow {TR} at (2,74) size 164x22
             RenderTableCell {TD} at (2,74) size 47x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 42x18
                 text run at (2,2) width 42: "foobar"

--- a/LayoutTests/platform/mac/fast/table/absolute-table-at-bottom-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/absolute-table-at-bottom-expected.txt
@@ -29,21 +29,21 @@ layer at (0,0) size 800x186
 layer at (120,550) size 120x50
   RenderTable {TABLE} at (120,550) size 120x50 [border: (1px solid #FF0000)]
     RenderTableSection {TBODY} at (1,1) size 118x48
-      RenderTableRow {TR} at (0,2) size 118x44
+      RenderTableRow {TR} at (2,2) size 114x44
         RenderTableCell {TD} at (2,14) size 114x20 [r=0 c=0 rs=1 cs=1]
           RenderText {#text} at (1,13) size 60x18
             text run at (1,1) width 60: "Tall table"
 layer at (240,574) size 120x26
   RenderTable {TABLE} at (240,574) size 120x26 [border: (1px solid #FF0000)]
     RenderTableSection {TBODY} at (1,1) size 118x24
-      RenderTableRow {TR} at (0,2) size 118x20
+      RenderTableRow {TR} at (2,2) size 114x20
         RenderTableCell {TD} at (2,2) size 114x20 [r=0 c=0 rs=1 cs=1]
           RenderText {#text} at (1,1) size 84x18
             text run at (1,1) width 84: "Normal table"
 layer at (360,574) size 120x26
   RenderTable {TABLE} at (360,574) size 120x26 [border: (1px solid #FF0000)]
     RenderTableSection {TBODY} at (1,1) size 118x24
-      RenderTableRow {TR} at (0,2) size 118x20
+      RenderTableRow {TR} at (2,2) size 114x20
         RenderTableCell {TD} at (2,2) size 114x20 [r=0 c=0 rs=1 cs=1]
           RenderText {#text} at (1,1) size 70x18
             text run at (1,1) width 70: "Short table"

--- a/LayoutTests/platform/mac/fast/table/add-before-anonymous-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/add-before-anonymous-child-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
           text run at (409,0) width 324: "The green square should be above the blue square."
       RenderTable {TABLE} at (0,96) size 104x204
         RenderTableSection {TBODY} at (0,0) size 104x204
-          RenderTableRow (anonymous) at (0,2) size 104x200
+          RenderTableRow (anonymous) at (2,2) size 100x200
             RenderTableCell (anonymous) at (2,2) size 100x200 [r=0 c=0 rs=1 cs=1]
               RenderBlock {TR} at (0,0) size 100x100 [bgcolor=#008000]
               RenderBlock {TR} at (0,100) size 100x100 [bgcolor=#0000FF]

--- a/LayoutTests/platform/mac/fast/table/auto-with-percent-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/auto-with-percent-height-expected.txt
@@ -5,23 +5,23 @@ layer at (0,0) size 800x156
     RenderBody {BODY} at (8,16) size 784x124
       RenderTable {TABLE} at (16,0) size 86x60 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 80x54
-          RenderTableRow {TR} at (0,2) size 80x50
+          RenderTableRow {TR} at (2,2) size 76x50
             RenderTableCell {TD} at (2,2) size 76x50 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 72x24 [color=#FFFFFF] [bgcolor=#800080]
                 RenderTableSection {TBODY} at (0,0) size 72x24
-                  RenderTableRow {TR} at (0,2) size 72x20
+                  RenderTableRow {TR} at (2,2) size 68x20
                     RenderTableCell {TD} at (2,2) size 68x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 66x18
                         text run at (1,1) width 66: "Table One"
               RenderTable {TABLE} at (1,25) size 74x24 [color=#FFFFFF] [bgcolor=#800080]
                 RenderTableSection {TBODY} at (0,0) size 74x24
-                  RenderTableRow {TR} at (0,2) size 74x20
+                  RenderTableRow {TR} at (2,2) size 70x20
                     RenderTableCell {TD} at (2,2) size 70x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 68x18
                         text run at (1,1) width 68: "Table Two"
       RenderTable {TABLE} at (16,76) size 69x48 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 63x42
-          RenderTableRow {TR} at (0,2) size 63x38
+          RenderTableRow {TR} at (2,2) size 59x38
             RenderTableCell {TD} at (2,2) size 59x38 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 57x18 [color=#FFFFFF] [bgcolor=#800080]
                 RenderText {#text} at (0,0) size 55x18

--- a/LayoutTests/platform/mac/fast/table/auto-with-percent-height-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/auto-with-percent-height-vertical-expected.txt
@@ -5,23 +5,23 @@ layer at (0,0) size 800x202
     RenderBody {BODY} at (8,16) size 784x170
       RenderTable {TABLE} at (16,0) size 60x86 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 54x80
-          RenderTableRow {TR} at (2,0) size 50x80
+          RenderTableRow {TR} at (2,2) size 50x76
             RenderTableCell {TD} at (2,2) size 50x76 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 24x72 [color=#FFFFFF] [bgcolor=#800080]
                 RenderTableSection {TBODY} at (0,0) size 24x72
-                  RenderTableRow {TR} at (2,0) size 20x72
+                  RenderTableRow {TR} at (2,2) size 20x68
                     RenderTableCell {TD} at (2,2) size 20x68 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 18x66
                         text run at (1,1) width 66: "Table One"
               RenderTable {TABLE} at (25,1) size 24x74 [color=#FFFFFF] [bgcolor=#800080]
                 RenderTableSection {TBODY} at (0,0) size 24x74
-                  RenderTableRow {TR} at (2,0) size 20x74
+                  RenderTableRow {TR} at (2,2) size 20x70
                     RenderTableCell {TD} at (2,2) size 20x70 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 18x68
                         text run at (1,1) width 68: "Table Two"
       RenderTable {TABLE} at (16,101) size 48x69 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 42x63
-          RenderTableRow {TR} at (2,0) size 38x63
+          RenderTableRow {TR} at (2,2) size 38x59
             RenderTableCell {TD} at (2,2) size 38x59 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 18x57 [color=#FFFFFF] [bgcolor=#800080]
                 RenderText {#text} at (0,0) size 18x55

--- a/LayoutTests/platform/mac/fast/table/border-collapsing/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/border-collapsing/004-expected.txt
@@ -95,7 +95,7 @@ layer at (0,0) size 785x1494
                 text run at (6,60) width 45: "border."
       RenderTable {TABLE} at (16,488) size 737x237 [border: (3px solid #0000FF)]
         RenderTableSection {TBODY} at (3,3) size 731x230
-          RenderTableRow {TR} at (0,16) size 731x34
+          RenderTableRow {TR} at (16,16) size 699x34
             RenderTableCell {TH} at (16,16) size 164x34 [border: (3px solid #800080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (40,8) size 84x18
                 text run at (40,8) width 84: "Header One"
@@ -105,7 +105,7 @@ layer at (0,0) size 785x1494
             RenderTableCell {TH} at (403,16) size 313x34 [border: (3px solid #800080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (108,8) size 96x18
                 text run at (108,8) width 96: "Header Three"
-          RenderTableRow {TR} at (0,66) size 731x66
+          RenderTableRow {TR} at (16,66) size 699x66
             RenderTableCell {TD} at (16,66) size 164x66 [border: (1px solid #008000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (6,6) size 119x54
                 text run at (6,6) width 119: "This table uses the"
@@ -121,7 +121,7 @@ layer at (0,0) size 785x1494
                 text run at (6,6) width 209: "The borders on the header cells, "
                 text run at (214,6) width 77: "on all sides,"
                 text run at (6,24) width 203: "should be medium solid purple."
-          RenderTableRow {TR} at (0,148) size 731x66
+          RenderTableRow {TR} at (16,148) size 699x66
             RenderTableCell {TD} at (16,148) size 164x66 [border: (1px solid #008000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (6,6) size 147x54
                 text run at (6,6) width 147: "The border of the table"
@@ -206,7 +206,7 @@ layer at (0,0) size 785x1494
                 text run at (6,78) width 42: "100%."
       RenderTable {TABLE} at (16,1032) size 737x227 [border: (3px solid #0000FF)]
         RenderTableSection {TBODY} at (3,3) size 731x220
-          RenderTableRow {TR} at (0,0) size 731x34
+          RenderTableRow {TR} at (8,0) size 715x34
             RenderTableCell {TH} at (8,0) size 202x34 [border: (3px solid #800080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (59,8) size 84x18
                 text run at (59,8) width 84: "Header One"
@@ -216,7 +216,7 @@ layer at (0,0) size 785x1494
             RenderTableCell {TH} at (430,0) size 294x34 [border: (3px solid #800080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (98,8) size 96x18
                 text run at (98,8) width 96: "Header Three"
-          RenderTableRow {TR} at (0,34) size 731x84
+          RenderTableRow {TR} at (8,34) size 715x84
             RenderTableCell {TD} at (8,52) size 202x48 [border: (1px solid #008000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (6,24) size 184x36
                 text run at (6,6) width 184: "This table uses the separated"
@@ -233,7 +233,7 @@ layer at (0,0) size 785x1494
                 text run at (6,6) width 209: "The borders on the header cells, "
                 text run at (214,6) width 37: "on all"
                 text run at (6,24) width 243: "sides, should be medium solid purple."
-          RenderTableRow {TR} at (0,118) size 731x102
+          RenderTableRow {TR} at (8,118) size 715x102
             RenderTableCell {TD} at (8,127) size 202x84 [border: (1px solid #008000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (6,15) size 189x72
                 text run at (6,6) width 183: "The border of the table itself"
@@ -272,7 +272,7 @@ layer at (0,0) size 785x1494
           RenderTableCol {COL} at (0,0) size 0x0 [border: (3px solid #FF0000)]
           RenderTableCol {COL} at (0,0) size 0x0 [border: (3px solid #FF0000)]
         RenderTableSection {THEAD} at (0,18) size 737x32 [border: (3px solid #FF0000)]
-          RenderTableRow {TR} at (0,2) size 737x28 [border: (3px solid #FF0000)]
+          RenderTableRow {TR} at (2,2) size 733x28 [border: (3px solid #FF0000)]
             RenderTableCell {TH} at (2,2) size 121x28 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (18,5) size 84x18
                 text run at (18,5) width 84: "Header One"
@@ -283,7 +283,7 @@ layer at (0,0) size 785x1494
               RenderText {#text} at (96,5) size 96x18
                 text run at (96,5) width 96: "Header Three"
         RenderTableSection {TBODY} at (0,50) size 737x132 [border: (3px solid #FF0000)]
-          RenderTableRow {TR} at (0,0) size 737x64 [border: (3px solid #FF0000)]
+          RenderTableRow {TR} at (2,0) size 733x64 [border: (3px solid #FF0000)]
             RenderTableCell {TD} at (2,0) size 121x64 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (5,5) size 96x54
                 text run at (5,5) width 96: "This table uses"
@@ -300,7 +300,7 @@ layer at (0,0) size 785x1494
                 text run at (5,23) width 102: "represent rows, "
                 text run at (106,23) width 159: "row-groups, columns, or"
                 text run at (5,41) width 101: "column-groups."
-          RenderTableRow {TR} at (0,66) size 737x64 [border: (3px solid #FF0000)]
+          RenderTableRow {TR} at (2,66) size 733x64 [border: (3px solid #FF0000)]
             RenderTableCell {TD} at (2,66) size 121x64 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (5,5) size 104x54
                 text run at (5,5) width 104: "There should be"

--- a/LayoutTests/platform/mac/fast/table/border-collapsing/004-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/border-collapsing/004-vertical-expected.txt
@@ -104,7 +104,7 @@ layer at (0,0) size 785x884
                   text run at (77,6) width 82: "of its border."
         RenderTable {TABLE} at (270,16) size 308x537 [border: (3px solid #0000FF)]
           RenderTableSection {TBODY} at (3,3) size 302x531
-            RenderTableRow {TR} at (16,0) size 34x531
+            RenderTableRow {TR} at (16,16) size 34x499
               RenderTableCell {TH} at (16,16) size 34x115 [border: (3px solid #800080)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (8,15) size 18x84
                   text run at (8,15) width 83: "Header One"
@@ -114,7 +114,7 @@ layer at (0,0) size 785x884
               RenderTableCell {TH} at (16,297) size 34x219 [border: (3px solid #800080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (8,61) size 18x96
                   text run at (8,61) width 95: "Header Three"
-            RenderTableRow {TR} at (66,0) size 102x531
+            RenderTableRow {TR} at (66,16) size 102x499
               RenderTableCell {TD} at (66,34) size 102x79 [border: (1px solid #008000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (24,6) size 54x96
                   text run at (24,-12) width 96: "This table uses"
@@ -132,7 +132,7 @@ layer at (0,0) size 785x884
                   text run at (24,-12) width 205: "The borders on the header cells,"
                   text run at (42,-12) width 199: "on all sides, should be medium"
                   text run at (60,-12) width 80: "solid purple."
-            RenderTableRow {TR} at (184,0) size 102x531
+            RenderTableRow {TR} at (184,16) size 102x499
               RenderTableCell {TD} at (184,16) size 102x115 [border: (1px solid #008000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (6,6) size 90x91
                   text run at (6,6) width 88: "The border of"
@@ -230,7 +230,7 @@ layer at (0,0) size 785x884
                   text run at (114,6) width 42: "100%."
         RenderTable {TABLE} at (958,16) size 280x537 [border: (3px solid #0000FF)]
           RenderTableSection {TBODY} at (3,3) size 274x531
-            RenderTableRow {TR} at (0,0) size 34x531
+            RenderTableRow {TR} at (0,8) size 34x515
               RenderTableCell {TH} at (0,8) size 34x145 [border: (3px solid #800080)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (8,30) size 18x84
                   text run at (8,30) width 83: "Header One"
@@ -240,7 +240,7 @@ layer at (0,0) size 785x884
               RenderTableCell {TH} at (0,314) size 34x210 [border: (3px solid #800080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (8,57) size 18x95
                   text run at (8,57) width 95: "Header Three"
-            RenderTableRow {TR} at (34,0) size 102x531
+            RenderTableRow {TR} at (34,8) size 102x515
               RenderTableCell {TD} at (34,26) size 102x109 [border: (1px solid #008000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (24,6) size 54x119
                   text run at (24,-12) width 119: "This table uses the"
@@ -259,7 +259,7 @@ layer at (0,0) size 785x884
                   text run at (42,-12) width 38: "cells, "
                   text run at (42,25) width 142: "on all sides, should be"
                   text run at (60,-12) width 137: "medium solid purple."
-            RenderTableRow {TR} at (136,0) size 138x531
+            RenderTableRow {TR} at (136,8) size 138x515
               RenderTableCell {TD} at (136,17) size 138x127 [border: (1px solid #008000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (15,6) size 108x132
                   text run at (15,-3) width 112: "The border of the"
@@ -304,7 +304,7 @@ layer at (0,0) size 785x884
             RenderTableCol {COL} at (0,0) size 0x0 [border: (3px solid #FF0000)]
             RenderTableCol {COL} at (0,0) size 0x0 [border: (3px solid #FF0000)]
           RenderTableSection {THEAD} at (18,0) size 50x537 [border: (3px solid #FF0000)]
-            RenderTableRow {TR} at (2,0) size 46x537 [border: (3px solid #FF0000)]
+            RenderTableRow {TR} at (2,2) size 46x533 [border: (3px solid #FF0000)]
               RenderTableCell {TH} at (2,2) size 46x88 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (5,18) size 36x51
                   text run at (5,18) width 51: "Header"
@@ -316,7 +316,7 @@ layer at (0,0) size 785x884
                 RenderText {#text} at (14,56) size 18x96
                   text run at (14,47) width 95: "Header Three"
           RenderTableSection {TBODY} at (68,0) size 204x537 [border: (3px solid #FF0000)]
-            RenderTableRow {TR} at (0,0) size 100x537 [border: (3px solid #FF0000)]
+            RenderTableRow {TR} at (0,2) size 100x533 [border: (3px solid #FF0000)]
               RenderTableCell {TD} at (0,2) size 100x88 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (5,5) size 90x64
                   text run at (5,5) width 64: "This table"
@@ -336,7 +336,7 @@ layer at (0,0) size 785x884
                   text run at (32,-4) width 187: "elements that represent rows,"
                   text run at (50,-4) width 158: "row-groups, columns, or"
                   text run at (68,-4) width 101: "column-groups."
-            RenderTableRow {TR} at (102,0) size 100x537 [border: (3px solid #FF0000)]
+            RenderTableRow {TR} at (102,2) size 100x533 [border: (3px solid #FF0000)]
               RenderTableCell {TD} at (102,2) size 100x88 [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (5,5) size 90x68
                   text run at (5,5) width 38: "There"

--- a/LayoutTests/platform/mac/fast/table/border-collapsing/border-collapsing-head-foot-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/border-collapsing/border-collapsing-head-foot-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
           text run at (739,0) width 5: "."
       RenderTable {TABLE} at (0,44) size 317x307
         RenderTableSection {TBODY} at (0,0) size 317x307
-          RenderTableRow {TR} at (0,2) size 317x303
+          RenderTableRow {TR} at (2,2) size 313x303
             RenderTableCell {TD} at (2,2) size 77x303 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (11,11) size 55x87 [border: none]
                 RenderTableSection {THEAD} at (0,0) size 54x21

--- a/LayoutTests/platform/mac/fast/table/border-collapsing/border-collapsing-head-foot-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/border-collapsing/border-collapsing-head-foot-vertical-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
           text run at (739,0) width 5: "."
       RenderTable {TABLE} at (0,44) size 418x210
         RenderTableSection {TBODY} at (0,0) size 418x210
-          RenderTableRow {TR} at (0,2) size 418x206
+          RenderTableRow {TR} at (2,2) size 414x206
             RenderTableCell {TD} at (2,2) size 102x206 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (11,11) size 86x55 [border: none]
                 RenderTableSection {THEAD} at (0,0) size 21x54

--- a/LayoutTests/platform/mac/fast/table/cell-absolute-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/cell-absolute-child-expected.txt
@@ -21,12 +21,12 @@ layer at (0,0) size 800x600
           text run at (0,0) width 541: "You should see two identical green squares, 100x100 pixels each, next to each other."
       RenderTable {TABLE} at (0,86) size 106x156
         RenderTableSection {TBODY} at (0,0) size 106x156
-          RenderTableRow {TR} at (0,2) size 106x50
+          RenderTableRow {TR} at (2,2) size 102x50
             RenderTableCell {TD} at (2,26) size 102x2 [r=0 c=0 rs=1 cs=2]
-          RenderTableRow {TR} at (0,54) size 106x100
+          RenderTableRow {TR} at (2,54) size 102x100
             RenderTableCell {TD} at (2,54) size 100x2 [bgcolor=#008000] [r=1 c=0 rs=1 cs=1]
             RenderTableCell (anonymous) at (104,54) size 0x0 [r=1 c=1 rs=1 cs=1]
-layer at (11,149) size 98x98
-  RenderBlock (positioned) {DIV} at (11,149) size 98x98
-layer at (112,148) size 102x102
-  RenderBlock (positioned) {TD} at (112,148) size 102x102 [bgcolor=#008000]
+layer at (13,149) size 98x98
+  RenderBlock (positioned) {DIV} at (13,149) size 98x98
+layer at (114,148) size 102x102
+  RenderBlock (positioned) {TD} at (114,148) size 102x102 [bgcolor=#008000]

--- a/LayoutTests/platform/mac/fast/table/cell-pref-width-invalidation-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/cell-pref-width-invalidation-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x24
         RenderTableSection {TBODY} at (0,0) size 784x24
-          RenderTableRow {TR} at (0,2) size 784x20
+          RenderTableRow {TR} at (2,2) size 780x20
             RenderTableCell {TD} at (2,2) size 62x20 [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (66,11) size 716x2 [r=0 c=1 rs=1 cs=1]
       RenderBlock {DIV} at (0,24) size 784x0

--- a/LayoutTests/platform/mac/fast/table/cell-width-auto-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/cell-width-auto-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x514
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
           RenderTableSection {TBODY} at (0,0) size 256x186
-            RenderTableRow {TR} at (0,2) size 256x182
+            RenderTableRow {TR} at (2,2) size 252x182
               RenderTableCell {TD} at (2,2) size 150x182 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 148x180
                   text run at (1,1) width 91: "Cras tincidunt"
@@ -36,7 +36,7 @@ layer at (0,0) size 800x514
             text run at (0,0) width 153: "Table 2: width in <TD>"
         RenderTable {TABLE} at (0,304) size 260x186
           RenderTableSection {TBODY} at (0,0) size 260x186
-            RenderTableRow {TR} at (0,2) size 260x182
+            RenderTableRow {TR} at (2,2) size 256x182
               RenderTableCell {TD} at (2,2) size 152x182 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 149x180
                   text run at (1,1) width 91: "Cras tincidunt"

--- a/LayoutTests/platform/mac/fast/table/cellindex-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/cellindex-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 154x24
         RenderTableSection {TBODY} at (0,0) size 154x24
-          RenderTableRow {TR} at (0,2) size 154x20
+          RenderTableRow {TR} at (2,2) size 150x20
             RenderTableCell {TH} at (2,2) size 65x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 63x18
                 text run at (1,1) width 63: "Header 1"

--- a/LayoutTests/platform/mac/fast/table/colgroup-preceded-by-caption-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/colgroup-preceded-by-caption-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x136
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0 [bgcolor=#FFFF00]
         RenderTableSection {TBODY} at (0,36) size 275x24
-          RenderTableRow {TR} at (0,2) size 275x20
+          RenderTableRow {TR} at (2,2) size 271x20
             RenderTableCell {TD} at (2,2) size 271x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 269x18
                 text run at (1,1) width 269: "This line should have yellow background."
@@ -23,7 +23,7 @@ layer at (0,0) size 800x136
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0 [bgcolor=#FFFF00]
         RenderTableSection {TBODY} at (0,36) size 275x24
-          RenderTableRow {TR} at (0,2) size 275x20
+          RenderTableRow {TR} at (2,2) size 271x20
             RenderTableCell {TD} at (2,2) size 271x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 269x18
                 text run at (1,1) width 269: "This line should have yellow background."

--- a/LayoutTests/platform/mac/fast/table/colspan-with-all-percent-cells-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/colspan-with-all-percent-cells-expected.txt
@@ -5,13 +5,13 @@ layer at (0,0) size 800x276
     RenderBody {BODY} at (8,8) size 784x260
       RenderTable {TABLE} at (0,0) size 608x260
         RenderTableSection {TBODY} at (0,0) size 608x260
-          RenderTableRow {TR} at (0,2) size 608x154
+          RenderTableRow {TR} at (2,2) size 604x154
             RenderTableCell {TD} at (2,2) size 604x154 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=3]
               RenderTable {TABLE} at (2,2) size 600x150
                 RenderTableSection {TBODY} at (0,0) size 600x150
-                  RenderTableRow {TR} at (0,2) size 600x146
+                  RenderTableRow {TR} at (2,2) size 596x146
                     RenderTableCell {TD} at (2,74) size 596x2 [r=0 c=0 rs=1 cs=1]
-          RenderTableRow {TR} at (0,158) size 608x100
+          RenderTableRow {TR} at (2,158) size 604x100
             RenderTableCell {TD} at (2,158) size 113x4 [bgcolor=#008000] [border: (1px solid #000000)] [r=1 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (116,158) size 376x4 [bgcolor=#0000FF] [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
             RenderTableCell {TD} at (493,158) size 113x4 [bgcolor=#008000] [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/colspanMinWidth-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/colspanMinWidth-expected.txt
@@ -5,17 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 168x39
         RenderTableSection {TBODY} at (0,0) size 168x39
-          RenderTableRow {TR} at (0,2) size 168x2
+          RenderTableRow {TR} at (2,2) size 164x2
             RenderTableCell {TD} at (2,2) size 3x2 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=1]
-          RenderTableRow {TR} at (0,6) size 168x0
+          RenderTableRow {TR} at (2,6) size 164x0
             RenderTableCell {TD} at (2,6) size 160x2 [bgcolor=#008000] [r=1 c=0 rs=2 cs=2]
-          RenderTableRow {TR} at (0,8) size 168x0
+          RenderTableRow {TR} at (2,8) size 164x0
             RenderTableCell {TD} at (163,21) size 3x3 [bgcolor=#FF0000] [r=2 c=2 rs=2 cs=1]
-          RenderTableRow {TR} at (0,10) size 168x27
+          RenderTableRow {TR} at (2,10) size 164x27
             RenderTableCell {TD} at (2,10) size 160x27 [bgcolor=#00FFFF] [r=3 c=0 rs=1 cs=2]
               RenderTable {TABLE} at (1,1) size 158x25
                 RenderTableSection {TBODY} at (0,0) size 158x25
-                  RenderTableRow {TR} at (0,2) size 158x21
+                  RenderTableRow {TR} at (2,2) size 154x21
                     RenderTableCell {TD} at (2,11) size 2x3 [bgcolor=#FF00FF] [r=0 c=0 rs=1 cs=1]
                     RenderTableCell {TD} at (6,2) size 150x21 [bgcolor=#FFFF00] [r=0 c=1 rs=1 cs=1]
                       RenderTextControl {INPUT} at (1,1) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/mac/fast/table/dynamic-cellpadding-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/dynamic-cellpadding-expected.txt
@@ -5,14 +5,14 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 120x108 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 118x106
-          RenderTableRow {TR} at (0,2) size 118x50
+          RenderTableRow {TR} at (2,2) size 114x50
             RenderTableCell {TD} at (2,2) size 56x50 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (16,16) size 24x18
                 text run at (16,16) width 24: "100"
             RenderTableCell {TD} at (60,2) size 56x50 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (16,16) size 24x18
                 text run at (16,16) width 24: "200"
-          RenderTableRow {TR} at (0,54) size 118x50
+          RenderTableRow {TR} at (2,54) size 114x50
             RenderTableCell {TD} at (2,54) size 56x50 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (16,16) size 24x18
                 text run at (16,16) width 24: "300"

--- a/LayoutTests/platform/mac/fast/table/dynamic-descendant-percentage-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/dynamic-descendant-percentage-height-expected.txt
@@ -8,14 +8,14 @@ layer at (0,0) size 800x600
           text run at (0,0) width 357: "The following two green rectangles should be identical:"
       RenderTable {TABLE} at (0,34) size 284x104
         RenderTableSection {TBODY} at (0,0) size 284x104
-          RenderTableRow {TR} at (0,2) size 284x100
+          RenderTableRow {TR} at (2,2) size 280x100
             RenderTableCell {TD} at (2,2) size 280x100 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 278x98 [bgcolor=#008000] [border: (3px solid #000000)]
                 RenderText {#text} at (3,3) size 272x18
                   text run at (3,3) width 272: "This text should have a green background."
       RenderTable {TABLE} at (0,138) size 284x104
         RenderTableSection {TBODY} at (0,0) size 284x104
-          RenderTableRow {TR} at (0,2) size 284x100
+          RenderTableRow {TR} at (2,2) size 280x100
             RenderTableCell {TD} at (2,2) size 280x100 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 278x98 [bgcolor=#008000] [border: (3px solid #000000)]
                 RenderText {#text} at (3,3) size 272x18

--- a/LayoutTests/platform/mac/fast/table/early-table-layout-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/early-table-layout-expected.txt
@@ -5,14 +5,14 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 500x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 498x50
-          RenderTableRow {TR} at (0,2) size 498x22
+          RenderTableRow {TR} at (2,2) size 494x22
             RenderTableCell {TD} at (2,2) size 246x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 48x18
                 text run at (2,2) width 48: "cell 1,1"
             RenderTableCell {TD} at (250,2) size 246x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 48x18
                 text run at (2,2) width 48: "cell 1,2"
-          RenderTableRow {TR} at (0,26) size 498x22
+          RenderTableRow {TR} at (2,26) size 494x22
             RenderTableCell {TD} at (2,26) size 246x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 48x18
                 text run at (2,2) width 48: "cell 2,1"

--- a/LayoutTests/platform/mac/fast/table/edge-offsets-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/edge-offsets-expected.txt
@@ -29,19 +29,19 @@ layer at (8,104) size 102x102 clip at (9,105) size 100x85 scrollWidth 133
   RenderBlock {DIV} at (0,96) size 102x102 [border: (1px solid #0000FF)]
     RenderTable {TABLE} at (1,1) size 6x6
       RenderTableSection {TBODY} at (0,0) size 6x6
-        RenderTableRow {TR} at (0,2) size 6x2
+        RenderTableRow {TR} at (2,2) size 2x2
           RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=1 cs=1]
 layer at (8,224) size 102x102 clip at (9,225) size 100x85 scrollX 33 scrollWidth 133
   RenderBlock {DIV} at (0,216) size 102x102 [border: (1px solid #0000FF)]
     RenderTable {TABLE} at (95,1) size 6x6
       RenderTableSection {TBODY} at (0,0) size 6x6
-        RenderTableRow {TR} at (0,2) size 6x2
+        RenderTableRow {TR} at (2,2) size 2x2
           RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=1 cs=1]
 layer at (8,344) size 102x102 clip at (9,345) size 85x100 scrollHeight 133
   RenderBlock {DIV} at (0,336) size 102x102 [border: (1px solid #0000FF)]
     RenderTable {TABLE} at (1,1) size 6x6
       RenderTableSection {TBODY} at (0,0) size 6x6
-        RenderTableRow {TR} at (0,2) size 6x2
+        RenderTableRow {TR} at (2,2) size 2x2
           RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=1 cs=1]
 layer at (82,108) size 60x60 backgroundClip at (9,105) size 100x85 clip at (9,105) size 100x85
   RenderBlock (positioned) {DIV} at (70,0) size 60x60 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/fast/table/empty-cells-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/empty-cells-expected.txt
@@ -63,7 +63,7 @@ layer at (0,0) size 785x783
                 text run at (1,1) width 243: "First cell empty, table has cellpadding"
       RenderTable {TABLE} at (0,232) size 785x31 [border: (2px solid #000000)]
         RenderTableSection {TBODY} at (2,2) size 781x27
-          RenderTableRow {TR} at (0,1) size 781x25
+          RenderTableRow {TR} at (1,1) size 779x25
             RenderTableCell {TD} at (1,13) size 0x0 [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (2,4) size 778x19 [bgcolor=#FF0000] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (0,3) size 240x19

--- a/LayoutTests/platform/mac/fast/table/empty-table-percent-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/empty-table-percent-height-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#994444]
       RenderTable {TABLE} at (0,0) size 784x584 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x582
-          RenderTableRow {TR} at (0,2) size 782x578
+          RenderTableRow {TR} at (2,2) size 778x578
             RenderTableCell {TD} at (2,289) size 622x4 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (626,280) size 154x22 [border: (1px dashed #552222)] [r=0 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (2,280) size 150x0

--- a/LayoutTests/platform/mac/fast/table/fixed-nested-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-nested-expected.txt
@@ -5,12 +5,12 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 740x28 [bgcolor=#008000]
         RenderTableSection {TBODY} at (0,0) size 740x28
-          RenderTableRow {TR} at (0,2) size 740x24
+          RenderTableRow {TR} at (2,2) size 736x24
             RenderTableCell {TD} at (2,14) size 1x0 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (5,2) size 733x24 [r=0 c=1 rs=1 cs=1]
               RenderTable {TABLE} at (0,0) size 587x24
                 RenderTableSection {TBODY} at (0,0) size 587x24
-                  RenderTableRow {TR} at (0,2) size 587x20
+                  RenderTableRow {TR} at (2,2) size 583x20
                     RenderTableCell {TD} at (2,2) size 583x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 108x18
                         text run at (1,1) width 108: "here is some text"

--- a/LayoutTests/platform/mac/fast/table/fixed-table-non-cell-in-row-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-non-cell-in-row-expected.txt
@@ -17,5 +17,5 @@ layer at (0,0) size 800x600
           text run at (0,0) width 438: "The test is simply that the empty table below does not cause a crash."
       RenderTable {TABLE} at (0,86) size 100x100 [border: (3px solid #FF0000)]
         RenderTableSection {TBODY} at (3,3) size 94x94
-          RenderTableRow {TR} at (0,2) size 94x90
+          RenderTableRow {TR} at (2,2) size 90x90
             RenderTableCell {TD} at (2,46) size 90x2 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-inside-percent-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-inside-percent-table-expected.txt
@@ -5,13 +5,13 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x34 [bgcolor=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 784x34
-          RenderTableRow {TR} at (0,2) size 784x2
+          RenderTableRow {TR} at (2,2) size 780x2
             RenderTableCell {TD} at (2,2) size 780x2 [r=0 c=0 rs=1 cs=1]
-          RenderTableRow {TR} at (0,6) size 784x26
+          RenderTableRow {TR} at (2,6) size 780x26
             RenderTableCell {TD} at (2,6) size 780x26 [r=1 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 778x24 [bgcolor=#008000]
                 RenderTableSection {TBODY} at (0,0) size 778x24
-                  RenderTableRow {TR} at (0,2) size 778x20
+                  RenderTableRow {TR} at (2,2) size 774x20
                     RenderTableCell {TD} at (2,2) size 774x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 51x18
                         text run at (1,1) width 51: "Content"

--- a/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-auto-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-auto-table-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x36 [bgcolor=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 784x36
-          RenderTableRow {TR} at (0,2) size 784x32
+          RenderTableRow {TR} at (2,2) size 780x32
             RenderTableCell {TD} at (2,2) size 780x32 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 778x30 [bgcolor=#0000FF]
                 RenderTableSection {TBODY} at (0,0) size 778x30
-                  RenderTableRow {TR} at (0,2) size 778x26
+                  RenderTableRow {TR} at (2,2) size 774x26
                     RenderTableCell {TD} at (2,2) size 774x26 [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (1,1) size 772x24 [bgcolor=#008000]
                         RenderTableSection {TBODY} at (0,0) size 772x24
-                          RenderTableRow {TR} at (0,2) size 772x20
+                          RenderTableRow {TR} at (2,2) size 768x20
                             RenderTableCell {TD} at (2,2) size 768x20 [r=0 c=0 rs=1 cs=1]
                               RenderText {#text} at (1,1) size 51x18
                                 text run at (1,1) width 51: "Content"

--- a/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-div-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-div-expected.txt
@@ -5,16 +5,16 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x36 [bgcolor=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 784x36
-          RenderTableRow {TR} at (0,2) size 784x32
+          RenderTableRow {TR} at (2,2) size 780x32
             RenderTableCell {TD} at (2,2) size 780x32 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 150x30 [bgcolor=#800080]
                 RenderTable {TABLE} at (0,0) size 150x30 [bgcolor=#0000FF]
                   RenderTableSection {TBODY} at (0,0) size 150x30
-                    RenderTableRow {TR} at (0,2) size 150x26
+                    RenderTableRow {TR} at (2,2) size 146x26
                       RenderTableCell {TD} at (2,2) size 146x26 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TABLE} at (1,1) size 144x24 [bgcolor=#008000]
                           RenderTableSection {TBODY} at (0,0) size 144x24
-                            RenderTableRow {TR} at (0,2) size 144x20
+                            RenderTableRow {TR} at (2,2) size 140x20
                               RenderTableCell {TD} at (2,2) size 140x20 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (1,1) size 51x18
                                   text run at (1,1) width 51: "Content"

--- a/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-fixed-width-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-with-percent-width-inside-fixed-width-table-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x60 [bgcolor=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 784x60
-          RenderTableRow {TR} at (0,2) size 784x56
+          RenderTableRow {TR} at (2,2) size 780x56
             RenderTableCell {TD} at (2,2) size 780x56 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 778x54
                 RenderBlock (anonymous) at (0,0) size 778x18
@@ -13,15 +13,15 @@ layer at (0,0) size 800x600
                     text run at (0,0) width 24: "boo"
                 RenderTable {TABLE} at (0,18) size 100x36 [bgcolor=#800080]
                   RenderTableSection {TBODY} at (0,0) size 100x36
-                    RenderTableRow {TR} at (0,2) size 100x32
+                    RenderTableRow {TR} at (2,2) size 96x32
                       RenderTableCell {TD} at (2,2) size 96x32 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TABLE} at (1,1) size 94x30 [bgcolor=#0000FF]
                           RenderTableSection {TBODY} at (0,0) size 94x30
-                            RenderTableRow {TR} at (0,2) size 94x26
+                            RenderTableRow {TR} at (2,2) size 90x26
                               RenderTableCell {TD} at (2,2) size 90x26 [r=0 c=0 rs=1 cs=1]
                                 RenderTable {TABLE} at (1,1) size 88x24 [bgcolor=#008000]
                                   RenderTableSection {TBODY} at (0,0) size 88x24
-                                    RenderTableRow {TR} at (0,2) size 88x20
+                                    RenderTableRow {TR} at (2,2) size 84x20
                                       RenderTableCell {TD} at (2,2) size 84x20 [r=0 c=0 rs=1 cs=1]
                                         RenderText {#text} at (1,1) size 51x18
                                           text run at (1,1) width 51: "Content"

--- a/LayoutTests/platform/mac/fast/table/fixed-table-with-small-percent-width-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/fixed-table-with-small-percent-width-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x36 [bgcolor=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 784x36
-          RenderTableRow {TR} at (0,2) size 784x32
+          RenderTableRow {TR} at (2,2) size 780x32
             RenderTableCell {TD} at (2,2) size 780x32 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 778x30 [bgcolor=#0000FF]
                 RenderTableSection {TBODY} at (0,0) size 778x30
-                  RenderTableRow {TR} at (0,2) size 778x26
+                  RenderTableRow {TR} at (2,2) size 774x26
                     RenderTableCell {TD} at (2,2) size 774x26 [r=0 c=0 rs=1 cs=1]
                       RenderTable {TABLE} at (1,1) size 386x24 [bgcolor=#008000]
                         RenderTableSection {TBODY} at (0,0) size 386x24
-                          RenderTableRow {TR} at (0,2) size 386x20
+                          RenderTableRow {TR} at (2,2) size 382x20
                             RenderTableCell {TD} at (2,2) size 382x20 [r=0 c=0 rs=1 cs=1]
                               RenderText {#text} at (1,1) size 51x18
                                 text run at (1,1) width 51: "Content"

--- a/LayoutTests/platform/mac/fast/table/floating-th-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/floating-th-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 165x92 [border: (1px solid #000000)]
         RenderTableSection {THEAD} at (1,1) size 163x24
-          RenderTableRow {TR} at (0,2) size 163x20
+          RenderTableRow {TR} at (2,2) size 159x20
             RenderTableCell (anonymous) at (2,2) size 101x20 [r=0 c=0 rs=1 cs=1]
               RenderBlock (floating) {TH} at (0,0) size 51x20
                 RenderText {#text} at (1,1) size 49x18
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (1,1) size 49x18
                   text run at (1,1) width 49: "Head 2"
         RenderTableSection {TFOOT} at (1,69) size 163x22
-          RenderTableRow {TR} at (0,0) size 163x20
+          RenderTableRow {TR} at (2,0) size 159x20
             RenderTableCell {TD} at (2,0) size 101x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 54x18
                 text run at (1,1) width 54: "Footer 1"
@@ -22,14 +22,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (1,1) size 54x18
                 text run at (1,1) width 54: "Footer 2"
         RenderTableSection {TBODY} at (1,25) size 163x44
-          RenderTableRow {TR} at (0,0) size 163x20
+          RenderTableRow {TR} at (2,0) size 159x20
             RenderTableCell {TD} at (2,0) size 101x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 1"
             RenderTableCell {TD} at (104,0) size 57x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 2"
-          RenderTableRow {TR} at (0,22) size 163x20
+          RenderTableRow {TR} at (2,22) size 159x20
             RenderTableCell {TD} at (2,22) size 101x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 3"

--- a/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
@@ -2220,12 +2220,12 @@ layer at (393,24) size 392x150
       RenderTableCol {COLGROUP} at (0,0) size 0x0
       RenderTableCol {COLGROUP} at (0,0) size 0x0
       RenderTableSection {THEAD} at (0,18) size 355x40
-        RenderTableRow {TR} at (0,2) size 355x17
+        RenderTableRow {TR} at (2,2) size 351x17
           RenderTableCell {TH} at (2,19) size 73x2 [r=0 c=0 rs=2 cs=2]
           RenderTableCell {TH} at (76,2) size 277x17 [r=0 c=2 rs=1 cs=9]
             RenderText {#text} at (120,1) size 35x15
               text run at (120,1) width 35: "Frame"
-        RenderTableRow {TR} at (0,21) size 355x17
+        RenderTableRow {TR} at (2,21) size 351x17
           RenderTableCell {TH} at (76,21) size 27x17 [r=1 c=2 rs=1 cs=1]
             RenderText {#text} at (1,1) size 24x15
               text run at (1,1) width 24: "void"
@@ -2254,7 +2254,7 @@ layer at (393,24) size 392x150
             RenderText {#text} at (1,1) size 35x15
               text run at (1,1) width 35: "border"
       RenderTableSection {TBODY} at (0,58) size 355x95
-        RenderTableRow {TR} at (0,0) size 355x17
+        RenderTableRow {TR} at (2,0) size 351x17
           RenderTableCell {TH} at (2,38) size 33x17 [r=0 c=0 rs=5 cs=1]
             RenderText {#text} at (1,39) size 31x15
               text run at (1,1) width 31: "Rules"
@@ -2297,7 +2297,7 @@ layer at (393,24) size 392x150
             RenderInline {A} at (11,1) size 15x15 [color=#0000EE]
               RenderText {#text} at (11,1) size 15x15
                 text run at (11,1) width 15: "Go"
-        RenderTableRow {TR} at (0,19) size 355x17
+        RenderTableRow {TR} at (2,19) size 351x17
           RenderTableCell {TH} at (36,19) size 39x17 [r=1 c=1 rs=1 cs=1]
             RenderText {#text} at (1,1) size 37x15
               text run at (1,1) width 37: "groups"
@@ -2337,7 +2337,7 @@ layer at (393,24) size 392x150
             RenderInline {A} at (11,1) size 15x15 [color=#0000EE]
               RenderText {#text} at (11,1) size 15x15
                 text run at (11,1) width 15: "Go"
-        RenderTableRow {TR} at (0,38) size 355x17
+        RenderTableRow {TR} at (2,38) size 351x17
           RenderTableCell {TH} at (36,38) size 39x17 [r=2 c=1 rs=1 cs=1]
             RenderText {#text} at (11,1) size 27x15
               text run at (11,1) width 27: "rows"
@@ -2377,7 +2377,7 @@ layer at (393,24) size 392x150
             RenderInline {A} at (11,1) size 15x15 [color=#0000EE]
               RenderText {#text} at (11,1) size 15x15
                 text run at (11,1) width 15: "Go"
-        RenderTableRow {TR} at (0,57) size 355x17
+        RenderTableRow {TR} at (2,57) size 351x17
           RenderTableCell {TH} at (36,57) size 39x17 [r=3 c=1 rs=1 cs=1]
             RenderText {#text} at (15,1) size 23x15
               text run at (15,1) width 23: "cols"
@@ -2417,7 +2417,7 @@ layer at (393,24) size 392x150
             RenderInline {A} at (11,1) size 15x15 [color=#0000EE]
               RenderText {#text} at (11,1) size 15x15
                 text run at (11,1) width 15: "Go"
-        RenderTableRow {TR} at (0,76) size 355x17
+        RenderTableRow {TR} at (2,76) size 351x17
           RenderTableCell {TH} at (36,76) size 39x17 [r=4 c=1 rs=1 cs=1]
             RenderText {#text} at (23,1) size 15x15
               text run at (23,1) width 15: "all"

--- a/LayoutTests/platform/mac/fast/table/giantRowspan-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/giantRowspan-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,10) size 6x6
         RenderTableSection {TBODY} at (0,0) size 6x6
-          RenderTableRow {TR} at (0,2) size 6x2
+          RenderTableRow {TR} at (2,2) size 2x2
             RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=65534 cs=1]
 layer at (8,8) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 784x2 [color=#808080] [border: (1px inset #808080)]

--- a/LayoutTests/platform/mac/fast/table/insert-cell-before-form-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/insert-cell-before-form-expected.txt
@@ -19,11 +19,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 274: "There should be a line of green text below."
       RenderTable {TABLE} at (0,68) size 150x30 [color=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 150x30
-          RenderTableRow {TR} at (0,2) size 150x26
+          RenderTableRow {TR} at (2,2) size 146x26
             RenderTableCell {TD} at (2,2) size 146x26 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 144x24 [color=#000000]
                 RenderTableSection {TBODY} at (0,0) size 144x24
-                  RenderTableRow {TR} at (0,2) size 144x20 [color=#008000]
+                  RenderTableRow {TR} at (2,2) size 140x20 [color=#008000]
                     RenderTableCell {TD} at (2,2) size 140x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 138x18
                         text run at (1,1) width 138: "This should be green."

--- a/LayoutTests/platform/mac/fast/table/insert-row-before-form-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/insert-row-before-form-expected.txt
@@ -19,11 +19,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 274: "There should be a line of green text below."
       RenderTable {TABLE} at (0,68) size 150x30 [color=#FF0000]
         RenderTableSection {TBODY} at (0,0) size 150x30
-          RenderTableRow {TR} at (0,2) size 150x26
+          RenderTableRow {TR} at (2,2) size 146x26
             RenderTableCell {TD} at (2,2) size 146x26 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 144x24 [color=#008000]
                 RenderTableSection {TBODY} at (0,0) size 144x24
-                  RenderTableRow {TR} at (0,2) size 144x20
+                  RenderTableRow {TR} at (2,2) size 140x20
                     RenderTableCell {TD} at (2,2) size 140x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 138x18
                         text run at (1,1) width 138: "This should be green."

--- a/LayoutTests/platform/mac/fast/table/large-width-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/large-width-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x64 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x62
-          RenderTableRow {TR} at (0,2) size 782x58
+          RenderTableRow {TR} at (2,2) size 778x58
             RenderTableCell {TD} at (2,20) size 22x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (26,2) size 754x58 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (11,11) size 720x36

--- a/LayoutTests/platform/mac/fast/table/max-width-integer-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/max-width-integer-overflow-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
                       RenderBlock {DIV} at (0,0) size 310x24
                         RenderTable {TABLE} at (0,0) size 310x24 [bgcolor=#008000]
                           RenderTableSection {TBODY} at (0,0) size 310x24
-                            RenderTableRow {TR} at (0,2) size 310x20
+                            RenderTableRow {TR} at (2,2) size 306x20
                               RenderTableCell {TD} at (2,11) size 302x2 [r=0 c=0 rs=1 cs=1]
                               RenderTableCell {TD} at (306,11) size 2x2 [r=0 c=1 rs=1 cs=1]
             RenderTableCell {TD} at (755,0) size 25x24 [r=0 c=1 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/mozilla-bug10296-vertical-align-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/mozilla-bug10296-vertical-align-1-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x358
           text run at (0,0) width 547: "In each of the following tables the cells with 'Data' should all have the same baseline:"
       RenderTable {TABLE} at (0,92) size 459x119
         RenderTableSection {TBODY} at (0,0) size 459x118
-          RenderTableRow {TR} at (0,2) size 459x114
+          RenderTableRow {TR} at (2,2) size 455x114
             RenderTableCell {TD} at (2,74) size 35x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,74) size 31x18
                 text run at (2,2) width 31: "Data"
@@ -32,7 +32,7 @@ layer at (0,0) size 800x358
                 text run at (2,2) width 49: "Bottom"
       RenderTable {TABLE} at (0,210) size 459x119
         RenderTableSection {TBODY} at (0,0) size 459x118
-          RenderTableRow {TR} at (0,2) size 459x114
+          RenderTableRow {TR} at (2,2) size 455x114
             RenderTableCell {TD} at (2,2) size 29x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 25x18
                 text run at (2,2) width 25: "Top"

--- a/LayoutTests/platform/mac/fast/table/mozilla-bug10296-vertical-align-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/mozilla-bug10296-vertical-align-2-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x476
           text run at (0,0) width 547: "In each of the following tables the cells with 'Data' should all have the same baseline:"
       RenderTable {TABLE} at (0,92) size 459x119
         RenderTableSection {TBODY} at (0,0) size 459x118
-          RenderTableRow {TR} at (0,2) size 459x114
+          RenderTableRow {TR} at (2,2) size 455x114
             RenderTableCell {TD} at (2,2) size 186x114 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 182x110
                 text run at (2,2) width 182: "Data"
@@ -32,7 +32,7 @@ layer at (0,0) size 800x476
                 text run at (2,2) width 91: "Data"
       RenderTable {TABLE} at (0,210) size 459x119
         RenderTableSection {TBODY} at (0,0) size 459x118
-          RenderTableRow {TR} at (0,2) size 459x114
+          RenderTableRow {TR} at (2,2) size 455x114
             RenderTableCell {TD} at (2,2) size 29x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 25x18
                 text run at (2,2) width 25: "Top"
@@ -53,7 +53,7 @@ layer at (0,0) size 800x476
                 text run at (2,2) width 182: "Data"
       RenderTable {TABLE} at (0,328) size 459x119
         RenderTableSection {TBODY} at (0,0) size 459x118
-          RenderTableRow {TR} at (0,2) size 459x114
+          RenderTableRow {TR} at (2,2) size 455x114
             RenderTableCell {TD} at (2,2) size 29x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 25x18
                 text run at (2,2) width 25: "Top"

--- a/LayoutTests/platform/mac/fast/table/multiple-captions-display-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/multiple-captions-display-expected.txt
@@ -5,31 +5,31 @@ layer at (0,0) size 800x280
     RenderBody {body} at (8,8) size 784x264
       RenderTable {table} at (0,0) size 128x264
         RenderTableSection (anonymous) at (0,148) size 128x2
-          RenderTableRow (anonymous) at (0,0) size 128x0
+          RenderTableRow (anonymous) at (2,0) size 124x0
             RenderTableCell (anonymous) at (2,0) size 124x0 [r=0 c=0 rs=1 cs=1]
         RenderBlock {caption} at (0,36) size 128x36
           RenderText {#text} at (16,0) size 95x36
             text run at (16,0) width 95: "PASS: Normal"
             text run at (38,18) width 52: "Caption"
         RenderTableSection {thead} at (0,126) size 128x22
-          RenderTableRow (anonymous) at (0,2) size 128x18
+          RenderTableRow (anonymous) at (2,2) size 124x18
             RenderTableCell (anonymous) at (2,2) size 124x18 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 65x18
                 text run at (0,0) width 65: "HEADER"
         RenderTableSection {tbody} at (0,150) size 128x38
-          RenderTableRow (anonymous) at (0,0) size 128x36
+          RenderTableRow (anonymous) at (2,0) size 124x36
             RenderTableCell (anonymous) at (2,0) size 124x36 [r=0 c=0 rs=1 cs=1]
               RenderBR {br} at (0,0) size 0x18
               RenderText {#text} at (0,18) size 124x18
                 text run at (0,18) width 124: "Some body content"
               RenderBR {br} at (123,18) size 1x18
         RenderTableSection {tfoot} at (0,190) size 128x20
-          RenderTableRow (anonymous) at (0,0) size 128x18
+          RenderTableRow (anonymous) at (2,0) size 124x18
             RenderTableCell (anonymous) at (2,0) size 124x18 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 63x18
                 text run at (0,0) width 63: "FOOTER"
         RenderTableSection (anonymous) at (0,188) size 128x2
-          RenderTableRow (anonymous) at (0,0) size 128x0
+          RenderTableRow (anonymous) at (2,0) size 124x0
             RenderTableCell (anonymous) at (2,0) size 124x0 [r=0 c=0 rs=1 cs=1]
         RenderBlock {caption} at (0,72) size 128x54
           RenderText {#text} at (0,0) size 0x0
@@ -40,8 +40,8 @@ layer at (8,218) size 128x54
       text run at (26,0) width 76: "PASS: First"
       text run at (4,18) width 119: "Caption aligned to"
       text run at (29,36) width 70: "the bottom"
-layer at (10,156) size 231x18
-  RenderBlock (positioned) {caption} at (10,156) size 231x18
+layer at (12,156) size 231x18
+  RenderBlock (positioned) {caption} at (12,156) size 231x18
     RenderText {#text} at (0,0) size 231x18
       text run at (0,0) width 231: "PASS: Caption with a fixed position"
 layer at (8,8) size 128x36
@@ -49,8 +49,8 @@ layer at (8,8) size 128x36
     RenderText {#text} at (12,0) size 104x36
       text run at (15,0) width 97: "PASS: Caption"
       text run at (12,18) width 104: "with opacity 0.7"
-layer at (10,196) size 333x18
-  RenderBlock (positioned) {caption} at (10,196) size 334x18
+layer at (12,196) size 333x18
+  RenderBlock (positioned) {caption} at (12,196) size 334x18
     RenderText {#text} at (0,0) size 334x18
       text run at (0,0) width 334: "PASS: Caption with a fixed position and opacity 0.6"
 layer at (8,80) size 121x54

--- a/LayoutTests/platform/mac/fast/table/nested-percent-height-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/nested-percent-height-table-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,0) size 75x300 [bgcolor=#0000FF] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (0,0) size 75x300 [bgcolor=#008000]
                 RenderTableSection {TBODY} at (0,0) size 75x300
-                  RenderTableRow {TR} at (0,2) size 75x296
+                  RenderTableRow {TR} at (2,2) size 71x296
                     RenderTableCell {TD} at (2,140) size 71x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,139) size 69x18
                         text run at (1,1) width 69: "Inner table"

--- a/LayoutTests/platform/mac/fast/table/nobr-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/nobr-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x352
         RenderTable {TABLE} at (0,0) size 70x352 [border: (1px outset #000000)]
           RenderTableSection {TBODY} at (1,1) size 68x350
-            RenderTableRow {TR} at (0,2) size 68x346
+            RenderTableRow {TR} at (2,2) size 64x346
               RenderTableCell {TD} at (2,2) size 64x346 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 60x342
                   text run at (2,2) width 55: "This is a"

--- a/LayoutTests/platform/mac/fast/table/overflowHidden-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/overflowHidden-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 785x2424
     RenderBody {BODY} at (8,8) size 769x2408
       RenderTable {TABLE} at (0,0) size 418x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 414x108
-          RenderTableRow {TR} at (0,2) size 414x104
+          RenderTableRow {TR} at (2,2) size 410x104
             RenderTableCell {TD} at (308,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,112) size 769x36
@@ -13,7 +13,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,148) size 718x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 714x108
-          RenderTableRow {TR} at (0,2) size 714x104
+          RenderTableRow {TR} at (2,2) size 710x104
             RenderTableCell {TD} at (608,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,260) size 769x36
@@ -21,7 +21,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,296) size 718x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 714x108
-          RenderTableRow {TR} at (0,2) size 714x104
+          RenderTableRow {TR} at (2,2) size 710x104
             RenderTableCell {TD} at (608,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,408) size 769x36
@@ -29,7 +29,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,444) size 418x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 414x108
-          RenderTableRow {TR} at (0,2) size 414x104
+          RenderTableRow {TR} at (2,2) size 410x104
             RenderTableCell {TD} at (308,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,556) size 769x36
@@ -37,7 +37,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,592) size 418x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 414x108
-          RenderTableRow {TR} at (0,2) size 414x104
+          RenderTableRow {TR} at (2,2) size 410x104
             RenderTableCell {TD} at (2,2) size 104x104 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,704) size 769x36
@@ -45,10 +45,10 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,740) size 618x218 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 614x214
-          RenderTableRow {TR} at (0,2) size 614x104
+          RenderTableRow {TR} at (2,2) size 610x104
             RenderTableCell {TD} at (308,2) size 304x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 300x100 [bgcolor=#800080]
-          RenderTableRow {TR} at (0,108) size 614x104
+          RenderTableRow {TR} at (2,108) size 610x104
             RenderTableCell {TD} at (2,108) size 304x104 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 300x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,958) size 769x36
@@ -56,7 +56,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,994) size 718x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 714x108
-          RenderTableRow {TR} at (0,2) size 714x104
+          RenderTableRow {TR} at (2,2) size 710x104
             RenderTableCell {TD} at (608,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,1106) size 769x36
@@ -64,7 +64,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,1142) size 718x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 714x108
-          RenderTableRow {TR} at (0,2) size 714x104
+          RenderTableRow {TR} at (2,2) size 710x104
             RenderTableCell {TD} at (608,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,1254) size 769x36
@@ -72,7 +72,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,1290) size 718x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 714x108
-          RenderTableRow {TR} at (0,2) size 714x104
+          RenderTableRow {TR} at (2,2) size 710x104
             RenderTableCell {TD} at (608,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,1402) size 769x36
@@ -112,7 +112,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,2006) size 418x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 414x108
-          RenderTableRow {TR} at (0,2) size 414x104
+          RenderTableRow {TR} at (2,2) size 410x104
             RenderTableCell {TD} at (308,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,2118) size 769x36
@@ -120,7 +120,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,2154) size 433x112 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 429x108
-          RenderTableRow {TR} at (0,2) size 429x104
+          RenderTableRow {TR} at (2,2) size 425x104
             RenderTableCell {TD} at (323,2) size 104x104 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 100x100 [bgcolor=#800080]
       RenderBlock (anonymous) at (0,2266) size 769x36
@@ -128,7 +128,7 @@ layer at (0,0) size 785x2424
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,2302) size 470x106
         RenderTableSection {TBODY} at (0,0) size 470x106
-          RenderTableRow {TR} at (0,2) size 470x102
+          RenderTableRow {TR} at (2,2) size 466x102
             RenderTableCell {TD} at (366,2) size 102x102 [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 100x100 [bgcolor=#800080]
 layer at (12,12) size 304x104 clip at (13,13) size 302x102
@@ -195,8 +195,8 @@ layer at (10,2312) size 362x102 clip at (40,2342) size 302x27 scrollWidth 601
       RenderBlock {DIV} at (0,0) size 600x18 [bgcolor=#008000]
         RenderText {#text} at (0,0) size 152x18
           text run at (0,0) width 152: "Test with overflow:auto"
-layer at (14,90) size 600x18
-  RenderBlock (positioned) {DIV} at (14,90) size 600x18 [bgcolor=#00FFFF]
+layer at (16,90) size 600x18
+  RenderBlock (positioned) {DIV} at (16,90) size 600x18 [bgcolor=#00FFFF]
     RenderText {#text} at (0,0) size 213x18
       text run at (0,0) width 213: "With absolute positioning on div."
 layer at (14,203) size 600x18

--- a/LayoutTests/platform/mac/fast/table/relative-position-containment-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/relative-position-containment-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x336
           text run at (0,0) width 540: "Will be green if the relative positioned table cell properly acts as a containing block."
       RenderTable {TABLE} at (0,18) size 302x302 [border: (1px solid #000000)]
         RenderTableSection {TBODY} at (1,1) size 300x300
-          RenderTableRow {TR} at (0,100) size 300x100
+          RenderTableRow {TR} at (100,100) size 100x100
 layer at (109,127) size 100x100
   RenderTableCell {TD} at (100,150) size 100x0 [bgcolor=#FF0000] [r=0 c=0 rs=1 cs=1]
 layer at (109,127) size 100x100

--- a/LayoutTests/platform/mac/fast/table/replaced-percent-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/replaced-percent-height-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 610x206
         RenderTableSection {TBODY} at (0,0) size 610x206
-          RenderTableRow {TR} at (0,2) size 610x202
+          RenderTableRow {TR} at (2,2) size 606x202
             RenderTableCell {TD} at (2,93) size 402x20 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,92) size 400x18 [bgcolor=#008000]
                 RenderText {#text} at (0,0) size 143x18
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,222) size 784x0
       RenderTable {TABLE} at (0,222) size 610x206
         RenderTableSection {TBODY} at (0,0) size 610x206
-          RenderTableRow {TR} at (0,2) size 610x202
+          RenderTableRow {TR} at (2,2) size 606x202
             RenderTableCell {TD} at (2,2) size 402x202 [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 400x200 [bgcolor=#008000]
             RenderTableCell {TD} at (406,2) size 202x202 [r=0 c=1 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/rowindex-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/rowindex-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 354: "A: This table has the header and footer before the body (\"normal\" order)."
       RenderTable {TABLE} at (0,44) size 156x58 [border: (1px outset #000000)]
         RenderTableSection {THEAD} at (1,1) size 154x20
-          RenderTableRow {TR} at (0,2) size 154x16
+          RenderTableRow {TR} at (2,2) size 150x16
             RenderTableCell {TD} at (2,2) size 78x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 74x12
                 text run at (2,2) width 74: "table A, header"
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 0"
         RenderTableSection {TFOOT} at (1,39) size 154x18
-          RenderTableRow {TR} at (0,0) size 154x16
+          RenderTableRow {TR} at (2,0) size 150x16
             RenderTableCell {TD} at (2,0) size 78x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 70x12
                 text run at (2,2) width 70: "table A, footer"
@@ -27,7 +27,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 2"
         RenderTableSection {TBODY} at (1,21) size 154x18
-          RenderTableRow {TR} at (0,0) size 154x16
+          RenderTableRow {TR} at (2,0) size 150x16
             RenderTableCell {TD} at (2,0) size 78x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 65x12
                 text run at (2,2) width 65: "table A, body"
@@ -39,7 +39,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 351: "B: This table has the footer before the body and both before the header."
       RenderTable {TABLE} at (0,134) size 155x58 [border: (1px outset #000000)]
         RenderTableSection {TFOOT} at (1,39) size 153x18
-          RenderTableRow {TR} at (0,0) size 153x16
+          RenderTableRow {TR} at (2,0) size 149x16
             RenderTableCell {TD} at (2,0) size 77x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x12
                 text run at (2,2) width 69: "table B, footer"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 2"
         RenderTableSection {TBODY} at (1,21) size 153x18
-          RenderTableRow {TR} at (0,0) size 153x16
+          RenderTableRow {TR} at (2,0) size 149x16
             RenderTableCell {TD} at (2,0) size 77x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 64x12
                 text run at (2,2) width 64: "table B, body"
@@ -55,7 +55,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 1"
         RenderTableSection {THEAD} at (1,1) size 153x20
-          RenderTableRow {TR} at (0,2) size 153x16
+          RenderTableRow {TR} at (2,2) size 149x16
             RenderTableCell {TD} at (2,2) size 77x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x12
                 text run at (2,2) width 73: "table B, header"
@@ -67,14 +67,14 @@ layer at (0,0) size 800x600
           text run at (0,0) width 673: "C: This table has two footers before two bodies before two heads. The rows inside the extra footers and heads don't get row indices at all."
       RenderTable {TABLE} at (0,224) size 203x220 [border: (1px outset #000000)]
         RenderTableSection {TFOOT} at (1,183) size 201x36
-          RenderTableRow {TR} at (0,0) size 201x16
+          RenderTableRow {TR} at (2,0) size 197x16
             RenderTableCell {TD} at (2,0) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 112x12
                 text run at (2,2) width 112: "table C, footer A row A"
             RenderTableCell {TD} at (122,0) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 8"
-          RenderTableRow {TR} at (0,18) size 201x16
+          RenderTableRow {TR} at (2,18) size 197x16
             RenderTableCell {TD} at (2,18) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 110x12
                 text run at (2,2) width 110: "table C, footer A row B"
@@ -82,14 +82,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 9"
         RenderTableSection {TFOOT} at (1,39) size 201x36
-          RenderTableRow {TR} at (0,0) size 201x16
+          RenderTableRow {TR} at (2,0) size 197x16
             RenderTableCell {TD} at (2,0) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 110x12
                 text run at (2,2) width 110: "table C, footer B row A"
             RenderTableCell {TD} at (122,0) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 72x12
                 text run at (2,2) width 72: "rowIndex = 10"
-          RenderTableRow {TR} at (0,18) size 201x16
+          RenderTableRow {TR} at (2,18) size 197x16
             RenderTableCell {TD} at (2,18) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 109x12
                 text run at (2,2) width 109: "table C, footer B row B"
@@ -97,14 +97,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 72x12
                 text run at (2,2) width 72: "rowIndex = 11"
         RenderTableSection {TBODY} at (1,75) size 201x36
-          RenderTableRow {TR} at (0,0) size 201x16
+          RenderTableRow {TR} at (2,0) size 197x16
             RenderTableCell {TD} at (2,0) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 106x12
                 text run at (2,2) width 106: "table C, body A row A"
             RenderTableCell {TD} at (122,0) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 4"
-          RenderTableRow {TR} at (0,18) size 201x16
+          RenderTableRow {TR} at (2,18) size 197x16
             RenderTableCell {TD} at (2,18) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 105x12
                 text run at (2,2) width 105: "table C, body A row B"
@@ -112,14 +112,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 5"
         RenderTableSection {TBODY} at (1,111) size 201x36
-          RenderTableRow {TR} at (0,0) size 201x16
+          RenderTableRow {TR} at (2,0) size 197x16
             RenderTableCell {TD} at (2,0) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 105x12
                 text run at (2,2) width 105: "table C, body B row A"
             RenderTableCell {TD} at (122,0) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 6"
-          RenderTableRow {TR} at (0,18) size 201x16
+          RenderTableRow {TR} at (2,18) size 197x16
             RenderTableCell {TD} at (2,18) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 104x12
                 text run at (2,2) width 104: "table C, body B row B"
@@ -127,14 +127,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 7"
         RenderTableSection {THEAD} at (1,1) size 201x38
-          RenderTableRow {TR} at (0,2) size 201x16
+          RenderTableRow {TR} at (2,2) size 197x16
             RenderTableCell {TD} at (2,2) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 115x12
                 text run at (2,2) width 115: "table C, header A row A"
             RenderTableCell {TD} at (122,2) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 0"
-          RenderTableRow {TR} at (0,20) size 201x16
+          RenderTableRow {TR} at (2,20) size 197x16
             RenderTableCell {TD} at (2,20) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 114x12
                 text run at (2,2) width 114: "table C, header A row B"
@@ -142,14 +142,14 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 1"
         RenderTableSection {THEAD} at (1,147) size 201x36
-          RenderTableRow {TR} at (0,0) size 201x16
+          RenderTableRow {TR} at (2,0) size 197x16
             RenderTableCell {TD} at (2,0) size 119x16 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 114x12
                 text run at (2,2) width 114: "table C, header B row A"
             RenderTableCell {TD} at (122,0) size 77x16 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 66x12
                 text run at (2,2) width 66: "rowIndex = 2"
-          RenderTableRow {TR} at (0,18) size 201x16
+          RenderTableRow {TR} at (2,18) size 197x16
             RenderTableCell {TD} at (2,18) size 119x16 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 113x12
                 text run at (2,2) width 113: "table C, header B row B"

--- a/LayoutTests/platform/mac/fast/table/rtl-cell-display-none-assert-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/rtl-cell-display-none-assert-expected.txt
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 258: "No assertion failure means TEST PASS."
       RenderTable {TABLE} at (0,104) size 51x26 [border: (1px solid #008000)]
         RenderTableSection {TBODY} at (1,1) size 49x24
-          RenderTableRow {TR} at (0,2) size 49x20
+          RenderTableRow {TR} at (2,2) size 45x20
             RenderTableCell {TD} at (2,2) size 45x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 43x18
                 text run at (1,1) width 43: "Lorem"

--- a/LayoutTests/platform/mac/fast/table/spanOverlapRepaint-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/spanOverlapRepaint-expected.txt
@@ -5,17 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 172x45
         RenderTableSection {TBODY} at (0,0) size 172x45
-          RenderTableRow {TR} at (0,2) size 172x2
+          RenderTableRow {TR} at (2,2) size 168x2
             RenderTableCell {TD} at (2,2) size 6x2 [r=0 c=0 rs=1 cs=1]
-          RenderTableRow {TR} at (0,6) size 172x0
+          RenderTableRow {TR} at (2,6) size 168x0
             RenderTableCell {TD} at (2,6) size 6x2 [r=1 c=0 rs=2 cs=1]
-          RenderTableRow {TR} at (0,8) size 172x0
+          RenderTableRow {TR} at (2,8) size 168x0
             RenderTableCell {TD} at (10,24) size 160x3 [r=2 c=1 rs=2 cs=1]
-          RenderTableRow {TR} at (0,10) size 172x33
+          RenderTableRow {TR} at (2,10) size 168x33
             RenderTableCell {TD} at (2,10) size 168x33 [r=3 c=0 rs=1 cs=2]
               RenderTable {TABLE} at (1,1) size 166x31 [border: (2px outset #000000)]
                 RenderTableSection {TBODY} at (2,2) size 162x27
-                  RenderTableRow {TR} at (0,2) size 162x23
+                  RenderTableRow {TR} at (2,2) size 158x23
                     RenderTableCell {TD} at (2,11) size 4x5 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                     RenderTableCell {TD} at (8,2) size 152x23 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                       RenderTextControl {INPUT} at (2,2) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/mac/fast/table/table-and-parts-outline-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-and-parts-outline-expected.txt
@@ -10,14 +10,14 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,18) size 0x18
       RenderTable {TABLE} at (0,36) size 88x46
         RenderTableSection {TBODY} at (0,0) size 88x46
-          RenderTableRow {TR} at (0,2) size 88x20
+          RenderTableRow {TR} at (2,2) size 84x20
             RenderTableCell {TD} at (2,2) size 41x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 1"
             RenderTableCell {TD} at (44,2) size 42x20 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 2"
-          RenderTableRow {TR} at (0,24) size 88x20
+          RenderTableRow {TR} at (2,24) size 84x20
             RenderTableCell {TD} at (2,24) size 41x20 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 39x18
                 text run at (1,1) width 39: "Cell 3"

--- a/LayoutTests/platform/mac/fast/table/table-continuation-outline-paint-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-continuation-outline-paint-crash-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderTable {TABLE} at (0,18) size 41x22
         RenderTableSection (anonymous) at (0,0) size 41x22
-          RenderTableRow (anonymous) at (0,2) size 41x18
+          RenderTableRow (anonymous) at (2,2) size 37x18
             RenderTableCell (anonymous) at (2,2) size 37x18 [r=0 c=0 rs=1 cs=1]
               RenderInline {SPAN} at (0,0) size 37x18
                 RenderText {#text} at (0,0) size 37x18

--- a/LayoutTests/platform/mac/fast/table/table-display-types-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-display-types-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {TABLE} at (10,0) size 764x92 [border: (1px solid #000000)]
         RenderTable at (1,1) size 118x90
           RenderTableSection {THEAD} at (0,0) size 118x24
-            RenderTableRow {TR} at (0,2) size 118x20
+            RenderTableRow {TR} at (2,2) size 114x20
               RenderTableCell {TD} at (2,2) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 46x18
                   text run at (1,1) width 46: "Head 1"
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (1,1) size 46x18
                   text run at (1,1) width 46: "Head 2"
           RenderTableSection {TFOOT} at (0,68) size 118x22
-            RenderTableRow {TR} at (0,0) size 118x20
+            RenderTableRow {TR} at (2,0) size 114x20
               RenderTableCell {TD} at (2,0) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 54x18
                   text run at (1,1) width 54: "Footer 1"
@@ -22,14 +22,14 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (1,1) size 54x18
                   text run at (1,1) width 54: "Footer 2"
           RenderTableSection {TBODY} at (0,24) size 118x44
-            RenderTableRow {TR} at (0,0) size 118x20
+            RenderTableRow {TR} at (2,0) size 114x20
               RenderTableCell {TD} at (2,0) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 1"
               RenderTableCell {TD} at (59,0) size 57x20 [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 2"
-            RenderTableRow {TR} at (0,22) size 118x20
+            RenderTableRow {TR} at (2,22) size 114x20
               RenderTableCell {TD} at (2,22) size 56x20 [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 3"
@@ -42,66 +42,66 @@ layer at (0,0) size 800x600
       RenderBlock {TABLE} at (10,142) size 764x60 [border: (1px solid #000000)]
         RenderTable at (1,1) size 238x58
           RenderTableSection (anonymous) at (0,0) size 238x32
-            RenderTableRow (anonymous) at (0,2) size 238x28
+            RenderTableRow (anonymous) at (2,2) size 234x28
               RenderTableCell {THEAD} at (2,2) size 108x28 [r=0 c=0 rs=1 cs=1]
                 RenderTable at (0,0) size 108x28
                   RenderTableSection (anonymous) at (0,0) size 108x28
-                    RenderTableRow (anonymous) at (0,2) size 108x24
+                    RenderTableRow (anonymous) at (2,2) size 104x24
                       RenderTableCell {TR} at (2,2) size 104x24 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TD} at (0,0) size 52x24
                           RenderTableSection (anonymous) at (1,1) size 50x22
-                            RenderTableRow (anonymous) at (0,2) size 50x18
+                            RenderTableRow (anonymous) at (2,2) size 46x18
                               RenderTableCell (anonymous) at (2,2) size 46x18 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 46x18
                                   text run at (0,0) width 46: "Head 1"
                         RenderTable {TD} at (51,0) size 53x24
                           RenderTableSection (anonymous) at (1,1) size 50x22
-                            RenderTableRow (anonymous) at (0,2) size 50x18
+                            RenderTableRow (anonymous) at (2,2) size 46x18
                               RenderTableCell (anonymous) at (2,2) size 46x18 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 46x18
                                   text run at (0,0) width 46: "Head 2"
               RenderTableCell {TFOOT} at (111,2) size 125x28 [r=0 c=1 rs=1 cs=1]
                 RenderTable at (0,0) size 124x28
                   RenderTableSection (anonymous) at (0,0) size 124x28
-                    RenderTableRow (anonymous) at (0,2) size 124x24
+                    RenderTableRow (anonymous) at (2,2) size 120x24
                       RenderTableCell {TR} at (2,2) size 120x24 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TD} at (0,0) size 60x24
                           RenderTableSection (anonymous) at (1,1) size 58x22
-                            RenderTableRow (anonymous) at (0,2) size 58x18
+                            RenderTableRow (anonymous) at (2,2) size 54x18
                               RenderTableCell (anonymous) at (2,2) size 54x18 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 54x18
                                   text run at (0,0) width 54: "Footer 1"
                         RenderTable {TD} at (59,0) size 61x24
                           RenderTableSection (anonymous) at (1,1) size 58x22
-                            RenderTableRow (anonymous) at (0,2) size 58x18
+                            RenderTableRow (anonymous) at (2,2) size 54x18
                               RenderTableCell (anonymous) at (2,2) size 54x18 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 54x18
                                   text run at (0,0) width 54: "Footer 2"
           RenderTableSection {TBODY} at (0,32) size 238x26
-            RenderTableRow (anonymous) at (0,0) size 238x24
+            RenderTableRow (anonymous) at (2,0) size 234x24
               RenderTableCell {TR} at (2,0) size 108x24 [r=0 c=0 rs=1 cs=1]
                 RenderTable {TD} at (0,0) size 45x24
                   RenderTableSection (anonymous) at (1,1) size 43x22
-                    RenderTableRow (anonymous) at (0,2) size 43x18
+                    RenderTableRow (anonymous) at (2,2) size 39x18
                       RenderTableCell (anonymous) at (2,2) size 39x18 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 39x18
                           text run at (0,0) width 39: "Cell 1"
                 RenderTable {TD} at (44,0) size 46x24
                   RenderTableSection (anonymous) at (1,1) size 43x22
-                    RenderTableRow (anonymous) at (0,2) size 43x18
+                    RenderTableRow (anonymous) at (2,2) size 39x18
                       RenderTableCell (anonymous) at (2,2) size 39x18 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 39x18
                           text run at (0,0) width 39: "Cell 2"
               RenderTableCell {TR} at (111,0) size 125x24 [r=0 c=1 rs=1 cs=1]
                 RenderTable {TD} at (0,0) size 45x24
                   RenderTableSection (anonymous) at (1,1) size 43x22
-                    RenderTableRow (anonymous) at (0,2) size 43x18
+                    RenderTableRow (anonymous) at (2,2) size 39x18
                       RenderTableCell (anonymous) at (2,2) size 39x18 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 39x18
                           text run at (0,0) width 39: "Cell 3"
                 RenderTable {TD} at (44,0) size 46x24
                   RenderTableSection (anonymous) at (1,1) size 43x22
-                    RenderTableRow (anonymous) at (0,2) size 43x18
+                    RenderTableRow (anonymous) at (2,2) size 39x18
                       RenderTableCell (anonymous) at (2,2) size 39x18 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 39x18
                           text run at (0,0) width 39: "Cell 4"
@@ -113,7 +113,7 @@ layer at (0,0) size 800x600
           RenderBlock {TR} at (0,0) size 762x24
             RenderTable at (0,0) size 102x24
               RenderTableSection (anonymous) at (0,0) size 102x24
-                RenderTableRow (anonymous) at (0,2) size 102x20
+                RenderTableRow (anonymous) at (2,2) size 98x20
                   RenderTableCell {TD} at (2,2) size 48x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 46x18
                       text run at (1,1) width 46: "Head 1"
@@ -124,7 +124,7 @@ layer at (0,0) size 800x600
           RenderBlock {TR} at (0,0) size 762x24
             RenderTable at (0,0) size 118x24
               RenderTableSection (anonymous) at (0,0) size 118x24
-                RenderTableRow (anonymous) at (0,2) size 118x20
+                RenderTableRow (anonymous) at (2,2) size 114x20
                   RenderTableCell {TD} at (2,2) size 56x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 54x18
                       text run at (1,1) width 54: "Footer 1"
@@ -133,12 +133,12 @@ layer at (0,0) size 800x600
                       text run at (1,1) width 54: "Footer 2"
         RenderTable at (1,49) size 92x52
           RenderTableSection {TBODY} at (0,0) size 92x52
-            RenderTableRow (anonymous) at (0,2) size 92x48
+            RenderTableRow (anonymous) at (2,2) size 88x48
               RenderTableCell (anonymous) at (2,2) size 88x48 [r=0 c=0 rs=1 cs=1]
                 RenderBlock {TR} at (0,0) size 88x24
                   RenderTable at (0,0) size 88x24
                     RenderTableSection (anonymous) at (0,0) size 88x24
-                      RenderTableRow (anonymous) at (0,2) size 88x20
+                      RenderTableRow (anonymous) at (2,2) size 84x20
                         RenderTableCell {TD} at (2,2) size 41x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 39x18
                             text run at (1,1) width 39: "Cell 1"
@@ -148,7 +148,7 @@ layer at (0,0) size 800x600
                 RenderBlock {TR} at (0,24) size 88x24
                   RenderTable at (0,0) size 88x24
                     RenderTableSection (anonymous) at (0,0) size 88x24
-                      RenderTableRow (anonymous) at (0,2) size 88x20
+                      RenderTableRow (anonymous) at (2,2) size 84x20
                         RenderTableCell {TD} at (2,2) size 41x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 39x18
                             text run at (1,1) width 39: "Cell 3"

--- a/LayoutTests/platform/mac/fast/table/table-display-types-strict-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-display-types-strict-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x493
       RenderBlock {TABLE} at (10,0) size 764x92 [border: (1px solid #000000)]
         RenderTable at (1,1) size 118x90
           RenderTableSection {THEAD} at (0,0) size 118x24
-            RenderTableRow {TR} at (0,2) size 118x20
+            RenderTableRow {TR} at (2,2) size 114x20
               RenderTableCell {TD} at (2,2) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 46x18
                   text run at (1,1) width 46: "Head 1"
@@ -14,7 +14,7 @@ layer at (0,0) size 800x493
                 RenderText {#text} at (1,1) size 46x18
                   text run at (1,1) width 46: "Head 2"
           RenderTableSection {TFOOT} at (0,68) size 118x22
-            RenderTableRow {TR} at (0,0) size 118x20
+            RenderTableRow {TR} at (2,0) size 114x20
               RenderTableCell {TD} at (2,0) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 54x18
                   text run at (1,1) width 54: "Footer 1"
@@ -22,14 +22,14 @@ layer at (0,0) size 800x493
                 RenderText {#text} at (1,1) size 54x18
                   text run at (1,1) width 54: "Footer 2"
           RenderTableSection {TBODY} at (0,24) size 118x44
-            RenderTableRow {TR} at (0,0) size 118x20
+            RenderTableRow {TR} at (2,0) size 114x20
               RenderTableCell {TD} at (2,0) size 56x20 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 1"
               RenderTableCell {TD} at (59,0) size 57x20 [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 2"
-            RenderTableRow {TR} at (0,22) size 118x20
+            RenderTableRow {TR} at (2,22) size 114x20
               RenderTableCell {TD} at (2,22) size 56x20 [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 39x18
                   text run at (1,1) width 39: "Cell 3"
@@ -39,11 +39,11 @@ layer at (0,0) size 800x493
       RenderBlock {TABLE} at (10,102) size 764x51 [border: (1px solid #000000)]
         RenderTable at (1,1) size 222x49
           RenderTableSection (anonymous) at (0,0) size 222x28
-            RenderTableRow (anonymous) at (0,2) size 222x24
+            RenderTableRow (anonymous) at (2,2) size 218x24
               RenderTableCell {THEAD} at (2,2) size 100x24 [r=0 c=0 rs=1 cs=1]
                 RenderTable at (0,0) size 100x24
                   RenderTableSection (anonymous) at (0,0) size 100x24
-                    RenderTableRow (anonymous) at (0,2) size 100x20
+                    RenderTableRow (anonymous) at (2,2) size 96x20
                       RenderTableCell {TR} at (2,2) size 96x20 [r=0 c=0 rs=1 cs=1]
                         RenderInline {TD} at (0,0) size 48x21
                           RenderText {#text} at (1,1) size 46x19
@@ -54,7 +54,7 @@ layer at (0,0) size 800x493
               RenderTableCell {TFOOT} at (103,2) size 117x24 [r=0 c=1 rs=1 cs=1]
                 RenderTable at (0,0) size 116x24
                   RenderTableSection (anonymous) at (0,0) size 116x24
-                    RenderTableRow (anonymous) at (0,2) size 116x20
+                    RenderTableRow (anonymous) at (2,2) size 112x20
                       RenderTableCell {TR} at (2,2) size 112x20 [r=0 c=0 rs=1 cs=1]
                         RenderInline {TD} at (0,0) size 56x21
                           RenderText {#text} at (1,1) size 54x19
@@ -63,7 +63,7 @@ layer at (0,0) size 800x493
                           RenderText {#text} at (56,1) size 55x19
                             text run at (56,1) width 55: "Footer 2"
           RenderTableSection {TBODY} at (0,27) size 222x22
-            RenderTableRow (anonymous) at (0,0) size 222x20
+            RenderTableRow (anonymous) at (2,0) size 218x20
               RenderTableCell {TR} at (2,0) size 100x20 [r=0 c=0 rs=1 cs=1]
                 RenderInline {TD} at (0,0) size 41x21
                   RenderText {#text} at (1,1) size 39x19
@@ -83,7 +83,7 @@ layer at (0,0) size 800x493
           RenderBlock {TR} at (0,0) size 762x24
             RenderTable at (0,0) size 102x24
               RenderTableSection (anonymous) at (0,0) size 102x24
-                RenderTableRow (anonymous) at (0,2) size 102x20
+                RenderTableRow (anonymous) at (2,2) size 98x20
                   RenderTableCell {TD} at (2,2) size 48x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 46x18
                       text run at (1,1) width 46: "Head 1"
@@ -94,7 +94,7 @@ layer at (0,0) size 800x493
           RenderBlock {TR} at (0,0) size 762x24
             RenderTable at (0,0) size 118x24
               RenderTableSection (anonymous) at (0,0) size 118x24
-                RenderTableRow (anonymous) at (0,2) size 118x20
+                RenderTableRow (anonymous) at (2,2) size 114x20
                   RenderTableCell {TD} at (2,2) size 56x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 54x18
                       text run at (1,1) width 54: "Footer 1"
@@ -103,12 +103,12 @@ layer at (0,0) size 800x493
                       text run at (1,1) width 54: "Footer 2"
         RenderTable at (1,49) size 92x52
           RenderTableSection {TBODY} at (0,0) size 92x52
-            RenderTableRow (anonymous) at (0,2) size 92x48
+            RenderTableRow (anonymous) at (2,2) size 88x48
               RenderTableCell (anonymous) at (2,2) size 88x48 [r=0 c=0 rs=1 cs=1]
                 RenderBlock {TR} at (0,0) size 88x24
                   RenderTable at (0,0) size 88x24
                     RenderTableSection (anonymous) at (0,0) size 88x24
-                      RenderTableRow (anonymous) at (0,2) size 88x20
+                      RenderTableRow (anonymous) at (2,2) size 84x20
                         RenderTableCell {TD} at (2,2) size 41x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 39x18
                             text run at (1,1) width 39: "Cell 1"
@@ -118,7 +118,7 @@ layer at (0,0) size 800x493
                 RenderBlock {TR} at (0,24) size 88x24
                   RenderTable at (0,0) size 88x24
                     RenderTableSection (anonymous) at (0,0) size 88x24
-                      RenderTableRow (anonymous) at (0,2) size 88x20
+                      RenderTableRow (anonymous) at (2,2) size 84x20
                         RenderTableCell {TD} at (2,2) size 41x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 39x18
                             text run at (1,1) width 39: "Cell 3"

--- a/LayoutTests/platform/mac/fast/table/table-display-types-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-display-types-vertical-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 785x1238
       RenderBlock {TABLE} at (10,0) size 92x120 [border: (1px solid #000000)]
         RenderTable at (1,1) size 90x118
           RenderTableSection {THEAD} at (0,0) size 24x118
-            RenderTableRow {TR} at (2,0) size 20x118
+            RenderTableRow {TR} at (2,2) size 20x114
               RenderTableCell {TD} at (2,2) size 20x56 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 18x46
                   text run at (1,1) width 46: "Head 1"
@@ -14,7 +14,7 @@ layer at (0,0) size 785x1238
                 RenderText {#text} at (1,1) size 18x46
                   text run at (1,1) width 46: "Head 2"
           RenderTableSection {TFOOT} at (68,0) size 22x118
-            RenderTableRow {TR} at (0,0) size 20x118
+            RenderTableRow {TR} at (0,2) size 20x114
               RenderTableCell {TD} at (0,2) size 20x56 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 18x54
                   text run at (1,1) width 54: "Footer 1"
@@ -22,14 +22,14 @@ layer at (0,0) size 785x1238
                 RenderText {#text} at (1,1) size 18x54
                   text run at (1,1) width 54: "Footer 2"
           RenderTableSection {TBODY} at (24,0) size 44x118
-            RenderTableRow {TR} at (0,0) size 20x118
+            RenderTableRow {TR} at (0,2) size 20x114
               RenderTableCell {TD} at (0,2) size 20x56 [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 18x39
                   text run at (1,1) width 39: "Cell 1"
               RenderTableCell {TD} at (0,59) size 20x57 [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 18x39
                   text run at (1,1) width 39: "Cell 2"
-            RenderTableRow {TR} at (22,0) size 20x118
+            RenderTableRow {TR} at (22,2) size 20x114
               RenderTableCell {TD} at (22,2) size 20x56 [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 18x39
                   text run at (1,1) width 39: "Cell 3"
@@ -42,66 +42,66 @@ layer at (0,0) size 785x1238
       RenderBlock {TABLE} at (10,169) size 60x240 [border: (1px solid #000000)]
         RenderTable at (1,1) size 58x238
           RenderTableSection (anonymous) at (0,0) size 32x238
-            RenderTableRow (anonymous) at (2,0) size 28x238
+            RenderTableRow (anonymous) at (2,2) size 28x234
               RenderTableCell {THEAD} at (2,2) size 28x108 [r=0 c=0 rs=1 cs=1]
                 RenderTable at (0,0) size 28x108
                   RenderTableSection (anonymous) at (0,0) size 28x108
-                    RenderTableRow (anonymous) at (2,0) size 24x108
+                    RenderTableRow (anonymous) at (2,2) size 24x104
                       RenderTableCell {TR} at (2,2) size 24x104 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TD} at (0,0) size 24x52
                           RenderTableSection (anonymous) at (1,1) size 22x50
-                            RenderTableRow (anonymous) at (2,0) size 18x50
+                            RenderTableRow (anonymous) at (2,2) size 18x46
                               RenderTableCell (anonymous) at (2,2) size 18x46 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 18x46
                                   text run at (0,0) width 46: "Head 1"
                         RenderTable {TD} at (0,51) size 24x53
                           RenderTableSection (anonymous) at (1,1) size 22x50
-                            RenderTableRow (anonymous) at (2,0) size 18x50
+                            RenderTableRow (anonymous) at (2,2) size 18x46
                               RenderTableCell (anonymous) at (2,2) size 18x46 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 18x46
                                   text run at (0,0) width 46: "Head 2"
               RenderTableCell {TFOOT} at (2,111) size 28x125 [r=0 c=1 rs=1 cs=1]
                 RenderTable at (0,0) size 28x124
                   RenderTableSection (anonymous) at (0,0) size 28x124
-                    RenderTableRow (anonymous) at (2,0) size 24x124
+                    RenderTableRow (anonymous) at (2,2) size 24x120
                       RenderTableCell {TR} at (2,2) size 24x120 [r=0 c=0 rs=1 cs=1]
                         RenderTable {TD} at (0,0) size 24x60
                           RenderTableSection (anonymous) at (1,1) size 22x58
-                            RenderTableRow (anonymous) at (2,0) size 18x58
+                            RenderTableRow (anonymous) at (2,2) size 18x54
                               RenderTableCell (anonymous) at (2,2) size 18x54 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 18x54
                                   text run at (0,0) width 54: "Footer 1"
                         RenderTable {TD} at (0,59) size 24x61
                           RenderTableSection (anonymous) at (1,1) size 22x58
-                            RenderTableRow (anonymous) at (2,0) size 18x58
+                            RenderTableRow (anonymous) at (2,2) size 18x54
                               RenderTableCell (anonymous) at (2,2) size 18x54 [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (0,0) size 18x54
                                   text run at (0,0) width 54: "Footer 2"
           RenderTableSection {TBODY} at (32,0) size 26x238
-            RenderTableRow (anonymous) at (0,0) size 24x238
+            RenderTableRow (anonymous) at (0,2) size 24x234
               RenderTableCell {TR} at (0,2) size 24x108 [r=0 c=0 rs=1 cs=1]
                 RenderTable {TD} at (0,0) size 24x45
                   RenderTableSection (anonymous) at (1,1) size 22x43
-                    RenderTableRow (anonymous) at (2,0) size 18x43
+                    RenderTableRow (anonymous) at (2,2) size 18x39
                       RenderTableCell (anonymous) at (2,2) size 18x39 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 18x39
                           text run at (0,0) width 39: "Cell 1"
                 RenderTable {TD} at (0,44) size 24x46
                   RenderTableSection (anonymous) at (1,1) size 22x43
-                    RenderTableRow (anonymous) at (2,0) size 18x43
+                    RenderTableRow (anonymous) at (2,2) size 18x39
                       RenderTableCell (anonymous) at (2,2) size 18x39 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 18x39
                           text run at (0,0) width 39: "Cell 2"
               RenderTableCell {TR} at (0,111) size 24x125 [r=0 c=1 rs=1 cs=1]
                 RenderTable {TD} at (0,0) size 24x45
                   RenderTableSection (anonymous) at (1,1) size 22x43
-                    RenderTableRow (anonymous) at (2,0) size 18x43
+                    RenderTableRow (anonymous) at (2,2) size 18x39
                       RenderTableCell (anonymous) at (2,2) size 18x39 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 18x39
                           text run at (0,0) width 39: "Cell 3"
                 RenderTable {TD} at (0,44) size 24x46
                   RenderTableSection (anonymous) at (1,1) size 22x43
-                    RenderTableRow (anonymous) at (2,0) size 18x43
+                    RenderTableRow (anonymous) at (2,2) size 18x39
                       RenderTableCell (anonymous) at (2,2) size 18x39 [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (0,0) size 18x39
                           text run at (0,0) width 39: "Cell 4"
@@ -113,7 +113,7 @@ layer at (0,0) size 785x1238
           RenderBlock {TR} at (0,0) size 24x118
             RenderTable at (0,0) size 24x102
               RenderTableSection (anonymous) at (0,0) size 24x102
-                RenderTableRow (anonymous) at (2,0) size 20x102
+                RenderTableRow (anonymous) at (2,2) size 20x98
                   RenderTableCell {TD} at (2,2) size 20x48 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 18x46
                       text run at (1,1) width 46: "Head 1"
@@ -124,7 +124,7 @@ layer at (0,0) size 785x1238
           RenderBlock {TR} at (0,0) size 24x118
             RenderTable at (0,0) size 24x118
               RenderTableSection (anonymous) at (0,0) size 24x118
-                RenderTableRow (anonymous) at (2,0) size 20x118
+                RenderTableRow (anonymous) at (2,2) size 20x114
                   RenderTableCell {TD} at (2,2) size 20x56 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 18x54
                       text run at (1,1) width 54: "Footer 1"
@@ -133,12 +133,12 @@ layer at (0,0) size 785x1238
                       text run at (1,1) width 54: "Footer 2"
         RenderTable at (49,1) size 52x92
           RenderTableSection {TBODY} at (0,0) size 52x92
-            RenderTableRow (anonymous) at (2,0) size 48x92
+            RenderTableRow (anonymous) at (2,2) size 48x88
               RenderTableCell (anonymous) at (2,2) size 48x88 [r=0 c=0 rs=1 cs=1]
                 RenderBlock {TR} at (0,0) size 24x88
                   RenderTable at (0,0) size 24x88
                     RenderTableSection (anonymous) at (0,0) size 24x88
-                      RenderTableRow (anonymous) at (2,0) size 20x88
+                      RenderTableRow (anonymous) at (2,2) size 20x84
                         RenderTableCell {TD} at (2,2) size 20x41 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 18x39
                             text run at (1,1) width 39: "Cell 1"
@@ -148,7 +148,7 @@ layer at (0,0) size 785x1238
                 RenderBlock {TR} at (24,0) size 24x88
                   RenderTable at (0,0) size 24x88
                     RenderTableSection (anonymous) at (0,0) size 24x88
-                      RenderTableRow (anonymous) at (2,0) size 20x88
+                      RenderTableRow (anonymous) at (2,2) size 20x84
                         RenderTableCell {TD} at (2,2) size 20x41 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 18x39
                             text run at (1,1) width 39: "Cell 3"

--- a/LayoutTests/platform/mac/fast/table/table-hspace-align-center-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/table-hspace-align-center-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (153,0) size 478x30 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 474x26
-          RenderTableRow {TR} at (0,2) size 474x22
+          RenderTableRow {TR} at (2,2) size 470x22
             RenderTableCell {TD} at (2,2) size 470x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 466x18
                 text run at (2,2) width 466: "The hspace attribute should be ignored and this table should be centered."

--- a/LayoutTests/platform/mac/fast/table/tableInsideCaption-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/tableInsideCaption-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 206x78
         RenderTableSection {TBODY} at (0,0) size 206x78
-          RenderTableRow {TR} at (0,2) size 206x74
+          RenderTableRow {TR} at (2,2) size 202x74
             RenderTableCell {TD} at (2,2) size 202x74 [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (1,1) size 200x24
                 RenderTableSection {TBODY} at (0,0) size 200x24
-                  RenderTableRow {TR} at (0,2) size 200x20
+                  RenderTableRow {TR} at (2,2) size 196x20
                     RenderTableCell {TD} at (2,2) size 196x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 194x18
                         text run at (1,1) width 194: "This should all be on one line."
@@ -18,12 +18,12 @@ layer at (0,0) size 800x600
                 RenderBlock {CAPTION} at (0,0) size 200x24
                   RenderTable {TABLE} at (71,0) size 57x24
                     RenderTableSection {TBODY} at (0,0) size 57x24
-                      RenderTableRow {TR} at (0,2) size 57x20
+                      RenderTableRow {TR} at (2,2) size 53x20
                         RenderTableCell {TD} at (2,2) size 53x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 51x18
                             text run at (1,1) width 51: "Caption"
                 RenderTableSection {TBODY} at (0,26) size 200x22
-                  RenderTableRow {TR} at (0,0) size 200x20
+                  RenderTableRow {TR} at (2,0) size 196x20
                     RenderTableCell {TD} at (2,0) size 51x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 49x18
                         text run at (1,1) width 49: "Bottom"

--- a/LayoutTests/platform/mac/fast/table/unbreakable-images-quirk-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/unbreakable-images-quirk-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 88: "No line break"
       RenderTable {TABLE} at (0,18) size 123x60 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 123x60
-          RenderTableRow {TR} at (0,2) size 123x56
+          RenderTableRow {TR} at (2,2) size 119x56
             RenderTableCell {TD} at (2,2) size 119x56 [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 20x50 [bgcolor=#ADD8E6]
               RenderText {#text} at (21,37) size 77x18
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 88: "No line break"
       RenderTable {TABLE} at (0,114) size 103x60 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 103x60
-          RenderTableRow {TR} at (0,2) size 103x56
+          RenderTableRow {TR} at (2,2) size 99x56
             RenderTableCell {TD} at (2,2) size 99x56 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,37) size 77x18
                 text run at (1,37) width 77: "loremipsum"
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 154: "Line break after the \"a\"."
       RenderTable {TABLE} at (0,210) size 103x74 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 103x74
-          RenderTableRow {TR} at (0,2) size 103x70
+          RenderTableRow {TR} at (2,2) size 99x70
             RenderTableCell {TD} at (2,2) size 99x70 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 88x18
                 text run at (1,1) width 88: "a loremipsum"
@@ -42,7 +42,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 154: "Line break after the \"a\"."
       RenderTable {TABLE} at (0,320) size 123x110 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 123x110
-          RenderTableRow {TR} at (0,2) size 123x106
+          RenderTableRow {TR} at (2,2) size 119x106
             RenderTableCell {TD} at (2,2) size 119x106 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,37) size 12x18
                 text run at (1,37) width 12: "a "
@@ -56,7 +56,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 188: "Line break after \"wideword\"."
       RenderTable {TABLE} at (0,466) size 123x114 [bgcolor=#C0C0C0]
         RenderTableSection {TBODY} at (0,0) size 123x114
-          RenderTableRow {TR} at (0,2) size 123x110
+          RenderTableRow {TR} at (2,2) size 119x110
             RenderTableCell {TD} at (2,2) size 119x110 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,37) size 68x18
                 text run at (1,37) width 68: "wideword "

--- a/LayoutTests/platform/mac/fast/table/vertical-align-baseline-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/vertical-align-baseline-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x512
     RenderBody {BODY} at (8,8) size 784x496
       RenderTable {TABLE} at (0,0) size 662x496 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 660x494
-          RenderTableRow {TR} at (0,2) size 660x490
+          RenderTableRow {TR} at (2,2) size 656x490
             RenderTableCell {TD} at (2,88) size 47x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,88) size 43x18
                 text run at (2,2) width 43: "Lorem"
@@ -31,7 +31,7 @@ layer at (0,0) size 800x512
             RenderTableCell {TD} at (318,62) size 85x83 [border: (1px inset #000000)] [r=0 c=5 rs=1 cs=1]
               RenderTable {TABLE} at (2,62) size 80x79 [border: (1px outset #000000)]
                 RenderTableSection {TBODY} at (1,1) size 78x77
-                  RenderTableRow {TR} at (0,10) size 78x57
+                  RenderTableRow {TR} at (2,10) size 74x57
                     RenderTableCell {TD} at (2,10) size 74x57 [border: (10px solid #0000FF) (1px inset #000000) (5px solid #0000FF) (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,15) size 37x18
                         text run at (2,15) width 37: "tetuer"
@@ -44,12 +44,12 @@ layer at (0,0) size 800x512
             RenderTableCell {TD} at (526,29) size 66x158 [border: (1px inset #000000)] [r=0 c=8 rs=1 cs=1]
               RenderTable {TABLE} at (2,29) size 61x118 [border: (1px outset #000000)]
                 RenderTableSection {TBODY} at (1,1) size 59x116
-                  RenderTableRow {TR} at (0,2) size 59x80
+                  RenderTableRow {TR} at (2,2) size 55x80
                     RenderTableCell {TD} at (2,29) size 55x53 [border: (10px solid #0000FF) (1px inset #000000) (5px solid #0000FF) (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                       RenderBlock {DIV} at (6,52) size 43x18 [bgcolor=#FFB6C1]
                         RenderText {#text} at (0,0) size 43x18
                           text run at (0,0) width 43: "Lorem"
-                  RenderTableRow {TR} at (0,84) size 59x30
+                  RenderTableRow {TR} at (2,84) size 55x30
                     RenderTableCell {TD} at (2,84) size 55x30 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                       RenderText {#text} at (6,6) size 40x18
                         text run at (6,6) width 40: "ipsum"
@@ -69,11 +69,11 @@ layer at (0,0) size 800x512
               RenderBlock (floating) {DIV} at (2,72) size 25x30 [bgcolor=#90EE90]
                 RenderText {#text} at (0,0) size 17x18
                   text run at (0,0) width 17: "F3"
-layer at (264,0) size 60x50
-  RenderBlock (positioned) {DIV} at (263,0) size 61x50 [bgcolor=#FFFFE0]
+layer at (266,0) size 60x50
+  RenderBlock (positioned) {DIV} at (265,0) size 61x50 [bgcolor=#FFFFE0]
     RenderText {#text} at (0,0) size 9x18
       text run at (0,0) width 9: "P"
-layer at (416,13) size 60x50
-  RenderBlock (positioned) {DIV} at (415,13) size 61x50 [bgcolor=#FFFFE0]
+layer at (418,13) size 60x50
+  RenderBlock (positioned) {DIV} at (417,13) size 61x50 [bgcolor=#FFFFE0]
     RenderText {#text} at (0,0) size 9x18
       text run at (0,0) width 9: "P"

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -560,6 +560,7 @@ void RenderTableSection::layoutRows()
     m_forceSlowPaintPathWithOverflowingCell = false;
 
     LayoutUnit vspacing = table()->vBorderSpacing();
+    LayoutUnit hspacing = table()->hBorderSpacing();
     unsigned nEffCols = table()->numEffCols();
 
     LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || writingMode().isBlockFlipped());
@@ -569,9 +570,9 @@ void RenderTableSection::layoutRows()
         if (RenderTableRow* rowRenderer = m_grid[r].rowRenderer) {
             // FIXME: the x() position of the row should be table()->hBorderSpacing() so that it can 
             // report the correct offsetLeft. However, that will require a lot of rebaselining of test results.
-            rowRenderer->setLogicalLeft(0_lu);
+            rowRenderer->setLogicalLeft(0_lu + hspacing);
             rowRenderer->setLogicalTop(m_rowPos[r]);
-            rowRenderer->setLogicalWidth(logicalWidth());
+            rowRenderer->setLogicalWidth(logicalWidth() - (2 * hspacing));
             rowRenderer->setLogicalHeight(m_rowPos[r + 1] - m_rowPos[r] - vspacing);
             rowRenderer->updateLayerTransform();
             rowRenderer->clearOverflow();


### PR DESCRIPTION
#### 46a6e65737b16b6edef08aab306a7cb6383904f4
<pre>
The offsetLeft of rows should include border-spacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=119021">https://bugs.webkit.org/show_bug.cgi?id=119021</a>
<a href="https://rdar.apple.com/148517476">rdar://148517476</a>

Reviewed by NOBODY (OOPS!).

This is an attempt to fix the offset of border-spacing in tables layout.
Work in Progress. There is still a lot to do. Feel free to take over.

* LayoutTests/fast/table/*
* LayoutTests/platform/mac/fast/table/*
  Rebaselining a lot of tests in fast.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-spacing-included-in-sizes-001-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/bounding-box-computation-1-expected.txt
  Making progressions on a couple of tests for WPT

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-rows-with-zero-columns.html
  Changing the expected values so it aligns with Firefox.

* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::layoutRows):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46a6e65737b16b6edef08aab306a7cb6383904f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26184 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74690 "Failure limit exceed. At least found 388 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31878 "Found 2 new test failures: fast/css/box-shadow-and-border-radius.html fast/css/min-width-with-spanned-cell.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101106 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13656 "Found 60 new test failures: compositing/tiling/tiled-reflection-inwindow.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm css2.1/t040302-c61-ex-len-00-b-a.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13440 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6577 "Found 60 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html css2.1/t080301-c411-vt-mrgn-00-b.html css2.1/t0804-c5506-padn-t-00-b-a.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83417 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6657 "Found 60 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html css2.1/t080301-c411-vt-mrgn-00-b.html css2.1/t0804-c5506-padn-t-00-b-a.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25188 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18345 "Found 60 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html css2.1/t080301-c411-vt-mrgn-00-b.html css2.1/t0804-c5506-padn-t-00-b-a.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83675 "Failure limit exceed. At least found 354 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83129 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27773 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5452 "Found 60 new test failures: compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/at-import-001.htm css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18828 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25147 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30321 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->