### PR TITLE
Handle consecutive MultiColumnSets in propagateRepaintToParentWithOutlineAutoIfNeeded

### DIFF
--- a/LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash-expected.txt
+++ b/LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash or assertion.

--- a/LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash.html
+++ b/LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script>
+  onload = () => {
+    testRunner?.dumpAsText();
+    field.outerHTML = `A<div style="column-span: all;"></div>B`;
+    window.getSelection().selectAllChildren(document.body);
+    document.designMode = "on";
+    document.execCommand("fontName",false,"serif");
+    document.execCommand("insertOrderedList",false,null);
+    document.body.innerHTML = "PASS if no crash or assertion.";
+  }
+</script>
+A<div style="transform-style: preserve-3d; outline-style: auto;">
+  <fieldset style="overflow: -webkit-paged-y;">
+    <legend>A</legend>
+    <span id="field"></span>
+  </fieldset>
+</div>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -998,7 +998,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     // Issue repaint on the renderer with outline: auto.
     for (CheckedPtr renderer = this; renderer; renderer = renderer->parent()) {
         CheckedPtr originalRenderer = renderer;
-        if (CheckedPtr previousMultiColumnSet = dynamicDowncast<RenderMultiColumnSet>(renderer->previousSibling()); previousMultiColumnSet && !renderer->isLegend()) {
+        if (CheckedPtr previousMultiColumnSet = dynamicDowncast<RenderMultiColumnSet>(renderer->previousSibling()); previousMultiColumnSet && !renderer->isRenderMultiColumnSet() && !renderer->isLegend()) {
             CheckedPtr enclosingMultiColumnFlow = previousMultiColumnSet->multiColumnFlow();
             CheckedPtr renderMultiColumnPlaceholder = enclosingMultiColumnFlow->findColumnSpannerPlaceholder(downcast<RenderBox>(renderer.get()));
             ASSERT(renderMultiColumnPlaceholder);


### PR DESCRIPTION
#### 36bc13cd2769c34de02aee58a93ed29f7332a33e
<pre>
Handle consecutive MultiColumnSets in propagateRepaintToParentWithOutlineAutoIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=286931">https://bugs.webkit.org/show_bug.cgi?id=286931</a>
<a href="https://rdar.apple.com/148057180">rdar://148057180</a>

Reviewed by Alan Baradlay.

Special code was added in <a href="https://commits.webkit.org/259412@main">https://commits.webkit.org/259412@main</a> for
propagateRepaintToParentWithOutlineAutoIfNeeded() to handle placeholder
of MultiColumnSet. However, this code assumes the renderer argument of
findColumnSpannerPlaceholder() is necessarily a spanner if its previous
sibling is a MultiColumnSet, which is not the case in the reported
repro case. We align with RenderMultiColumnSet::requiresBalancing() and
skip the fix in that case. See bug 286931 for details.

* LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash-expected.txt: Added.
* LayoutTests/fast/rendering/render-multi-column-set-invalidate-002-crash.html: Added. Reduced from the original repro.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const): Don&apos;t try getting a spanner in the bad case when the renderer it itself a MultiColumnSet.

Originally-landed-as: 289651.3@webkit-2025.2-embargoed (90b6e2339664).
Canonical link: <a href="https://commits.webkit.org/293424@main">https://commits.webkit.org/293424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/563549520d652c1369f24fdd92b57d546ad6a8bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74784 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88741 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55143 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83236 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18985 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16074 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30478 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->