### PR TITLE
Revert 293145@main and use raw pointers in JSTrustedTypePolicy::visitAdditionalChildren

### DIFF
--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
@@ -33,21 +33,21 @@ namespace WebCore {
 template<typename Visitor>
 void JSTrustedTypePolicy::visitAdditionalChildren(Visitor& visitor)
 {
-    RefPtr<CreateHTMLCallback> protectedCreateHTML;
-    RefPtr<CreateScriptCallback> protectedCreateScript;
-    RefPtr<CreateScriptURLCallback> protectedCreateScriptURL;
+    SUPPRESS_UNCOUNTED_LOCAL CreateHTMLCallback* createHTML = nullptr;
+    SUPPRESS_UNCOUNTED_LOCAL CreateScriptCallback* createScript = nullptr;
+    SUPPRESS_UNCOUNTED_LOCAL CreateScriptURLCallback* createScriptURL = nullptr;
     {
         Locker locker { wrapped().lock() };
-        protectedCreateHTML = wrapped().options().createHTML;
-        protectedCreateScript = wrapped().options().createScript;
-        protectedCreateScriptURL = wrapped().options().createScriptURL;
+        createHTML = wrapped().options().createHTML.get();
+        createScript = wrapped().options().createScript.get();
+        createScriptURL = wrapped().options().createScriptURL.get();
     }
-    if (protectedCreateHTML)
-        protectedCreateHTML->visitJSFunction(visitor);
-    if (protectedCreateScript)
-        protectedCreateScript->visitJSFunction(visitor);
-    if (protectedCreateScriptURL)
-        protectedCreateScriptURL->visitJSFunction(visitor);
+    if (createHTML)
+        SUPPRESS_UNCOUNTED_ARG createHTML->visitJSFunction(visitor);
+    if (createScript)
+        SUPPRESS_UNCOUNTED_ARG createScript->visitJSFunction(visitor);
+    if (createScriptURL)
+        SUPPRESS_UNCOUNTED_ARG createScriptURL->visitJSFunction(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTrustedTypePolicy);


### PR DESCRIPTION
#### 2649b66cfa16f4f16da693980437cc6682a4f841
<pre>
Revert 293145@main and use raw pointers in JSTrustedTypePolicy::visitAdditionalChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=291023">https://bugs.webkit.org/show_bug.cgi?id=291023</a>

Reviewed by Chris Dumez.

This PR reverts 293145@main and use raw pointers in JSTrustedTypePolicy::visitAdditionalChildren
instead of RefPtr since these objects are not safe to be disposed in a non-main thread.

* Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp:
(WebCore::JSTrustedTypePolicy::visitAdditionalChildren):
* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.h:

Canonical link: <a href="https://commits.webkit.org/293220@main">https://commits.webkit.org/293220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88fb76831cb8a7aa090e0ff95b99fb3eebbdadef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26373 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/31983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101295 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55167 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48262 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105784 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25378 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83257 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27902 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25336 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->