### PR TITLE
[JSC] Add MultiGetByVal FTL node

### DIFF
--- a/JSTests/stress/multi-get-by-val-cse.js
+++ b/JSTests/stress/multi-get-by-val-cse.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array) {
+    var r = array[0] * array[0];
+    array[0] = 33;
+    return r * array[0];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test([5.5]), 5.5 * 5.5 * 33);
+    shouldBe(test(new Float32Array([5.5])), 5.5 * 5.5 * 33);
+    shouldBe(test(new Float64Array([5.5])), 5.5 * 5.5 * 33);
+}

--- a/JSTests/stress/multi-get-by-val-double-oob.js
+++ b/JSTests/stress/multi-get-by-val-double-oob.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array, index) {
+    return array[index];
+}
+noInline(test);
+
+let jsarray = [5.5];
+let f32array = new Float32Array([5.5]);
+let f64array = new Float64Array([5.5]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray, 0), 5.5);
+    shouldBe(test(f32array, 0), 5.5);
+    shouldBe(test(f64array, 0), 5.5);
+    shouldBe(test(jsarray, 1), undefined);
+    shouldBe(test(f32array, 1), undefined);
+    shouldBe(test(f64array, 1), undefined);
+}

--- a/JSTests/stress/multi-get-by-val-double.js
+++ b/JSTests/stress/multi-get-by-val-double.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array) {
+    return array[0] * array[0];
+}
+noInline(test);
+
+let jsarray = [5.5];
+let f32array = new Float32Array([5.5]);
+let f64array = new Float64Array([5.5]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray), 5.5 * 5.5);
+    shouldBe(test(f32array), 5.5 * 5.5);
+    shouldBe(test(f64array), 5.5 * 5.5);
+}

--- a/JSTests/stress/multi-get-by-val-mixed-oob.js
+++ b/JSTests/stress/multi-get-by-val-mixed-oob.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array, index) {
+    return array[index];
+}
+noInline(test);
+
+let jsarray = [42];
+let f32array = new Float32Array([42]);
+let f64array = new Float64Array([42]);
+let i32array = new Int32Array([42]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray, 0), 42);
+    shouldBe(test(f32array, 0), 42);
+    shouldBe(test(f64array, 0), 42);
+    shouldBe(test(i32array, 0), 42);
+    shouldBe(test(jsarray, 1), undefined);
+    shouldBe(test(f32array, 1), undefined);
+    shouldBe(test(f64array, 1), undefined);
+    shouldBe(test(i32array, 1), undefined);
+}

--- a/JSTests/stress/multi-get-by-val-mixed.js
+++ b/JSTests/stress/multi-get-by-val-mixed.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array) {
+    return array[0] * array[0];
+}
+noInline(test);
+
+let jsarray = [42];
+let f32array = new Float32Array([42]);
+let f64array = new Float64Array([42]);
+let i32array = new Int32Array([42]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray), 42 * 42);
+    shouldBe(test(f32array), 42 * 42);
+    shouldBe(test(f64array), 42 * 42);
+    shouldBe(test(i32array), 42 * 42);
+}

--- a/JSTests/stress/multi-get-by-val-non-double-oob.js
+++ b/JSTests/stress/multi-get-by-val-non-double-oob.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array, index) {
+    return array[index];
+}
+noInline(test);
+
+let jsarray = [42];
+let i16array = new Int16Array([42]);
+let i32array = new Int32Array([42]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray, 0), 42);
+    shouldBe(test(i16array, 0), 42);
+    shouldBe(test(i32array, 0), 42);
+    shouldBe(test(jsarray, 1), undefined);
+    shouldBe(test(i16array, 1), undefined);
+    shouldBe(test(i32array, 1), undefined);
+}

--- a/JSTests/stress/multi-get-by-val-non-double.js
+++ b/JSTests/stress/multi-get-by-val-non-double.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(array) {
+    return array[0] * array[0];
+}
+noInline(test);
+
+let jsarray = [42];
+let i16array = new Int16Array([42]);
+let i32array = new Int32Array([42]);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(jsarray), 42 * 42);
+    shouldBe(test(i16array), 42 * 42);
+    shouldBe(test(i32array), 42 * 42);
+}

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -190,6 +190,11 @@ public:
     Array::Action action() const { return static_cast<Array::Action>(u.asBytes.action); }
     bool mayBeLargeTypedArray() const { return u.asBytes.mayBeLargeTypedArray; }
     bool mayBeResizableOrGrowableSharedTypedArray() const { return u.asBytes.mayBeResizableOrGrowableSharedTypedArray; }
+
+    void setSpeculation(Array::Speculation speculation)
+    {
+        u.asBytes.speculation = speculation;
+    }
     
     unsigned asWord() const { return u.asWord; }
     

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -506,6 +506,7 @@ private:
             break;
         }
 
+        case MultiGetByVal:
         case EnumeratorGetByVal:
         case GetByVal:
         case GetByValMegamorphic: {

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -161,6 +161,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case PutByValMegamorphic:
         case GetByVal:
         case GetByValMegamorphic:
+        case MultiGetByVal:
         case StringAt:
         case StringCharAt:
         case StringCharCodeAt:
@@ -1127,7 +1128,72 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         RELEASE_ASSERT_NOT_REACHED();
         return;
     }
-        
+
+    case MultiGetByVal: {
+        ArrayMode mode = node->arrayMode();
+        LocationKind indexedPropertyLoc = indexedPropertyLocForResultType(node->result());
+        for (unsigned i = 0; i < sizeof(ArrayModes) * 8; ++i) {
+            ArrayModes oneArrayMode = 1ULL << i;
+            if (node->arrayModes() & oneArrayMode) {
+                switch (oneArrayMode) {
+                case asArrayModesIgnoringTypedArrays(ArrayWithInt32): {
+                    if (mode.isInBounds() || mode.isOutOfBoundsSaneChain()) {
+                        read(Butterfly_publicLength);
+                        read(IndexedInt32Properties);
+                        break;
+                    }
+                    clobberTop();
+                    break;
+                }
+                case asArrayModesIgnoringTypedArrays(ArrayWithDouble): {
+                    if (mode.isInBounds() || mode.isOutOfBoundsSaneChain()) {
+                        read(Butterfly_publicLength);
+                        read(IndexedDoubleProperties);
+                        break;
+                    }
+                    clobberTop();
+                    break;
+                }
+                case asArrayModesIgnoringTypedArrays(ArrayWithContiguous): {
+                    if (mode.isInBounds() || mode.isOutOfBoundsSaneChain()) {
+                        read(Butterfly_publicLength);
+                        read(IndexedContiguousProperties);
+                        break;
+                    }
+                    clobberTop();
+                    break;
+                }
+                case Int8ArrayMode:
+                case Int16ArrayMode:
+                case Int32ArrayMode:
+                case Uint8ArrayMode:
+                case Uint8ClampedArrayMode:
+                case Float16ArrayMode:
+                case Uint16ArrayMode:
+                case Uint32ArrayMode:
+                case Float32ArrayMode:
+                case Float64ArrayMode:
+                case BigInt64ArrayMode:
+                case BigUint64ArrayMode:
+                    // Even if we hit out-of-bounds, this is fine. TypedArray does not propagate access to its [[Prototype]] when out-of-bounds access happens.
+                    read(TypedArrayProperties);
+                    read(MiscFields);
+                    if (mode.mayBeResizableOrGrowableSharedTypedArray()) {
+                        write(MiscFields);
+                        write(TypedArrayProperties);
+                    }
+                    break;
+                default:
+                    DFG_CRASH(graph, node, "impossible array mode for MultiGetByVal");
+                    break;
+                }
+            }
+        }
+        if (!mode.isOutOfBounds())
+            def(HeapLocation(indexedPropertyLoc, IndexedProperties, graph.child(node, 0).node(), LazyNode(graph.child(node, 1).node()), nullptr, std::bit_cast<void*>(static_cast<uintptr_t>(node->arrayModes()))), LazyNode(node));
+        return;
+    }
+
     case GetMyArgumentByVal:
     case GetMyArgumentByValOutOfBounds: {
         read(Stack);

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -570,6 +570,9 @@ bool doesGC(Graph& graph, Node* node)
             return true;
         return false;
 
+    case MultiGetByVal:
+        return true;
+
     case ResolveRope:
         return true;
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1211,19 +1211,55 @@ private:
                 break;
             case Array::Generic:
                 if (node->op() == GetByValMegamorphic) {
-                    fixEdge<ObjectUse>(m_graph.varArgChild(node, 0));
-                    fixEdge<StringUse>(m_graph.varArgChild(node, 1));
-                } else {
-                    if (m_graph.varArgChild(node, 0)->shouldSpeculateObject()) {
-                        if (m_graph.varArgChild(node, 1)->shouldSpeculateString()) {
-                            fixEdge<ObjectUse>(m_graph.varArgChild(node, 0));
-                            fixEdge<StringUse>(m_graph.varArgChild(node, 1));
-                            break;
-                        }
+                    fixEdge<ObjectUse>(m_graph.child(node, 0));
+                    fixEdge<StringUse>(m_graph.child(node, 1));
+                    break;
+                }
 
-                        if (m_graph.varArgChild(node, 1)->shouldSpeculateSymbol()) {
-                            fixEdge<ObjectUse>(m_graph.varArgChild(node, 0));
-                            fixEdge<SymbolUse>(m_graph.varArgChild(node, 1));
+                if (m_graph.child(node, 0)->shouldSpeculateObject()) {
+                    if (m_graph.child(node, 1)->shouldSpeculateString()) {
+                        fixEdge<ObjectUse>(m_graph.child(node, 0));
+                        fixEdge<StringUse>(m_graph.child(node, 1));
+                        break;
+                    }
+
+                    if (m_graph.child(node, 1)->shouldSpeculateSymbol()) {
+                        fixEdge<ObjectUse>(m_graph.child(node, 0));
+                        fixEdge<SymbolUse>(m_graph.child(node, 1));
+                        break;
+                    }
+
+                    if (m_graph.m_plan.isFTL()) {
+                        if (node->op() == GetByVal && m_graph.child(node, 1)->shouldSpeculateInt32()) {
+                            if (m_graph.hasExitSite(node->origin.semantic, OutOfBounds)) {
+                                auto old = node->arrayMode();
+                                old.setSpeculation(Array::OutOfBounds);
+                                node->setArrayMode(old);
+                            }
+
+                            ArrayModes arrayModes = 0;
+                            {
+                                CodeBlock* profiledBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
+                                ConcurrentJSLocker locker(profiledBlock->m_lock);
+                                if (ArrayProfile* arrayProfile = profiledBlock->getArrayProfile(locker, node->origin.semantic.bytecodeIndex()))
+                                    arrayModes = arrayProfile->observedArrayModes(locker);
+                            }
+                            auto info = refineArrayModesForMultiByVal(node, arrayModes);
+                            if (!info)
+                                break;
+
+                            NodeFlags flags = 0;
+                            std::tie(arrayModes, flags) = info.value();
+
+                            fixEdge<CellUse>(m_graph.child(node, 0));
+                            fixEdge<Int32Use>(m_graph.child(node, 1));
+                            auto* data = m_graph.m_multiGetByValData.add(MultiGetByValData {
+                                arrayModes,
+                                arrayMode,
+                            });
+                            node->convertToMultiGetByVal(data);
+                            if (flags == NodeResultDouble)
+                                node->setResult(NodeResultDouble);
                             break;
                         }
                     }
@@ -3408,6 +3444,7 @@ private:
         case MakeAtomString:
         case CallCustomAccessorGetter:
         case CallCustomAccessorSetter:
+        case MultiGetByVal:
             break;
 #else // not ASSERT_ENABLED
         default:
@@ -4383,7 +4420,74 @@ private:
             return;
         } }
     }
-    
+
+    static std::optional<std::tuple<ArrayModes, NodeFlags>> refineArrayModesForMultiByVal(Node* node, ArrayModes arrayModes)
+    {
+        constexpr ArrayModes supportedArrays = 0
+            | asArrayModesIgnoringTypedArrays(ArrayWithInt32)
+            | asArrayModesIgnoringTypedArrays(ArrayWithDouble)
+            | asArrayModesIgnoringTypedArrays(ArrayWithContiguous)
+            | CopyOnWriteArrayWithInt32ArrayMode
+            | CopyOnWriteArrayWithDoubleArrayMode
+            | CopyOnWriteArrayWithContiguousArrayMode
+            | Int8ArrayMode
+            | Int16ArrayMode
+            | Int32ArrayMode
+            | Uint8ArrayMode
+            | Uint8ClampedArrayMode
+            // | Float16ArrayMode // Not supporting right now.
+            | Uint16ArrayMode
+            | Uint32ArrayMode
+            | Float32ArrayMode
+            | Float64ArrayMode
+            // | BigInt64ArrayMode // Not supporting right now.
+            // | BigUint64ArrayMode // Not supporting right now.
+            | 0;
+
+        constexpr ArrayModes preferDoubleResult = 0
+            | asArrayModesIgnoringTypedArrays(ArrayWithDouble)
+            | CopyOnWriteArrayWithDoubleArrayMode
+            | Float16ArrayMode
+            | Float32ArrayMode
+            | Float64ArrayMode;
+
+        if (!arrayModes)
+            return { };
+
+        // NonArray IndexingMode includes various subtle array-like objects, including DirectArguments, String, etc.
+        // We do not support them in Multi-ByVal ops.
+        if (~supportedArrays & arrayModes)
+            return { };
+
+        // Unify CoW ArrayModes into non-CoW ones.
+        if (arrayModes & CopyOnWriteArrayWithInt32ArrayMode) {
+            arrayModes &= ~CopyOnWriteArrayWithInt32ArrayMode;
+            arrayModes |= asArrayModesIgnoringTypedArrays(ArrayWithInt32);
+        }
+
+        if (arrayModes & CopyOnWriteArrayWithDoubleArrayMode) {
+            arrayModes &= ~CopyOnWriteArrayWithDoubleArrayMode;
+            arrayModes |= asArrayModesIgnoringTypedArrays(ArrayWithDouble);
+        }
+
+        if (arrayModes & CopyOnWriteArrayWithContiguousArrayMode) {
+            arrayModes &= ~CopyOnWriteArrayWithContiguousArrayMode;
+            arrayModes |= asArrayModesIgnoringTypedArrays(ArrayWithContiguous);
+        }
+
+        unsigned count = std::popcount(arrayModes);
+        if (count > Options::maxAccessVariantListSize())
+            return { };
+
+        NodeFlags flags = NodeResultJS;
+        if (!node->arrayMode().isOutOfBounds()) {
+            if ((arrayModes & preferDoubleResult) == arrayModes)
+                flags = NodeResultDouble;
+        }
+
+        return std::tuple { arrayModes, flags };
+    }
+
     bool alwaysUnboxSimplePrimitives()
     {
 #if USE(JSVALUE64)

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -233,6 +233,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, "numberOfBoundArguments = "_s, node->numberOfBoundArguments());
     if (node->hasArrayMode())
         out.print(comma, node->arrayMode());
+    if (node->hasArrayModes())
+        out.print(comma, ArrayModesDump(node->arrayModes()));
     if (node->hasArithUnaryType())
         out.print(comma, "Type:"_s, node->arithUnaryType());
     if (node->hasArithMode())

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1278,6 +1278,7 @@ public:
     Bag<MultiGetByOffsetData> m_multiGetByOffsetData;
     Bag<MultiPutByOffsetData> m_multiPutByOffsetData;
     Bag<MultiDeleteByOffsetData> m_multiDeleteByOffsetData;
+    Bag<MultiGetByValData> m_multiGetByValData;
     Bag<MatchStructureData> m_matchStructureData;
     Bag<ObjectMaterializationData> m_objectMaterializationData;
     Bag<CallVarargsData> m_callVarargsData;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -208,6 +208,7 @@ namespace JSC { namespace DFG {
     macro(GetByValMegamorphic, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(GetByValWithThis, NodeResultJS | NodeMustGenerate) \
     macro(GetByValWithThisMegamorphic, NodeResultJS | NodeMustGenerate) \
+    macro(MultiGetByVal, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(GetMyArgumentByVal, NodeResultJS | NodeMustGenerate) \
     macro(GetMyArgumentByValOutOfBounds, NodeResultJS | NodeMustGenerate) \
     macro(VarargsLength, NodeMustGenerate | NodeResultInt32) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -639,6 +639,11 @@ private:
             break;
         }
 
+        case MultiGetByVal: {
+            changed |= mergePrediction(node->getHeapPrediction());
+            break;
+        }
+
         case StringAt: {
             if (node->arrayMode().isOutOfBounds())
                 changed |= mergePrediction(SpecString | SpecOther);
@@ -1530,6 +1535,7 @@ private:
         case ArithMod:
         case ArithAbs:
         case GetByVal:
+        case MultiGetByVal:
         case ToThis:
         case ToPrimitive: 
         case ToPropertyKey:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -412,6 +412,9 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringCodePointAt:
         return node->arrayMode().alreadyChecked(graph, node, state.forNode(graph.child(node, 0)));
 
+    case MultiGetByVal:
+        return false;
+
     case ArrayPush:
         return node->arrayMode().alreadyChecked(graph, node, state.forNode(graph.varArgChild(node, 1)));
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4431,6 +4431,7 @@ void SpeculativeJIT::compile(Node* node)
     case PutByValMegamorphic:
     case InByIdMegamorphic:
     case InByValMegamorphic:
+    case MultiGetByVal:
         DFG_CRASH(m_graph, node, "unexpected node in DFG backend");
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6566,6 +6566,7 @@ void SpeculativeJIT::compile(Node* node)
     case IdentityWithProfile:
     case CPUIntrinsic:
     case CallWasm:
+    case MultiGetByVal:
         DFG_CRASH(m_graph, node, "Unexpected node");
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGTypeCheckHoistingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGTypeCheckHoistingPhase.cpp
@@ -275,6 +275,7 @@ private:
                 case GetButterfly:
                 case EnumeratorGetByVal:
                 case GetByVal:
+                case MultiGetByVal:
                 case PutByValDirect:
                 case PutByVal:
                 case PutByValAlias:
@@ -361,6 +362,7 @@ private:
                 case GetButterfly:
                 case EnumeratorGetByVal:
                 case GetByVal:
+                case MultiGetByVal:
                 case PutByValDirect:
                 case PutByVal:
                 case PutByValAlias:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -453,6 +453,7 @@ inline CapabilityLevel canCompile(Node* node)
     case GetByValMegamorphic:
     case GetByValWithThis:
     case GetByValWithThisMegamorphic:
+    case MultiGetByVal:
     case PutByVal:
     case PutByValAlias:
     case PutByValMegamorphic:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1084,6 +1084,9 @@ private:
         case GetByVal:
             compileGetByVal();
             break;
+        case MultiGetByVal:
+            compileMultiGetByVal();
+            break;
         case GetByValMegamorphic:
             compileGetByValMegamorphic();
             break;
@@ -6516,6 +6519,288 @@ IGNORE_CLANG_WARNINGS_END
             setDouble(result);
         else
             setJSValue(result);
+    }
+
+    void compileMultiGetByVal()
+    {
+        constexpr ArrayModes arrayModesForJSArray = ALL_ARRAY_ARRAY_MODES;
+        constexpr ArrayModes arrayModesForTypedArrays = ALL_TYPED_ARRAY_MODES;
+
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        ArrayModes arrayModes = m_node->arrayModes();
+        ArrayMode arrayMode = m_node->arrayMode();
+        Vector<ValueFromBlock> results;
+
+        Edge& baseEdge = m_graph.child(m_node, 0);
+        Edge& indexEdge = m_graph.child(m_node, 1);
+        LValue base = lowCell(baseEdge);
+        LValue index = lowInt32(indexEdge);
+
+        LBasicBlock continuation = m_out.newBlock();
+        LBasicBlock bailout = m_out.newBlock();
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(continuation);
+
+        if (arrayModes & arrayModesForJSArray) {
+            auto arrayModeToIndexingType = [&](ArrayModes oneArrayMode) {
+                switch (oneArrayMode) {
+                case asArrayModesIgnoringTypedArrays(ArrayWithInt32):
+                    return ArrayWithInt32;
+                case asArrayModesIgnoringTypedArrays(ArrayWithDouble):
+                    return ArrayWithDouble;
+                case asArrayModesIgnoringTypedArrays(ArrayWithContiguous):
+                    return ArrayWithContiguous;
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                    return ArrayWithContiguous;
+                }
+            };
+
+            constexpr IndexingType indexingModeMask = IsArray | IndexingShapeMask;
+            LValue indexingMode = m_out.load8ZeroExt32(base, m_heaps.JSCell_indexingTypeAndMisc);
+            LValue maskedIndexingType = m_out.bitAnd(indexingMode, m_out.constInt32(indexingModeMask));
+
+            auto tryLoadJSArray = [&](IndexingType expectedType, LBasicBlock continuation) {
+                LValue butterfly = m_out.loadPtr(base, m_heaps.JSObject_butterfly);
+                LValue length = m_out.load32(butterfly, m_heaps.Butterfly_publicLength);
+                auto& heap = ([&] -> IndexedAbstractHeap& {
+                    switch (expectedType) {
+                    case ArrayWithInt32:
+                        return m_heaps.indexedInt32Properties;
+                    case ArrayWithContiguous:
+                        return m_heaps.indexedContiguousProperties;
+                    case ArrayWithDouble:
+                        return m_heaps.indexedDoubleProperties;
+                    default:
+                        return m_heaps.indexedContiguousProperties;
+                    }
+                })();
+
+                LValue isOutOfBounds = m_out.aboveOrEqual(index, length);
+
+                if (arrayMode.isInBounds()) {
+                    speculate(OutOfBounds, noValue(), nullptr, isOutOfBounds);
+                    LValue isHole = nullptr;
+                    LValue result = nullptr;
+                    if (expectedType == ArrayWithDouble) {
+                        LValue doubleResult = m_out.loadDouble(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
+                        isHole = m_out.doubleNotEqualOrUnordered(doubleResult, doubleResult);
+                        if (m_node->hasDoubleResult())
+                            result = doubleResult;
+                        else
+                            result = boxDouble(doubleResult);
+                    } else {
+                        result = m_out.load64(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
+                        isHole = m_out.isZero64(result);
+                    }
+                    if (arrayMode.isInBoundsSaneChain()) {
+                        if (m_node->hasDoubleResult())
+                            result = m_out.select(isHole, m_out.constDouble(std::bit_cast<int64_t>(PNaN)), result);
+                        else
+                            result = m_out.select(isHole, m_out.constInt64(JSValue::encode(jsUndefined())), result);
+                    } else
+                        speculate(LoadFromHole, noValue(), nullptr, isHole);
+                    results.append(m_out.anchor(result));
+                    m_out.jump(continuation);
+                    return;
+                }
+
+                ASSERT(!m_node->hasDoubleResult());
+                LBasicBlock fastCase = m_out.newBlock();
+                LBasicBlock slowCase = m_out.newBlock();
+
+                m_out.branch(isOutOfBounds, rarely(slowCase), usually(fastCase));
+
+                m_out.appendTo(fastCase);
+                if (expectedType == ArrayWithDouble) {
+                    LValue doubleValue = m_out.loadDouble(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
+                    LValue result = boxDouble(doubleValue);
+                    results.append(m_out.anchor(result));
+                    m_out.branch(m_out.doubleNotEqualOrUnordered(doubleValue, doubleValue), rarely(slowCase), usually(continuation));
+                } else {
+                    LValue result = m_out.load64(baseIndexWithProvenValue(heap, butterfly, index, indexEdge));
+                    results.append(m_out.anchor(result));
+                    m_out.branch(m_out.isZero64(result), rarely(slowCase), usually(continuation));
+                }
+
+                m_out.appendTo(slowCase);
+                if (arrayMode.isOutOfBoundsSaneChain()) {
+                    speculate(NegativeIndex, noValue(), nullptr, m_out.lessThan(index, m_out.int32Zero));
+                    results.append(m_out.anchor(m_out.constInt64(JSValue::ValueUndefined)));
+                } else
+                    results.append(m_out.anchor(vmCall(Int64, operationGetByValObjectInt, weakPointer(globalObject), base, index)));
+                m_out.jump(continuation);
+            };
+
+            for (unsigned i = 0; i < sizeof(ArrayModes) * 8; ++i) {
+                ArrayModes oneArrayMode = 1ULL << i;
+                if ((arrayModes & arrayModesForJSArray) & oneArrayMode) {
+                    IndexingType indexingType = arrayModeToIndexingType(oneArrayMode);
+                    LBasicBlock next = m_out.newBlock();
+                    LBasicBlock handled = m_out.newBlock();
+                    m_out.branch(m_out.equal(maskedIndexingType, m_out.constInt32(indexingType)), unsure(handled), unsure(next));
+                    m_out.appendTo(handled);
+                    tryLoadJSArray(indexingType, continuation);
+                    m_out.appendTo(next);
+                }
+            }
+        }
+
+        if (arrayModes & arrayModesForTypedArrays) {
+            auto arrayModeToTypedArrayType = [&](ArrayModes oneArrayMode) {
+                switch (oneArrayMode) {
+                case Int8ArrayMode:
+                    return TypeInt8;
+                case Int16ArrayMode:
+                    return TypeInt16;
+                case Int32ArrayMode:
+                    return TypeInt32;
+                case Uint8ArrayMode:
+                    return TypeUint8;
+                case Uint8ClampedArrayMode:
+                    return TypeUint8Clamped;
+                case Uint16ArrayMode:
+                    return TypeUint16;
+                case Uint32ArrayMode:
+                    return TypeUint32;
+                case Float16ArrayMode:
+                    return TypeFloat16;
+                case Float32ArrayMode:
+                    return TypeFloat32;
+                case Float64ArrayMode:
+                    return TypeFloat64;
+                case BigInt64ArrayMode:
+                    return TypeBigInt64;
+                case BigUint64ArrayMode:
+                    return TypeBigUint64;
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                    return TypeBigUint64;
+                }
+            };
+
+            auto tryLoadTypedArray = [&](TypedArrayType type, LValue storage, LBasicBlock continuation) {
+                TypedPointer pointer = pointerIntoTypedArray(storage, index, type);
+
+                auto loadValue = [&]() -> LValue {
+                    if (isInt(type))
+                        return loadFromIntTypedArray(pointer, type);
+
+                    ASSERT(isFloat(type));
+
+                    switch (type) {
+                    case TypeFloat16:
+                        return m_out.loadFloat16AsDouble(pointer);
+                    case TypeFloat32:
+                        return m_out.floatToDouble(m_out.loadFloat(pointer));
+                    case TypeFloat64:
+                        return m_out.loadDouble(pointer);
+                    default:
+                        DFG_CRASH(m_graph, m_node, "Bad typed array type");
+                    }
+                    return nullptr;
+                };
+
+                LValue unboxedResult = loadValue();
+                if (isInt(type)) {
+                    ASSERT(!m_node->hasDoubleResult()); // Right now, it is yes. We extend later.
+                    auto speculateOrAdjust = [&](LValue result) {
+                        if (elementSize(type) < 4 || isSigned(type))
+                            return boxInt32(result);
+
+                        if (m_node->shouldSpeculateInt32()) {
+                            speculate(Overflow, noValue(), nullptr, m_out.lessThan(result, m_out.int32Zero));
+                            return boxInt32(result);
+                        }
+
+                        return boxDouble(m_out.unsignedToDouble(result));
+                    };
+                    results.append(m_out.anchor(speculateOrAdjust(unboxedResult)));
+                } else {
+                    if (m_node->hasDoubleResult())
+                        results.append(m_out.anchor(unboxedResult));
+                    else
+                        results.append(m_out.anchor(boxDouble(m_out.purifyNaN(unboxedResult))));
+                }
+                m_out.jump(continuation);
+            };
+
+            // If it is only one TypedArray type, we do not need to make a slow operation.
+            if (std::popcount(arrayModes & arrayModesForTypedArrays) == 1) {
+                ArrayModes oneArrayMode = arrayModes & arrayModesForTypedArrays;
+                auto typedArrayType = arrayModeToTypedArrayType(oneArrayMode);
+                LBasicBlock next = m_out.newBlock();
+                LBasicBlock handled = m_out.newBlock();
+                ASSERT(isTypedView(typedArrayType));
+                m_out.branch(m_out.equal(m_out.load8ZeroExt32(base, m_heaps.JSCell_typeInfoType), m_out.constInt32(typeForTypedArrayType(typedArrayType))), unsure(handled), unsure(next));
+
+                m_out.appendTo(handled);
+                LValue length = typedArrayLength(base, arrayMode.mayBeResizableOrGrowableSharedTypedArray(), arrayModeToTypedArrayType(arrayModes & arrayModesForTypedArrays), baseEdge);
+
+#if USE(LARGE_TYPED_ARRAYS)
+                auto isOutOfBounds = m_out.aboveOrEqual(m_out.signExt32To64(index), length);
+#else
+                auto isOutOfBounds = m_out.aboveOrEqual(index, length);
+#endif
+                if (arrayMode.isOutOfBounds()) {
+                    auto fastCase = m_out.newBlock();
+                    results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
+                    m_out.branch(isOutOfBounds, rarely(continuation), usually(fastCase));
+                    m_out.appendTo(fastCase);
+                }
+
+                LValue vector = m_out.loadPtr(base, m_heaps.JSArrayBufferView_vector);
+                LValue storage = caged(Gigacage::Primitive, vector, base);
+                tryLoadTypedArray(typedArrayType, storage, continuation);
+                m_out.appendTo(next);
+            } else {
+                LBasicBlock checkLength = m_out.newBlock();
+                m_out.branch(isTypedArrayView(base), unsure(checkLength), rarely(bailout));
+
+                m_out.appendTo(checkLength);
+                LValue length = typedArrayLength(base, arrayMode.mayBeResizableOrGrowableSharedTypedArray(), std::nullopt, baseEdge);
+
+#if USE(LARGE_TYPED_ARRAYS)
+                auto isOutOfBounds = m_out.aboveOrEqual(m_out.signExt32To64(index), length);
+#else
+                auto isOutOfBounds = m_out.aboveOrEqual(index, length);
+#endif
+                if (arrayMode.isOutOfBounds()) {
+                    auto fastCase = m_out.newBlock();
+                    results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
+                    m_out.branch(isOutOfBounds, rarely(continuation), usually(fastCase));
+                    m_out.appendTo(fastCase);
+                }
+
+                LValue vector = m_out.loadPtr(base, m_heaps.JSArrayBufferView_vector);
+                LValue storage = caged(Gigacage::Primitive, vector, base);
+
+                for (unsigned i = 0; i < sizeof(ArrayModes) * 8; ++i) {
+                    ArrayModes oneArrayMode = 1ULL << i;
+                    if ((arrayModes & arrayModesForTypedArrays) & oneArrayMode) {
+                        auto typedArrayType = arrayModeToTypedArrayType(oneArrayMode);
+                        LBasicBlock next = m_out.newBlock();
+                        LBasicBlock handled = m_out.newBlock();
+                        ASSERT(isTypedView(typedArrayType));
+                        m_out.branch(m_out.equal(m_out.load8ZeroExt32(base, m_heaps.JSCell_typeInfoType), m_out.constInt32(typeForTypedArrayType(typedArrayType))), unsure(handled), unsure(next));
+
+                        m_out.appendTo(handled);
+                        tryLoadTypedArray(typedArrayType, storage, continuation);
+                        m_out.appendTo(next);
+                    }
+                }
+            }
+        }
+        m_out.jump(bailout);
+
+        m_out.appendTo(bailout, continuation);
+        speculate(BadIndexingType, jsValueValue(base), nullptr, m_out.booleanTrue);
+        m_out.unreachable();
+
+        m_out.appendTo(continuation, lastNext);
+        if (m_node->hasDoubleResult())
+            setDouble(m_out.phi(Double, results));
+        else
+            setJSValue(m_out.phi(Int64, results));
     }
 
     void compileGetMyArgumentByVal()


### PR DESCRIPTION
#### ed70771c0c6ac564e7b2068c4b7a26bf301d238b
<pre>
[JSC] Add MultiGetByVal FTL node
<a href="https://bugs.webkit.org/show_bug.cgi?id=291030">https://bugs.webkit.org/show_bug.cgi?id=291030</a>
<a href="https://rdar.apple.com/148552535">rdar://148552535</a>

Reviewed by Yijia Huang.

This patch adds new FTL node MultiGetByVal. In DFG / FTL, we attempt to
make GetByVal access monomorphic by collecting ArrayProfile data. And
most of cases, we can achieve that since JSArrays will become
monomorphic via Arrayify node. However there is a case that cannot be
handled by Arrayify, for example, handling multiple TypedArrays, or
handling TypedArrays and JSArrays at one site. In this case, we use
Array::Generic and IC will be used. While IC is relatively fast, it is
still slower than completely inlined code. And since IC can handle
anything, we cannot model this nodes&apos; effect precisely. Thus we start
saying this node is &quot;clobber world&quot; and this makes the other
optimization pessimistic around this node, like, preventing some nodes
from moved outside of the loop.

In this patch, we add new FTL MultiGetByVal node which handles multiple
arrays inline and very well. When we found something not listed in this
node, we will do OSR exit, thus clobberizing phase can model this node&apos;s
effect very precisely, encouraging the optimization around this node. We
do this only in FTL since we would like to collect information more via
IC in DFG, and then FTL will use this feedback to fully inline the
accesses.

The emitted code is organized as follows,

    if (base is JSArray Int32Shape) {
        ... Int32Shape access ...
    } else if (base is JSArray DoubleShape) {
        ... DoubleShape access ...
    } else if (base is JSArray Contiguous) {
        ... ContiguousShape access ...
    } else if (base is TypedArrays) {
        if (base is Int8Array) {
            ...
        } else if (base is ...) {
            ...
        } else {
            bailout
        }
    } else {
        bailout
    }

Some of these clauses will not be emitted and it is controlled via
ArrayModes collected from ArrayProfile.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::setSpeculation):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::refineArrayModesForMultiByVal):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToMultiGetByVal):
(JSC::DFG::Node::hasHeapPrediction):
(JSC::DFG::Node::hasMultiGetByValData):
(JSC::DFG::Node::multiGetByValData):
(JSC::DFG::Node::hasArrayModes):
(JSC::DFG::Node::arrayModes):
(JSC::DFG::Node::hasArrayMode):
(JSC::DFG::Node::arrayMode):
(JSC::DFG::Node::setArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGTypeCheckHoistingPhase.cpp:
(JSC::DFG::TypeCheckHoistingPhase::identifyRedundantStructureChecks):
(JSC::DFG::TypeCheckHoistingPhase::identifyRedundantArrayChecks):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileMultiGetByVal):

Canonical link: <a href="https://commits.webkit.org/293254@main">https://commits.webkit.org/293254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2773d5f8d14c076057732f865b089441852b364f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74791 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31962 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101272 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13766 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6703 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48239 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96894 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83241 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18994 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30487 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120515 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25133 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33750 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->