### PR TITLE
Instruction movaps access unaligned memory in JavaScriptCore operationHasEnumerableIndexedProperty

### DIFF
--- a/JSTests/stress/stack-height-check.js
+++ b/JSTests/stress/stack-height-check.js
@@ -1,0 +1,13 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0.5")
+
+function test(value) {
+}
+noInline(test);
+
+const v19 = [11, 22, 33, 44, 55, 66, 77];
+for (const v20 in v19) {
+  const v24 = new Proxy({}, {});
+  v19.__proto__ = v24;
+  test(v20)
+  for(let i=0; i<200; i++){}
+}

--- a/LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash-expected.txt
+++ b/LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash.html
+++ b/LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+frames.open("dummy").cookieStore.onchange = _ => {};
+</script>

--- a/LayoutTests/fast/html/autopopover-mismatch-crash-expected.txt
+++ b/LayoutTests/fast/html/autopopover-mismatch-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/html/autopopover-mismatch-crash.html
+++ b/LayoutTests/fast/html/autopopover-mismatch-crash.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<p id="element">PASS if no crash.</p>
+<script>
+ (async () => {
+  testRunner?.waitUntilDone();
+  testRunner?.dumpAsText();
+  var iterations = parseFloat(document.location.search.substring(1));
+  if (!iterations)
+    iterations = 0;
+  if (iterations == 20) {
+    testRunner?.notifyDone();
+    return;
+  }
+  element.popover = `on`;
+  iterations++;
+  location = `?` + iterations;
+  await (() => { constraints = { audio: true }; return navigator.mediaDevices.getUserMedia(constraints) })();
+  element.showPopover();
+  await (() => { name = `foo`; return window.cookieStore.delete(name) })();
+  element.popover = `auto`;
+})();
+ </script>

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15994,8 +15994,11 @@ void SpeculativeJIT::compileHasIndexedProperty(Node* node, S_JITOperation_GCZ sl
     addSlowPathGeneratorLambda([=, this, savePlans = WTFMove(savePlans), slowCases = WTFMove(slowCases)]() {
         slowCases.link(this);
 
-        if (preserveIndexReg)
+        if (preserveIndexReg) {
             pushToSave(indexGPR);
+            if (!isARM64())
+                pushToSave(indexGPR);
+        }
         silentSpill(savePlans);
 
         setupArguments<S_JITOperation_GCZ>(LinkableConstant::globalObject(*this, node), baseGPR, indexGPR);
@@ -16008,8 +16011,11 @@ void SpeculativeJIT::compileHasIndexedProperty(Node* node, S_JITOperation_GCZ sl
         setupResults(resultGPR);
 
         silentFill(savePlans);
-        if (preserveIndexReg)
+        if (preserveIndexReg) {
+            if (!isARM64())
+                popToRestore(indexGPR);
             popToRestore(indexGPR);
+        }
 
         if (exceptionReg)
             exceptionCheck(*exceptionReg);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2046,7 +2046,7 @@ JSC_DEFINE_HOST_FUNCTION(functionReadFile, (JSGlobalObject* globalObject, CallFr
         return JSValue::encode(jsString(vm, String::fromUTF8WithLatin1Fallback(content->span())));
 
     Structure* structure = globalObject->typedArrayStructure(TypeUint8, content->isResizableOrGrowableShared());
-    JSObject* result = JSUint8Array::create(globalObject, structure, WTFMove(content));
+    JSObject* result = JSUint8Array::create(vm, structure, WTFMove(content));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     return JSValue::encode(result);

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
@@ -165,7 +165,7 @@ template<typename Adaptor>
 JSArrayBufferView* GenericTypedArrayView<Adaptor>::wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
 {
     UNUSED_PARAM(lexicalGlobalObject);
-    return Adaptor::JSViewType::create(globalObject, globalObject->typedArrayStructure(Adaptor::typeValue, isResizableOrGrowableShared()), this);
+    return Adaptor::JSViewType::tryCreate(globalObject, globalObject->typedArrayStructure(Adaptor::typeValue, isResizableOrGrowableShared()), this);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -96,8 +96,9 @@ public:
     static JSGenericTypedArrayView* createWithFastVector(JSGlobalObject*, Structure*, size_t length, void* vector);
     static JSGenericTypedArrayView* createUninitialized(JSGlobalObject*, Structure*, size_t length);
     static JSGenericTypedArrayView* create(JSGlobalObject*, Structure*, RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
-    static JSGenericTypedArrayView* create(JSGlobalObject*, Structure*, RefPtr<typename Adaptor::ViewType>&& impl);
+    static JSGenericTypedArrayView* create(VM&, Structure*, RefPtr<typename Adaptor::ViewType>&& impl);
     static JSGenericTypedArrayView* create(Structure*, JSGlobalObject*, RefPtr<typename Adaptor::ViewType>&& impl);
+    static JSGenericTypedArrayView* tryCreate(JSGlobalObject*, Structure*, RefPtr<typename Adaptor::ViewType>&& impl);
     
     inline size_t byteLength() const;
     inline size_t byteLengthRaw() const;

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -187,7 +187,7 @@ ExceptionOr<JSC::JSValue> AudioBuffer::getChannelData(JSDOMGlobalObject& globalO
     auto& channelData = m_channels[channelIndex];
     auto constructJSArray = [&] {
         constexpr bool isResizableOrGrowableShared = false;
-        return JSC::JSFloat32Array::create(&globalObject, globalObject.typedArrayStructure(JSC::TypeFloat32, isResizableOrGrowableShared), channelData.copyRef());
+        return JSC::JSFloat32Array::create(globalObject.vm(), globalObject.typedArrayStructure(JSC::TypeFloat32, isResizableOrGrowableShared), channelData.copyRef());
     };
 
     if (globalObject.worldIsNormal()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10555,8 +10555,7 @@ void Document::removeTopLayerElement(Element& element)
     auto didRemove = m_topLayerElements.remove(element);
     RELEASE_ASSERT(didRemove);
     if (auto* candidatePopover = dynamicDowncast<HTMLElement>(element); candidatePopover && candidatePopover->isPopoverShowing() && candidatePopover->popoverState() == PopoverState::Auto) {
-        auto didRemove = m_autoPopoverList.remove(*candidatePopover);
-        RELEASE_ASSERT(didRemove);
+        m_autoPopoverList.remove(*candidatePopover);
 #if PLATFORM(IOS_FAMILY) && ENABLE(TOUCH_EVENTS)
         if (!needsPointerEventHandlingForPopover())
             invalidateRenderingDependentRegions();


### PR DESCRIPTION
#### 270e6902426e6042abb9165cdc087f72bcc9ab58
<pre>
Instruction movaps access unaligned memory in JavaScriptCore operationHasEnumerableIndexedProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=287791">https://bugs.webkit.org/show_bug.cgi?id=287791</a>
<a href="https://rdar.apple.com/144977122">rdar://144977122</a>

Reviewed by Yijia Huang.

Except for ARM64, pushToSave just pushes the register to the stack. So
in x64 etc., stack height alignment can be broken when we only do
pushing once. We need to do twice to align stack with 16-bytes.

* JSTests/stress/stack-height-check.js: Added.
(test):
(const.v20.in.v19.test.v20):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Originally-landed-as: 289651.210@safari-7621-branch (d58fb4361f2a). <a href="https://rdar.apple.com/148053095">rdar://148053095</a>
Canonical link: <a href="https://commits.webkit.org/293472@main">https://commits.webkit.org/293472@main</a>
</pre>
----------------------------------------------------------------------
#### fb3ec12e769daf2b97e9f8669b862f71ea210483
<pre>
ASAN_TRAP | JSArrayBufferView::ConstructionContext::ConstructionContext; JSC::JSGenericTypedArrayView::create; JSC::GenericTypedArrayView::wrapImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=286835">https://bugs.webkit.org/show_bug.cgi?id=286835</a>

Reviewed by Keith Miller.

Follow-up fix to 289651.4@webkit-2025.2-embargoed. Instead of modifying
the create() method, let&apos;s add a tryCreate() instead and use it when
calling wrapImpl() to wrap an impl array, to preserve the invariant from
the original method.

This partly reverts the changes in 289651.4@webkit-2025.2-embargoed to
preserve the invariant for other callers.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h:
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::wrapImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::create):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::tryCreate):
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::getChannelData):

Originally-landed-as: 289651.7@webkit-2025.2-embargoed (d3ca3297d8b8). <a href="https://rdar.apple.com/148053299">rdar://148053299</a>
Canonical link: <a href="https://commits.webkit.org/293471@main">https://commits.webkit.org/293471@main</a>
</pre>
----------------------------------------------------------------------
#### 92b125a71deb15d41f0573e903869b03073d333c
<pre>
Add a test for a NULLPTR crash in startListeningForCookieChangeNotifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=286834">https://bugs.webkit.org/show_bug.cgi?id=286834</a>

Reviewed by Ryosuke Niwa.

It was crashing when the url argument contains a null string but this was fixed
by <a href="https://commits.webkit.org/289567@main">https://commits.webkit.org/289567@main</a> which block cookies for an invalid
url.

* LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash-expected.txt: Added.
* LayoutTests/fast/cookie-store/start-listening-for-change-with-null-url-crash.html: Added.

Originally-landed-as: 289651.6@webkit-2025.2-embargoed (181f1f4f7cd0). <a href="https://rdar.apple.com/148053473">rdar://148053473</a>
Canonical link: <a href="https://commits.webkit.org/293470@main">https://commits.webkit.org/293470@main</a>
</pre>
----------------------------------------------------------------------
#### cc63d0ccefff30b0ea6a3ffb2533c27628e0bae7
<pre>
ASAN_TRAP | WebCore::Document::removeTopLayerElement; WebCore::Element::removeFromTopLayer; WebCore::Element::removedFromAncestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=286837">https://bugs.webkit.org/show_bug.cgi?id=286837</a>

Reviewed by Tim Nguyen.

Reloading a document can cause it to become not fully active. That is one of the reasons why
HTMLElement::checkPopoverValidity can fail. In the test case it does fail at the final
instruction where popover is set to &apos;auto&apos;, as part of the popoverAttributeChanged steps. So
we end up with an &apos;auto&apos; popover that is still showing, and any gc/deletion of the element
will end up in Document::removeTopLayerElement, the if statement will be true and the RELEASE_ASSERT
hit, since the element was never added to m_autoPopoverList, as the test case demonstrates.

Fixing this has proven to be hard, so just remove the RELEASE_ASSERT since we have now a situation where
the popover was not necessarily added to m_autoPopoverList.

* LayoutTests/fast/html/autopopover-mismatch-crash-expected.txt: Added.
* LayoutTests/fast/html/autopopover-mismatch-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addTopLayerElement):
(WebCore::Document::removeTopLayerElement):

Originally-landed-as: 289651.5@webkit-2025.2-embargoed (7e6ca0c83e15). <a href="https://rdar.apple.com/148053623">rdar://148053623</a>
Canonical link: <a href="https://commits.webkit.org/293469@main">https://commits.webkit.org/293469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a68d8f31f814044c11caa3103491632dc3e1d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75311 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48893 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91614 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106419 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97554 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84280 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83781 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19743 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16103 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31160 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121170 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25794 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33884 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->