### PR TITLE
Potential 'overflow' issue commited to upstream libwebrtc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/printf.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/printf.c
@@ -75,11 +75,10 @@ int BIO_printf(BIO *bio, const char *format, ...) {
     return -1;
   }
 
-  if ((size_t) out_len >= sizeof(buf)) {
-    const int requested_len = out_len;
-    // The output was truncated. Note that vsnprintf's return value
-    // does not include a trailing NUL, but the buffer must be sized
-    // for it.
+  if ((size_t)out_len >= sizeof(buf)) {
+    const size_t requested_len = (size_t)out_len;
+    // The output was truncated. Note that vsnprintf's return value does not
+    // include a trailing NUL, but the buffer must be sized for it.
     out = OPENSSL_malloc(requested_len + 1);
     out_malloced = 1;
     if (out == NULL) {
@@ -88,7 +87,7 @@ int BIO_printf(BIO *bio, const char *format, ...) {
     va_start(args, format);
     out_len = vsnprintf(out, requested_len + 1, format, args);
     va_end(args);
-    assert(out_len == requested_len);
+    assert(out_len == (int)requested_len);
   } else {
     out = buf;
   }


### PR DESCRIPTION
#### be6636fc60b850b6bdd97241f1d88205502deaf4
<pre>
Potential &apos;overflow&apos; issue commited to upstream libwebrtc
<a href="https://rdar.apple.com/141802173">rdar://141802173</a>

Reviewed by Jean-Yves Avenard.

Cherrry-picking of <a href="https://boringssl.googlesource.com/boringssl/+/168777fbc49296eeb54b5da8fc7dfcae1a4d3e27.">https://boringssl.googlesource.com/boringssl/+/168777fbc49296eeb54b5da8fc7dfcae1a4d3e27.</a>

* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/printf.c:
(BIO_printf):

Originally-landed-as: 283286.609@safari-7620-branch (d55b7f471238). <a href="https://rdar.apple.com/148117561">rdar://148117561</a>
Canonical link: <a href="https://commits.webkit.org/293223@main">https://commits.webkit.org/293223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba45cde0b1aac8ce2b3df5f1d728e1d5bcdeedf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48742 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74759 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6668 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105706 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83206 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21026 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25258 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->