### PR TITLE
[JSC] Add boxDoubleAsDouble support in x64

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -7648,16 +7648,27 @@ public:
 
     void add64(FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        UNUSED_PARAM(left);
-        UNUSED_PARAM(right);
-        UNUSED_PARAM(dest);
+        if (supportsAVX()) {
+            m_assembler.vpaddq_rrr(right, left, dest);
+            return;
+        }
+
+        if (left == dest && right == dest)
+            m_assembler.paddq_rr(dest, dest);
+        else if (left == dest)
+            m_assembler.paddq_rr(right, dest);
+        else if (right == dest)
+            m_assembler.paddq_rr(left, dest);
+        else {
+            m_assembler.movaps_rr(left, dest);
+            m_assembler.paddq_rr(right, dest);
+        }
     }
 
     void sub64(FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        UNUSED_PARAM(left);
-        UNUSED_PARAM(right);
-        UNUSED_PARAM(dest);
+        ASSERT(supportsAVX());
+        m_assembler.vpsubq_rrr(right, left, dest);
     }
 
     void vectorAdd(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -2753,12 +2753,68 @@ public:
         m_formatter.twoByteOp(OP2_ADDPS_VpsWps, (RegisterID)vd, (RegisterID)vn);
     }
 
+    void paddb_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+        // 66 0F FC /r PADDB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDB_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void paddw_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+        // 66 0F FD /r PADDW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDW_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void paddd_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+        // 66 0F FE /r PADDD xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDD_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void paddq_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+        // 66 0F D4 /r PADDQ xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDQ_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void psubb_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubb:psubw:psubd
+        // 66 0F F8 /r PSUBB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBB_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void psubw_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubb:psubw:psubd
+        // 66 0F F9 /r PSUBW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBW_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
     void psubd_rr(XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubb:psubw:psubd
         // 66 0F FA /r PSUBD xmm1, xmm2/m128
         m_formatter.prefix(PRE_SSE_66);
         m_formatter.twoByteOp(OP2_PSUBD_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void psubq_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubq
+        // 66 0F FB /r PSUBQ xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBQ_VdqWdq, (RegisterID)vd, (RegisterID)vn);
     }
 
     enum class RoundingType : uint8_t {

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -65,8 +65,10 @@ private:
                     break;
                 }
 
-#if CPU(ARM64)
                 case DoubleRep: {
+                    if (!isARM64() && !isX86_64_AVX())
+                        break;
+
                     switch (node->child1()->op()) {
                     case GetClosureVar:
                     case GetGlobalVar:
@@ -85,7 +87,6 @@ private:
                     }
                     break;
                 }
-#endif
 
                 default:
                     break;
@@ -111,17 +112,17 @@ private:
                     break;
                 }
 
-#if CPU(ARM64)
                 case GetClosureVar:
                 case GetGlobalVar:
                 case GetGlobalLexicalVariable:
                 case MultiGetByOffset:
                 case GetByOffset: {
+                    if (!isARM64() && !isX86_64_AVX())
+                        break;
                     if (candidates.contains(node))
                         usersOf.add(node, Vector<Node*>());
                     break;
                 }
-#endif
 
                 case ValueRep: {
                     if (candidates.contains(node))
@@ -219,19 +220,23 @@ private:
                             break;
                         }
 
-#if CPU(ARM64)
                         case GetClosureVar:
                         case GetGlobalVar:
                         case GetGlobalLexicalVariable:
                         case MultiGetByOffset:
                         case GetByOffset: {
+                            if (!isARM64() && !isX86_64_AVX()) {
+                                ok = false;
+                                dumpEscape("Unsupported incoming value to Phi: ", node);
+                                break;
+                            }
+
                             if (isEscaped(node)) {
                                 ok = false;
                                 dumpEscape("Phi Incoming Get is escaped: ", node);
                             }
                             break;
                         }
-#endif
 
                         case ValueRep: {
                             if (node->child1().useKind() != DoubleRepUse) {
@@ -283,14 +288,17 @@ private:
                     case MovHint:
                         break;
 
-#if CPU(ARM64)
                     // We can handle these nodes only when we have FPRReg addition in integer form.
                     case PutByOffset:
                     case MultiPutByOffset:
                     case PutClosureVar:
                     case PutGlobalVariable:
+                        if (!isARM64() && !isX86_64_AVX()) {
+                            dumpEscape("Normal escape: ", user);
+                            ok = false;
+                            break;
+                        }
                         break;
-#endif
 
                     case Upsilon: {
                         Node* phi = user->phi();
@@ -356,16 +364,18 @@ private:
                         newChild = incomingValue;
                         break;
                     }
-#if CPU(ARM64)
+
                     case GetClosureVar:
                     case GetGlobalVar:
                     case GetGlobalLexicalVariable:
                     case MultiGetByOffset:
                     case GetByOffset: {
+                        if (!isARM64() && !isX86_64_AVX())
+                            RELEASE_ASSERT_NOT_REACHED();
                         newChild = incomingValue;
                         break;
                     }
-#endif
+
                     default:
                         RELEASE_ASSERT_NOT_REACHED();
                         break;
@@ -383,17 +393,17 @@ private:
                 break;
             }
 
-#if CPU(ARM64)
             case GetClosureVar:
             case GetGlobalVar:
             case GetGlobalLexicalVariable:
             case MultiGetByOffset:
             case GetByOffset: {
+                if (!isARM64() && !isX86_64_AVX())
+                    RELEASE_ASSERT_NOT_REACHED();
                 candidate->setResult(NodeResultDouble);
                 resultNode = candidate;
                 break;
             }
-#endif
 
             default:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -419,23 +429,29 @@ private:
                     user->child1() = Edge(resultNode, DoubleRepUse);
                     break;
 
-#if CPU(ARM64)
                 case PutByOffset:
+                    if (!isARM64() && !isX86_64_AVX())
+                        RELEASE_ASSERT_NOT_REACHED();
                     user->child3() = Edge(resultNode, DoubleRepUse);
                     break;
 
                 case MultiPutByOffset:
+                    if (!isARM64() && !isX86_64_AVX())
+                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, DoubleRepUse);
                     break;
 
                 case PutClosureVar:
+                    if (!isARM64() && !isX86_64_AVX())
+                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, DoubleRepUse);
                     break;
 
                 case PutGlobalVariable:
+                    if (!isARM64() && !isX86_64_AVX())
+                        RELEASE_ASSERT_NOT_REACHED();
                     user->child2() = Edge(resultNode, DoubleRepUse);
                     break;
-#endif
 
                 case Upsilon: {
                     Node* phi = user->phi();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -2136,7 +2136,6 @@ private:
 
     LValue boxDoubleAsDouble(LValue value)
     {
-        ASSERT(isARM64());
         PatchpointValue* result = m_out.patchpoint(Double);
         result->append(value, ValueRep::SomeRegister);
         result->append(m_out.doubleEncodeOffsetAsDouble, ValueRep::SomeRegister);
@@ -2150,7 +2149,6 @@ private:
 
     LValue unboxDoubleAsDouble(LValue value)
     {
-        ASSERT(isARM64());
         PatchpointValue* result = m_out.patchpoint(Double);
         result->append(value, ValueRep::SomeRegister);
         result->append(m_out.doubleEncodeOffsetAsDouble, ValueRep::SomeRegister);


### PR DESCRIPTION
#### 4181ce02baf360a01779283f673d8de5c530cc2b
<pre>
[JSC] Add boxDoubleAsDouble support in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=291058">https://bugs.webkit.org/show_bug.cgi?id=291058</a>
<a href="https://rdar.apple.com/148572491">rdar://148572491</a>

Reviewed by Keith Miller.

Use AVX integer addition in FPRegisterID in x64 to avoid FPR and GPR
round-trip.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::add64):
(JSC::MacroAssemblerX86_64::sub64):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToDouble):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::boxDoubleAsDouble):
(JSC::FTL::DFG::LowerDFGToB3::unboxDoubleAsDouble):

Canonical link: <a href="https://commits.webkit.org/293246@main">https://commits.webkit.org/293246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4fae84fe9dac20475219324005db031ca941a37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74832 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31994 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48284 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/90994 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105806 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96939 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25400 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83285 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19039 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15927 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25358 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120560 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25178 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33762 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->