### PR TITLE
Reduce use of `(NSString *)` casting in WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -66,7 +66,7 @@ void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParam
 void GPUProcess::updateProcessName()
 {
 #if !PLATFORM(MACCATALYST)
-    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)m_uiProcessName];
+    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), m_uiProcessName.createNSString().get()];
     auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
     ASSERT_UNUSED(result, result == noErr);
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -180,8 +180,8 @@ private:
 static ResourceError toResourceError(String payload, Model& model)
 {
     return ResourceError { [NSError errorWithDomain:@"RKModelLoaderUSD" code:-1 userInfo:@{
-        NSLocalizedDescriptionKey: (NSString *)payload,
-        NSURLErrorFailingURLErrorKey: (NSURL *)model.url()
+        NSLocalizedDescriptionKey: payload.createNSString().get(),
+        NSURLErrorFailingURLErrorKey: model.url().createNSURL().get()
     }] };
 }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -152,11 +152,11 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
 
 #if USE(CFNETWORK_CONTENT_ENCODING_SNIFFING_OVERRIDE)
     if (contentEncodingSniffingPolicy == WebCore::ContentEncodingSniffingPolicy::Disable)
-        [mutableRequest _setProperty:@YES forKey:(NSString *)kCFURLRequestContentDecoderSkipURLCheck];
+        [mutableRequest _setProperty:@YES forKey:bridge_cast(kCFURLRequestContentDecoderSkipURLCheck)];
 #endif
 
     if (!shouldContentSniff)
-        [mutableRequest _setProperty:@NO forKey:(NSString *)_kCFURLConnectionPropertyShouldSniff];
+        [mutableRequest _setProperty:@NO forKey:bridge_cast(_kCFURLConnectionPropertyShouldSniff)];
 
     if (!boundInterfaceIdentifier.isNull())
         [mutableRequest setBoundInterfaceIdentifier:boundInterfaceIdentifier];

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1352,14 +1352,14 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
     auto dictionary = adoptNS([[NSMutableDictionary alloc] init]);
     if (httpProxy.isValid()) {
-        [dictionary setObject:httpProxy.host().createNSString().get() forKey:(NSString *)kCFStreamPropertyHTTPProxyHost];
+        [dictionary setObject:httpProxy.host().createNSString().get() forKey:bridge_cast(kCFStreamPropertyHTTPProxyHost)];
         if (auto port = httpProxy.port())
-            [dictionary setObject:@(*port) forKey:(NSString *)kCFStreamPropertyHTTPProxyPort];
+            [dictionary setObject:@(*port) forKey:bridge_cast(kCFStreamPropertyHTTPProxyPort)];
     }
     if (httpsProxy.isValid()) {
-        [dictionary setObject:httpsProxy.host().createNSString().get() forKey:(NSString *)kCFStreamPropertyHTTPSProxyHost];
+        [dictionary setObject:httpsProxy.host().createNSString().get() forKey:bridge_cast(kCFStreamPropertyHTTPSProxyHost)];
         if (auto port = httpsProxy.port())
-            [dictionary setObject:@(*port) forKey:(NSString *)kCFStreamPropertyHTTPSProxyPort];
+            [dictionary setObject:@(*port) forKey:bridge_cast(kCFStreamPropertyHTTPSProxyPort)];
     }
     return dictionary;
 
@@ -1940,7 +1940,7 @@ std::unique_ptr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageP
         [ensureMutableRequest() addValue:StringView(protocol).createNSString().get() forHTTPHeaderField:@"Sec-WebSocket-Protocol"];
 
     // rdar://problem/68057031: explicitly disable sniffing for WebSocket handshakes.
-    [nsRequest _setProperty:@NO forKey:(NSString *)_kCFURLConnectionPropertyShouldSniff];
+    [nsRequest _setProperty:@NO forKey:bridge_cast(_kCFURLConnectionPropertyShouldSniff)];
 
 #if ENABLE(APP_PRIVACY_REPORT)
     if (!request.isAppInitiated())

--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -58,7 +58,7 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if !PLATFORM(MACCATALYST)
-    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), (NSString *)parameters.uiProcessName];
+    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), parameters.uiProcessName.createNSString().get()];
     _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
 #endif
 }

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -55,8 +55,8 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const
         auto archiver = adoptNS([WKKeyedCoder new]);
         [downcast<MediaPlaybackTargetContextCocoa>(context).outputContext() encodeWithCoder:archiver.get()];
         auto dictionary = [archiver accumulatedDictionary];
-        m_contextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
-        m_contextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
+        m_contextID = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"]);
+        m_contextType = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"]);
 #endif
     } else if (is<MediaPlaybackTargetContextMock>(context))
         m_state = downcast<MediaPlaybackTargetContextMock>(context).state();

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -245,10 +245,10 @@ CALayer *VideoPresentationInterfaceLMK::captionsLayer()
     m_spatialTrackingLabel = makeString(createVersion4UUIDString());
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     if (prefersSpatialAudioExperience())
-        [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.AudioTether"];
+        [m_spatialTrackingLayer setValue:m_spatialTrackingLabel.createNSString().get() forKeyPath:@"separatedOptions.AudioTether"];
     else
 #endif
-        [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
+        [m_spatialTrackingLayer setValue:m_spatialTrackingLabel.createNSString().get() forKeyPath:@"separatedOptions.STSLabel"];
     [m_captionsLayer addSublayer:m_spatialTrackingLayer.get()];
 
     return m_captionsLayer.get();

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -123,7 +123,7 @@ NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)
 
     [actionContext setAllowedActionUTIs:@[ @"com.apple.dial" ]];
 
-    NSArray *proposedMenuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForValue:(NSString *)telephoneNumber type:PAL::get_DataDetectorsCore_DDBinderPhoneNumberKey() service:nil context:actionContext.get()];
+    NSArray *proposedMenuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForValue:telephoneNumber.createNSString().get() type:PAL::get_DataDetectorsCore_DDBinderPhoneNumberKey() service:nil context:actionContext.get()];
     for (NSMenuItem *item in proposedMenuItems) {
         auto action = actionForMenuItem(item);
         if ([action.actionUTI hasPrefix:@"com.apple.dial"]) {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -26,6 +26,8 @@
 #include "GeneratedWebKitSecureCoding.h"
 
 #include "ArgumentCodersCocoa.h"
+#include <wtf/cocoa/TypeCastsCocoa.h>
+
 #if USE(AVFOUNDATION)
 #include <pal/cocoa/AVFoundationSoftLink.h>
 #endif
@@ -130,11 +132,11 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(
 CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_AVOutputContextSerializationKeyContextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
+    m_AVOutputContextSerializationKeyContextID = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"]);
     if (![m_AVOutputContextSerializationKeyContextID isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextID = nullptr;
 
-    m_AVOutputContextSerializationKeyContextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
+    m_AVOutputContextSerializationKeyContextType = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"]);
     if (![m_AVOutputContextSerializationKeyContextType isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextType = nullptr;
 
@@ -177,7 +179,7 @@ CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(
 CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
+    m_StringKey = checked_objc_cast<NSString>([dictionary objectForKey:@"StringKey"]);
     if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 
@@ -285,7 +287,7 @@ CoreIPCDDScannerResult::CoreIPCDDScannerResult(
 CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
+    m_StringKey = checked_object_cast<NSString>([dictionary objectForKey:@"StringKey"]);
     if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -218,7 +218,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
     auto interfaceAndObject = _exportedObjects.get(interfaceIdentifier);
     if (!interfaceAndObject.second) {
-        NSLog(@"Did not find a registered object for the interface \"%@\"", (NSString *)interfaceIdentifier);
+        NSLog(@"Did not find a registered object for the interface \"%@\"", interfaceIdentifier.createNSString().get());
         return;
     }
 

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -550,7 +550,7 @@ RetainPtr<NSObject<NSSecureCoding>> Object::toNSObject()
         auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:dictionary.size()]);
         for (auto& pair : dictionary.map()) {
             if (auto nsObject = pair.value ? Ref { *pair.value }->toNSObject() : RetainPtr<NSObject<NSSecureCoding>>())
-                [result setObject:nsObject.get() forKey:(NSString *)pair.key];
+                [result setObject:nsObject.get() forKey:pair.key.createNSString().get()];
         }
         return result;
     }

--- a/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
@@ -37,16 +37,16 @@ NSDictionary *BackgroundFetchState::toDictionary() const
 {
     // FIXME: Expose icon URLS.
     return @{
-        @"TopOrigin" : (NSString *)topOrigin.toString(),
-        @"Scope" : (NSURL *)scope,
-        @"WebIdentifier" : (NSString *)identifier,
-        @"Title" : (NSString *)options.title,
+        @"TopOrigin" : topOrigin.toString().createNSString().get(),
+        @"Scope" : scope.createNSURL().get(),
+        @"WebIdentifier" : identifier.createNSString().get(),
+        @"Title" : options.title.createNSString().get(),
         @"DownloadTotal" : @(downloadTotal),
         @"Downloaded" : @(downloaded),
         @"UploadTotal" : @(uploadTotal),
         @"Uploaded" : @(uploaded),
-        @"Result" : (NSString *)(convertEnumerationToString(result)),
-        @"FailureReason" : (NSString *)(convertEnumerationToString(failureReason)),
+        @"Result" : convertEnumerationToString(result).createNSString().get(),
+        @"FailureReason" : convertEnumerationToString(failureReason).createNSString().get(),
         @"IsPaused" : @(isPaused),
     };
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -29,8 +29,10 @@
 #if HAVE(CONTACTS)
 
 #import <pal/spi/cocoa/ContactsSPI.h>
-#import <pal/cocoa/ContactsSoftLink.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+
+#import <pal/cocoa/ContactsSoftLink.h>
 
 namespace WebKit {
 
@@ -42,7 +44,7 @@ CoreIPCCNPhoneNumber::CoreIPCCNPhoneNumber(CNPhoneNumber *cnPhoneNumber)
 
 RetainPtr<id> CoreIPCCNPhoneNumber::toID() const
 {
-    return [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:(NSString *)m_digits countryCode:(NSString *)m_countryCode];
+    return [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:m_digits.createNSString().get() countryCode:m_countryCode.createNSString().get()];
 }
 
 CoreIPCCNPostalAddress::CoreIPCCNPostalAddress(CNPostalAddress *cnPostalAddress)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
@@ -66,9 +66,9 @@ RetainPtr<id> CoreIPCDateComponents::toID() const
         [components setValue:m_componentValues[i] forComponent:calendarUnitForComponentIndex[i]];
 
     if (!m_calendarIdentifier.isEmpty())
-        components.get().calendar = [NSCalendar calendarWithIdentifier:(NSString *)m_calendarIdentifier];
+        components.get().calendar = [NSCalendar calendarWithIdentifier:m_calendarIdentifier.createNSString().get()];
     if (!m_timeZoneName.isEmpty())
-        components.get().timeZone = [NSTimeZone timeZoneWithName:(NSString *)m_timeZoneName];
+        components.get().timeZone = [NSTimeZone timeZoneWithName:m_timeZoneName.createNSString().get()];
 
     return components;
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
@@ -57,7 +57,7 @@ CoreIPCLocale::CoreIPCLocale(String&& identifier)
 
 RetainPtr<id> CoreIPCLocale::toID() const
 {
-    return adoptNS([[NSLocale alloc] initWithLocaleIdentifier:(NSString *)m_identifier]);
+    return adoptNS([[NSLocale alloc] initWithLocaleIdentifier:m_identifier.createNSString().get()]);
 }
 
 std::optional<String> CoreIPCLocale::canonicalLocaleStringReplacement(const String& identifier)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -263,7 +263,7 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
                     auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:1]);
                     if (!s.isNull() && !headerPair.first.isNull()) {
                         [array addObject: s];
-                        [headerFields setObject:array.get() forKey:(NSString *)headerPair.first];
+                        [headerFields setObject:array.get() forKey:headerPair.first.createNSString().get()];
                     }
                 },
                 [&] (const Vector<String>& vector) {
@@ -271,7 +271,7 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
                     for (auto& item : vector)
                         [array addObject: item];
                     if (!headerPair.first.isNull())
-                        [headerFields setObject:array.get() forKey:(NSString *)headerPair.first];
+                        [headerFields setObject:array.get() forKey:headerPair.first.createNSString().get()];
                 }
             );
         }

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -94,7 +94,7 @@ NSDictionary *WebPushMessage::toDictionary() const
     return @{
         WebKitPushDataKey : nsData ? nsData.get() : [NSNull null],
         WebKitPushRegistrationURLKey : (NSURL *)registrationURL,
-        WebKitPushPartitionKey : (NSString *)pushPartitionString,
+        WebKitPushPartitionKey : pushPartitionString.createNSString().get(),
         WebKitNotificationPayloadKey : nsPayload ? nsPayload.get() : [NSNull null]
     };
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -41,8 +41,8 @@ namespace API {
 
 static WTF::String mimeTypeInferredFromFileExtension(const API::Attachment& attachment)
 {
-    if (NSString *fileExtension = [(NSString *)attachment.fileName() pathExtension])
-        return WebCore::MIMETypeRegistry::mimeTypeForExtension(WTF::String(fileExtension));
+    if (RetainPtr<NSString> fileExtension = [attachment.fileName().createNSString() pathExtension])
+        return WebCore::MIMETypeRegistry::mimeTypeForExtension(WTF::String(fileExtension.get()));
 
     return { };
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -207,7 +207,7 @@ private:
 - (void)_addScriptMessageHandler:(WebKit::WebScriptMessageHandler&)scriptMessageHandler
 {
     if (!_userContentControllerProxy->addUserScriptMessageHandler(scriptMessageHandler))
-        [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", (NSString *)scriptMessageHandler.name()];
+        [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", scriptMessageHandler.name().createNSString().get()];
 }
 
 - (void)addScriptMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler name:(NSString *)name

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2153,7 +2153,7 @@ static NSDictionary *dictionaryRepresentationForEditorState(const WebKit::Editor
         @"italic": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics) ? @YES : @NO,
         @"underline": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline) ? @YES : @NO,
         @"text-alignment": @(nsTextAlignment(static_cast<WebKit::TextAlignment>(postLayoutData.textAlignment))),
-        @"text-color": (NSString *)serializationForCSS(postLayoutData.textColor)
+        @"text-color": serializationForCSS(postLayoutData.textColor).createNSString().get()
     };
 }
 
@@ -3394,9 +3394,9 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
     if (!info->documentURL.isNull())
         [result setObject:(NSURL *)info->documentURL forKey:_WKTextManipulationTokenUserInfoDocumentURLKey];
     if (!info->tagName.isNull())
-        [result setObject:(NSString *)info->tagName forKey:_WKTextManipulationTokenUserInfoTagNameKey];
+        [result setObject:info->tagName.createNSString().get() forKey:_WKTextManipulationTokenUserInfoTagNameKey];
     if (!info->roleAttribute.isNull())
-        [result setObject:(NSString *)info->roleAttribute forKey:_WKTextManipulationTokenUserInfoRoleAttributeKey];
+        [result setObject:info->roleAttribute.createNSString().get() forKey:_WKTextManipulationTokenUserInfoRoleAttributeKey];
     [result setObject:@(info->isVisible) forKey:_WKTextManipulationTokenUserInfoVisibilityKey];
 
     return result;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -212,7 +212,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         auto* validationBubble = _page->validationBubble();
         String message = validationBubble ? validationBubble->message() : emptyString();
         double fontSize = validationBubble ? validationBubble->fontSize() : 0;
-        return @{ userInterfaceItem: @{ @"message": (NSString *)message, @"fontSize": @(fontSize) } };
+        return @{ userInterfaceItem: @{ @"message": message.createNSString().get(), @"fontSize": @(fontSize) } };
     }
 
     if (NSDictionary *contents = _page->contentsOfUserInterfaceItem(userInterfaceItem))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
@@ -42,7 +42,7 @@
         return nil;
 
     _url = (NSURL *)linkIcon.url;
-    _mimeType = (NSString *)linkIcon.mimeType;
+    _mimeType = linkIcon.mimeType.createNSString();
 
     if (linkIcon.size)
         _size = adoptNS([[NSNumber alloc] initWithUnsignedInt:linkIcon.size.value()]);
@@ -61,7 +61,7 @@
 
     _attributes = adoptNS([[NSMutableDictionary alloc] initWithCapacity:linkIcon.attributes.size()]);
     for (auto& attributePair : linkIcon.attributes)
-        _attributes.get()[(NSString *)attributePair.first] = attributePair.second;
+        _attributes.get()[attributePair.first.createNSString().get()] = attributePair.second;
 
     return self;
 }

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -144,7 +144,7 @@ void AutomationSessionClient::loadWebExtensionWithOptions(WebKit::WebAutomationS
         return;
     }
 
-    [m_delegate.get() _automationSession:wrapper(session) loadWebExtensionWithOptions:toAPI(options) resource:(NSString *)resource completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *extensionId) mutable {
+    [m_delegate.get() _automationSession:wrapper(session) loadWebExtensionWithOptions:toAPI(options) resource:resource.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *extensionId) mutable {
         completionHandler(extensionId);
     }).get()];
 }

--- a/Source/WebKit/UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm
@@ -29,6 +29,7 @@
 #if ENABLE(FULL_KEYBOARD_ACCESS)
 
 #import "WebProcessPool.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "AccessibilitySupportSPI.h"
@@ -94,7 +95,7 @@ static inline BOOL platformIsFullKeyboardAccessEnabled()
     notitificationName = KeyboardUIModeDidChangeNotification;
 #elif PLATFORM(IOS_FAMILY)
     notificationCenter = [NSNotificationCenter defaultCenter];
-    notitificationName = (NSString *)kAXSFullKeyboardAccessEnabledNotification;
+    notitificationName = bridge_cast(kAXSFullKeyboardAccessEnabledNotification);
 #endif
     
     if (notitificationName)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1481,7 +1481,7 @@ static URL fontURLFromName(ASCIILiteral fontName)
 static RetainPtr<CTFontDescriptorRef> fontDescription(ASCIILiteral fontName)
 {
     RetainPtr nsFontName = fontName.createNSString();
-    RetainPtr attributes = @{ (NSString *)kCTFontFamilyNameAttribute: nsFontName.get(), (NSString *)kCTFontRegistrationScopeAttribute: @(kCTFontPriorityComputer) };
+    RetainPtr attributes = @{ bridge_cast(kCTFontFamilyNameAttribute): nsFontName.get(), bridge_cast(kCTFontRegistrationScopeAttribute): @(kCTFontPriorityComputer) };
     return adoptCF(CTFontDescriptorCreateWithAttributes((__bridge CFDictionaryRef)attributes.get()));
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -113,7 +113,7 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
     for (auto& identifier : rulesetIdentifiers) {
         auto ruleset = extension->declarativeNetRequestRuleset(identifier);
         if (!ruleset)
-            return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier);
+            return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"Failed to apply rules. Invalid ruleset id: %@.", identifier.createNSString().get());
 
         validatedRulesets.append(ruleset.value());
     }
@@ -293,7 +293,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
 {
     [storage createSavepointWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, apiName, rulesToAdd, ruleIDsToRemove](NSUUID *savepointIdentifier, NSString *errorMessage) mutable {
         if (errorMessage)
-            RELEASE_LOG_ERROR(Extensions, "Unable to create %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), errorMessage);
+            RELEASE_LOG_ERROR(Extensions, "Unable to create %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, uniqueIdentifier().createNSString().get(), errorMessage);
 
         if (errorMessage.length) {
             completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
@@ -302,13 +302,13 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
 
         [storage updateRulesByRemovingIDs:ruleIDsToRemove addRules:rulesToAdd completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, apiName, savepointIdentifier](NSString *errorMessage) mutable {
             if (errorMessage)
-                RELEASE_LOG_ERROR(Extensions, "Unable to update %{public}@ rules for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), errorMessage);
+                RELEASE_LOG_ERROR(Extensions, "Unable to update %{public}@ rules for extension %{private}@. Error: %{public}@", storageType, uniqueIdentifier().createNSString().get(), errorMessage);
 
             if (errorMessage.length) {
                 // Update was unsucessful, rollback the changes to the database.
                 [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, apiName, errorMessage](NSString *savepointErrorMessage) mutable {
                     if (savepointErrorMessage)
-                        RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
+                        RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, uniqueIdentifier().createNSString().get(), savepointErrorMessage);
 
                     completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
                 }).get()];
@@ -322,7 +322,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
                     // Load was unsucessful, rollback the changes to the database.
                     [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, apiName](NSString *savepointErrorMessage) mutable {
                         if (savepointErrorMessage)
-                            RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
+                            RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, uniqueIdentifier().createNSString().get(), savepointErrorMessage);
 
                         // Load the declarativeNetRequest rules again after rolling back the dynamic update.
                         loadDeclarativeNetRequestRules([completionHandler = WTFMove(completionHandler), apiName](bool success) mutable {
@@ -341,7 +341,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
                 // Load was successful, commit the changes to the database.
                 [storage commitSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType](NSString *savepointErrorMessage) mutable {
                     if (savepointErrorMessage)
-                        RELEASE_LOG_ERROR(Extensions, "Unable to commit %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
+                        RELEASE_LOG_ERROR(Extensions, "Unable to commit %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, uniqueIdentifier().createNSString().get(), savepointErrorMessage);
 
                     completionHandler({ });
                 }).get()];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
@@ -68,7 +68,7 @@ void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier web
 
         extension->evaluateScript(scriptSource, frameURL, std::nullopt, std::nullopt, [completionHandler = WTFMove(completionHandler)](Inspector::ExtensionEvaluationResult&& result) mutable {
             if (!result) {
-                RELEASE_LOG_ERROR(Extensions, "Inspector could not evaluate script (%{public}@)", (NSString *)extensionErrorToString(result.error()));
+                RELEASE_LOG_ERROR(Extensions, "Inspector could not evaluate script (%{public}@)", extensionErrorToString(result.error()).createNSString().get());
                 completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector could not evaluate script"));
                 return;
             }
@@ -90,7 +90,7 @@ void WebExtensionContext::devToolsInspectedWindowReload(WebPageProxyIdentifier w
 
     extension->reloadIgnoringCache(ignoreCache, std::nullopt, std::nullopt, [](Inspector::ExtensionVoidResult&& result) {
         if (!result)
-            RELEASE_LOG_ERROR(Extensions, "Inspector could not reload page (%{public}@)", (NSString *)extensionErrorToString(result.error()));
+            RELEASE_LOG_ERROR(Extensions, "Inspector could not reload page (%{public}@)", extensionErrorToString(result.error()).createNSString().get());
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
@@ -51,7 +51,7 @@ void WebExtensionContext::devToolsPanelsCreate(WebPageProxyIdentifier webPagePro
 
     extension->createTab(title, { baseURL(), iconPath }, { baseURL(), pagePath }, [completionHandler = WTFMove(completionHandler)](Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
-            RELEASE_LOG_ERROR(Extensions, "Inspector could not create panel (%{public}@)", (NSString *)extensionErrorToString(result.error()));
+            RELEASE_LOG_ERROR(Extensions, "Inspector could not create panel (%{public}@)", extensionErrorToString(result.error()).createNSString().get());
             completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector could not create the panel"));
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -46,7 +46,7 @@ void WebExtensionContext::addListener(WebCore::FrameIdentifier frameIdentifier, 
     if (!frame)
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(listenerType), (NSString *)toDebugString(contentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(listenerType), toDebugString(contentWorldType).createNSString().get());
 
     if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier))
         m_backgroundContentEventListeners.add(listenerType);
@@ -71,7 +71,7 @@ void WebExtensionContext::removeListener(WebCore::FrameIdentifier frameIdentifie
     if (!frame)
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}zu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(listenerType), (NSString *)toDebugString(contentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}zu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(listenerType), toDebugString(contentWorldType).createNSString().get());
 
     if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier)) {
         for (size_t i = 0; i < removedCount; ++i)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -48,7 +48,7 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType sourceCon
 
     if (!isPortConnected(sourceContentWorldType, targetContentWorldType, channelIdentifier)) {
         // The port might not be open on the other end yet. Queue the message until it does open.
-        RELEASE_LOG_DEBUG(Extensions, "Enqueued message for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+        RELEASE_LOG_DEBUG(Extensions, "Enqueued message for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(targetContentWorldType).createNSString().get());
 
         auto& messages = m_portQueuedMessages.ensure({ targetContentWorldType, channelIdentifier }, [] {
             return Vector<MessagePageProxyIdentifierPair> { };
@@ -98,7 +98,7 @@ void WebExtensionContext::addPorts(WebExtensionContentWorldType sourceContentWor
     ASSERT(!addedPortCounts.isEmpty());
 
     for (auto& entry : addedPortCounts) {
-        RELEASE_LOG_DEBUG(Extensions, "Added %{public}u port(s) for channel %{public}llu in %{public}@ world for page %{public}llu", entry.value, channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType), entry.key.toUInt64());
+        RELEASE_LOG_DEBUG(Extensions, "Added %{public}u port(s) for channel %{public}llu in %{public}@ world for page %{public}llu", entry.value, channelIdentifier.toUInt64(), toDebugString(sourceContentWorldType).createNSString().get(), entry.key.toUInt64());
 
         if (isBackgroundPage(entry.key))
             m_lastBackgroundPortActivityTime = MonotonicTime::now();
@@ -115,7 +115,7 @@ void WebExtensionContext::addPorts(WebExtensionContentWorldType sourceContentWor
 
 void WebExtensionContext::removePort(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, WebPageProxyIdentifier webPageProxyIdentifier)
 {
-    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world for page %{public}llu", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType), webPageProxyIdentifier.toUInt64());
+    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world for page %{public}llu", channelIdentifier.toUInt64(), toDebugString(sourceContentWorldType).createNSString().get(), webPageProxyIdentifier.toUInt64());
 
     if (m_ports.remove({ sourceContentWorldType, channelIdentifier }))
         clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
@@ -134,7 +134,7 @@ void WebExtensionContext::addNativePort(WebExtensionMessagePort& nativePort)
     constexpr auto contentWorldType = WebExtensionContentWorldType::Native;
     auto channelIdentifier = nativePort.channelIdentifier();
 
-    RELEASE_LOG_DEBUG(Extensions, "Added 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Added 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(contentWorldType).createNSString().get());
 
     m_ports.add({ contentWorldType, channelIdentifier });
     m_nativePortMap.add(channelIdentifier, nativePort);
@@ -145,7 +145,7 @@ void WebExtensionContext::removeNativePort(WebExtensionMessagePort& nativePort)
     constexpr auto contentWorldType = WebExtensionContentWorldType::Native;
     auto channelIdentifier = nativePort.channelIdentifier();
 
-    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(contentWorldType).createNSString().get());
 
     clearQueuedPortMessages(WebExtensionContentWorldType::Main, channelIdentifier);
 
@@ -172,7 +172,7 @@ bool WebExtensionContext::isPortConnected(WebExtensionContentWorldType sourceCon
 {
     const auto sourceWorldCount = openPortCount(sourceContentWorldType, channelIdentifier);
 
-    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), sourceWorldCount, (NSString *)toDebugString(sourceContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), sourceWorldCount, toDebugString(sourceContentWorldType).createNSString().get());
 
     // When the worlds are the same, it is connected if there are 2 ports remaining.
     if (isEqual(sourceContentWorldType, targetContentWorldType))
@@ -180,7 +180,7 @@ bool WebExtensionContext::isPortConnected(WebExtensionContentWorldType sourceCon
 
     const auto targetWorldCount = openPortCount(targetContentWorldType, channelIdentifier);
 
-    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), targetWorldCount, (NSString *)toDebugString(targetContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), targetWorldCount, toDebugString(targetContentWorldType).createNSString().get());
 
     // When the worlds are different, it is connected if there is 1 port in each world remaining.
     return sourceWorldCount && targetWorldCount;
@@ -203,7 +203,7 @@ Vector<WebExtensionContext::MessagePageProxyIdentifierPair> WebExtensionContext:
 
 void WebExtensionContext::firePortMessageEventsIfNeeded(WebExtensionContentWorldType targetContentWorldType, std::optional<WebPageProxyIdentifier> sendingPageProxyIdentifier, WebExtensionPortChannelIdentifier channelIdentifier, const String& messageJSON)
 {
-    RELEASE_LOG_DEBUG(Extensions, "Sending message to port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Sending message to port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(targetContentWorldType).createNSString().get());
 
     constexpr auto type = WebExtensionEventListenerType::PortOnMessage;
 
@@ -236,7 +236,7 @@ void WebExtensionContext::fireQueuedPortMessageEventsIfNeeded(WebExtensionConten
     if (messages.isEmpty())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Sending %{public}zu queued message(s) to port channel %{public}llu in %{public}@ world", messages.size(), channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Sending %{public}zu queued message(s) to port channel %{public}llu in %{public}@ world", messages.size(), channelIdentifier.toUInt64(), toDebugString(targetContentWorldType).createNSString().get());
 
     for (auto& entry : messages) {
         auto& sendingPageProxyIdentifier = std::get<std::optional<WebPageProxyIdentifier>>(entry);
@@ -272,7 +272,7 @@ void WebExtensionContext::sendQueuedNativePortMessagesIfNeeded(WebExtensionPortC
 void WebExtensionContext::clearQueuedPortMessages(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
 {
     if (m_portQueuedMessages.remove({ contentWorldType, channelIdentifier }))
-        RELEASE_LOG_DEBUG(Extensions, "Cleared queued message(s) for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+        RELEASE_LOG_DEBUG(Extensions, "Cleared queued message(s) for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(contentWorldType).createNSString().get());
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // Inspector content world is a special alias of Main. Include it when Main is requested (and vice versa).
@@ -289,7 +289,7 @@ void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWor
     if (isPortConnected(sourceContentWorldType, targetContentWorldType, channelIdentifier))
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Sending disconnect event for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Sending disconnect event for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), toDebugString(targetContentWorldType).createNSString().get());
 
     constexpr auto type = WebExtensionEventListenerType::PortOnDisconnect;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -324,7 +324,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
         return;
     }
 
-    auto *applicationIdentifier = !applicationID.isNull() ? (NSString *)applicationID : nil;
+    auto *applicationIdentifier = !applicationID.isNull() ? applicationID.createNSString().get() : nil;
 
     [delegate webExtensionController:extensionController->wrapper() sendMessage:message toApplicationWithIdentifier:applicationIdentifier forExtensionContext:wrapper() replyHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id replyMessage, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -198,7 +198,7 @@ void WebExtensionContext::scriptingUpdateRegisteredScripts(const Vector<WebExten
         auto scriptID = parameters.identifier;
         RefPtr registeredScript = m_registeredScriptsMap.get(scriptID);
         if (!registeredScript) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"no existing script with ID '%@'", (NSString *)scriptID));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no existing script with ID '%@'", scriptID.createNSString().get()));
             return;
         }
 
@@ -273,7 +273,7 @@ void WebExtensionContext::scriptingUnregisterContentScripts(const Vector<String>
 
     for (auto& scriptID : ids) {
         if (!m_registeredScriptsMap.contains(scriptID)) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"no script with ID '%@'", (NSString *)scriptID));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no script with ID '%@'", scriptID.createNSString().get()));
             return;
         }
     }
@@ -303,20 +303,20 @@ void WebExtensionContext::loadRegisteredContentScripts()
 
     [registeredContentScriptsStore() getScriptsWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }](NSArray *scripts, NSString *errorMessage) mutable {
         if (errorMessage) {
-            RELEASE_LOG_ERROR(Extensions, "Unable to get registered scripts for extension %{private}@. Error: %{public}@", (NSString *)m_uniqueIdentifier, errorMessage);
+            RELEASE_LOG_ERROR(Extensions, "Unable to get registered scripts for extension %{private}@. Error: %{public}@", m_uniqueIdentifier.createNSString().get(), errorMessage);
             return;
         }
 
         Vector<WebExtensionRegisteredScriptParameters> parametersVector;
         if (!WebExtensionAPIScripting::parseRegisteredContentScripts(scripts, FirstTimeRegistration::Yes, parametersVector, &errorMessage)) {
-            RELEASE_LOG_ERROR(Extensions, "Failed to parse injected content data for extension %{private}@. Error: %{public}@", (NSString *)m_uniqueIdentifier, errorMessage);
+            RELEASE_LOG_ERROR(Extensions, "Failed to parse injected content data for extension %{private}@. Error: %{public}@", m_uniqueIdentifier.createNSString().get(), errorMessage);
             return;
         }
 
         DynamicInjectedContentsMap injectedContentsMap;
         createInjectedContentForScripts(parametersVector, FirstTimeRegistration::Yes, injectedContentsMap, nil, &errorMessage);
         if (errorMessage) {
-            RELEASE_LOG_ERROR(Extensions, "Failed to create injected content data for extension %{private}@. Error: %{public}@", (NSString *)m_uniqueIdentifier, errorMessage);
+            RELEASE_LOG_ERROR(Extensions, "Failed to create injected content data for extension %{private}@. Error: %{public}@", m_uniqueIdentifier.createNSString().get(), errorMessage);
             return;
         }
 
@@ -349,7 +349,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto scriptID = parameters.identifier;
 
         if (firstTimeRegistration == FirstTimeRegistration::Yes && (m_registeredScriptsMap.contains(scriptID) || idsToAdd.contains(scriptID))) {
-            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", (NSString *)scriptID);
+            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", scriptID.createNSString().get());
             return false;
         }
 
@@ -393,13 +393,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *matchesArray = parameters.matchPatterns ? createNSArray(parameters.matchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in matchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", (NSString *)scriptID);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", scriptID.createNSString().get());
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", (NSString *)scriptID, matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", scriptID.createNSString().get(), matchPatternString);
                 return false;
             }
 
@@ -410,13 +410,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *excludeMatchesArray = parameters.excludeMatchPatterns ? createNSArray(parameters.excludeMatchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in excludeMatchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", (NSString *)scriptID);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", scriptID.createNSString().get());
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", (NSString *)scriptID, matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", scriptID.createNSString().get(), matchPatternString);
                 return false;
             }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -352,7 +352,7 @@ bool WebExtensionContext::load(WebExtensionController& controller, String storag
     readStateFromStorage();
 
     auto lastSeenBaseURL = URL { objectForKey<NSString>(m_state, lastSeenBaseURLStateKey) };
-    [m_state setObject:(NSString *)m_baseURL.string() forKey:lastSeenBaseURLStateKey];
+    [m_state setObject:m_baseURL.string().createNSString().get() forKey:lastSeenBaseURLStateKey];
 
     if (NSString *displayName = protectedExtension()->displayName())
         [m_state setObject:displayName forKey:lastSeenDisplayNameStateKey];
@@ -4868,7 +4868,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
             NSError *serializationError;
             NSData *dynamicRulesAsData = encodeJSONData(rules, JSONOptions::FragmentsAllowed, &serializationError);
             if (serializationError)
-                RELEASE_LOG_ERROR(Extensions, "Unable to serialize dynamic declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), privacyPreservingDescription(serializationError));
+                RELEASE_LOG_ERROR(Extensions, "Unable to serialize dynamic declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", uniqueIdentifier().createNSString().get(), privacyPreservingDescription(serializationError));
             else
                 [allJSONData addObject:dynamicRulesAsData];
 
@@ -4892,7 +4892,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
         NSError *serializationError;
         NSData *sessionRulesAsData = encodeJSONData(rules, JSONOptions::FragmentsAllowed, &serializationError);
         if (serializationError)
-            RELEASE_LOG_ERROR(Extensions, "Unable to serialize session declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), privacyPreservingDescription(serializationError));
+            RELEASE_LOG_ERROR(Extensions, "Unable to serialize session declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", uniqueIdentifier().createNSString().get(), privacyPreservingDescription(serializationError));
         else
             [allJSONData addObject:sessionRulesAsData];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -147,7 +147,7 @@ void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> data
     for (auto& uniqueIdentifier : uniqueIdentifiers) {
         String displayName;
         if (!WebExtensionContext::readDisplayNameFromState(stateFilePath(uniqueIdentifier), displayName)) {
-            RELEASE_LOG_ERROR(Extensions, "Failed to read extension display name from State.plist for extension: %{private}@", (NSString *)uniqueIdentifier);
+            RELEASE_LOG_ERROR(Extensions, "Failed to read extension display name from State.plist for extension: %{private}@", uniqueIdentifier.createNSString().get());
             continue;
         }
 
@@ -158,7 +158,7 @@ void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> data
 
             RefPtr storage = sqliteStore(storageDirectory(uniqueIdentifier), dataType, this->extensionContext(uniqueIdentifier));
             if (!storage) {
-                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)uniqueIdentifier);
+                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", uniqueIdentifier.createNSString().get());
                 record->addError(@"Unable to calculate extension storage", dataType);
                 continue;
             }
@@ -208,7 +208,7 @@ void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> dataT
 
         RefPtr storage = sqliteStore(storageDirectory(matchingUniqueIdentifier), dataType, this->extensionContext(matchingUniqueIdentifier));
         if (!storage) {
-            RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)matchingUniqueIdentifier);
+            RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", matchingUniqueIdentifier.createNSString().get());
             record->addError(@"Unable to calculcate extension storage", dataType);
             continue;
         }
@@ -239,7 +239,7 @@ void WebExtensionController::removeData(OptionSet<WebExtensionDataType> dataType
             RefPtr extensionContext = this->extensionContext(uniqueIdentifier);
             RefPtr storage = sqliteStore(storageDirectory(uniqueIdentifier), dataType, extensionContext);
             if (!storage) {
-                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)uniqueIdentifier);
+                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", uniqueIdentifier.createNSString().get());
                 record->addError(@"Unable to delete extension storage", dataType);
                 continue;
             }
@@ -314,7 +314,7 @@ bool WebExtensionController::load(WebExtensionContext& extensionContext, NSError
 
     auto extensionDirectory = storageDirectory(extensionContext);
     if (!!extensionDirectory && !FileSystem::makeAllDirectories(extensionDirectory))
-        RELEASE_LOG_ERROR(Extensions, "Failed to create directory: %{private}@", (NSString *)extensionDirectory);
+        RELEASE_LOG_ERROR(Extensions, "Failed to create directory: %{private}@", extensionDirectory.createNSString().get());
 
     if (!extensionContext.load(*this, extensionDirectory, outError)) {
         m_extensionContexts.remove(extensionContext);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -155,10 +155,10 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
             }
 
             if (parameters.function) {
-                NSString *javaScript = [NSString stringWithFormat:@"return (%@)(...arguments)", (NSString *)parameters.function.value()];
+                RetainPtr javaScript = adoptNS([[NSString alloc] initWithFormat:@"return (%@)(...arguments)", parameters.function.value().createNSString().get()]);
                 NSArray *arguments = parameters.arguments ? parseJSON(parameters.arguments.value(), JSONOptions::FragmentsAllowed) : @[ ];
 
-                [webView _callAsyncJavaScript:javaScript arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
+                [webView _callAsyncJavaScript:javaScript.get() arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));
                 }).get()];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -45,26 +45,26 @@ NSError *toAPI(WebExtensionMessagePort::Error error)
         return nil;
 
     WKWebExtensionMessagePortError errorCode;
-    NSString *message;
+    RetainPtr<NSString> message;
 
     switch (error.value().first) {
     case WebKit::WebExtensionMessagePort::ErrorType::Unknown:
         errorCode = WKWebExtensionMessagePortErrorUnknown;
-        message = (NSString *)error.value().second.value_or("An unknown error occurred."_s);
+        message = error.value().second.value_or("An unknown error occurred."_s).createNSString();
         break;
 
     case WebKit::WebExtensionMessagePort::ErrorType::NotConnected:
         errorCode = WKWebExtensionMessagePortErrorNotConnected;
-        message = (NSString *)error.value().second.value_or("Message port is not connected and cannot send messages."_s);
+        message = error.value().second.value_or("Message port is not connected and cannot send messages."_s).createNSString().get();
         break;
 
     case WebKit::WebExtensionMessagePort::ErrorType::MessageInvalid:
         errorCode = WKWebExtensionMessagePortErrorMessageInvalid;
-        message = (NSString *)error.value().second.value_or("Message is not JSON-serializable."_s);
+        message = error.value().second.value_or("Message is not JSON-serializable."_s).createNSString().get();
         break;
     }
 
-    return [NSError errorWithDomain:WKWebExtensionMessagePortErrorDomain code:errorCode userInfo:@{ NSDebugDescriptionErrorKey: message }];
+    return [NSError errorWithDomain:WKWebExtensionMessagePortErrorDomain code:errorCode userInfo:@{ NSDebugDescriptionErrorKey: message.get() }];
 }
 
 WebExtensionMessagePort::Error toWebExtensionMessagePortError(NSError *error)

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -354,10 +354,10 @@ void WebInspectorUIProxy::updateInspectorWindowTitle() const
 
     unsigned level = inspectionLevel();
     if (level > 1) {
-        NSString *debugTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector [%d] — %@", "Web Inspector window title when inspecting Web Inspector"), level, (NSString *)m_urlString];
+        NSString *debugTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector [%d] — %@", "Web Inspector window title when inspecting Web Inspector"), level, m_urlString.createNSString().get()];
         [m_inspectorWindow setTitle:debugTitle];
     } else {
-        NSString *title = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector — %@", "Web Inspector window title"), (NSString *)m_urlString];
+        NSString *title = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector — %@", "Web Inspector window title"), m_urlString.createNSString().get()];
         [m_inspectorWindow setTitle:title];
     }
 }

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -349,8 +349,8 @@ void DragDropInteractionState::stageDragItem(const DragItem& item, DragSourceSta
         dragPreviewContent,
         item.image.indicatorData(),
         item.image.visiblePath(),
-        item.title.isEmpty() ? nil : (NSString *)item.title,
-        item.url.isEmpty() ? nil : (NSURL *)item.url,
+        item.title.isEmpty() ? nil : item.title.createNSString().get(),
+        item.url.isEmpty() ? nil : item.url.createNSURL().get(),
         true, // We assume here that drag previews need to be updated until proven otherwise in updatePreviewsForActiveDragSources().
         item.containsSelection,
         ++currentDragSourceItemIdentifier
@@ -395,7 +395,7 @@ void DragDropInteractionState::updatePreviewsForActiveDragSources()
             continue;
 
         if (source.action.contains(DragSourceAction::Link)) {
-            dragItem.previewProvider = [title = retainPtr((NSString *)source.linkTitle), url = retainPtr((NSURL *)source.linkURL)] () -> UIDragPreview * {
+            dragItem.previewProvider = [title = source.linkTitle.createNSString(), url = retainPtr((NSURL *)source.linkURL)] () -> UIDragPreview * {
                 RetainPtr preview = [UIDragPreview previewForURL:url.get() title:title.get()];
 #if PLATFORM(VISION)
                 // FIXME: This is a slightly unfortunate since we end up copying the preview parameters,

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -382,7 +382,7 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
     NSUndoManager *undoManager = [contentView() undoManagerForWebView];
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:((undoOrRedo == UndoOrRedo::Undo) ? @selector(undoEditing:) : @selector(redoEditing:)) object:commandObjC.get()];
     if (!actionName.isEmpty())
-        [undoManager setActionName:(NSString *)actionName];
+        [undoManager setActionName:actionName.createNSString().get()];
 }
 
 void PageClientImpl::clearAllEditCommands()

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -321,7 +321,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _spatialTrackingView = adoptNS([[UIView alloc] init]);
         [_spatialTrackingView layer].separatedState = kCALayerSeparatedStateTracked;
         _spatialTrackingLabel = makeString("WKContentView Label: "_s, createVersion4UUIDString());
-        [[_spatialTrackingView layer] setValue:(NSString *)_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
+        [[_spatialTrackingView layer] setValue:_spatialTrackingLabel.createNSString().get() forKeyPath:@"separatedOptions.STSLabel"];
         [_spatialTrackingView setAutoresizingMask:UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_spatialTrackingView setFrame:CGRectMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds), 0, 0)];
         [_spatialTrackingView setUserInteractionEnabled:NO];

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -51,7 +51,7 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
             continue;
 
         CGFloat actualFontSize = initialFontSize;
-        [(NSString *)item.text _legacy_sizeWithFont:font minFontSize:minimumOptionFontSize actualFontSize:&actualFontSize forWidth:textWidth lineBreakMode:NSLineBreakByWordWrapping];
+        [item.text.createNSString() _legacy_sizeWithFont:font minFontSize:minimumOptionFontSize actualFontSize:&actualFontSize forWidth:textWidth lineBreakMode:NSLineBreakByWordWrapping];
 
         if (actualFontSize > 0 && actualFontSize < adjustedSize)
             adjustedSize = actualFontSize;

--- a/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm
@@ -36,6 +36,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/WTFString.h>
 
 static BOOL isRegularDeviceVariant()
@@ -434,7 +435,7 @@ static WKNumberPadKey alternateKeyAtPosition(WKNumberPadButtonPosition position)
     [button setDefaultKey:defaultKeyAtPosition(position, [_controller inputMode])];
     [button setAlternateKey:alternateKeyAtPosition(position)];
     [button setButtonPosition:position];
-    [button titleLabel].font = [UIFont systemFontOfSize:numberPadLabelFontSize() weight:UIFontWeightSemibold design:(NSString *)kCTFontUIFontDesignRounded];
+    [button titleLabel].font = [UIFont systemFontOfSize:numberPadLabelFontSize() weight:UIFontWeightSemibold design:bridge_cast(kCTFontUIFontDesignRounded)];
     [button setUserInteractionEnabled:NO];
     return button.autorelease();
 }

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -503,7 +503,7 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
     }
 
     if (!m_context.selectedText().isEmpty())
-        [items addObject:(NSString *)m_context.selectedText()];
+        [items addObject:m_context.selectedText().createNSString().get()];
 
     if (![items count])
         return nil;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -56,9 +56,9 @@ static NSString * const oldShortcutKey = @"oldShortcut";
 static inline NSDictionary *toAPI(const WebExtensionCommandParameters& command)
 {
     return @{
-        nameKey: (NSString *)command.identifier,
-        descriptionKey: (NSString *)command.description,
-        shortcutKey: (NSString *)command.shortcut
+        nameKey: command.identifier.createNSString().get(),
+        descriptionKey: command.description.createNSString().get(),
+        shortcutKey: command.shortcut.createNSString().get()
     };
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -82,7 +82,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
 
         if (!result.value()) {
             // If an error occurred, element 0 will be undefined, and element 1 will contain an object giving details about the error.
-            callback->call(@[ undefinedValue, @{ isExceptionKey: @YES, valueKey: result.value().error() ? (NSString *)result.value().error()->message : @"" } ]);
+            callback->call(@[ undefinedValue, @{ isExceptionKey: @YES, valueKey: result.value().error() ? result.value().error()->message.createNSString().get() : @"" } ]);
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -222,7 +222,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 {
     for (auto& permission : permissions) {
         if (!WebExtension::supportedPermissions().contains(permission)) {
-            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", (NSString *)permission);
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", permission.createNSString().get());
             return false;
         }
     }
@@ -230,7 +230,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
     for (auto& origin : origins) {
         auto pattern = WebExtensionMatchPattern::getOrCreate(origin);
         if (!pattern || !pattern->isSupported()) {
-            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", (NSString *)origin);
+            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", origin.createNSString().get());
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -77,7 +77,7 @@ void WebExtensionAPIPort::add()
 
     addResult.iterator->value.add(*this);
 
-    RELEASE_LOG_DEBUG(Extensions, "Added port for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Added port for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), toDebugString(contentWorldType()).createNSString().get());
 }
 
 void WebExtensionAPIPort::remove()
@@ -138,7 +138,7 @@ void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSStri
     if (isQuarantined())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Sent port message for channel %{public}llu from %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Sent port message for channel %{public}llu from %{public}@ world", channelIdentifier().toUInt64(), toDebugString(contentWorldType()).createNSString().get());
 
     WebProcess::singleton().send(Messages::WebExtensionContext::PortPostMessage(contentWorldType(), targetContentWorldType(), owningPageProxyIdentifier(), channelIdentifier(), message), extensionContext().identifier());
 }
@@ -155,7 +155,7 @@ void WebExtensionAPIPort::fireMessageEventIfNeeded(id message)
     if (isDisconnected() || isQuarantined() || !m_onMessage || m_onMessage->listeners().isEmpty())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Fired port message event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Fired port message event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), toDebugString(contentWorldType()).createNSString().get());
 
     for (auto& listener : m_onMessage->listeners()) {
         auto globalContext = listener->globalContext();
@@ -170,7 +170,7 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
     if (isDisconnected())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu disconnected in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu disconnected in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, toDebugString(contentWorldType()).createNSString().get());
 
     m_disconnected = true;
 
@@ -182,7 +182,7 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
     if (!m_onDisconnect || m_onDisconnect->listeners().isEmpty())
         return;
 
-    RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, (NSString *)toDebugString(contentWorldType()));
+    RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, toDebugString(contentWorldType()).createNSString().get());
 
     for (auto& listener : m_onDisconnect->listeners()) {
         auto globalContext = listener->globalContext();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -567,7 +567,7 @@ NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters& parameters, co
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
 
     if (parameters.extensionUniqueIdentifier)
-        result[idKey] = (NSString *)parameters.extensionUniqueIdentifier.value();
+        result[idKey] = parameters.extensionUniqueIdentifier.value().createNSString().get();
 
     if (parameters.tabParameters)
         result[tabKey] = toWebAPI(parameters.tabParameters.value());
@@ -581,15 +581,15 @@ NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters& parameters, co
         auto baseURLOrigin = makeString(baseURL.protocol(), "://"_s, baseURL.host());
 
         if (equalIgnoringASCIICase(securityOrigin, baseURLOrigin))
-            result[originKey] = (NSString *)baseURLOrigin;
+            result[originKey] = baseURLOrigin.createNSString().get();
         else
-            result[originKey] = (NSString *)securityOrigin;
+            result[originKey] = securityOrigin.createNSString().get();
 
-        result[urlKey] = (NSString *)parameters.url.string();
+        result[urlKey] = parameters.url.string().createNSString().get();
     }
 
     if (parameters.documentIdentifier.isValid())
-        result[documentIdKey] = (NSString *)parameters.documentIdentifier.toString();
+        result[documentIdKey] = parameters.documentIdentifier.toString().createNSString().get();
 
     return [result copy];
 }
@@ -806,7 +806,7 @@ void WebExtensionContextProxy::dispatchRuntimeInstalledEvent(WebExtensionContext
     NSDictionary *details;
 
     if (installReason == WebExtensionContext::InstallReason::ExtensionUpdate)
-        details = @{ reasonKey: toWebAPI(installReason), previousVersionKey: (NSString *)previousVersion };
+        details = @{ reasonKey: toWebAPI(installReason), previousVersionKey: previousVersion.createNSString().get() };
     else
         details = @{ reasonKey: toWebAPI(installReason) };
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -75,7 +75,7 @@ static ParseResult parseSidebarActionDetails(NSDictionary *details)
 
 static std::variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
 {
-    id maybeValue = [dict objectForKey:key];
+    RetainPtr<id> maybeValue = [dict objectForKey:key];
     if (!maybeValue && required)
         return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
 
@@ -85,13 +85,14 @@ static std::variant<std::monostate, String, SidebarError> parseDetailsStringFrom
         return std::monostate();
     }
 
-    if (![maybeValue isKindOfClass:NSString.class]) {
+    RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
+    if (!nsStringValue]) {
         if (required)
             return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]) };
         return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
     }
 
-    return String((NSString *)maybeValue);
+    return String(nsStringValue.get());
 }
 
 template<typename VariantType>

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -141,10 +141,10 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
         result[idKey] = @(toWebAPI(parameters.identifier.value()));
 
     if (parameters.url)
-        result[urlKey] = !parameters.url.value().isNull() ? (NSString *)parameters.url.value().string() : emptyURLValue;
+        result[urlKey] = !parameters.url.value().isNull() ? parameters.url.value().string().createNSString().get() : emptyURLValue;
 
     if (parameters.title)
-        result[titleKey] = !parameters.title.value().isNull() ? (NSString *)parameters.title.value() : emptyTitleValue;
+        result[titleKey] = !parameters.title.value().isNull() ? parameters.title.value().createNSString().get() : emptyTitleValue;
 
     if (parameters.windowIdentifier)
         result[windowIdKey] = @(toWebAPI(parameters.windowIdentifier.value()));
@@ -364,7 +364,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         for (auto& patternString : parameters.urlPatterns.value()) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", (NSString *)patternString);
+                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", patternString.createNSString().get());
                 return false;
             }
         }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -59,7 +59,7 @@ static NSDictionary *toWebAPI(WebExtensionFrameParameters frameInfo)
 
     result[errorOccurredKey] = @(frameInfo.errorOccurred);
     result[parentFrameIdKey] = @(toWebAPI(frameInfo.parentFrameIdentifier));
-    result[urlKey] = frameInfo.url && !frameInfo.url.value().isNull() ? (NSString *)frameInfo.url.value().string() : emptyURLValue;
+    result[urlKey] = frameInfo.url && !frameInfo.url.value().isNull() ? frameInfo.url.value().string().createNSString().get() : emptyURLValue;
 
     if (frameInfo.frameIdentifier)
         result[frameIdKey] = @(toWebAPI(frameInfo.frameIdentifier.value()));

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -613,7 +613,7 @@ void PDFPluginBase::addArchiveResource()
     // FIXME: It's a hack to force add a resource to DocumentLoader. PDF documents should just be fetched as CachedResources.
 
     // Add just enough data for context menu handling and web archives to work.
-    NSDictionary* headers = @{ @"Content-Disposition": (NSString *)m_suggestedFilename, @"Content-Type" : @"application/pdf" };
+    NSDictionary* headers = @{ @"Content-Disposition": m_suggestedFilename.createNSString().get(), @"Content-Type" : @"application/pdf" };
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_view->mainResourceURL() statusCode:200 HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headers]);
     ResourceResponse synthesizedResponse(response.get());
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -145,7 +145,7 @@
     RefPtr plugin = _plugin.get();
     plugin->didMutatePDFDocument();
 
-    NSString *fieldName = (NSString *)[[notification userInfo] objectForKey:@"PDFFormFieldName"];
+    NSString *fieldName = checked_objc_cast<NSString>([[notification userInfo] objectForKey:@"PDFFormFieldName"]);
     plugin->repaintAnnotationsForFormField(fieldName);
 }
 @end

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -151,7 +151,7 @@ void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::Attr
             if (![value isKindOfClass:[NSString class]])
                 return;
             markers.addMarker(attributeCoreRange, WebCore::DocumentMarkerType::PlatformTextChecking,
-                WebCore::DocumentMarker::PlatformTextCheckingData { key, (NSString *)value });
+                WebCore::DocumentMarker::PlatformTextCheckingData { key, checked_objc_cast<NSString>(value) });
 
             // FIXME: Switch to constants after rdar://problem/48914153 is resolved.
             if ([key isEqualToString:@"NSSpellingState"]) {

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -654,19 +654,19 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
     RetainPtr<NSString> applicationName;
     switch (m_processType) {
     case ProcessType::Inspector:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
         break;
     case ProcessType::ServiceWorker:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), (NSString *)m_uiProcessName, (NSString *)m_registrableDomain.string()];
+        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), m_uiProcessName.createNSString().get(), m_registrableDomain.string().createNSString().get()];
         break;
     case ProcessType::PrewarmedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
         break;
     case ProcessType::CachedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
         break;
     case ProcessType::WebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
         break;
     }
 


### PR DESCRIPTION
#### 5fabb9ba8a2c72b2e512423d8d8b8ef6c76ee057
<pre>
Reduce use of `(NSString *)` casting in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=291006">https://bugs.webkit.org/show_bug.cgi?id=291006</a>

Reviewed by Geoffrey Garen.

Reduce use of `(NSString *)` casting in WebKit/. Instead use modern casting such as bridge_cast() /
checked_objc_cast() / dynamic_objc_cast() or `String::createNSString()` (when used to convert a
String to a NSString). Using `createNSString()` is beneficial because it makes it clearer we&apos;re
allocating a new NSString and it doesn&apos;t rely on autorelease (which is often unnecessary).

* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::updateProcessName):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::toResourceError):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::proxyDictionary):
(WebKit::NetworkSessionCocoa::createWebSocketTask):
* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::initializeProcessName):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::captionsLayer):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemForTelephoneNumber):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::toNSObject):
* Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm:
(WebKit::BackgroundFetchState::toDictionary const):
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::CoreIPCCNPhoneNumber::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm:
(WebKit::CoreIPCDateComponents::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm:
(WebKit::CoreIPCLocale::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::toDictionary const):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::mimeTypeInferredFromFileExtension):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController _addScriptMessageHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForEditorState):
(createUserInfo):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _contentsOfUserInterfaceItem:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm:
(-[_WKLinkIconParameters _initWithLinkIcon:]):
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::AutomationSessionClient::loadWebExtensionWithOptions):
* Source/WebKit/UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm:
(-[WKFullKeyboardAccessWatcher init]):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::fontDescription):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers):
(WebKit::WebExtensionContext::updateDeclarativeNetRequestRulesInStorage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm:
(WebKit::WebExtensionContext::devToolsInspectedWindowEval):
(WebKit::WebExtensionContext::devToolsInspectedWindowReload):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm:
(WebKit::WebExtensionContext::devToolsPanelsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::addPorts):
(WebKit::WebExtensionContext::removePort):
(WebKit::WebExtensionContext::addNativePort):
(WebKit::WebExtensionContext::removeNativePort):
(WebKit::WebExtensionContext::isPortConnected):
(WebKit::WebExtensionContext::firePortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::fireQueuedPortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::clearQueuedPortMessages):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::sendNativeMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
(WebKit::WebExtensionContext::loadRegisteredContentScripts):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::getDataRecords):
(WebKit::WebExtensionController::getDataRecord):
(WebKit::WebExtensionController::removeData):
(WebKit::WebExtensionController::load):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::toAPI):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::updateInspectorWindowTitle const):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::stageDragItem):
(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::registerEditCommand):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm:
(adjustedFontSize):
* Source/WebKit/UIProcess/ios/forms/WKNumberPadView.mm:
(-[WKNumberPadView _buttonForPosition:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
(WebKit::toAPI):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::validatePermissionsDetails):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::add):
(WebKit::WebExtensionAPIPort::postMessage):
(WebKit::WebExtensionAPIPort::fireMessageEventIfNeeded):
(WebKit::WebExtensionAPIPort::fireDisconnectEventIfNeeded):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionContextProxy::dispatchRuntimeInstalledEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseDetailsStringFromKey):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPITabs::parseTabQueryOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::toWebAPI):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::addArchiveResource):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(-[WKPDFFormMutationObserver formChanged:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::updateProcessName):
* Source/WebKit/webpushd/WebClipCache.mm:
(WebPushD::webClipExists):
(WebPushD::webClipIdentifierForOrigin):
(WebPushD::WebClipCache::persist):
(WebPushD::WebClipCache::visibleWebClipIdentifiers):
(WebPushD::WebClipCache::isWebClipVisible):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformDefaultActionBundleIdentifier):
(WebPushD::platformNotificationCenterBundleIdentifier):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::showNotification):
(WebPushD::WebPushDaemon::cancelNotification):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::requestPushPermission):
(WebPushD::WebPushDaemon::setAppBadge):
(WebPushD::WebPushDaemon::getAppBadgeForTesting):

Canonical link: <a href="https://commits.webkit.org/293212@main">https://commits.webkit.org/293212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b93c56b54c772b91c4e5197f9b186d212a0a513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98130 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48659 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74712 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55072 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/97616 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83699 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83152 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18856 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/24995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->