### PR TITLE
[iOS] 2 layout tests fast/forms/date/date-*.html are failing

### DIFF
--- a/LayoutTests/platform/ios/fast/forms/date/date-input-rendering-basic-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/date/date-input-rendering-basic-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (82,0) size 4x19
-        text run at (82,0) width 4: " "
+      RenderText {#text} at (86,0) size 4x19
+        text run at (86,0) width 4: " "
       RenderText {#text} at (0,0) size 0x0
-layer at (8,8) size 82x22 clip at (9,9) size 80x20
-  RenderFlexibleBox {INPUT} at (0,0) size 82x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 70x14
-      RenderText {#text} at (5,0) size 60x14
-        text run at (5,0) width 60: "Apr 1, 1976"
-layer at (94,8) size 82x22 clip at (95,9) size 80x20
-  RenderFlexibleBox {INPUT} at (86,0) size 82x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 70x14
-      RenderText {#text} at (5,0) size 60x14
-        text run at (5,0) width 60: "Apr 1, 1976"
+layer at (8,8) size 86x22 clip at (9,9) size 84x20
+  RenderFlexibleBox {INPUT} at (0,0) size 86x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 74x14
+      RenderText {#text} at (7,0) size 60x14
+        text run at (7,0) width 60: "Apr 1, 1976"
+layer at (98,8) size 86x22 clip at (99,9) size 84x20
+  RenderFlexibleBox {INPUT} at (90,0) size 86x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 74x14
+      RenderText {#text} at (7,0) size 60x14
+        text run at (7,0) width 60: "Apr 1, 1976"

--- a/LayoutTests/platform/ios/fast/forms/date/date-pseudo-elements-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/date/date-pseudo-elements-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (82,0) size 4x19
-        text run at (82,0) width 4: " "
+      RenderText {#text} at (86,0) size 4x19
+        text run at (86,0) width 4: " "
       RenderText {#text} at (0,0) size 0x0
-layer at (8,8) size 82x22 clip at (9,9) size 80x20
-  RenderFlexibleBox {INPUT} at (0,0) size 82x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 70x14
-      RenderText {#text} at (5,0) size 60x14
-        text run at (5,0) width 60: "Apr 1, 1976"
-layer at (94,8) size 82x22 clip at (95,9) size 80x20
-  RenderFlexibleBox {INPUT} at (86,0) size 82x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-    RenderBlock {DIV} at (6,4) size 70x14
-      RenderText {#text} at (5,0) size 60x14
-        text run at (5,0) width 60: "Apr 1, 1976"
+layer at (8,8) size 86x22 clip at (9,9) size 84x20
+  RenderFlexibleBox {INPUT} at (0,0) size 86x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 74x14
+      RenderText {#text} at (7,0) size 60x14
+        text run at (7,0) width 60: "Apr 1, 1976"
+layer at (98,8) size 86x22 clip at (99,9) size 84x20
+  RenderFlexibleBox {INPUT} at (90,0) size 86x22 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+    RenderBlock {DIV} at (6,4) size 74x14
+      RenderText {#text} at (7,0) size 60x14
+        text run at (7,0) width 60: "Apr 1, 1976"


### PR DESCRIPTION
#### 1c3f2adbca0ac0338a9c0b1b90e55426f32718bc
<pre>
[iOS] 2 layout tests fast/forms/date/date-*.html are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287204">https://bugs.webkit.org/show_bug.cgi?id=287204</a>
<a href="https://rdar.apple.com/144348683">rdar://144348683</a>

Reviewed by Megan Gardner, Abrar Rahman Protyasha, and Aditya Keerthi.

The width of date controls has increased due to 292441@main
calculating a larger estimated maximum width. Updated the
test expectations for date-pseudo-elements.html &amp;
date-input-rendering-basic-expected.html to account for
this.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/fast/forms/date/date-input-rendering-basic-expected.txt:
* LayoutTests/platform/ios/fast/forms/date/date-pseudo-elements-expected.txt:

Canonical link: <a href="https://commits.webkit.org/293256@main">https://commits.webkit.org/293256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ff9000fcf88cf7bd3401904ae4e9b8c1bffbc1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31984 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6738 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48272 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83266 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25346 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->