### PR TITLE
[990d58df312b55ff] ASAN_TRAP | WebKit::WebCookieJar::addChangeListenerWithAccess; WebKit::WebCookieJar::addChangeListener; WebCore::CookieStore::eventListenersDidChange

### DIFF
--- a/LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol-expected.txt
+++ b/LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol-expected.txt
@@ -1,0 +1,1 @@
+Pass if no crash

--- a/LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol.html
+++ b/LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol.html
@@ -1,0 +1,12 @@
+Pass if no crash
+
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    window.onload = () => {
+        window.cookieStore.onchange = () => {};
+        let secondWindow = window.open("#secondWindow");
+        secondWindow.cookieStore.onchange = () => {};
+    }
+</script>

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -622,6 +622,9 @@ void CookieStore::stop()
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     auto host = document->url().host().toString();
+    if (host.isEmpty())
+        return;
+
     page->protectedCookieJar()->removeChangeListener(host, *this);
 #endif
     m_hasChangeEventListener = false;
@@ -649,6 +652,10 @@ void CookieStore::eventListenersDidChange()
     if (!document)
         return;
 
+    auto host = document->url().host().toString();
+    if (host.isEmpty())
+        return;
+
     bool hadChangeEventListener = m_hasChangeEventListener;
     m_hasChangeEventListener = hasEventListeners(eventNames().changeEvent);
 
@@ -661,7 +668,6 @@ void CookieStore::eventListenersDidChange()
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     Ref cookieJar = page->cookieJar();
-    auto host = document->url().host().toString();
     if (m_hasChangeEventListener)
         cookieJar->addChangeListener(*document, *this);
     else

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1001,17 +1001,22 @@ void NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications(const U
     if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow)
         return completionHandler({ });
 
+    auto host = url.host().toString();
+    MESSAGE_CHECK_COMPLETION(m_hostsWithCookieListeners.isValidValue(host), completionHandler(false));
+
     bool startedListening = false;
     if (CheckedPtr networkStorageSession = storageSession())
         startedListening = networkStorageSession->startListeningForCookieChangeNotifications(*this, url, firstParty, frameID, pageID, protectedNetworkProcess()->shouldRelaxThirdPartyCookieBlockingForPage(webPageProxyID));
 
     if (startedListening)
-        m_hostsWithCookieListeners.add(url.host().toString());
+        m_hostsWithCookieListeners.add(host);
     completionHandler(startedListening);
 }
 
 void NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications(const String& host)
 {
+    MESSAGE_CHECK(m_hostsWithCookieListeners.isValidValue(host));
+
     bool removed = m_hostsWithCookieListeners.remove(host);
     ASSERT_UNUSED(removed, removed);
 


### PR DESCRIPTION
#### 39104faa73bc82f25ab31998a7bf842f8701600e
<pre>
[990d58df312b55ff] ASAN_TRAP | WebKit::WebCookieJar::addChangeListenerWithAccess; WebKit::WebCookieJar::addChangeListener; WebCore::CookieStore::eventListenersDidChange
<a href="https://bugs.webkit.org/show_bug.cgi?id=288666">https://bugs.webkit.org/show_bug.cgi?id=288666</a>
<a href="https://rdar.apple.com/144404037">rdar://144404037</a>

Reviewed by Chris Dumez.

Event listeners are keyed on the host of the document that registered them. If the request comes from
a file protocol, the host will be empty and attempting to use an empty string as the key of a HashMap
causes an assert to be hit, leading to a crash.

We fix this by ensuring that the CookieStore and WebCookieJar do not attempt to register event listeners
with empty host names and if, somehow, such a request were to make it to the Network Process, that process
will kill the sending Web Process.

Credit to Rob Buis for doing most of the work in creating the layout test.

* LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol-expected.txt: Added.
* LayoutTests/cookies/cookie-store-register-eventlistener-from-file-protocol.html: Added.
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::stop):
(WebCore::CookieStore::eventListenersDidChange):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications):
(WebKit::NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications):

Originally-landed-as: 289651.191@safari-7621-branch (9bf48496fa9a). <a href="https://rdar.apple.com/148056335">rdar://148056335</a>
Canonical link: <a href="https://commits.webkit.org/293237@main">https://commits.webkit.org/293237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f24ce2dbe7084f8e933bdc2a5c6a901f178630

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74786 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31955 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83770 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18987 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30480 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->