### PR TITLE
LLInt GetByIdModeMetadata should not hold potentially dead structure IDs

### DIFF
--- a/Source/JavaScriptCore/bytecode/GetByIdMetadata.h
+++ b/Source/JavaScriptCore/bytecode/GetByIdMetadata.h
@@ -136,22 +136,32 @@ inline void GetByIdModeMetadata::setUnsetMode(Structure* structure)
 {
     mode = GetByIdMode::Unset;
     unsetMode.structureID = structure->id();
+    defaultMode.cachedOffset = 0;
 }
 
 inline void GetByIdModeMetadata::setArrayLengthMode()
 {
     mode = GetByIdMode::ArrayLength;
+    // We should clear the structure ID to avoid the old structure ID being saved.
+    defaultMode.structureID = StructureID();
+    defaultMode.cachedOffset = 0;
     // Prevent the prototype cache from ever happening.
     hitCountForLLIntCaching = 0;
 }
 
 inline void GetByIdModeMetadata::setProtoLoadMode(Structure* structure, PropertyOffset offset, JSObject* cachedSlot)
 {
-    mode = GetByIdMode::ProtoLoad; // This must be first set. In 64bit architecture, this field is shared with protoLoadMode.cachedSlot.
+    // We rely on ProtoLoad being 0, or else the high bits of the pointer would write the wrong mode and hit count
+    static_assert(!static_cast<std::underlying_type_t<GetByIdMode>>(GetByIdMode::ProtoLoad)); // In 64bit architecture, this field is shared with protoLoadMode.cachedSlot.
+
     protoLoadMode.structureID = structure->id();
     protoLoadMode.cachedOffset = offset;
+
     // We know that this pointer will remain valid because it will be cleared by either a watchpoint fire or
     // during GC when we clear the LLInt caches.
+
+    // The write to cachedSlot also writes the mode, since they overlap in the struct layout. We know that
+    // the mode ProtoLoad is 0 by the static assertion above.
     protoLoadMode.cachedSlot = cachedSlot;
 
     ASSERT(mode == GetByIdMode::ProtoLoad);


### PR DESCRIPTION
#### 78b9637e3457ef457fa6578d362071d1569b8793
<pre>
LLInt GetByIdModeMetadata should not hold potentially dead structure IDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287567">https://bugs.webkit.org/show_bug.cgi?id=287567</a>
<a href="https://rdar.apple.com/144076957">rdar://144076957</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

GetByIdModeMetadata does not reset its structure ID upon transitioning to ArrayLengthMode,
meaning that this could get held over across another reset. This could later cause access
to a freed (or reallocated) structure ID.

This patch also cleans up the code in `setProtoLoadMode` slightly to clear up the specific
writes being performed.

This does not apply to other modes, since they set their structure ID explicitly. Since the
mutator thread is the thread changing modes, it will only invalidate the structure ID after
the call to clearToDefaultModeWithoutCache finishes, meaning that the structure ID already
is cleared.

* Source/JavaScriptCore/bytecode/GetByIdMetadata.h:
(JSC::GetByIdModeMetadata::clearToDefaultModeWithoutCache):
(JSC::GetByIdModeMetadata::setUnsetMode):
(JSC::GetByIdModeMetadata::setArrayLengthMode):
(JSC::GetByIdModeMetadata::setProtoLoadMode):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFromLLInt):

Originally-landed-as: 289651.165@safari-7621-branch (a93595279e2b). <a href="https://rdar.apple.com/148058163">rdar://148058163</a>
Canonical link: <a href="https://commits.webkit.org/293257@main">https://commits.webkit.org/293257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36698924f3f5c6e1b1ba940071d603f05a15d18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48223 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90933 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105745 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96878 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18978 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30471 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120499 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25117 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33747 "Found 1 new JSC binary failure: testapi, Found 19734 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_lastindexof.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_length.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->