### PR TITLE
[JSC] JITWorklist: precise thread wakeup

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -108,9 +108,10 @@ CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
     m_queues[tier].append(WTFMove(plan));
 
     if (m_numberOfActiveThreads < Options::numberOfWorklistThreads()
-        && m_ongoingCompilationsPerTier[tier] < m_maximumNumberOfConcurrentCompilationsPerTier[tier])
+        && m_ongoingCompilationsPerTier[tier] < m_maximumNumberOfConcurrentCompilationsPerTier[tier]) {
         m_planEnqueued->notifyOne(locker);
-
+        m_numberOfActiveThreads++;
+    }
     return CompilationDeferred;
 }
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -81,7 +81,6 @@ auto JITWorklistThread::poll(const AbstractLocker& locker) -> PollResult
         if (queue.isEmpty())
             continue;
 
-
         if (m_worklist.m_ongoingCompilationsPerTier[i] >= m_worklist.m_maximumNumberOfConcurrentCompilationsPerTier[i])
             continue;
 
@@ -96,24 +95,15 @@ auto JITWorklistThread::poll(const AbstractLocker& locker) -> PollResult
 
         RELEASE_ASSERT(m_plan->stage() == JITPlanStage::Preparing);
         m_worklist.m_ongoingCompilationsPerTier[i]++;
-        if (!m_isActive) {
-            m_worklist.m_numberOfActiveThreads++;
-            m_isActive = true;
-        }
         return PollResult::Work;
     }
-
-    if (m_isActive) {
-        RELEASE_ASSERT(m_worklist.m_numberOfActiveThreads);
-        m_worklist.m_numberOfActiveThreads--;
-        m_isActive = false;
-    }
+    RELEASE_ASSERT(m_worklist.m_numberOfActiveThreads);
+    m_worklist.m_numberOfActiveThreads--;
     return PollResult::Wait;
 }
 
 auto JITWorklistThread::work() -> WorkResult
 {
-    ASSERT(m_isActive);
     WorkScope workScope(*this);
 
     Locker locker { m_rightToRun };

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -61,7 +61,6 @@ private:
     JITWorklist& m_worklist;
     RefPtr<JITPlan> m_plan { nullptr };
     Safepoint* m_safepoint { nullptr };
-    bool m_isActive { false };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### d76be1e1e9203de97d1bf7c71bb01663bb777f41
<pre>
[JSC] JITWorklist: precise thread wakeup
<a href="https://bugs.webkit.org/show_bug.cgi?id=291008">https://bugs.webkit.org/show_bug.cgi?id=291008</a>
<a href="https://rdar.apple.com/148532082">rdar://148532082</a>

Reviewed by Yusuke Suzuki and Yijia Huang.

Previously, m_numberOfActiveThreads tracked the number of
threads that are running. Instead, change the meaning slightly
to be the number of threads that are running or have been
notified to wake up (but not necessarily running yet).

This allows enqueue() to be precise on when a notify is needed,
avoiding spurious notifies while waiting for a thread to wake up
or be created.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::enqueue):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::poll):
* Source/JavaScriptCore/jit/JITWorklistThread.h:

Canonical link: <a href="https://commits.webkit.org/293800@main">https://commits.webkit.org/293800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d444d1872a8a04a1959d31623880cf4392ccabad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48669 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26222 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74719 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31902 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6605 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48111 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90821 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105633 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96766 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30359 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120387 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25005 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33728 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->