### PR TITLE
Address more Safer CPP failures in WebKit/UIProcess/API

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -633,6 +633,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webauthn/AuthenticationExtensionsClientInputsJSON.h
     Modules/webauthn/AuthenticationExtensionsClientOutputs.h
     Modules/webauthn/AuthenticationExtensionsClientOutputsJSON.h
+    Modules/webauthn/AuthenticatorAssertionResponse.h
     Modules/webauthn/AuthenticatorCoordinator.h
     Modules/webauthn/AuthenticatorCoordinatorClient.h
     Modules/webauthn/AuthenticatorResponseData.h

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -14,7 +14,6 @@ Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
 Shared/Extensions/_WKWebExtensionSQLiteHelpers.h
 Shared/Extensions/_WKWebExtensionSQLiteRow.mm
 Shared/Extensions/_WKWebExtensionSQLiteStatement.mm
-UIProcess/API/C/WKPage.cpp
 UIProcess/Automation/WebAutomationSession.h
 UIProcess/WebProcessPool.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -8,9 +8,7 @@ Platform/IPC/Connection.h
 Platform/IPC/StreamClientConnection.cpp
 Shared/Cocoa/WKObject.mm
 Shared/JavaScriptEvaluationResult.mm
-UIProcess/API/APIDataTask.cpp
 UIProcess/API/C/WKAuthenticationChallenge.cpp
-UIProcess/API/C/WKAuthenticationDecisionListener.cpp
 UIProcess/API/C/WKBackForwardListRef.cpp
 UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKContextConfigurationRef.cpp
@@ -47,8 +45,6 @@ UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
 UIProcess/API/C/WKWebsiteDataStoreRef.cpp
 UIProcess/API/C/WKWebsitePolicies.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
-UIProcess/API/Cocoa/WKContentRuleList.mm
-UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm

--- a/Source/WebKit/UIProcess/API/APIDataTask.cpp
+++ b/Source/WebKit/UIProcess/API/APIDataTask.cpp
@@ -57,7 +57,7 @@ void DataTask::cancel()
 void DataTask::networkProcessCrashed()
 {
     m_activity = nullptr;
-    m_client->didCompleteWithError(*this, WebCore::internalError(m_originalURL));
+    protectedClient()->didCompleteWithError(*this, WebCore::internalError(m_originalURL));
 }
 
 DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr<WebKit::WebPageProxy>&& page, WTF::URL&& originalURL, bool shouldRunAtForegroundPriority)
@@ -75,7 +75,7 @@ DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr
 void DataTask::didCompleteWithError(WebCore::ResourceError&& error)
 {
     m_activity = nullptr;
-    m_client->didCompleteWithError(*this, WTFMove(error));
+    protectedClient()->didCompleteWithError(*this, WTFMove(error));
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
@@ -46,12 +46,12 @@ WKAuthenticationDecisionListenerRef WKAuthenticationChallengeGetDecisionListener
 
 WKProtectionSpaceRef WKAuthenticationChallengeGetProtectionSpace(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toImpl(challenge)->protectionSpace());
+    return toAPI(toProtectedImpl(challenge)->protectionSpace());
 }
 
 WKCredentialRef WKAuthenticationChallengeGetProposedCredential(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toImpl(challenge)->proposedCredential());
+    return toAPI(toProtectedImpl(challenge)->proposedCredential());
 }
 
 int WKAuthenticationChallengeGetPreviousFailureCount(WKAuthenticationChallengeRef challenge)

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationDecisionListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationDecisionListener.cpp
@@ -41,15 +41,15 @@ WKTypeID WKAuthenticationDecisionListenerGetTypeID()
 
 void WKAuthenticationDecisionListenerUseCredential(WKAuthenticationDecisionListenerRef authenticationListener, WKCredentialRef credential)
 {
-    WebKit::toImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? WebKit::toImpl(credential)->credential() : WebCore::Credential());
+    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? WebKit::toProtectedImpl(credential)->credential() : WebCore::Credential());
 }
 
 void WKAuthenticationDecisionListenerCancel(WKAuthenticationDecisionListenerRef authenticationListener)
 {
-    WebKit::toImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::Cancel);
+    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::Cancel);
 }
 
 void WKAuthenticationDecisionListenerRejectProtectionSpaceAndContinue(WKAuthenticationDecisionListenerRef authenticationListener)
 {
-    WebKit::toImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
+    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
 }

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -40,45 +40,45 @@ WKTypeID WKBackForwardListGetTypeID()
 
 WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toImpl(listRef)->currentItem());
+    return toAPI(toProtectedImpl(listRef)->currentItem());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toImpl(listRef)->backItem());
+    return toAPI(toProtectedImpl(listRef)->backItem());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toImpl(listRef)->forwardItem());
+    return toAPI(toProtectedImpl(listRef)->forwardItem());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)
 {
-    return toAPI(toImpl(listRef)->itemAtIndex(index));
+    return toAPI(toProtectedImpl(listRef)->itemAtIndex(index));
 }
 
 void WKBackForwardListClear(WKBackForwardListRef listRef)
 {
-    toImpl(listRef)->clear();
+    toProtectedImpl(listRef)->clear();
 }
 
 unsigned WKBackForwardListGetBackListCount(WKBackForwardListRef listRef)
 {
-    return toImpl(listRef)->backListCount();
+    return toProtectedImpl(listRef)->backListCount();
 }
 
 unsigned WKBackForwardListGetForwardListCount(WKBackForwardListRef listRef)
 {
-    return toImpl(listRef)->forwardListCount();
+    return toProtectedImpl(listRef)->forwardListCount();
 }
 
 WKArrayRef WKBackForwardListCopyBackListWithLimit(WKBackForwardListRef listRef, unsigned limit)
 {
-    return toAPILeakingRef(toImpl(listRef)->backListAsAPIArrayWithLimit(limit));
+    return toAPILeakingRef(toProtectedImpl(listRef)->backListAsAPIArrayWithLimit(limit));
 }
 
 WKArrayRef WKBackForwardListCopyForwardListWithLimit(WKBackForwardListRef listRef, unsigned limit)
 {
-    return toAPILeakingRef(toImpl(listRef)->forwardListAsAPIArrayWithLimit(limit));
+    return toAPILeakingRef(toProtectedImpl(listRef)->forwardListAsAPIArrayWithLimit(limit));
 }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -94,6 +94,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include "WebProtectionSpace.h"
+#include <WebCore/AuthenticatorAssertionResponse.h>
 #include <WebCore/AutoplayEvent.h>
 #include <WebCore/ContentRuleListResults.h>
 #include <WebCore/FrameLoaderClient.h>
@@ -2298,7 +2299,8 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&& responses, WebKit::WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&& completionHandler) const final
                 {
                     ASSERT(!responses.isEmpty());
-                    completionHandler(responses[0].ptr());
+                    Ref firstResponse = responses[0];
+                    completionHandler(firstResponse.ptr());
                 }
 
                 void decidePolicyForLocalAuthenticator(CompletionHandler<void(WebKit::LocalAuthenticatorPolicy)>&& completionHandler) const final

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
@@ -37,7 +37,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContentRuleList.class, self))
         return;
 
-    _contentRuleList->~ContentRuleList();
+    Ref { *_contentRuleList }->~ContentRuleList();
 
     [super dealloc];
 }
@@ -52,7 +52,7 @@
 - (NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return _contentRuleList->name();
+    return Ref { *_contentRuleList }->name();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -63,7 +63,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContentRuleListStore.class, self))
         return;
 
-    _contentRuleListStore->~ContentRuleListStore();
+    self._protectedContentListStore->~ContentRuleListStore();
 
     [super dealloc];
 }
@@ -86,10 +86,15 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #endif
 }
 
+- (Ref<API::ContentRuleListStore>)_protectedContentListStore
+{
+    return *_contentRuleListStore;
+}
+
 - (void)compileContentRuleListForIdentifier:(NSString *)identifier encodedContentRuleList:(NSString *)encodedContentRuleList completionHandler:(void (^)(WKContentRuleList *, NSError *))completionHandler
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->compileContentRuleList(identifier, encodedContentRuleList, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    self._protectedContentListStore->compileContentRuleList(identifier, encodedContentRuleList, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         if (error) {
             auto userInfo = @{ NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list compilation failed: %s", error.message().c_str()] };
 
@@ -105,7 +110,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)lookUpContentRuleListForIdentifier:(NSString *)identifier completionHandler:(void (^)(WKContentRuleList *, NSError *))completionHandler
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->lookupContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    self._protectedContentListStore->lookupContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         if (error) {
             auto userInfo = @{NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list lookup failed: %s", error.message().c_str()]};
             auto wkError = toWKErrorCode(error);
@@ -121,7 +126,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)getAvailableContentRuleListIdentifiers:(void (^)(NSArray<NSString *>*))completionHandler
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->getAvailableContentRuleListIdentifiers([completionHandler = makeBlockPtr(completionHandler)](Vector<String> identifiers) {
+    self._protectedContentListStore->getAvailableContentRuleListIdentifiers([completionHandler = makeBlockPtr(completionHandler)](Vector<String> identifiers) {
         completionHandler(createNSArray(identifiers).get());
     });
 #endif
@@ -130,7 +135,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)removeContentRuleListForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSError *))completionHandler
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->removeContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](std::error_code error) {
+    self._protectedContentListStore->removeContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](std::error_code error) {
         if (error) {
             auto userInfo = @{NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list removal failed: %s", error.message().c_str()]};
             ASSERT(toWKErrorCode(error) == WKErrorContentRuleListStoreRemoveFailed);
@@ -158,35 +163,35 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)_removeAllContentRuleLists
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->synchronousRemoveAllContentRuleLists();
+    self._protectedContentListStore->synchronousRemoveAllContentRuleLists();
 #endif
 }
 
 - (void)_invalidateContentRuleListVersionForIdentifier:(NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->invalidateContentRuleListVersion(identifier);
+    self._protectedContentListStore->invalidateContentRuleListVersion(identifier);
 #endif
 }
 
 - (void)_corruptContentRuleListHeaderForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->corruptContentRuleListHeader(identifier, usingCurrentVersion);
+    self._protectedContentListStore->corruptContentRuleListHeader(identifier, usingCurrentVersion);
 #endif
 }
 
 - (void)_corruptContentRuleListActionsMatchingEverythingForIdentifier:(NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->corruptContentRuleListActionsMatchingEverything(identifier);
+    self._protectedContentListStore->corruptContentRuleListActionsMatchingEverything(identifier);
 #endif
 }
 
 - (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->invalidateContentRuleListHeader(identifier);
+    self._protectedContentListStore->invalidateContentRuleListHeader(identifier);
 #endif
 }
 
@@ -194,7 +199,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 {
 #if ENABLE(CONTENT_EXTENSIONS)
     auto handler = adoptNS([completionHandler copy]);
-    _contentRuleListStore->getContentRuleListSource(identifier, [handler](String source) {
+    self._protectedContentListStore->getContentRuleListSource(identifier, [handler](String source) {
         auto rawHandler = (void (^)(NSString *))handler.get();
         if (source.isNull()) {
             // This should not be necessary since there are no nullability annotations


### PR DESCRIPTION
#### 9f3cc787da2c7be04b7a8a3b75f92bfbf856a420
<pre>
Address more Safer CPP failures in WebKit/UIProcess/API
<a href="https://bugs.webkit.org/show_bug.cgi?id=291019">https://bugs.webkit.org/show_bug.cgi?id=291019</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/API/APIDataTask.cpp:
(API::DataTask::networkProcessCrashed):
(API::DataTask::didCompleteWithError):
* Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp:
(WKAuthenticationChallengeGetProtectionSpace):
(WKAuthenticationChallengeGetProposedCredential):
* Source/WebKit/UIProcess/API/C/WKAuthenticationDecisionListener.cpp:
(WKAuthenticationDecisionListenerUseCredential):
(WKAuthenticationDecisionListenerCancel):
(WKAuthenticationDecisionListenerRejectProtectionSpaceAndContinue):
* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetCurrentItem):
(WKBackForwardListGetBackItem):
(WKBackForwardListGetForwardItem):
(WKBackForwardListGetItemAtIndex):
(WKBackForwardListClear):
(WKBackForwardListGetBackListCount):
(WKBackForwardListGetForwardListCount):
(WKBackForwardListCopyBackListWithLimit):
(WKBackForwardListCopyForwardListWithLimit):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm:
(-[WKContentRuleList dealloc]):
(-[WKContentRuleList identifier]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore dealloc]):
(-[WKContentRuleListStore _protectedContentListStore]):
(-[WKContentRuleListStore compileContentRuleListForIdentifier:encodedContentRuleList:completionHandler:]):
(-[WKContentRuleListStore lookUpContentRuleListForIdentifier:completionHandler:]):
(-[WKContentRuleListStore getAvailableContentRuleListIdentifiers:]):
(-[WKContentRuleListStore removeContentRuleListForIdentifier:completionHandler:]):
(-[WKContentRuleListStore _removeAllContentRuleLists]):
(-[WKContentRuleListStore _invalidateContentRuleListVersionForIdentifier:]):
(-[WKContentRuleListStore _corruptContentRuleListHeaderForIdentifier:usingCurrentVersion:]):
(-[WKContentRuleListStore _corruptContentRuleListActionsMatchingEverythingForIdentifier:]):
(-[WKContentRuleListStore _invalidateContentRuleListHeaderForIdentifier:]):
(-[WKContentRuleListStore _getContentRuleListSourceForIdentifier:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/293252@main">https://commits.webkit.org/293252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74e16caac06e90782aad6f9cbafb465b54551c04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74855 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6774 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48310 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25426 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83308 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21039 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19073 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15931 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25384 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->