### PR TITLE
Missing exception checks in AudioWorkletProcessor.cpp leading to an OOB write

### DIFF
--- a/LayoutTests/webaudio/audioworklet-exception-handling-expected.txt
+++ b/LayoutTests/webaudio/audioworklet-exception-handling-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webaudio/audioworklet-exception-handling.html
+++ b/LayoutTests/webaudio/audioworklet-exception-handling.html
@@ -1,0 +1,87 @@
+<html>
+<head></head>
+<body>
+This test passes if it does not crash.
+<script>
+
+globalThis.testRunner?.dumpAsText();
+
+const PROCESSOR_CODE = `Object.prototype.__defineSetter__('x', () => {
+    throw 1;
+});
+
+class CustomProcessor extends AudioWorkletProcessor {
+    static get parameterDescriptors() {
+        return [
+            {
+                name: 'x',
+                defaultValue: 1,
+                minValue: 0,
+                maxValue: 1,
+                automationRate: 'a-rate',
+            },
+            {
+                name: '0',
+                defaultValue: 1,
+                minValue: 0,
+                maxValue: 1,
+                automationRate: 'a-rate',
+            },
+            {
+                name: '10000000',
+                defaultValue: 1,
+                minValue: 0,
+                maxValue: 1,
+                automationRate: 'a-rate',
+            },
+            {
+                name: '5',
+                defaultValue: 1,
+                minValue: 0,
+                maxValue: 1,
+                automationRate: 'a-rate',
+            },
+        ];
+    }
+
+    process(inputs, outputs, parameters) {
+        return false;
+    }
+}
+
+registerProcessor('custom-processor', CustomProcessor);
+`;
+
+const PROCESSOR_URL = URL.createObjectURL(new Blob([PROCESSOR_CODE], { type: 'text/javascript' }));
+
+async function trigger() {
+    const context = new OfflineAudioContext(2, 1, 44100);
+    await context.audioWorklet.addModule(PROCESSOR_URL);
+
+    const node = new AudioWorkletNode(context, 'custom-processor');
+
+    const source = context.createBufferSource();
+    source.buffer = context.createBuffer(1, 1, 44100);
+    source.connect(node).connect(context.destination);
+    source.start();
+
+    await context.startRendering();
+}
+
+async function main() {
+    for (let i = 0; i < 30; i++) {
+        await trigger();
+    }
+}
+
+globalThis.testRunner?.waitUntilDone();
+
+main().catch(e => {
+    console.log(e);
+}).finally(() => {
+    globalThis.testRunner?.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -80,10 +80,13 @@ static JSObject* toJSObject(JSValueInWrappedObject& wrapper)
     return wrapper ? jsDynamicCast<JSObject*>(wrapper.getValue()) : nullptr;
 }
 
-static JSFloat32Array* constructJSFloat32Array(JSGlobalObject& globalObject, unsigned length, std::span<const float> data = { })
+static JSFloat32Array* constructJSFloat32Array(VM& vm, JSGlobalObject& globalObject, unsigned length, std::span<const float> data = { })
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     constexpr bool isResizableOrGrowableShared = false;
     auto* jsArray = JSFloat32Array::create(&globalObject, globalObject.typedArrayStructure(TypeFloat32, isResizableOrGrowableShared), length);
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (!data.empty())
         memcpySpan(jsArray->typedSpan(), data.first(length));
     return jsArray;
@@ -98,26 +101,33 @@ static JSObject* constructFrozenKeyValueObject(VM& vm, JSGlobalObject& globalObj
         PutPropertySlot slot(object, false, PutPropertySlot::PutById);
         // Per the specification, if the value is constant, we pass the JS an array with length 1, with the array item being the constant.
         unsigned jsArraySize = pair.value->containsConstantValue() ? 1 : pair.value->size();
-        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), constructJSFloat32Array(globalObject, jsArraySize, pair.value->span()), slot);
+        auto* array = constructJSFloat32Array(vm, globalObject, jsArraySize, pair.value->span());
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), array, slot);
+        RETURN_IF_EXCEPTION(scope, nullptr);
     }
     JSC::objectConstructorFreeze(&globalObject, object);
-    EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
+    RETURN_IF_EXCEPTION(scope, nullptr);
     return object;
 }
 
 enum class ShouldPopulateWithBusData : bool { No, Yes };
 
 template <typename T>
-static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, JSC::ThrowScope& scope, const T& bus, ShouldPopulateWithBusData shouldPopulateWithBusData)
+static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, const T& bus, ShouldPopulateWithBusData shouldPopulateWithBusData)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     unsigned numberOfChannels = busChannelCount(bus.get());
     auto* channelsData = JSArray::create(vm, globalObject.originalArrayStructureForIndexingType(ArrayWithContiguous), numberOfChannels);
     for (unsigned j = 0; j < numberOfChannels; ++j) {
         auto* channel = bus->channel(j);
-        channelsData->setIndexQuickly(vm, j, constructJSFloat32Array(globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->span() : std::span<const float> { }));
+        auto array = constructJSFloat32Array(vm, globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->span() : std::span<const float> { });
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        channelsData->setIndexQuickly(vm, j, array);
     }
     JSC::objectConstructorFreeze(&globalObject, channelsData);
-    EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
+    RETURN_IF_EXCEPTION(scope, nullptr);
     return channelsData;
 }
 
@@ -126,19 +136,25 @@ static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, con
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* array = JSArray::create(vm, globalObject.originalArrayStructureForIndexingType(ArrayWithContiguous), buses.size());
-    for (unsigned i = 0; i < buses.size(); ++i)
-        array->setIndexQuickly(vm, i, constructFrozenJSArray(vm, globalObject, scope, buses[i], shouldPopulateWithBusData));
+    for (unsigned i = 0; i < buses.size(); ++i) {
+        auto* innerArray = constructFrozenJSArray(vm, globalObject, buses[i], shouldPopulateWithBusData);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        array->setIndexQuickly(vm, i, innerArray);
+    }
     JSC::objectConstructorFreeze(&globalObject, array);
-    EXCEPTION_ASSERT(!scope.exception());
+    RETURN_IF_EXCEPTION(scope, nullptr);
     return array;
 }
 
-static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, JSArray& jsArray, Vector<Ref<AudioBus>>& buses)
+static void copyDataFromJSArrayToBuses(VM& vm, JSGlobalObject& globalObject, JSArray& jsArray, Vector<Ref<AudioBus>>& buses)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     // We can safely make assumptions about the structure of the JSArray since we use frozen arrays.
     for (unsigned i = 0; i < buses.size(); ++i) {
         auto& bus = buses[i];
         auto* channelsArray = getArrayAtIndex<JSArray>(jsArray, globalObject, i);
+        RETURN_IF_EXCEPTION(scope, void());
         if (UNLIKELY(!channelsArray)) {
             bus->zero();
             continue;
@@ -146,6 +162,7 @@ static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, JSArray& js
         for (unsigned j = 0; j < bus->numberOfChannels(); ++j) {
             auto* channel = bus->channel(j);
             auto* jsChannelData = getArrayAtIndex<JSFloat32Array>(*channelsArray, globalObject, j);
+            RETURN_IF_EXCEPTION(scope, void());
             if (LIKELY(jsChannelData && !jsChannelData->isShared() && jsChannelData->length() == channel->length()))
                 memcpySpan(channel->mutableSpan(), jsChannelData->typedSpan().first(channel->length()));
             else
@@ -154,20 +171,24 @@ static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, JSArray& js
     }
 }
 
-static bool copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vector<RefPtr<AudioBus>>& buses, JSArray* jsArray)
+static bool copyDataFromBusesToJSArray(VM& vm, JSGlobalObject& globalObject, const Vector<RefPtr<AudioBus>>& buses, JSArray* jsArray)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     if (!jsArray)
         return false;
 
     for (size_t busIndex = 0; busIndex < buses.size(); ++busIndex) {
         auto& bus = buses[busIndex];
         auto* jsChannelsArray = getArrayAtIndex<JSArray>(*jsArray, globalObject, busIndex);
+        RETURN_IF_EXCEPTION(scope, false);
         unsigned numberOfChannels = busChannelCount(bus.get());
         if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
             return false;
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
             auto* channel = bus->channel(channelIndex);
             auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
+            RETURN_IF_EXCEPTION(scope, false);
             if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
             memcpySpan(jsChannelArray->typedSpan(), channel->mutableSpan().first(jsChannelArray->length()));
@@ -178,11 +199,14 @@ static bool copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vecto
 
 static bool copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObject, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, JSObject* jsObject)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     if (!jsObject)
         return false;
 
     for (auto& pair : paramValuesMap) {
         auto* jsTypedArray = jsDynamicCast<JSFloat32Array*>(jsObject->get(&globalObject, Identifier::fromString(vm, pair.key)));
+        RETURN_IF_EXCEPTION(scope, false);
         if (!jsTypedArray)
             return false;
         unsigned expectedLength = pair.value->containsConstantValue() ? 1 : pair.value->size();
@@ -193,20 +217,24 @@ static bool copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObj
     return true;
 }
 
-static bool zeroJSArray(JSGlobalObject& globalObject, const Vector<Ref<AudioBus>>& outputs, JSArray* jsArray)
+static bool zeroJSArray(VM& vm, JSGlobalObject& globalObject, const Vector<Ref<AudioBus>>& outputs, JSArray* jsArray)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     if (!jsArray)
         return false;
 
     for (size_t busIndex = 0; busIndex < outputs.size(); ++busIndex) {
         auto& bus = outputs[busIndex];
         auto* jsChannelsArray = getArrayAtIndex<JSArray>(*jsArray, globalObject, busIndex);
+        RETURN_IF_EXCEPTION(scope, false);
         unsigned numberOfChannels = busChannelCount(bus.get());
         if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
             return false;
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
             auto* channel = bus->channel(channelIndex);
             auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
+            RETURN_IF_EXCEPTION(scope, false);
             if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
             zeroSpan(jsChannelArray->typedSpan());
@@ -237,17 +265,31 @@ AudioWorkletProcessor::AudioWorkletProcessor(AudioWorkletGlobalScope& globalScop
 
 void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObject, MarkedArgumentBuffer& args, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     // For performance reasons, we cache the arrays passed to JS and reconstruct them only when the topology changes.
-    if (!copyDataFromBusesToJSArray(globalObject, inputs, toJSArray(m_jsInputs)))
-        m_jsInputs.setWeakly(constructFrozenJSArray(vm, globalObject, inputs, ShouldPopulateWithBusData::Yes));
+    bool success = copyDataFromBusesToJSArray(vm, globalObject, inputs, toJSArray(m_jsInputs));
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!success) {
+        auto* array = constructFrozenJSArray(vm, globalObject, inputs, ShouldPopulateWithBusData::Yes);
+        RETURN_IF_EXCEPTION(scope, void());
+        m_jsInputs.setWeakly(array);
+    }
     args.append(m_jsInputs.getValue());
 
-    if (!zeroJSArray(globalObject, outputs, toJSArray(m_jsOutputs)))
-        m_jsOutputs.setWeakly(constructFrozenJSArray(vm, globalObject, outputs, ShouldPopulateWithBusData::No));
+    success = zeroJSArray(vm, globalObject, outputs, toJSArray(m_jsOutputs));
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!success) {
+        auto* array = constructFrozenJSArray(vm, globalObject, outputs, ShouldPopulateWithBusData::No);
+        RETURN_IF_EXCEPTION(scope, void());
+        m_jsOutputs.setWeakly(array);
+    }
     args.append(m_jsOutputs.getValue());
 
-    if (!copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues)))
+    success = copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues));
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!success)
         m_jsParamValues.setWeakly(constructFrozenKeyValueObject(vm, globalObject, paramValuesMap));
+
     args.append(m_jsParamValues.getValue());
 }
 
@@ -268,9 +310,15 @@ bool AudioWorkletProcessor::process(const Vector<RefPtr<AudioBus>>& inputs, Vect
     auto& vm = globalObject->vm();
     JSLockHolder lock(vm);
 
+    auto scope = DECLARE_THROW_SCOPE(vm);
     MarkedArgumentBuffer args;
     buildJSArguments(vm, *globalObject, args, inputs, outputs, paramValuesMap);
     ASSERT(!args.hasOverflowed());
+    if (UNLIKELY(scope.exception())) {
+        reportException(globalObject, scope.exception());
+        threwException = true;
+        return false;
+    }
 
     NakedPtr<JSC::Exception> returnedException;
     auto result = JSCallbackData::invokeCallback(*globalObject, wrapper(), jsUndefined(), args, JSCallbackData::CallbackType::Object, Identifier::fromString(vm, "process"_s), returnedException);
@@ -280,7 +328,7 @@ bool AudioWorkletProcessor::process(const Vector<RefPtr<AudioBus>>& inputs, Vect
         return false;
     }
 
-    copyDataFromJSArrayToBuses(*globalObject, *toJSArray(m_jsOutputs), outputs);
+    copyDataFromJSArrayToBuses(vm, *globalObject, *toJSArray(m_jsOutputs), outputs);
 
     return result.toBoolean(globalObject);
 }


### PR DESCRIPTION
#### 7d56f3cb679665596a459a73abb3c4cfd5b6fac1
<pre>
Missing exception checks in AudioWorkletProcessor.cpp leading to an OOB write
<a href="https://bugs.webkit.org/show_bug.cgi?id=288452">https://bugs.webkit.org/show_bug.cgi?id=288452</a>
<a href="https://rdar.apple.com/145525358">rdar://145525358</a>

Reviewed by Yusuke Suzuki.

Add missing exception checks in AudioWorkletProcessor.cpp.

* LayoutTests/webaudio/audioworklet-exception-handling-expected.txt: Added.
* LayoutTests/webaudio/audioworklet-exception-handling.html: Added.
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::getArrayAtIndex):
(WebCore::constructJSFloat32Array):
(WebCore::constructFrozenKeyValueObject):
(WebCore::constructFrozenJSArray):
(WebCore::copyDataFromJSArrayToBuses):
(WebCore::copyDataFromBusesToJSArray):
(WebCore::copyDataFromParameterMapToJSObject):
(WebCore::zeroJSArray):
(WebCore::AudioWorkletProcessor::buildJSArguments):
(WebCore::AudioWorkletProcessor::process):

Originally-landed-as: 289651.171@safari-7621-branch (56ecf8401bfc). <a href="https://rdar.apple.com/148057712">rdar://148057712</a>
Canonical link: <a href="https://commits.webkit.org/293635@main">https://commits.webkit.org/293635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/530d29e499707563de892f96ee888508e77fdfec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32772 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106915 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26540 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19359 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/clicking-noninteractive-labelable-content.html ipc/serialized-type-info.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84629 "Found 6 new test failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-002.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/integrity.html imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/fetch.https.html imported/w3c/web-platform-tests/web-locks/lock-attributes.tentative.https.any.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31681 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26300 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->