### PR TITLE
[JSC] Remove some unnecessary NodeMustGenerate

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -135,6 +135,7 @@ private:
         fixDoubleOrBooleanEdge(leftChild);
         fixDoubleOrBooleanEdge(rightChild);
         node->setResult(NodeResultDouble);
+        node->clearFlags(NodeMustGenerate);
     }
     
     void fixupArithMul(Node* node, Edge& leftChild, Edge& rightChild)
@@ -164,6 +165,7 @@ private:
         fixDoubleOrBooleanEdge(leftChild);
         fixDoubleOrBooleanEdge(rightChild);
         node->setResult(NodeResultDouble);
+        node->clearFlags(NodeMustGenerate);
     }
 
     void fixupBlock(BasicBlock* block)
@@ -307,7 +309,7 @@ private:
             fixDoubleOrBooleanEdge(node->child2());
             node->setOp(ArithSub);
             node->setResult(NodeResultDouble);
-
+            node->clearFlags(NodeMustGenerate);
             break;
         }
 
@@ -586,6 +588,7 @@ private:
             fixDoubleOrBooleanEdge(node->child1());
             fixDoubleOrBooleanEdge(node->child2());
             node->setResult(NodeResultDouble);
+            node->clearFlags(NodeMustGenerate);
             break;
         }
             
@@ -690,6 +693,7 @@ private:
                     convertToDouble(rightChild);
                     node->setOp(ArithMul);
                     node->setResult(NodeResultDouble);
+                    node->clearFlags(NodeMustGenerate);
                     break;
                 }
 
@@ -698,6 +702,7 @@ private:
                     convertToDouble(leftChild);
                     node->setOp(ArithMul);
                     node->setResult(NodeResultDouble);
+                    node->clearFlags(NodeMustGenerate);
                     break;
                 }
             }
@@ -789,6 +794,7 @@ private:
                 fixDoubleOrBooleanEdge(child);
             });
             node->setResult(NodeResultDouble);
+            node->clearFlags(NodeMustGenerate);
             break;
         }
             
@@ -835,9 +841,8 @@ private:
             }
 
             node->setOp(ArithPow);
-            node->clearFlags(NodeMustGenerate);
             node->setResult(NodeResultDouble);
-
+            node->clearFlags(NodeMustGenerate);
             fixupArithPow(node);
             break;
         }


### PR DESCRIPTION
#### fac0c0fda49a34df27b4def7fb6a638deccd7bc2
<pre>
[JSC] Remove some unnecessary NodeMustGenerate
<a href="https://bugs.webkit.org/show_bug.cgi?id=291046">https://bugs.webkit.org/show_bug.cgi?id=291046</a>
<a href="https://rdar.apple.com/148564419">rdar://148564419</a>

Reviewed by Mark Lam.

These DoubleRep nodes do not need to keep NodeMustGenerate.
This patch clears them.

* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDiv):
(JSC::DFG::FixupPhase::fixupArithMul):
(JSC::DFG::FixupPhase::fixupNode):

Canonical link: <a href="https://commits.webkit.org/293225@main">https://commits.webkit.org/293225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36339c091a9a7e61f7548d27bd3916cd0cf48e56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74793 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48241 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90951 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96896 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83242 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/18996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15922 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25315 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120517 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25135 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33751 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->