### PR TITLE
Use `ASCIILiteral` instead of `const char*` for `MediaRecorderPrivateWriterWebM`

### DIFF
--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -52,8 +52,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaRecorderPrivateWriterWebM);
 
-static const char* kH264CodecId = "V_MPEG4/ISO/AVC";
-static const char* kPcmCodecId = "A_PCM/FLOAT/IEEE";
+static constexpr auto kH264CodecId = "V_MPEG4/ISO/AVC"_s;
+static constexpr auto kPcmCodecId = "A_PCM/FLOAT/IEEE"_s;
 
 static const char* mkvCodeIcForMediaVideoCodecId(FourCC codec)
 {
@@ -62,9 +62,9 @@ static const char* mkvCodeIcForMediaVideoCodecId(FourCC codec)
     case 'vp92':
     case kCMVideoCodecType_VP9: return mkvmuxer::Tracks::kVp9CodecId;
     case kCMVideoCodecType_AV1: return mkvmuxer::Tracks::kAv1CodecId;
-    case kCMVideoCodecType_H264: return kH264CodecId;
+    case kCMVideoCodecType_H264: return kH264CodecId.characters();
     case kAudioFormatOpus: return mkvmuxer::Tracks::kOpusCodecId;
-    case kAudioFormatLinearPCM: return kPcmCodecId;
+    case kAudioFormatLinearPCM: return kPcmCodecId.characters();
     default:
         ASSERT_NOT_REACHED("Unsupported codec");
         return "";


### PR DESCRIPTION
#### b4daa76a68c75a373d8e81d786b2303e68ccfaa8
<pre>
Use `ASCIILiteral` instead of `const char*` for `MediaRecorderPrivateWriterWebM`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291033">https://bugs.webkit.org/show_bug.cgi?id=291033</a>
<a href="https://rdar.apple.com/problem/148553117">rdar://problem/148553117</a>

Reviewed by Chris Dumez.

Using Safer CPP constructs to enhance run-time performance and memory safety
particularly avoiding out-of-bounds access bugs. Also making the code more concise.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::mkvCodeIcForMediaVideoCodecId):

Canonical link: <a href="https://commits.webkit.org/293528@main">https://commits.webkit.org/293528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89e990ae056708b9f15a871aa4a597ae5546dcc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74790 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31968 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83776 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5559 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/18995 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30488 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->