### PR TITLE
Remove useSCContentSharingPicker preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8146,18 +8146,6 @@ UsePreHTML5ParserQuirks:
     WebCore:
       default: false
 
-UseSCContentSharingPicker:
-  type: bool
-  status: internal
-  humanReadableName: "Use SCContentSharingPicker"
-  humanReadableDescription: "Use SCContentSharingPicker when available"
-  condition: HAVE(SC_CONTENT_SHARING_PICKER)
-  defaultValue:
-    WebKit:
-      default: WebKit::defaultUseSCContentSharingPicker()
-    WebCore:
-      default: false
-
 UseSceneKitForModel:
   type: bool
   status: unstable

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -47,10 +47,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformMediaSessionManager);
 bool PlatformMediaSessionManager::m_alternateWebMPlayerEnabled;
 #endif
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-bool PlatformMediaSessionManager::s_useSCContentSharingPicker;
-#endif
-
 #if ENABLE(VP9)
 bool PlatformMediaSessionManager::m_vp9DecoderEnabled;
 bool PlatformMediaSessionManager::m_swVPDecodersAlwaysEnabled;
@@ -788,24 +784,6 @@ bool PlatformMediaSessionManager::alternateWebMPlayerEnabled()
 {
 #if ENABLE(ALTERNATE_WEBM_PLAYER)
     return m_alternateWebMPlayerEnabled;
-#else
-    return false;
-#endif
-}
-
-void PlatformMediaSessionManager::setUseSCContentSharingPicker(bool use)
-{
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    s_useSCContentSharingPicker = use;
-#else
-    UNUSED_PARAM(use);
-#endif
-}
-
-bool PlatformMediaSessionManager::useSCContentSharingPicker()
-{
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    return s_useSCContentSharingPicker;
 #else
     return false;
 #endif

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -67,8 +67,6 @@ public:
 
     WEBCORE_EXPORT static void setAlternateWebMPlayerEnabled(bool);
     WEBCORE_EXPORT static bool alternateWebMPlayerEnabled();
-    WEBCORE_EXPORT static void setUseSCContentSharingPicker(bool);
-    WEBCORE_EXPORT static bool useSCContentSharingPicker();
 
 #if ENABLE(VP9)
     WEBCORE_EXPORT static void setShouldEnableVP9Decoder(bool);

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -203,7 +203,7 @@ bool ScreenCaptureKitSharingSessionManager::isAvailable()
 bool ScreenCaptureKitSharingSessionManager::useSCContentSharingPicker()
 {
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-    return PlatformMediaSessionManager::useSCContentSharingPicker() && isAvailable();
+    return isAvailable();
 #else
     return false;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -291,11 +291,6 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
         PlatformMediaSessionManager::setAlternateWebMPlayerEnabled(*m_preferences.alternateWebMPlayerEnabled);
 #endif
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    if (updatePreference(m_preferences.useSCContentSharingPicker, preferences.useSCContentSharingPicker))
-        PlatformMediaSessionManager::setUseSCContentSharingPicker(*m_preferences.useSCContentSharingPicker);
-#endif
-
 #if ENABLE(EXTENSION_CAPABILITIES)
     if (updatePreference(m_preferences.mediaCapabilityGrantsEnabled, preferences.mediaCapabilityGrantsEnabled))
         PlatformMediaSessionManager::setMediaCapabilityGrantsEnabled(*m_preferences.mediaCapabilityGrantsEnabled);
@@ -383,15 +378,6 @@ void GPUProcess::didDrawRemoteToPDF(PageIdentifier pageID, RefPtr<SharedBuffer>&
 void GPUProcess::setMockCaptureDevicesEnabled(bool isEnabled)
 {
     WebCore::MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(isEnabled);
-}
-
-void GPUProcess::setUseSCContentSharingPicker(bool use)
-{
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    WebCore::PlatformMediaSessionManager::setUseSCContentSharingPicker(use);
-#else
-    UNUSED_PARAM(use);
-#endif
 }
 
 void GPUProcess::setOrientationForMediaCapture(WebCore::IntDegrees orientation)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -195,7 +195,6 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     void setMockCaptureDevicesEnabled(bool);
-    void setUseSCContentSharingPicker(bool);
     void enableMicrophoneMuteStatusAPI();
     void setOrientationForMediaCapture(WebCore::IntDegrees);
     void rotationAngleForCaptureDeviceChanged(const String&, WebCore::VideoFrameRotation);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -59,9 +59,6 @@ messages -> GPUProcess : AuxiliaryProcess {
     SetShouldListenToVoiceActivity(bool shouldListen)
     EnableMicrophoneMuteStatusAPI()
 #endif
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    SetUseSCContentSharingPicker(bool use)
-#endif
 #if PLATFORM(MAC)
     SetScreenProperties(struct WebCore::ScreenProperties screenProperties)
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -44,10 +44,6 @@ struct GPUProcessPreferences {
     std::optional<bool> alternateWebMPlayerEnabled;
 #endif
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    std::optional<bool> useSCContentSharingPicker;
-#endif
-
 #if ENABLE(EXTENSION_CAPABILITIES)
     std::optional<bool> mediaCapabilityGrantsEnabled;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -29,9 +29,6 @@ struct WebKit::GPUProcessPreferences {
 #if ENABLE(ALTERNATE_WEBM_PLAYER)
     std::optional<bool> alternateWebMPlayerEnabled;
 #endif
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    std::optional<bool> useSCContentSharingPicker;
-#endif
 #if ENABLE(EXTENSION_CAPABILITIES)
     std::optional<bool> mediaCapabilityGrantsEnabled;
 #endif

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -84,18 +84,6 @@ bool defaultRemoveBackgroundEnabled()
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-bool defaultUseSCContentSharingPicker()
-{
-    static bool enabled = false;
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        enabled = os_feature_enabled(Bilby, Newsroom);
-    });
-    return enabled;
-}
-#endif
-
 } // namespace WebKit
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPreferencesDefaultValuesCocoaAdditions.mm>)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -160,10 +160,6 @@ bool defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();
 bool defaultUseGPUProcessForDOMRenderingEnabled();
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-bool defaultUseSCContentSharingPicker();
-#endif
-
 #if USE(LIBWEBRTC)
 bool defaultPeerConnectionEnabledAvailable();
 #endif

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -239,18 +239,6 @@ void GPUProcessProxy::setUseMockCaptureDevices(bool value)
     send(Messages::GPUProcess::SetMockCaptureDevicesEnabled { m_useMockCaptureDevices }, 0);
 }
 
-void GPUProcessProxy::setUseSCContentSharingPicker(bool use)
-{
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    if (use == m_useSCContentSharingPicker)
-        return;
-    m_useSCContentSharingPicker = use;
-    send(Messages::GPUProcess::SetUseSCContentSharingPicker { m_useSCContentSharingPicker }, 0);
-#else
-    UNUSED_PARAM(use);
-#endif
-}
-
 void GPUProcessProxy::enableMicrophoneMuteStatusAPI()
 {
     if (m_isMicrophoneMuteStatusAPIEnabled)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -97,7 +97,6 @@ public:
 
 #if ENABLE(MEDIA_STREAM)
     void setUseMockCaptureDevices(bool);
-    void setUseSCContentSharingPicker(bool);
     void enableMicrophoneMuteStatusAPI();
     void setOrientationForMediaCapture(WebCore::IntDegrees);
     void rotationAngleForCaptureDeviceChanged(const String&, WebCore::VideoFrameRotation);
@@ -243,9 +242,6 @@ private:
     bool m_shouldListenToVoiceActivity { false };
     Markable<WebPageProxyIdentifier> m_lastPageUsingMicrophone;
     bool m_isMicrophoneMuteStatusAPIEnabled { false };
-#endif
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    bool m_useSCContentSharingPicker { false };
 #endif
 #if PLATFORM(COCOA)
     bool m_hasSentTCCDSandboxExtension { false };

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -1139,17 +1139,6 @@ void UserMediaPermissionRequestManagerProxy::syncWithWebCorePrefs() const
         page->legacyMainFrameProcess().protectedProcessPool()->ensureProtectedGPUProcess()->setUseMockCaptureDevices(mockDevicesEnabled);
 #endif
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    auto useSharingPicker = preferences->useSCContentSharingPicker();
-
-#if ENABLE(GPU_PROCESS)
-    if (useSharingPicker)
-        page->legacyMainFrameProcess().protectedProcessPool()->ensureProtectedGPUProcess()->setUseSCContentSharingPicker(useSharingPicker);
-#endif
-
-    PlatformMediaSessionManager::setUseSCContentSharingPicker(useSharingPicker);
-#endif
-
     if (MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled() == mockDevicesEnabled)
         return;
     MockRealtimeMediaSourceCenter::setMockRealtimeMediaSourceCenterEnabled(mockDevicesEnabled);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4829,10 +4829,6 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     PlatformMediaSessionManager::setAlternateWebMPlayerEnabled(settings.alternateWebMPlayerEnabled());
 #endif
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    PlatformMediaSessionManager::setUseSCContentSharingPicker(settings.useSCContentSharingPicker());
-#endif
-
 #if ENABLE(VP9)
     PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(store.getBoolValueForKey(WebPreferencesKey::sWVPDecodersAlwaysEnabledKey()));
 #endif


### PR DESCRIPTION
#### ec73e4251368beae311ed197ea19c604e353de5d
<pre>
Remove useSCContentSharingPicker preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=291005">https://bugs.webkit.org/show_bug.cgi?id=291005</a>
<a href="https://rdar.apple.com/148530253">rdar://148530253</a>

Reviewed by Jer Noble.

Remove the `useSCContentSharingPicker` preference as it is no longer useful for testing.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::setUseSCContentSharingPicker): Deleted.
(WebCore::PlatformMediaSessionManager::useSCContentSharingPicker): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::useSCContentSharingPicker):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences):
(WebKit::GPUProcess::setUseSCContentSharingPicker): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultUseSCContentSharingPicker): Deleted.
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::setUseSCContentSharingPicker): Deleted.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::syncWithWebCorePrefs const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/293195@main">https://commits.webkit.org/293195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c083b286d85902553546d344c2ceee67fce6dbf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31897 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48096 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90806 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105618 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96751 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21013 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27796 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18851 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30344 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120372 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24990 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33724 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->