### PR TITLE
[visionOS] Notify the media player when entering & exiting external playback in LinearMediaPlayer

### DIFF
--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -635,6 +635,18 @@ void HTMLVideoElement::didExitFullscreenOrPictureInPicture()
     HTMLMediaElement::didStopBeingFullscreenElement();
 }
 
+void HTMLVideoElement::didEnterExternalPlayback()
+{
+    if (RefPtr player = this->player())
+        player->setInFullscreenOrPictureInPicture(true);
+}
+
+void HTMLVideoElement::didExitExternalPlayback()
+{
+    if (RefPtr player = this->player())
+        player->setInFullscreenOrPictureInPicture(false);
+}
+
 bool HTMLVideoElement::isChangingPresentationMode() const
 {
     return isChangingVideoFullscreenMode();

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -106,6 +106,8 @@ public:
     WEBCORE_EXPORT void setPresentationMode(VideoPresentationMode);
     WEBCORE_EXPORT void didEnterFullscreenOrPictureInPicture(const FloatSize&);
     WEBCORE_EXPORT void didExitFullscreenOrPictureInPicture();
+    WEBCORE_EXPORT void didEnterExternalPlayback();
+    WEBCORE_EXPORT void didExitExternalPlayback();
     WEBCORE_EXPORT bool isChangingPresentationMode() const;
     WEBCORE_EXPORT void setPresentationModeIgnoringPermissionsPolicy(VideoPresentationMode);
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -189,6 +189,7 @@ public:
     virtual void supportsLinearMediaPlayerChanged(bool) { }
     virtual void spatialVideoMetadataChanged(const std::optional<SpatialVideoMetadata>&) { };
     virtual void isImmersiveVideoChanged(bool) { };
+    virtual void didSetVideoReceiverEndpoint() { };
 #endif
     virtual void ensureControlsManager() { }
     virtual void modelDestroyed() { }

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -94,6 +94,10 @@ public:
     virtual void didExitFullscreen() { };
     virtual void didCleanupFullscreen() { };
     virtual void fullscreenMayReturnToInline() { };
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    virtual void didEnterExternalPlayback() { };
+    virtual void didExitExternalPlayback() { };
+#endif
     virtual void setRequiresTextTrackRepresentation(bool) { }
     virtual void setTextTrackRepresentationBounds(const IntRect&) { }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1889,6 +1889,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setVideoTarget(const PlatformVideoTar
 
     // Transition to docking goes: Layer -> StagedVideoRenderer -> Renderer
     // Transition from docking goes: Renderer -> StagedLayer -> Layer
+    // Transition to external playback goes: Layer -> StagedVideoRenderer -> Renderer
+    // Transition from external playback goes: Renderer -> StagedLayer -> Layer
     auto oldAcceleratedVideoMode = m_acceleratedVideoMode;
     switch (oldAcceleratedVideoMode) {
     case AcceleratedVideoMode::Layer:

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -67,6 +67,8 @@ private:
     UIViewController *playerViewController() const final;
     void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)> &&, CompletionHandler<void(bool)>&&) final;
     void exitExternalPlayback() final;
+    bool cleanupExternalPlayback() final;
+    void didSetVideoReceiverEndpoint() final;
     void tryToStartPictureInPicture() final { }
     void stopPictureInPicture() final { }
     void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
@@ -75,7 +77,6 @@ private:
     void setContentDimensions(const WebCore::FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final { }
     bool isExternalPlaybackActive() const final { return false; }
-    bool cleanupExternalPlayback() final;
     bool willRenderToLayer() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
     CALayer *captionsLayer() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -175,6 +175,7 @@ void VideoPresentationInterfaceLMK::enterExternalPlayback(CompletionHandler<void
             playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
         }
+
         handler(success, m_playerViewController.get());
     }).get()];
 }
@@ -201,6 +202,9 @@ void VideoPresentationInterfaceLMK::exitExternalPlayback()
         }
         invalidatePlayerViewController();
 
+        if (RefPtr model = this->videoPresentationModel())
+            model->didExitExternalPlayback();
+
         if (handler)
             handler(success);
     }).get()];
@@ -215,6 +219,17 @@ bool VideoPresentationInterfaceLMK::cleanupExternalPlayback()
 
     exitExternalPlayback();
     return true;
+}
+
+void VideoPresentationInterfaceLMK::didSetVideoReceiverEndpoint()
+{
+    if (linearMediaPlayer().presentationState != WKSLinearMediaPresentationStateExternal)
+        return;
+
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+
+    if (RefPtr model = this->videoPresentationModel())
+        model->didEnterExternalPlayback();
 }
 
 UIViewController *VideoPresentationInterfaceLMK::playerViewController() const

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -46,6 +46,9 @@
 #if HAVE(PIP_SKIP_PREROLL)
 #import <WebCore/VideoPresentationInterfaceMac.h>
 #endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+#import <WebCore/VideoPresentationInterfaceIOS.h>
+#endif
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -1061,6 +1064,16 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
 
     VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), contextId, WTFMove(playerIdentifier), endpoint, endpointIdentifier);
     xpc_connection_send_message(xpcConnection.get(), endpointMessage.encode().get());
+
+    RefPtr videoPresentationManager = page->videoPresentationManager();
+    if (!videoPresentationManager)
+        return;
+
+    RefPtr controlsManagerInterface = videoPresentationManager->controlsManagerInterface();
+    if (!controlsManagerInterface)
+        return;
+
+    controlsManagerInterface->didSetVideoReceiverEndpoint();
 #else
     UNUSED_PARAM(contextId);
     UNUSED_PARAM(endpoint);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -114,6 +114,10 @@ private:
     void didExitFullscreen() final;
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    void didEnterExternalPlayback() final;
+    void didExitExternalPlayback() final;
+#endif
     void setRequiresTextTrackRepresentation(bool) final;
     void setTextTrackRepresentationBounds(const WebCore::IntRect&) final;
 
@@ -258,6 +262,10 @@ private:
     void setVideoFullscreenFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);
     void fullscreenModeChanged(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void fullscreenMayReturnToInline(PlaybackSessionContextIdentifier);
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    void didEnterExternalPlayback(PlaybackSessionContextIdentifier);
+    void didExitExternalPlayback(PlaybackSessionContextIdentifier);
+#endif
 
     void requestCloseAllMediaPresentations(PlaybackSessionContextIdentifier, bool finishedWithMedia, CompletionHandler<void()>&&);
     void callCloseCompletionHandlers();

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -451,6 +451,22 @@ void VideoPresentationModelContext::fullscreenMayReturnToInline()
         manager->fullscreenMayReturnToInline(m_contextId);
 }
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+void VideoPresentationModelContext::didEnterExternalPlayback()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    if (RefPtr manager = m_manager.get())
+        manager->didEnterExternalPlayback(m_contextId);
+}
+
+void VideoPresentationModelContext::didExitExternalPlayback()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    if (RefPtr manager = m_manager.get())
+        manager->didExitExternalPlayback(m_contextId);
+}
+#endif
+
 void VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& completionHandler)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
@@ -1526,6 +1542,20 @@ void VideoPresentationManagerProxy::fullscreenMayReturnToInline(PlaybackSessionC
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::FullscreenMayReturnToInline(contextId, page->isViewVisible()), page->webPageIDInMainFrameProcess());
 }
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+void VideoPresentationManagerProxy::didEnterExternalPlayback(PlaybackSessionContextIdentifier contextId)
+{
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidEnterExternalPlayback(contextId), page->webPageIDInMainFrameProcess());
+}
+
+void VideoPresentationManagerProxy::didExitExternalPlayback(PlaybackSessionContextIdentifier contextId)
+{
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidExitExternalPlayback(contextId), page->webPageIDInMainFrameProcess());
+}
+#endif
 
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -207,6 +207,10 @@ protected:
     void didEnterFullscreen(PlaybackSessionContextIdentifier, std::optional<WebCore::FloatSize>);
     void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);
+#if PLATFORM(VISION)
+    void didEnterExternalPlayback(PlaybackSessionContextIdentifier);
+    void didExitExternalPlayback(PlaybackSessionContextIdentifier);
+#endif
     void setVideoLayerFrameFenced(PlaybackSessionContextIdentifier, WebCore::FloatRect bounds, WTF::MachSendRight&&);
     void setVideoLayerGravityEnum(PlaybackSessionContextIdentifier, unsigned gravity);
     void setVideoFullscreenFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -38,6 +38,10 @@ messages -> VideoPresentationManager {
     DidEnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::FloatSize> size)
     FailedToEnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     DidCleanupFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
+#if PLATFORM(VISION)
+    DidEnterExternalPlayback(WebKit::PlaybackSessionContextIdentifier contextId)
+    DidExitExternalPlayback(WebKit::PlaybackSessionContextIdentifier contextId)
+#endif
     SetVideoLayerFrameFenced(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect bounds, MachSendRight machSendRight)
     SetVideoLayerGravityEnum(WebKit::PlaybackSessionContextIdentifier contextId, unsigned gravity)
     SetVideoFullscreenFrame(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -735,6 +735,32 @@ void VideoPresentationManager::didEnterFullscreen(PlaybackSessionContextIdentifi
     });
 }
 
+#if PLATFORM(VISION)
+void VideoPresentationManager::didEnterExternalPlayback(PlaybackSessionContextIdentifier contextId)
+{
+    auto [model, interface] = ensureModelAndInterface(contextId);
+    INFO_LOG(LOGIDENTIFIER, model->logIdentifier());
+
+    RefPtr<HTMLVideoElement> videoElement = model->videoElement();
+    if (!videoElement)
+        return;
+
+    videoElement->didEnterExternalPlayback();
+}
+
+void VideoPresentationManager::didExitExternalPlayback(PlaybackSessionContextIdentifier contextId)
+{
+    auto [model, interface] = ensureModelAndInterface(contextId);
+    INFO_LOG(LOGIDENTIFIER, model->logIdentifier());
+
+    RefPtr<HTMLVideoElement> videoElement = model->videoElement();
+    if (!videoElement)
+        return;
+
+    videoElement->didExitExternalPlayback();
+}
+#endif
+
 void VideoPresentationManager::failedToEnterFullscreen(PlaybackSessionContextIdentifier contextId)
 {
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 7ec7b4de596e9bd0b42dba0732a47ce7e306afd7
<pre>
[visionOS] Notify the media player when entering &amp; exiting external playback in LinearMediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=291029">https://bugs.webkit.org/show_bug.cgi?id=291029</a>
<a href="https://rdar.apple.com/148287113">rdar://148287113</a>

Reviewed by Jean-Yves Avenard.

External playback mechanism in LinearMediaPlayer used to rely on setting the
videoReceiverEndpoint to NULL to trigger the media player to switch back to
layer based rendering.

Since 42991@main, we no longer get this behavior for free. Instead we need to
notify the media player when we enter/exit external playback similar to
fullscreen/PiP.

One particularly important point for the flow to work is that we must notify
WebGPU that inFullscreenOrPip changed ONLY after the video target changed.

For exiting external playback, this is trivial because LinearMediaPlayer is
setting the videoReceiverEndpoint to NULL directly.

For entering external playback, the video target is not set UNTIL LMK calls
back with setVideoReceiverEndpoint, which happens asynchronously after LMK is
configured for external playback. Thus VideoPresentationInterfaceLMK now waits
for a message that the video receiver endpoint was set before notifying the
media player that fullscreen/PiP state changed.

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::didEnterExternalPlayback):
(WebCore::HTMLVideoElement::didExitExternalPlayback):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::didEnterExternalPlayback):
(WebCore::VideoPresentationModel::didExitExternalPlayback):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::enterExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::exitExternalPlayback):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::didEnterExternalPlayback):
(WebKit::VideoPresentationModelContext::didExitExternalPlayback):
(WebKit::VideoPresentationManagerProxy::didEnterExternalPlayback):
(WebKit::VideoPresentationManagerProxy::didExitExternalPlayback):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::didEnterExternalPlayback):
(WebKit::VideoPresentationManager::didExitExternalPlayback):

Canonical link: <a href="https://commits.webkit.org/293272@main">https://commits.webkit.org/293272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a4751851073a81585469b8bf0fea7e11005eb6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48340 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25456 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83861 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83335 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5653 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19108 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25415 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->