### PR TITLE
Auto-expand “details” element for find-in-page and scrolling to fragments

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -973,9 +973,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-005.html [ ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=228843
-imported/w3c/web-platform-tests/html/rendering/the-details-element/auto-expand-details-text-fragment.html [ Skip ]
-
 # Cross-Origin-Embedder-Policy: credentialless is not supported.
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/credentialless
 

--- a/LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details-expected.txt
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details-expected.txt
@@ -1,0 +1,19 @@
+Verifies that find and replace can be used to replace words in an editable area. This test requires WebKitTestRunner.
+
+After replacing 'orange' with 'apricot':
+| "\n            "
+| <p>
+|   "Apple banana <#selection-anchor>apricot<#selection-focus>."
+| "\n        "
+
+First editor after replacing 'banana' with 'watermelon':
+| "\n            "
+| <p>
+|   "Apple <#selection-anchor>watermelon<#selection-focus> apricot."
+| "\n        "
+
+Second editor after replacing 'banana' with 'watermelon':
+| "\n            "
+| <p>
+|   "Kiwi watermelon pear."
+| "\n        "

--- a/LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <details id="details">
+        <summary>Show content</summary>
+        <div id="editor" contenteditable>
+            <p>Apple banana orange.</p>
+        </div>
+    </details>
+    <details id="otherDetails">
+        <summary>Show content</summary>
+        <div id="otherEditor" contenteditable>
+            <p>Kiwi banana pear.</p>
+        </div>
+    </details>
+    <div id="log"></div>
+</body>
+<script>
+Markup.waitUntilDone();
+Markup.description("Verifies that find and replace can be used to replace words in an editable area. This test requires WebKitTestRunner.");
+
+function waitForDetailsOpening(element) {
+    return new Promise(resolve => {
+        element.ontoggle = () => {
+            if (element.open)
+                resolve();
+        }
+    });
+}
+
+onload = async () => {
+    testRunner.findStringMatchesInPage("orange", []);
+    testRunner.indicateFindMatch(0);
+    await Promise.all([waitForDetailsOpening(details), UIHelper.ensurePresentationUpdate()]);
+    testRunner.replaceFindMatchesAtIndices([0], "apricot", false);
+    Markup.dump("editor", "After replacing 'orange' with 'apricot'");
+
+    if (!details.open) {
+        log.textContent += "FAIL because first element didn't expand after first replacement.\n";
+    }
+
+    if (otherDetails.open) {
+        log.textContent += "FAIL because second element expanded after first replacement, despite word not matching in second element.\n";
+    }
+
+    details.open = false;
+
+    testRunner.findStringMatchesInPage("banana", []);
+    testRunner.indicateFindMatch(0);
+    await Promise.all([waitForDetailsOpening(details), UIHelper.ensurePresentationUpdate()]);
+    testRunner.indicateFindMatch(1);
+    await Promise.all([waitForDetailsOpening(otherDetails), UIHelper.ensurePresentationUpdate()]);
+    testRunner.replaceFindMatchesAtIndices([0, 1], "watermelon", false);
+    Markup.dump("editor", "First editor after replacing 'banana' with 'watermelon'");
+    Markup.dump("otherEditor", "Second editor after replacing 'banana' with 'watermelon'");
+
+    if (!details.open) {
+        log.textContent += "FAIL because first element didn't expand after second replacement.\n";
+    }
+
+    if (!otherDetails.open) {
+        log.textContent += "FAIL because second element didn't expand after second replacement.\n";
+    }
+
+    if (log.textContent)
+        Markup.dump("log");
+
+    Markup.notifyDone();
+};
+</script>
+</html>

--- a/LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt
@@ -1,0 +1,9 @@
+
+PASS auto-expand on find-in-page match: details-simple
+PASS auto-expand on find-in-page match: details-in-p
+PASS auto-expand on find-in-page match: details-in-table
+PASS auto-expand on find-in-page match: details-nested-simple
+PASS auto-expand on find-in-page match: details-nested-target-in-p
+PASS auto-expand on find-in-page match: details-nested-target-in-table
+PASS auto-expand on find-in-page match: details-summary-nested-simple
+

--- a/LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><html lang><meta charset="utf-8">
+<title>find-in-page with closed details elements</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<hr>
+<script>
+findStringInDetails = (id, contents) => {
+    promise_test(async () => {
+        document.body.insertAdjacentHTML("beforeend", `<details id=${id}>${contents}</details>`);
+        const details = document.getElementById(id);
+        let e = await new Promise((resolve) => {
+            details.addEventListener("toggle", resolve, { once: true });
+            testRunner.findString(id, []);
+        });
+        details.remove();
+        assert_equals(e.newState, "open", `newState is “open”: ${id}`);
+        assert_equals(e.oldState, "closed", `oldState was “closed”: ${id}`);
+        assert_true(details.open, `details element is open: ${id}`);
+    }, `auto-expand on find-in-page match: ${id}`);
+}
+let target;
+target = "details-simple"; findStringInDetails(target, target);
+target = "details-in-p"; findStringInDetails(target, `<p>${target}</p>`);
+target = "details-in-table"; findStringInDetails(target, `<table><tr><td>${target}</table>`);
+target = "details-nested-simple"; findStringInDetails(target, `<details>${target}</details>`);
+target = "details-nested-target-in-p"; findStringInDetails(target, `<details><p>${target}</p></details>`);
+target = "details-nested-target-in-table"; findStringInDetails(target, `<details><table><tr><td>${target}</table></details>`);
+target = "details-summary-nested-simple"; findStringInDetails(target, `<details><summary>${target}</summary></details>`);
+</script>

--- a/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt
@@ -1,0 +1,3 @@
+
+PASS find-in-page with summary of closed details element: summary-simple
+

--- a/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><html lang><meta charset="utf-8">
+<title>find-in-page with summary of closed details element</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<details></details>
+<script>
+findStringInDetails = (id, contents) => {
+    const t = async_test(`find-in-page with summary of closed details element: ${id}`);
+    document.body.insertAdjacentHTML("beforeend", `<details id=${id}>${contents}</details>`);
+    const details = document.getElementById(id);
+    details.ontoggle = t.step_func_done(function(e) {
+        assert_unreached("toggle event fired on closed details element");
+    });
+    t.step_timeout(() => {
+        assert_true(!details.open);
+        details.remove();
+        t.done();
+    }, 3000);
+    testRunner.findString(id, []);
+}
+let target;
+target = "summary-simple"; findStringInDetails(target, `<summary>${target}</summary>`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt
@@ -1,4 +1,5 @@
 spacer
+target
 
-FAIL auto-expand-details-element-fragment assert_true: <details> should be opened by navigating to an element inside it. expected true got false
+PASS auto-expand-details-element-fragment
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1799,6 +1799,10 @@ http/tests/download/convert-cached-load-to-download.html [ Skip ]
 # Can't load application/octet-stream in WK1
 http/tests/mime/html-with-nosniff-html.html [ Skip ]
 
+# testRunner.findString function is WK2-only, not implemented for WK1.
+editing/text-iterator/find-in-page-in-closed-details.html [ Skip ]
+editing/text-iterator/find-in-page-in-summary-of-closed-details.html [ Skip ]
+
 # dumpPolicyDelegateCallbacks is not supported in DumpRenderTree
 fast/loader/iframe-src-invalid-url.html [ Skip ]
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2366,6 +2366,20 @@ DetachableMediaSourceEnabled:
     WebCore:
       default: false
 
+DetailsAutoExpandEnabled:
+  type: bool
+  status: testable
+  category: html
+  humanReadableName: "HTML auto-expanding <details>"
+  humanReadableDescription: "Enable HTML auto-expanding <details>"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DeveloperExtrasEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1369,6 +1369,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/HTMLCollectionInlines.h
     html/HTMLDListElement.h
     html/HTMLDataListElement.h
+    html/HTMLDetailsElement.h
     html/HTMLDirectoryElement.h
     html/HTMLDivElement.h
     html/HTMLDocument.h

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -73,7 +73,7 @@ enum class TextIteratorBehavior : uint16_t {
     // Used by accessibility to expose untransformed kana text.
     IgnoresFullSizeKana = 1 << 14,
 
-    // Used when we want to make 'content-visibility: auto' auto-expanding `<details>` or `hidden=until-found` content discoverable.
+    // Used when we want to make 'content-visibility: auto', auto-expanding `<details>` or `hidden=until-found` content discoverable.
     EntersSkippedContentRelevantToUser = 1 << 15
 };
 

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -23,6 +23,7 @@
 #include "HTMLDetailsElement.h"
 
 #include "AXObjectCache.h"
+#include "ComposedTreeAncestorIterator.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentInlines.h"
 #include "ElementChildIteratorInlines.h"
@@ -216,6 +217,24 @@ void HTMLDetailsElement::ensureDetailsExclusivityAfterMutation()
 void HTMLDetailsElement::toggleOpen()
 {
     setBooleanAttribute(HTMLNames::openAttr, !hasAttributeWithoutSynchronization(HTMLNames::openAttr));
+}
+
+// https://html.spec.whatwg.org/#ancestor-details-revealing-algorithm
+void revealClosedDetailsAncestors(Node& node)
+{
+    if (!node.document().settings().detailsAutoExpandEnabled())
+        return;
+
+    Ref currentNode = node;
+    while (currentNode->parentInComposedTree()) {
+        if (RefPtr slot = currentNode->assignedSlot(); slot && slot->userAgentPart() == UserAgentParts::detailsContent() && slot->shadowHost()) {
+            currentNode = *slot->shadowHost();
+            Ref details = downcast<HTMLDetailsElement>(currentNode);
+            if (!details->hasAttributeWithoutSynchronization(HTMLNames::openAttr))
+                details->toggleOpen();
+        } else
+            currentNode = *currentNode->parentInComposedTree();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -61,4 +61,6 @@ private:
     RefPtr<ToggleEventTask> m_toggleEventTask;
 };
 
+WEBCORE_EXPORT void revealClosedDetailsAncestors(Node&);
+
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -59,6 +59,7 @@
 #include "FrameTree.h"
 #include "GraphicsContext.h"
 #include "HTMLBodyElement.h"
+#include "HTMLDetailsElement.h"
 #include "HTMLEmbedElement.h"
 #include "HTMLFrameElement.h"
 #include "HTMLFrameSetElement.h"
@@ -2747,8 +2748,9 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
         scrollPositionAnchor = m_frame->document();
     maintainScrollPositionAtAnchor(scrollPositionAnchor.get());
     
-    // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
     if (anchorElement) {
+        revealClosedDetailsAncestors(*anchorElement);
+        // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
         if (anchorElement->isFocusable())
             document.setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, FocusVisibility::Visible });
         else {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1215,6 +1215,9 @@ public:
     inline Isolation isolation() const;
     inline bool hasIsolation() const;
 
+    inline void setAutoRevealsWhenFound();
+    inline bool autoRevealsWhenFound() const;
+
     bool shouldPlaceVerticalScrollbarOnLeft() const;
 
     inline bool usesStandardScrollbarStyle() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -882,6 +882,8 @@ inline Visibility RenderStyle::usedVisibility() const
     return static_cast<Visibility>(m_inheritedFlags.visibility);
 }
 
+inline bool RenderStyle::autoRevealsWhenFound() const { return m_rareInheritedData->autoRevealsWhenFound; }
+
 #if ENABLE(CURSOR_VISIBILITY)
 constexpr CursorVisibility RenderStyle::initialCursorVisibility() { return CursorVisibility::Auto; }
 #endif

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -685,6 +685,8 @@ inline void RenderStyle::setBlendMode(BlendMode mode)
 inline void RenderStyle::setIsForceHidden() { SET(m_rareInheritedData, isForceHidden, true); }
 inline void RenderStyle::setIsolation(Isolation isolation) { SET_NESTED(m_nonInheritedData, rareData, isolation, static_cast<unsigned>(isolation)); }
 
+inline void RenderStyle::setAutoRevealsWhenFound() { SET(m_rareInheritedData, autoRevealsWhenFound, true); }
+
 #undef SET
 #undef SET_BORDER_COLOR
 #undef SET_DOUBLY_NESTED

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -145,6 +145,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , isInSubtreeWithBlendMode(false)
     , isForceHidden(false)
     , usedContentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
+    , autoRevealsWhenFound(false)
     , insideDefaultButton(false)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
@@ -246,6 +247,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , isInSubtreeWithBlendMode(o.isInSubtreeWithBlendMode)
     , isForceHidden(o.isForceHidden)
     , usedContentVisibility(o.usedContentVisibility)
+    , autoRevealsWhenFound(o.autoRevealsWhenFound)
     , insideDefaultButton(o.insideDefaultButton)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
@@ -377,6 +379,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && hasAutoAccentColor == o.hasAutoAccentColor
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
         && isForceHidden == o.isForceHidden
+        && autoRevealsWhenFound == o.autoRevealsWhenFound
         && usedTouchActions == o.usedTouchActions
         && eventListenerRegionTypes == o.eventListenerRegionTypes
         && effectiveInert == o.effectiveInert
@@ -504,6 +507,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectiveInert);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isInSubtreeWithBlendMode);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isForceHidden);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, autoRevealsWhenFound);
 
     LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -182,6 +182,8 @@ public:
 
     unsigned usedContentVisibility : 2; // ContentVisibility
 
+    unsigned autoRevealsWhenFound : 1;
+
     unsigned insideDefaultButton : 1;
 
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -40,6 +40,7 @@
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "HTMLBodyElement.h"
+#include "HTMLDetailsElement.h"
 #include "HTMLDialogElement.h"
 #include "HTMLDivElement.h"
 #include "HTMLInputElement.h"
@@ -649,6 +650,9 @@ void Adjuster::adjust(RenderStyle& style) const
 
         if (m_element->invokedPopover())
             style.setIsPopoverInvoker();
+
+        if (m_document->settings().detailsAutoExpandEnabled() && is<HTMLDetailsElement>(element))
+            style.setAutoRevealsWhenFound();
     }
 
     if (shouldInheritTextDecorationsInEffect(style, m_element.get()))

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -972,6 +972,12 @@ void WKPageSelectFindMatch(WKPageRef pageRef, int32_t matchIndex)
     toImpl(pageRef)->selectFindMatch(matchIndex);
 }
 
+void WKPageIndicateFindMatch(WKPageRef pageRef, uint32_t matchIndex)
+{
+    CRASH_IF_SUSPENDED;
+    toImpl(pageRef)->indicateFindMatch(matchIndex);
+}
+
 void WKPageFindString(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -220,6 +220,7 @@ WK_EXPORT void WKPageCountStringMatches(WKPageRef page, WKStringRef string, WKFi
 WK_EXPORT void WKPageFindStringMatches(WKPageRef page, WKStringRef string, WKFindOptions findOptions, unsigned maxMatchCount);
 WK_EXPORT void WKPageGetImageForFindMatch(WKPageRef page, int32_t matchIndex);
 WK_EXPORT void WKPageSelectFindMatch(WKPageRef page, int32_t matchIndex);
+WK_EXPORT void WKPageIndicateFindMatch(WKPageRef page, uint32_t matchIndex);
 
 WK_EXPORT void WKPageSetPageContextMenuClient(WKPageRef page, const WKPageContextMenuClientBase* client);
 WK_EXPORT void WKPageSetPageDiagnosticLoggingClient(WKPageRef page, const WKPageDiagnosticLoggingClientBase* client);

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/FrameSelection.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/HTMLDetailsElement.h>
 #include <WebCore/ImageAnalysisQueue.h>
 #include <WebCore/ImageOverlay.h>
 #include <WebCore/LocalFrame.h>
@@ -504,7 +505,9 @@ void FindController::didFindString()
     if (!selectedFrame)
         return;
 
-    selectedFrame->checkedSelection()->revealSelection();
+    CheckedRef selection = selectedFrame->selection();
+    selection->revealSelection();
+    revealClosedDetailsAncestors(*selection->selection().start().protectedAnchorNode());
 }
 
 void FindController::didHideFindIndicator()

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/GraphicsLayer.h>
+#include <WebCore/HTMLDetailsElement.h>
 #include <WebCore/ImageOverlay.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
@@ -159,6 +160,8 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
             break;
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
+
+            revealClosedDetailsAncestors(simpleRange->protectedStartContainer());
 
             if (m_findPageOverlay)
                 setTextIndicatorWithRange(*simpleRange);

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -36,6 +36,7 @@
 #import <WebCore/Editor.h>
 #import <WebCore/FocusController.h>
 #import <WebCore/GraphicsContext.h>
+#import <WebCore/HTMLDetailsElement.h>
 #import <WebCore/ImageOverlay.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>
@@ -180,6 +181,7 @@ void FindController::didFindString()
     // text, so we reveal the text at the center of the viewport.
     // FIXME: Find a better way to estimate the obscured area (https://webkit.org/b/183889).
     frame->selection().revealSelection(SelectionRevealMode::RevealUpToMainFrame, ScrollAlignment::alignCenterAlways, WebCore::RevealExtentOption::DoNotRevealExtent);
+    revealClosedDetailsAncestors(*frame->selection().selection().start().anchorNode());
 }
 
 void FindController::didFailToFindString()

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -154,6 +154,7 @@ interface TestRunner {
     // Text search testing.
     Promise<boolean> findString(DOMString target, object optionsArray);
     undefined findStringMatchesInPage(DOMString target, object optionsArray);
+    undefined indicateFindMatch(unsigned long matchIndex);
     undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
 
     // Evaluating script in a special context.

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -752,6 +752,11 @@ void postPageMessage(const char* name, bool value)
     postPageMessage(name, adoptWK(WKBooleanCreate(value)));
 }
 
+void postPageMessage(const char* name, unsigned value)
+{
+    postPageMessage(name, adoptWK(WKUInt64Create(value)));
+}
+
 void postPageMessage(const char* name, const char* value)
 {
     postPageMessage(name, toWK(value));

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -221,6 +221,7 @@ void postSynchronousMessage(const char* name, const void* value) = delete;
 
 void postPageMessage(const char* name);
 void postPageMessage(const char* name, bool value);
+void postPageMessage(const char* name, unsigned value);
 void postPageMessage(const char* name, const char* value);
 void postPageMessage(const char* name, WKStringRef value);
 void postPageMessage(const char* name, WKDataRef value);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -347,6 +347,11 @@ void TestRunner::findStringMatchesInPage(JSContextRef context, JSStringRef targe
     }
 }
 
+void TestRunner::indicateFindMatch(JSContextRef context, uint32_t index)
+{
+    postPageMessage("IndicateFindMatch", index);
+}
+
 void TestRunner::replaceFindMatchesAtIndices(JSContextRef context, JSValueRef matchIndicesAsValue, JSStringRef replacementText, bool selectionOnly)
 {
     auto& bundle = InjectedBundle::singleton();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -184,6 +184,7 @@ public:
     // Text search testing.
     void findString(JSContextRef, JSStringRef, JSValueRef optionsArray, JSValueRef callback);
     void findStringMatchesInPage(JSContextRef, JSStringRef, JSValueRef optionsArray);
+    void indicateFindMatch(JSContextRef, uint32_t index);
     void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
 
     // Local storage

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -693,6 +693,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "IndicateFindMatch")) {
+        WKPageIndicateFindMatch(TestController::singleton().mainWebView()->page(), uint64Value(messageBody));
+        return;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "StopLoading"))
         return WKPageStopLoading(TestController::singleton().mainWebView()->page());
 


### PR DESCRIPTION
#### 23cdbeb3cd776e2337f220c18b86f0ddb639bd50
<pre>
Auto-expand “details” element for find-in-page and scrolling to fragments
<a href="https://bugs.webkit.org/show_bug.cgi?id=228843">https://bugs.webkit.org/show_bug.cgi?id=228843</a>
<a href="https://rdar.apple.com/81856620">rdar://81856620</a>

Reviewed by Darin Adler.

This change causes any closed &lt;details&gt; element to be opened
automatically (auto-expanded) if either:

- the user is using find-in-page and a descendant node of the closed
  &lt;details&gt; element contains a match for the given search string
- the user is navigating to a fragment ID and the fragment ID is for a
  descendant element of the closed &lt;details&gt; element

…per the requirements in the HTML spec’s Find-in-page section at
<a href="https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found">https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found</a>

Otherwise, without this change, when a descendant node of a closed
&lt;details&gt; element contains a match for the given find-in-page search
string, or when navigating to a fragment ID for a descendant element of
a closed &lt;details&gt; element, the closed &lt;details&gt; element isn’t opened
automatically (not auto-expanded).

Changes to TextIterator ensure that content inside details elements are
not skipped over for the purposes of find-in-page.

This change also introduces the DetailsAutoExpandEnabled preference
(disabled by default), for controlling whether &lt;details&gt; elements get
auto-expanded under the conditions described above.

And this also adds a testRunner.indicateMatchIndex(index) function —
to emulate jumping through matches in the non-findString codepath.

Original PR by: Michael[tm] Smith &lt;mike@w3.org&gt;

* LayoutTests/TestExpectations:
* LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details-expected.txt: Added.
* LayoutTests/editing/find/cocoa/find-and-replace-in-closed-details.html: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::TextIterator):
(WebCore::isRendererAccessible):
(WebCore::isConsideredSkippedContent):
* Source/WebCore/editing/TextIteratorBehavior.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::revealClosedDetailsAncestors):
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragmentInternal):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::autoRevealsWhenFound const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setAutoRevealsWhenFound):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageIndicateFindMatch):
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::didFindString):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::didFindString):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::postPageMessage):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::indicateFindMatch):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/296708@main">https://commits.webkit.org/296708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79318c2d9002c0ea7604cc5d9a34c4bb45eb4296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/19467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114585 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/59618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/111343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/59618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112328 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/23660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/98517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16660 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59207 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101879 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117697 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107936 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36421 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/26957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36792 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94779 "1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91952 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41790 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/132202 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35986 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35821 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->