### PR TITLE
Adopt more smart pointers in NavigationHistoryEntry.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -886,7 +886,6 @@ page/LocalFrameView.cpp
 page/Location.cpp
 page/NavigationDestination.cpp
 page/NavigationDestination.h
-page/NavigationHistoryEntry.cpp
 page/NavigationTransition.cpp
 page/Navigator.cpp
 page/NavigatorLoginStatus.cpp

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -66,7 +66,7 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigatio
     RefPtr state = historyItem->navigationAPIStateObject();
     if (!state)
         state = other.m_state;
-    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(other.scriptExecutionContext()), WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(other.protectedScriptExecutionContext().get()), WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -118,7 +118,7 @@ uint64_t NavigationHistoryEntry::index() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return -1;
-    return document->domWindow()->navigation().entries().findIf([this] (auto& entry) {
+    return document->protectedWindow()->protectedNavigation()->entries().findIf([this] (auto& entry) {
         return entry.ptr() == this;
     });
 }
@@ -141,16 +141,17 @@ JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) c
     if (!document || !document->isFullyActive())
         return JSC::jsUndefined();
 
-    if (!m_state)
+    RefPtr state = m_state;
+    if (!state)
         return JSC::jsUndefined();
 
-    return m_state->deserialize(globalObject, &globalObject, SerializationErrorMode::Throwing);
+    return state->deserialize(globalObject, &globalObject, SerializationErrorMode::Throwing);
 }
 
 void NavigationHistoryEntry::setState(RefPtr<SerializedScriptValue>&& state)
 {
     m_state = state;
-    m_associatedHistoryItem->setNavigationAPIStateObject(WTFMove(state));
+    protectedAssociatedHistoryItem()->setNavigationAPIStateObject(WTFMove(state));
 }
 
 auto NavigationHistoryEntry::DocumentState::fromContext(ScriptExecutionContext* context) -> DocumentState


### PR DESCRIPTION
#### 6082fe0de5f1802ce7fa481c64f636479fb0267f
<pre>
Adopt more smart pointers in NavigationHistoryEntry.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=291037">https://bugs.webkit.org/show_bug.cgi?id=291037</a>
<a href="https://rdar.apple.com/148555292">rdar://148555292</a>

Reviewed by Per Arne Vollan and Chris Dumez.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::index const):
(WebCore::NavigationHistoryEntry::getState const):
(WebCore::NavigationHistoryEntry::setState):

Canonical link: <a href="https://commits.webkit.org/293466@main">https://commits.webkit.org/293466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b73428cfe076ea95afbe272972e631bdb6240f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75322 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32450 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7331 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48915 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83786 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19765 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31182 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->