### PR TITLE
Annotate SetMockWebAuthenticationConfiguration endpoint with AllowTestOnlyIPC

### DIFF
--- a/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: CTAP HID failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/ctap-hid-success.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-success.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: CTAP HID success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/ctap-nfc-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-nfc-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: CTAP NFC failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/idl.https.html
+++ b/LayoutTests/http/wpt/webauthn/idl.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!doctype html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <meta charset=utf-8>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] silent failure cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner -->
+<!DOCTYPE html><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock ccid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-cross-origin.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-cross-origin.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-with-invalid-parameters.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-with-invalid-parameters.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] with invalid parameters.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-ip-address.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-ip-address.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <title>Web Authentication API: Invoke PublicKeyCredential in ip addresses.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -576,7 +576,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    SetMockWebAuthenticationConfiguration(struct WebCore::MockWebAuthenticationConfiguration configuration);
+    [EnabledBy=AllowTestOnlyIPC] SetMockWebAuthenticationConfiguration(struct WebCore::MockWebAuthenticationConfiguration configuration);
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -40,6 +40,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/_WKAuthenticationExtensionsClientInputs.h>
 #import <WebKit/_WKAuthenticationExtensionsClientOutputs.h>
 #import <WebKit/_WKAuthenticatorAssertionResponse.h>
@@ -413,14 +414,21 @@ void cleanUpKeychain()
 
 } // namesapce;
 
+static RetainPtr<TestWKWebView> setUpTestWebViewForTestAuthenticationPanel()
+{
+    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    [configuration _setAllowTestOnlyIPC:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    return webView;
+}
+
 #if HAVE(NEAR_FIELD)
 TEST(WebAuthenticationPanel, NoPanelNfcSucceed)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     [webView focus];
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -437,9 +445,7 @@ TEST(WebAuthenticationPanel, NoPanelHidSuccess)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     [webView focus];
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -456,9 +462,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess1)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -482,9 +486,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess2)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -508,9 +510,7 @@ TEST(WebAuthenticationPanel, PanelRacy1)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsRacy:true];
     [webView setUIDelegate:delegate.get()];
@@ -531,9 +531,7 @@ TEST(WebAuthenticationPanel, PanelRacy2)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsRacy:true];
     [webView setUIDelegate:delegate.get()];
@@ -559,9 +557,7 @@ TEST(WebAuthenticationPanel, PanelTwice)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -581,9 +577,7 @@ TEST(WebAuthenticationPanel, ReloadHidCancel)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -600,9 +594,7 @@ TEST(WebAuthenticationPanel, LocationChangeHidCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
     RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -619,9 +611,7 @@ TEST(WebAuthenticationPanel, NewLoadHidCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
     RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -637,9 +627,7 @@ TEST(WebAuthenticationPanel, CloseHidCancel)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -676,9 +664,7 @@ TEST(WebAuthenticationPanel, SubFrameChangeLocationHidCancel)
         });
     });
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -722,9 +708,7 @@ TEST(WebAuthenticationPanel, SubFrameDestructionHidCancel)
         });
     });
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -740,9 +724,7 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -768,9 +750,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -785,9 +765,7 @@ TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-u2f-no-credentials" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -807,9 +785,7 @@ TEST(WebAuthenticationPanel, FakePanelHidSuccess)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsFake:true];
     [webView setUIDelegate:delegate.get()];
@@ -825,9 +801,7 @@ TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsFake:true];
     [webView setUIDelegate:delegate.get()];
@@ -848,9 +822,7 @@ TEST(WebAuthenticationPanel, NullPanelHidSuccess)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
@@ -866,9 +838,7 @@ TEST(WebAuthenticationPanel, NullPanelHidCtapNoCredentialsFound)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
@@ -885,9 +855,7 @@ TEST(WebAuthenticationPanel, PanelMultipleNFCTagsPresent)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-multiple-tags" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -903,9 +871,7 @@ TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -927,9 +893,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -949,9 +913,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -966,9 +928,7 @@ TEST(WebAuthenticationPanel, PinGetRetriesError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-retries-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     [webView focus];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView waitForMessage:@"Unknown internal error. Error code: 2"];
@@ -979,9 +939,7 @@ TEST(WebAuthenticationPanel, PinGetKeyAgreementError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-key-agreement-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     [webView focus];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView waitForMessage:@"Unknown internal error. Error code: 2"];
@@ -992,9 +950,7 @@ TEST(WebAuthenticationPanel, PinRequestPinErrorNoDelegate)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     [webView focus];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView waitForMessage:@"Pin is null."];
@@ -1005,9 +961,7 @@ TEST(WebAuthenticationPanel, PinRequestPinErrorNullDelegate)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
@@ -1022,9 +976,7 @@ TEST(WebAuthenticationPanel, PinRequestPinError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1041,9 +993,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinBlockedError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1060,9 +1010,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthBlockedError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1079,9 +1027,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinInvalidErrorAndRetry)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1097,9 +1043,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthInvalidErrorAndRetry)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1115,9 +1059,7 @@ TEST(WebAuthenticationPanel, MakeCredentialInternalUV)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-internal-uv" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1131,9 +1073,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPin)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1148,9 +1088,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-auth-blocked-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1167,9 +1105,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-invalid-error-retry" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1190,9 +1126,7 @@ TEST(WebAuthenticationPanel, GetAssertionPin)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1212,9 +1146,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUV)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1233,9 +1165,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1255,9 +1185,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1279,9 +1207,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1298,10 +1224,9 @@ TEST(WebAuthenticationPanel, NfcPinCachedDisconnect)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-pin-disconnect" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1316,9 +1241,7 @@ TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
@@ -1338,9 +1261,7 @@ TEST(WebAuthenticationPanel, MultipleAccounts)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1359,9 +1280,7 @@ TEST(WebAuthenticationPanel, LAError)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-error" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1375,9 +1294,7 @@ TEST(WebAuthenticationPanel, LADuplicateCredential)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1391,11 +1308,12 @@ TEST(WebAuthenticationPanel, LADuplicateCredential)
 TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)
 {
     reset();
+    // In case this wasn't cleaned up by another test.
+    cleanUpKeychain();
+
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1417,9 +1335,7 @@ TEST(WebAuthenticationPanel, LANoCredential)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1438,9 +1354,7 @@ TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
     reset();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1457,11 +1371,12 @@ TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
 TEST(WebAuthenticationPanel, LAGetAssertion)
 {
     reset();
+    // In case this wasn't cleaned up by another test.
+    cleanUpKeychain();
+
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1476,11 +1391,12 @@ TEST(WebAuthenticationPanel, LAGetAssertion)
 TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)
 {
     reset();
+    // In case this wasn't cleaned up by another test.
+    cleanUpKeychain();
+
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1511,9 +1427,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
     webAuthenticationPanelRequestNoGesture = false;
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la-no-mock" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1529,11 +1443,12 @@ TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
 TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 {
     reset();
+    // In case this wasn't cleaned up by another test.
+    cleanUpKeychain();
+
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
-    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
     auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -2496,6 +2411,8 @@ TEST(WebAuthenticationPanel, ImportMalformedCredential)
 TEST(WebAuthenticationPanel, DeleteOneCredential)
 {
     reset();
+    // In case this wasn't cleaned up by another test.
+    cleanUpKeychain();
 
     ASSERT_TRUE(addKeyToKeychain(testES256PrivateKeyBase64, "example.com"_s, testUserEntityBundleBase64));
 


### PR DESCRIPTION
#### 33084aad7f78b54a89c0372efe9802860edd4649
<pre>
Annotate SetMockWebAuthenticationConfiguration endpoint with AllowTestOnlyIPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=287249">https://bugs.webkit.org/show_bug.cgi?id=287249</a>
<a href="https://rdar.apple.com/144224078">rdar://144224078</a>

Reviewed by Sihui Liu and Ryosuke Niwa.

Annotate SetMockWebAuthenticationConfiguration endpoint with AllowTestOnlyIPC

* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:

Originally-landed-as: 289651.122@safari-7621-branch (187eb9fbee7c). <a href="https://rdar.apple.com/148058467">rdar://148058467</a>
Canonical link: <a href="https://commits.webkit.org/293668@main">https://commits.webkit.org/293668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd8ba4e21eea81021a608f68397a1ac4c1ed5cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75652 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102410 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14711 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106892 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26517 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19344 "Found 1 new test failure: ipc/serialized-type-info.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84611 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84124 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20260 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16205 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31658 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->