### PR TITLE
WIP Improve readability of RenderBlock::computePreferredLogicalWidths.

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2372,15 +2372,34 @@ void RenderBlock::computePreferredLogicalWidths()
 
     const RenderStyle& styleToUse = style();
     auto lengthToUse = overridingLogicalWidthForFlexBasisComputation().value_or(styleToUse.logicalWidth());
-    if (!isRenderTableCell() && lengthToUse.isFixed() && lengthToUse.value() >= 0 && !(isDeprecatedFlexItem() && !lengthToUse.intValue())) {
-        m_minPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(lengthToUse);
-        m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth;
-    } else if (shouldComputeLogicalWidthFromAspectRatio()) {
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
-        m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);
-        m_maxPreferredLogicalWidth = std::max(0_lu, m_maxPreferredLogicalWidth);
-    } else 
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+
+    auto preferredLogicalWidths = [&] -> std::pair<LayoutUnit, LayoutUnit> {
+        switch (lengthToUse.type()) {
+        case LengthType::Fixed: {
+            if (isRenderTableCell() || lengthToUse.value() < 0 || (isDeprecatedFlexItem() && !lengthToUse.intValue()))
+                break;
+            auto contentBoxSize = adjustContentBoxLogicalWidthForBoxSizing(lengthToUse);
+            return { contentBoxSize, contentBoxSize };
+        }
+        case LengthType::Auto:
+        case LengthType::MinContent:
+        case LengthType::MaxContent:
+            break;
+        default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Got invalid length type %u", static_cast<unsigned>(lengthToUse.type()));
+            break;
+        }
+
+        if (shouldComputeLogicalWidthFromAspectRatio()) {
+            auto logicalWidthFromAspectRatio = std::max({ }, computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
+            return { logicalWidthFromAspectRatio, logicalWidthFromAspectRatio };
+        }
+        LayoutUnit minIntrinsicLogicalWidth, maxIntrinsicLogicalWidth;
+        computeIntrinsicLogicalWidths(minIntrinsicLogicalWidth, maxIntrinsicLogicalWidth);
+        return { minIntrinsicLogicalWidth, maxIntrinsicLogicalWidth };
+    };
+
+    std::tie(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth) = preferredLogicalWidths();
 
     RenderBox::computePreferredLogicalWidths(styleToUse.logicalMinWidth(), styleToUse.logicalMaxWidth(), borderAndPaddingLogicalWidth());
 


### PR DESCRIPTION
#### 6176275ca7e38b8155fef2c13b3b5717e5e63bb3
<pre>
WIP Improve readability of RenderBlock::computePreferredLogicalWidths.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computePreferredLogicalWidths):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6176275ca7e38b8155fef2c13b3b5717e5e63bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26546 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74945 "Found 344 new test failures: accessibility/table-cell-spans.html accessibility/table-detection.html accessibility/table-nofirstbody.html css1/box_properties/float_on_text_elements.html css1/box_properties/width.html css1/formatting_model/floating_elements.html css1/formatting_model/vertical_formatting.html css2.1/t080301-c411-vt-mrgn-00-b.html css3/calc/table-calcs.html css3/calc/table-empty-cells.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32104 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83677 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6969 "Too many flaky failures: http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-wildcard.html, http/tests/security/contentSecurityPolicy/user-style-sheet-font-crasher.py, http/wpt/content-security-policy/sandbox-manifest-blocked.html, imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=backspace, imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=forwarddelete, imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-after-attachshadow.html, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.html?h265_annexb_hardware, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.html?h265_annexb_software, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.worker.html?h265_annexb_hardware, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.worker.html?h265_annexb_software, mathml/presentation/menclose-notation-equivalence.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25550 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18601 "Found unexpected failure with change (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83919 "Found 353 new test failures: accessibility/table-cell-spans.html accessibility/table-detection.html accessibility/table-nofirstbody.html css1/box_properties/float_on_text_elements.html css1/box_properties/width.html css1/formatting_model/floating_elements.html css1/formatting_model/vertical_formatting.html css2.1/t080301-c411-vt-mrgn-00-b.html css3/calc/table-calcs.html css3/calc/table-empty-cells.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85128 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83400 "Found 4 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19204 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30691 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->