### PR TITLE
[Page color sampling] wallflowersanfrancisco.com: top header fails fixed container edge detection

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container-expected.txt
@@ -1,0 +1,5 @@
+PASS edgeColors.top is "rgb(212, 214, 185)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        header {
+            position: fixed;
+            top: -40px;
+            width: 100%;
+            height: 40px;
+        }
+
+        .header-content {
+            background: rgb(212, 214, 185);
+            width: 100%;
+            height: 64px;
+            position: absolute;
+            top: 40px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        edgeColors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColors.top", "rgb(212, 214, 185)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header>
+    <div class="header-content"></div>
+</header>
+<div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4645,7 +4645,7 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
             return { };
     }
 
-    if (request.viewportConstrainedLayersOnly() && !m_hasViewportConstrainedDescendant && !isViewportConstrained())
+    if (request.viewportConstrainedLayersOnly() && !m_hasViewportConstrainedDescendant && !isViewportConstrained() && !hasFixedAncestor())
         return { };
 
     // The natural thing would be to keep HitTestingTransformState on the stack, but it's big, so we heap-allocate.
@@ -6136,6 +6136,9 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
 
     updateTransform();
     updateFilterPaintingStrategy();
+
+    if (oldStyle && oldStyle->hasViewportConstrainedPosition() != isViewportConstrained())
+        dirtyAncestorChainHasViewportConstrainedDescendantStatus();
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(TOUCH_EVENTS)
     if (diff == StyleDifference::RecompositeLayer || diff >= StyleDifference::LayoutPositionedMovementOnly)


### PR DESCRIPTION
#### a6de6250ffe204ed27ad7da6cb27bcc8304743f1
<pre>
[Page color sampling] wallflowersanfrancisco.com: top header fails fixed container edge detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=291015">https://bugs.webkit.org/show_bug.cgi?id=291015</a>
<a href="https://rdar.apple.com/148538974">rdar://148538974</a>

Reviewed by Tim Horton.

Make a couple of minor adjustments to fix top fixed container edge detection on this website:

-   In the case where a layer becomes viewport-constrained and the ancestor layers have already
    computed `m_hasViewportConstrainedDescendant`, nothing currently sets the dirty bit on the
    ancestor chain, which causes us to incorrectly bail from `RenderLayer::hitTestLayer` when trying
    to detect fixed-position containers.

-   There are cases where we still need to proceed with hit-testing if a layer itself is neither
    viewport-constrained nor contains viewport-constrained descendants, but has viewport-constrained
    ancestors. This can occur if there&apos;s a composited layer that&apos;s positioned relative to an off-
    screen fixed-position layer; in this case, the absolutely-positioned layer still behaves as if
    it were fixed, but our current heuristics miss it altogether.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::styleChanged const):

Canonical link: <a href="https://commits.webkit.org/293204@main">https://commits.webkit.org/293204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d098c1e85350531e90da70902babcf26e22996cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74734 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88685 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55094 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6622 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25199 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->