### PR TITLE
wixstudio.com: Grid item with width: max-content overflows width: max-content grid and min-content column.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="Grid item's min content contribution should be its max-content size">
+<style>
+.grid-box {
+  display: grid;
+  width: max-content;
+  grid-template-columns: min-content;
+  font: 20px/1 Ahem;
+  background-color: green;
+}    
+.grid-item {
+  width: max-content;
+  color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="grid-box">
+    <div class="grid-item">x x x</div>
+    <div style="height: 80px;"></div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2387,6 +2387,9 @@ void RenderBlock::computePreferredLogicalWidths()
     if (!isRenderTableCell() && lengthToUse.isFixed() && lengthToUse.value() >= 0 && !(isDeprecatedFlexItem() && !lengthToUse.intValue())) {
         m_minPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(lengthToUse);
         m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth;
+    } else if (lengthToUse.isMaxContent()) {
+        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth;
     } else if (shouldComputeLogicalWidthFromAspectRatio()) {
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
         m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);


### PR DESCRIPTION
#### 5762dcfd7a2b70730a056cae86ee934cc875a2d6
<pre>
wixstudio.com: Grid item with width: max-content overflows width: max-content grid and min-content column.
<a href="https://rdar.apple.com/147837389">rdar://147837389</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289961">https://bugs.webkit.org/show_bug.cgi?id=289961</a>

Reviewed by Alan Baradlay.

Consider the following piece of grid content:
&lt;grid style=&quot;width: max-content; grid-template-columns: min-content;&quot;&gt;
  &lt;item style=&quot;width: max-content&quot;&gt;foo bar&lt;/item&gt;
&lt;/grid&gt;

When sizing the grid to resolve its max-content size, we run the grid
track sizing algorithm, which requires the min-content contribution of
the grid item. The track sizing algorithm uses minPreferredLogicalWidth()
to compute this size, which eventually calls into RenderBlock::computePreferredLogicalWidths(),
and we end up setting the minimum preferred logical width to its min-content
size, completely ignoring the width: max-content on the box. This ends up
sizing the grid to the content&apos;s min-content size, but the content ends
up getting sized to its max-content size when we perform layout on it
after all of the track sizing and other grid activities.

In RenderBlock::computePreferredLogicalWidths(), we can check to see for
width: max-content and set the min preferred logical width to the
max-content size if we reach this case.

Note that RenderBlock::computeChildPreferredLogicalWidths() has some
logic to do this already, but we cannot use this in this case since the
logic doesn&apos;t work for other types of grid content (e.g. orthogonal grid
items).

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computePreferredLogicalWidths):

Canonical link: <a href="https://commits.webkit.org/293420@main">https://commits.webkit.org/293420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a9ccc1f3791acae458985b32939a5b0054ae18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89158 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55517 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7123 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84132 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26192 "Failed to checkout and rebase branch from PR 43617") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21216 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19534 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30955 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->