### PR TITLE
IndexValueStore::removeRecord should only remove the IndexValueEntry when it's empty

### DIFF
--- a/LayoutTests/storage/indexeddb/cursor-continue-add-error-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-error-private-expected.txt
@@ -1,0 +1,17 @@
+Adding record fails due to index uniqueness during cursor iteration.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+cursorRequest = scoreIndex.openCursor()
+cursor = event.target.result
+PASS cursor.key is 100
+cursor.continue()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/cursor-continue-add-error-private.html
+++ b/LayoutTests/storage/indexeddb/cursor-continue-add-error-private.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script>
+description("Adding record fails due to index uniqueness during cursor iteration.");
+
+function prepareDatabase()
+{
+    database = event.target.result;
+    transaction = event.target.transaction;
+    // Transaction will be aborted due to failed request.
+    transaction.onabort = finishJSTest;
+
+    objectStore = database.createObjectStore('records', {autoIncrement: true});
+    objectStore.add({userid:10, score:100}).onerror = unexpectedErrorCallback;
+
+    // Different users can have same score.
+    scoreIndex = objectStore.createIndex('index1', 'score', {unique: false});
+    // One user can only have one record.
+    userIndex = objectStore.createIndex('index2', 'userid', {unique: true});
+
+    evalAndLog("cursorRequest = scoreIndex.openCursor()");
+    cursorRequest.onsuccess = (event) => {
+        evalAndLog("cursor = event.target.result");
+        if (!cursor)
+            return;
+
+        shouldBe("cursor.key", "100");
+
+        // This insertion should fail because user cannot have two records.
+        addRequest = objectStore.add({userid:10, score:100});
+        addRequest.onsuccess = unexpectedSuccessCallback;
+        addRequest.onerror = (event) => {
+            evalAndLog("cursor.continue()");
+        }
+    }
+}
+
+indexedDBTest(prepareDatabase);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -128,7 +128,7 @@ void IndexValueStore::removeRecord(const IDBKeyData& indexKey, const IDBKeyData&
     if (!iterator->value)
         return;
 
-    if (iterator->value->removeKey(valueKey)) {
+    if (iterator->value->removeKey(valueKey) && !iterator->value->getCount()) {
         m_records.remove(iterator);
         m_orderedKeys.erase(indexKey);
     }


### PR DESCRIPTION
#### bc288cc3dabb6c3cd54cebd78443842458685971
<pre>
IndexValueStore::removeRecord should only remove the IndexValueEntry when it&apos;s empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=285703">https://bugs.webkit.org/show_bug.cgi?id=285703</a>
<a href="https://rdar.apple.com/142446346">rdar://142446346</a>

Reviewed by Sihui Liu.

The previous implementation was removing the entire `IndexValueEntry` object (iterator-&gt;value)
when successfully removing the specified key. However, when the index has been set up to allow
duplicate values, it may have multiple keys. So in that case, after removing a key from the
entry, its count may still not be zero, namely, `iterator-&gt;value-&gt;getCount() &gt; 0`. Consequently,
an incorrect entry could be removed prematurely without notifying the cursors referencing it,
which then can lead to use-after-free.

* LayoutTests/storage/indexeddb/cursor-continue-add-error-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/cursor-continue-add-error-private.html: Added.
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::removeRecord):

Originally-landed-as: 283286.610@safari-7620-branch (02c5baaa939c). <a href="https://rdar.apple.com/148117429">rdar://148117429</a>
Canonical link: <a href="https://commits.webkit.org/293250@main">https://commits.webkit.org/293250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c263db0804076964c6833c0450a667d85d54d800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31930 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88717 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55117 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6666 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105702 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83203 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18935 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->