### PR TITLE
Remove VP9 preference code from PlatformMediaSessionManager

### DIFF
--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -788,31 +788,6 @@ bool PlatformMediaSessionManager::alternateWebMPlayerEnabled()
     return false;
 #endif
 }
-
-#if ENABLE(VP9)
-void PlatformMediaSessionManager::setShouldEnableVP9Decoder(bool vp9DecoderEnabled)
-{
-    m_vp9DecoderEnabled = vp9DecoderEnabled;
-}
-
-bool PlatformMediaSessionManager::shouldEnableVP9Decoder()
-{
-    return m_vp9DecoderEnabled;
-}
-
-void PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(bool swVPDecodersAlwaysEnabled)
-{
-    m_swVPDecodersAlwaysEnabled = swVPDecodersAlwaysEnabled;
-#if PLATFORM(COCOA)
-    VP9TestingOverrides::singleton().setSWVPDecodersAlwaysEnabled(swVPDecodersAlwaysEnabled);
-#endif
-}
-
-bool PlatformMediaSessionManager::swVPDecodersAlwaysEnabled()
-{
-    return m_swVPDecodersAlwaysEnabled;
-}
-#endif // ENABLE(VP9)
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 bool PlatformMediaSessionManager::mediaCapabilityGrantsEnabled()

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,13 +67,6 @@ public:
 
     WEBCORE_EXPORT static void setAlternateWebMPlayerEnabled(bool);
     WEBCORE_EXPORT static bool alternateWebMPlayerEnabled();
-
-#if ENABLE(VP9)
-    WEBCORE_EXPORT static void setShouldEnableVP9Decoder(bool);
-    WEBCORE_EXPORT static bool shouldEnableVP9Decoder();
-    WEBCORE_EXPORT static void setSWVPDecodersAlwaysEnabled(bool);
-    WEBCORE_EXPORT static bool swVPDecodersAlwaysEnabled();
-#endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     WEBCORE_EXPORT static bool mediaCapabilityGrantsEnabled();

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,9 +78,9 @@ void MediaSessionManagerCocoa::ensureCodecsRegistered()
 #if ENABLE(VP9)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if (shouldEnableVP9Decoder())
+        if (WebCore::shouldEnableVP9Decoder())
             registerSupplementalVP9Decoder();
-        if (shouldEnableSWVP9Decoder())
+        if (WebCore::shouldEnableSWVP9Decoder())
             registerWebKitVP9Decoder();
     });
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ struct MediaCapabilitiesInfo;
 struct VideoConfiguration;
 struct VideoInfo;
 
+WEBCORE_EXPORT bool shouldEnableVP9Decoder();
 WEBCORE_EXPORT bool shouldEnableSWVP9Decoder();
 WEBCORE_EXPORT void registerWebKitVP9Decoder();
 WEBCORE_EXPORT void registerSupplementalVP9Decoder();
@@ -88,12 +89,16 @@ public:
     void setSWVPDecodersAlwaysEnabled(bool);
     bool swVPDecodersAlwaysEnabled() const { return m_swVPDecodersAlwaysEnabled; }
 
+    void setShouldEnableVP9Decoder(bool);
+    bool shouldEnableVP9Decoder() const;
+
 private:
     std::optional<bool> m_hardwareDecoderDisabled;
     std::optional<bool> m_vp9DecoderDisabled;
-    bool m_swVPDecodersAlwaysEnabled { false };
     std::optional<ScreenDataOverrides> m_screenSizeAndScale;
     Function<void(bool)> m_configurationChangedCallback;
+    bool m_vp9DecoderEnabled { false };
+    bool m_swVPDecodersAlwaysEnabled { false };
 };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,6 +98,16 @@ void VP9TestingOverrides::resetOverridesToDefaultValues()
         m_configurationChangedCallback(true);
 }
 
+void VP9TestingOverrides::setShouldEnableVP9Decoder(bool enabled)
+{
+    m_swVPDecodersAlwaysEnabled = enabled;
+}
+
+bool VP9TestingOverrides::shouldEnableVP9Decoder() const
+{
+    return m_vp9DecoderEnabled;
+}
+
 enum class ResolutionCategory : uint8_t {
     R_480p,
     R_720p,
@@ -138,6 +148,11 @@ void registerSupplementalVP9Decoder()
 
     if (canLoad_VideoToolbox_VTRegisterSupplementalVideoDecoderIfAvailable())
         softLink_VideoToolbox_VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9);
+}
+
+bool shouldEnableVP9Decoder()
+{
+    return VP9TestingOverrides::singleton().shouldEnableVP9Decoder();
 }
 
 static bool isSWDecodersAlwaysEnabled()

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -298,7 +298,7 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
 
 #if ENABLE(VP9)
     if (updatePreference(m_preferences.vp9DecoderEnabled, preferences.vp9DecoderEnabled)) {
-        PlatformMediaSessionManager::setShouldEnableVP9Decoder(*m_preferences.vp9DecoderEnabled);
+        VP9TestingOverrides::singleton().setShouldEnableVP9Decoder(*m_preferences.vp9DecoderEnabled);
 #if PLATFORM(COCOA)
         if (!m_haveEnabledVP9Decoder && *m_preferences.vp9DecoderEnabled) {
             m_haveEnabledVP9Decoder = true;
@@ -306,9 +306,10 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
         }
 #endif
     }
-    if (preferences.swVPDecodersAlwaysEnabled != std::exchange(m_preferences.swVPDecodersAlwaysEnabled, preferences.swVPDecodersAlwaysEnabled))
-        PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(m_preferences.swVPDecodersAlwaysEnabled);
 #if PLATFORM(COCOA)
+    if (preferences.swVPDecodersAlwaysEnabled != std::exchange(m_preferences.swVPDecodersAlwaysEnabled, preferences.swVPDecodersAlwaysEnabled))
+        VP9TestingOverrides::singleton().setSWVPDecodersAlwaysEnabled(m_preferences.swVPDecodersAlwaysEnabled);
+
     if (!m_haveEnabledSWVP9Decoder && WebCore::shouldEnableSWVP9Decoder()) {
         WebCore::registerWebKitVP9Decoder();
         m_haveEnabledSWVP9Decoder = true;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -362,6 +362,7 @@
 #include <WebCore/LegacyWebArchive.h>
 #include <WebCore/SVGImage.h>
 #include <WebCore/TextPlaceholderElement.h>
+#include <WebCore/VP9UtilitiesCocoa.h>
 #include <pal/spi/cg/ImageIOSPI.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -1124,8 +1125,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     send(Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation(m_contextForVisibilityPropagation->cachedContextID()));
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && !HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
 
-#if ENABLE(VP9)
-    PlatformMediaSessionManager::setShouldEnableVP9Decoder(parameters.shouldEnableVP9Decoder);
+#if ENABLE(VP9) && PLATFORM(COCOA)
+    VP9TestingOverrides::singleton().setShouldEnableVP9Decoder(parameters.shouldEnableVP9Decoder);
 #endif
 
     page->setCanUseCredentialStorage(parameters.canUseCredentialStorage);
@@ -4829,8 +4830,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     PlatformMediaSessionManager::setAlternateWebMPlayerEnabled(settings.alternateWebMPlayerEnabled());
 #endif
 
-#if ENABLE(VP9)
-    PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(store.getBoolValueForKey(WebPreferencesKey::sWVPDecodersAlwaysEnabledKey()));
+#if ENABLE(VP9) && PLATFORM(COCOA)
+    VP9TestingOverrides::singleton().setSWVPDecodersAlwaysEnabled(store.getBoolValueForKey(WebPreferencesKey::sWVPDecodersAlwaysEnabledKey()));
 #endif
 
     // FIXME: This should be automated by adding a new field in WebPreferences*.yaml


### PR DESCRIPTION
#### 9c90034fa4439d65df4f3b2f5001bcc79ee73fec
<pre>
Remove VP9 preference code from PlatformMediaSessionManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=291034">https://bugs.webkit.org/show_bug.cgi?id=291034</a>
<a href="https://rdar.apple.com/148553383">rdar://148553383</a>

Reviewed by Jer Noble and Jean Yves Avenard.

The VP9 preference code in PlatformMediaSessionManager was partially duplicated in
VP9Utilities, duplicate the rest and remove it all from PlatformMediaSessionManager.

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::setShouldEnableVP9Decoder): Deleted.
(WebCore::PlatformMediaSessionManager::shouldEnableVP9Decoder): Deleted.
(WebCore::PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled): Deleted.
(WebCore::PlatformMediaSessionManager::swVPDecodersAlwaysEnabled): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::ensureCodecsRegistered):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::VP9TestingOverrides::setShouldEnableVP9Decoder):
(WebCore::VP9TestingOverrides::shouldEnableVP9Decoder const):
(WebCore::shouldEnableVP9Decoder):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::updatePreferences):
</pre>