### PR TITLE
[WebGPU] https://gnikoloff.github.io/webgpu-raytracer/ does not work in STP 215

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -32,8 +32,10 @@
 #include <climits>
 #include <concepts>
 #include <cstring>
+#include <errno.h>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 #include <type_traits>
 #include <utility>
@@ -1540,6 +1542,19 @@ ALWAYS_INLINE void lazyInitialize(const std::unique_ptr<T>& ptr, std::unique_ptr
     const_cast<std::unique_ptr<T>&>(ptr) = std::move(obj);
 }
 
+ALWAYS_INLINE std::optional<double> stringToDouble(std::span<const char> buffer, size_t& parsedLength)
+{
+    RELEASE_ASSERT(buffer.back() == '\0');
+    char* end;
+    auto result = std::strtod(buffer.data(), &end);
+    if (errno == ERANGE) {
+        parsedLength = 0;
+        return std::nullopt;
+    }
+    parsedLength = end - buffer.data();
+    return result;
+}
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1603,6 +1618,7 @@ using WTF::spanHasPrefix;
 using WTF::spanHasSuffix;
 using WTF::spansOverlap;
 using WTF::spanReinterpretCast;
+using WTF::stringToDouble;
 using WTF::toTwosComplement;
 using WTF::tryBinarySearch;
 using WTF::unsafeMakeSpan;

--- a/Source/WebGPU/WGSL/tests/hex-double-lchar.wgsl
+++ b/Source/WebGPU/WGSL/tests/hex-double-lchar.wgsl
@@ -1,0 +1,9 @@
+// RUN: %metal main 2>&1 | %check
+
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK-L: 1.1754943508222875e-38
+  let f32min = 0x1p-126;
+  // CHECK-L: 3.4028234663852886e+38
+  let f32max = 0x1.fffffep+127;
+}

--- a/Source/WebGPU/WGSL/tests/hex-double-uchar.wgsl
+++ b/Source/WebGPU/WGSL/tests/hex-double-uchar.wgsl
@@ -1,0 +1,10 @@
+// RUN: %metal main 2>&1 | %check
+
+@compute @workgroup_size(1)
+fn main() {
+  // ⚠️ -- the emoji ensures the file will be parsed as uchar
+  // CHECK-L: 1.1754943508222875e-38
+  let f32min = 0x1p-126;
+  // CHECK-L: 3.4028234663852886e+38
+  let f32max = 0x1.fffffep+127;
+}


### PR DESCRIPTION
#### 73d060809f17d37207d99ea66d0c43c21682dc6a
<pre>
[WebGPU] <a href="https://gnikoloff.github.io/webgpu-raytracer/">https://gnikoloff.github.io/webgpu-raytracer/</a> does not work in STP 215
<a href="https://bugs.webkit.org/show_bug.cgi?id=290857">https://bugs.webkit.org/show_bug.cgi?id=290857</a>
<a href="https://rdar.apple.com/148358085">rdar://148358085</a>

Reviewed by Geoffrey Garen and Mike Wyrzykowski.

There were 2 issues preventing the website from running:
- The first one was addresssed in 293154@main, where we incorrectly tried to unpack
  pointers to resources twice
- This patch fixes the second issue, where we did not parse hex floats correctly.
  We used fast_float before (through WTF::parseHexDouble), but that didn&apos;t handle
  hex floats. Instead, switch to using `std::strtod` through a wrapper that ensures
  that the string is null terminated.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::stringToDouble):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Source/WebGPU/WGSL/tests/hex-double-lchar.wgsl: Added.
* Source/WebGPU/WGSL/tests/hex-double-uchar.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/293362@main">https://commits.webkit.org/293362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3251aedb3541c0357240bc8649e7ac44b7a69be2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74973 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48458 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105982 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97117 "Found 1 new JSC stress test failure: stress/v8-typedarray-resizablearraybuffer.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83945 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19237 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30717 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120734 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25354 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33790 "Found 19734 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->