### PR TITLE
[web-animations] start time of animations created during a page rendering update should match that update's timeline time

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7908,3 +7908,5 @@ webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.h
 fast/forms/color/input-color-swatch-overlay-appearance.html [ Skip ]
 
 webkit.org/b/288831 [ Debug ] fast/css/shadow-box-recursion-depth.html [ Pass Timeout ]
+
+webkit.org/b/291974 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html [ Skip ]

--- a/LayoutTests/compositing/backing/backface-visibility-flip-expected.txt
+++ b/LayoutTests/compositing/backing/backface-visibility-flip-expected.txt
@@ -16,6 +16,7 @@ Front Back
               (position 10.00 10.00)
               (bounds 300.00 300.00)
               (preserves3D 1)
+              (transform [1.00 0.00 -0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
               (children 2
                 (GraphicsLayer
                   (bounds 300.00 300.00)

--- a/LayoutTests/compositing/backing/backface-visibility-flip.html
+++ b/LayoutTests/compositing/backing/backface-visibility-flip.html
@@ -29,7 +29,7 @@
             height: 100%;
         }
         .flipping {
-            -webkit-animation: flip 2s forwards;
+            -webkit-animation: flip 3600s forwards;
         }
         
         .front, .back {
@@ -60,8 +60,13 @@
             }, 250);
         }
         
-        function testDone()
+        async function testDone()
         {
+            // Wait a couple of frames for the first animation frame to
+            // have been committed so we get stable results.
+            await new Promise(requestAnimationFrame);
+            await new Promise(requestAnimationFrame);
+
             var layersResult = document.getElementById('layers');
             if (window.testRunner) {
                 layersResult.innerText = window.internals.layerTreeAsText(document);

--- a/LayoutTests/compositing/backing/backing-store-attachment-empty-keyframe.html
+++ b/LayoutTests/compositing/backing/backing-store-attachment-empty-keyframe.html
@@ -22,7 +22,7 @@
     }
     
     .mover.animating {
-        animation: slide 1s linear forwards;
+        animation: slide 3600s linear forwards;
     }
 
     @keyframes slide {

--- a/LayoutTests/compositing/backing/transition-extent-expected.txt
+++ b/LayoutTests/compositing/backing/transition-extent-expected.txt
@@ -16,6 +16,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 1)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
         (GraphicsLayer
           (position 20.00 1500.00)
@@ -23,6 +24,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 0)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
       )
     )

--- a/LayoutTests/compositing/backing/transition-extent.html
+++ b/LayoutTests/compositing/backing/transition-extent.html
@@ -13,7 +13,7 @@
             width: 100px;
             height: 100px;
             background-color: silver;
-            transition: transform 2s;
+            transition: transform 3600s;
             transform: rotate3d(0, 0, 1, 0deg)
         }
 

--- a/LayoutTests/compositing/layer-creation/overlap-animation-clipping.html
+++ b/LayoutTests/compositing/layer-creation/overlap-animation-clipping.html
@@ -35,11 +35,11 @@
     }
     
     .animating1 {
-      -webkit-animation: translate1 2s linear infinite alternate;
+      -webkit-animation: translate1 36000s linear infinite alternate ;
     }
 
     .animating2 {
-      -webkit-animation: translate2 2s linear infinite alternate;
+      -webkit-animation: translate2 36000s linear infinite alternate;
     }
     
     @-webkit-keyframes translate1 {

--- a/LayoutTests/compositing/layer-creation/overlap-animation-container.html
+++ b/LayoutTests/compositing/layer-creation/overlap-animation-container.html
@@ -42,7 +42,7 @@
     }
     
     .animating1 {
-      -webkit-animation: translate1 2s linear infinite alternate;
+      -webkit-animation: translate1 3600s linear infinite alternate;
     }
    
     @-webkit-keyframes translate1 {

--- a/LayoutTests/compositing/layer-creation/overlap-animation-expected.txt
+++ b/LayoutTests/compositing/layer-creation/overlap-animation-expected.txt
@@ -19,6 +19,7 @@
                   (position 10.00 10.00)
                   (bounds 100.00 100.00)
                   (contentsOpaque 1)
+                  (transform [1.00 0.00 0.00 0.00] [-0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
                 )
                 (GraphicsLayer
                   (position 10.00 120.00)

--- a/LayoutTests/compositing/layer-creation/overlap-animation.html
+++ b/LayoutTests/compositing/layer-creation/overlap-animation.html
@@ -21,7 +21,7 @@
     }
     
     .animating {
-      -webkit-animation: spin 2s infinite linear;
+      -webkit-animation: spin 3600s infinite linear;
     }
     
     @-webkit-keyframes spin {
@@ -42,8 +42,10 @@
       box.className = 'animating box';
     }
     
-    function animationStarted()
+    async function animationStarted()
     {
+      await new Promise(requestAnimationFrame);
+      await new Promise(requestAnimationFrame);
       if (window.testRunner) {
         document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
         testRunner.notifyDone();

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
@@ -12,4 +12,5 @@ PASS Setting the start time of a play-pending animation applies a pending playba
 PASS Setting the start time of a playing animation applies a pending playback rate
 PASS Setting the start time on a running animation updates the play state
 PASS Setting the start time on a reverse running animation updates the play state
+PASS Checking the start time of animations started at various times between two page rendering updates
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
@@ -325,5 +325,58 @@ promise_test(async t => {
 }, 'Setting the start time on a reverse running animation updates the play '
    + 'state');
 
+promise_test(async t => {
+  const make_animation = () => createDiv(t).animate(null, 100 * MS_PER_SEC);
+
+  // Wait for a couple of page rendering updates to run and record the timeline time.
+  await waitForAnimationFrames(2);
+  const timelineTimeForFirstPageRenderingUpdate = document.timeline.currentTime;
+
+  // Create a first animation that is created during the page rendering update.
+  // This animation should have its start time set to the current timeline time.
+  const animStartedDuringPageRenderingUpdate = make_animation();
+
+  // Wait for a new JS call frame and start another animation. This animation
+  // should have its start time set to the timeline time of the next page
+  // rendering update.
+  await new Promise(setTimeout);
+  const animStartedAfterTimeout = make_animation();
+
+  // Wait for another new JS call frame and start another animation. This
+  // animation, like the previous one, should have its start time set to
+  // the timeline time of the next page rendering update.
+  await new Promise(setTimeout);
+  const animStartedAfterAnotherTimeout = make_animation();
+
+  // Now wait until the next page rendering update and record the timeline time.
+  await waitForAnimationFrames(1);
+  const timelineTimeForSecondPageRenderingUpdate = document.timeline.currentTime;
+
+  // Create an animation that is created during this second page rendering update.
+  // This animation should have its start time set to the new timeline time.
+  const animStartedDuringSecondPageRenderingUpdate = make_animation();
+
+  // All animations should be ready by the next animation frame.
+  await waitForAnimationFrames(1);
+
+  const assert_start_time = (animation, expected, description) => {
+    assert_approx_equals(animation.startTime, expected, 0.0001,
+      `Start time of animation started ${description}`);
+  };
+
+  assert_start_time(animStartedDuringPageRenderingUpdate,
+    timelineTimeForFirstPageRenderingUpdate,
+    "during the first page rendering update");
+  assert_start_time(animStartedAfterTimeout,
+    timelineTimeForSecondPageRenderingUpdate,
+    "after waiting for a new JS call frame");
+  assert_start_time(animStartedAfterAnotherTimeout,
+    timelineTimeForSecondPageRenderingUpdate,
+    "after waiting for another new JS call frame");
+  assert_start_time(animStartedDuringSecondPageRenderingUpdate,
+    timelineTimeForSecondPageRenderingUpdate,
+    "during the second page rendering update");
+}, 'Checking the start time of animations started at various times between two page rendering updates');
+
 </script>
 </body>

--- a/LayoutTests/platform/ios/compositing/backing/transition-extent-expected.txt
+++ b/LayoutTests/platform/ios/compositing/backing/transition-extent-expected.txt
@@ -16,6 +16,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 1)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
         (GraphicsLayer
           (position 20.00 1500.00)
@@ -23,6 +24,7 @@ The second box should not have attached backing store.
           (contentsOpaque 1)
           (drawsContent 1)
           (backingStoreAttached 0)
+          (transform [1.00 -0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
         )
       )
     )

--- a/LayoutTests/platform/mac/compositing/visible-rect/animated-from-none-expected.txt
+++ b/LayoutTests/platform/mac/compositing/visible-rect/animated-from-none-expected.txt
@@ -35,6 +35,7 @@
                   (position -100.00 0.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
                   (visible rect 100.00, 0.00 100.00 x 200.00)
                   (coverage rect 100.00, 0.00 500.00 x 200.00)
                   (intersects coverage rect 1)

--- a/LayoutTests/webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html
+++ b/LayoutTests/webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html
@@ -27,6 +27,8 @@ promise_test(async test => {
     const target = document.body.appendChild(document.createElement("div"));
     target.classList.add("target");
 
+    assert_equals(target.getAnimations().length, 0, "There are no animations applied initially.");
+
     const getAnimation = () => {
         const animations = target.getAnimations();
         assert_equals(animations.length, 1, "There is one animation applied to the target.");
@@ -41,13 +43,16 @@ promise_test(async test => {
     let retargetedTransition;
 
     // Start the initial transition.
-    await new Promise(requestAnimationFrame);
     target.classList.add("in-flight");
     initialTransition = getAnimation();
     
     // Wait until the animation is complete and retarget the transition to the same value.
-    await(initialTransition.ready);
-    await(new Promise(resolve => setTimeout(resolve, 100)));
+    await initialTransition.ready;
+
+    const timeout = new Promise(resolve => setTimeout(resolve, 100));
+
+    await Promise.all([timeout, initialTransition.finished]);
+
     target.classList.add("retargeted");
     retargetedTransition = getAnimation();
 

--- a/LayoutTests/webanimations/custom-effect/custom-effect.html
+++ b/LayoutTests/webanimations/custom-effect/custom-effect.html
@@ -12,15 +12,15 @@ promise_test(async t => {
     let numberOfCalls = 0;
     let customEffectProgress = null;
 
+    await waitForAnimationFrames(1);
+    await new Promise(setTimeout);
+
     const animation = document.timeline.animate(progress => {
         customEffectProgress = progress;
         numberOfCalls++;
     }, { duration: 1 });
 
     assert_equals(customEffectProgress, null, "Callback does not fire upon creation.");
-
-    await waitForAnimationFrames(1);
-    assert_equals(customEffectProgress, 0, "Callback is first fired with progress = 0.");
 
     await animation.finished;
     const numberOfCallsAfterEffectEnded = numberOfCalls;

--- a/LayoutTests/webanimations/offset-anchor-animation-yields-compositing.html
+++ b/LayoutTests/webanimations/offset-anchor-animation-yields-compositing.html
@@ -6,7 +6,7 @@ testRunner.waitUntilDone();
 testRunner.dumpAsText();
 
 document.getElementById("target").animate({
-    offsetAnchor: ["0 0", "100% 100%"]
+    offsetAnchor: ["0 0", "0 0"]
 }, 1000 * 60).ready.then(() => {
     document.getElementById("results").innerText = internals.layerTreeAsText(document);
     testRunner.notifyDone();

--- a/LayoutTests/webanimations/offset-distance-animation-yields-compositing.html
+++ b/LayoutTests/webanimations/offset-distance-animation-yields-compositing.html
@@ -6,7 +6,7 @@ testRunner.waitUntilDone();
 testRunner.dumpAsText();
 
 document.getElementById("target").animate({
-    offsetDistance: ["0", "100%"]
+    offsetDistance: ["0", "0"]
 }, 1000 * 60).ready.then(() => {
     document.getElementById("results").innerText = internals.layerTreeAsText(document);
     testRunner.notifyDone();

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -47,6 +47,11 @@ void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
 {
     updateGlobalPosition(animation);
 
+    if (animation.pending()) {
+        if (CheckedPtr controller = this->controller())
+            controller->addPendingAnimation(animation);
+    }
+
     if (m_animations.add(animation)) {
         auto* timeline = animation.timeline();
         if (timeline && timeline != this)

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -57,6 +57,7 @@ public:
     void removeTimeline(AnimationTimeline&);
     void detachFromDocument();
     void updateAnimationsAndSendEvents(ReducedResolutionSeconds);
+    void addPendingAnimation(WebAnimation&);
 
     std::optional<Seconds> currentTime();
     std::optional<FramesPerSecond> maximumAnimationFrameRate() const { return m_frameRateAligner.maximumFrameRate(); }
@@ -75,7 +76,7 @@ private:
 
     ReducedResolutionSeconds liveCurrentTime() const;
     void cacheCurrentTime(ReducedResolutionSeconds);
-    void maybeClearCachedCurrentTime();
+    void processPendingAnimations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
@@ -86,12 +87,12 @@ private:
 
     UncheckedKeyHashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;
-    TaskCancellationGroup m_currentTimeClearingTaskCancellationGroup;
+    WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_pendingAnimations;
+    TaskCancellationGroup m_pendingAnimationsProcessingTaskCancellationGroup;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     FrameRateAligner m_frameRateAligner;
     Markable<Seconds, Seconds::MarkableTraits> m_cachedCurrentTime;
     bool m_isSuspended { false };
-    bool m_waitingOnVMIdle { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -299,10 +299,8 @@ void DocumentTimeline::removeReplacedAnimations()
         //    Otherwise, queue a task to dispatch removeEvent at animation. The task source for this task is the DOM manipulation task source.
         auto scheduledTime = [&]() -> std::optional<Seconds> {
             if (auto* documentTimeline = dynamicDowncast<DocumentTimeline>(animation->timeline())) {
-                if (auto currentTime = documentTimeline->currentTime()) {
-                    ASSERT(currentTime->time());
-                    return documentTimeline->convertTimelineTimeToOriginRelativeTime(*currentTime->time());
-                }
+                auto currentTime = MonotonicTime::now().secondsSinceEpoch();
+                return documentTimeline->convertTimelineTimeToOriginRelativeTime(currentTime);
             }
             return std::nullopt;
         }();

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -137,6 +137,8 @@ public:
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
     std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
 
+    void setPendingStartTime(WebAnimationTime pendingStartTime) { m_pendingStartTime = pendingStartTime; }
+
     virtual Variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(Variant<FramesPerSecond, AnimationFrameRatePreset>&&);
     std::optional<FramesPerSecond> frameRate() const { return m_effectiveFrameRate; }
@@ -219,6 +221,7 @@ private:
     void applyPendingPlaybackRate();
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
     void autoAlignStartTime();
+    void maybeMarkAsReady();
     bool isTimeValid(const std::optional<WebAnimationTime>&) const;
 
     // ActiveDOMObject.
@@ -240,6 +243,7 @@ private:
     UniqueRef<FinishedPromise> m_finishedPromise;
     std::optional<WebAnimationTime> m_previousCurrentTime;
     std::optional<WebAnimationTime> m_startTime;
+    std::optional<WebAnimationTime> m_pendingStartTime;
     std::optional<WebAnimationTime> m_holdTime;
     MarkableDouble m_pendingPlaybackRate;
     double m_playbackRate { 1 };


### PR DESCRIPTION
#### 483c60c629b8394400c134b686ec549c1cf2c0f5
<pre>
[web-animations] start time of animations created during a page rendering update should match that update&apos;s timeline time
<a href="https://bugs.webkit.org/show_bug.cgi?id=290993">https://bugs.webkit.org/show_bug.cgi?id=290993</a>
<a href="https://rdar.apple.com/138844796">rdar://138844796</a>

Reviewed by Dean Jackson.

WebKit differs from Chrome and Firefox when setting the start time of animations
created during a page rendering update.

In WebKit, we mark any animation that is pending as ready when we run the &quot;update
animations and send events&quot; [0] step, which means that all animations pending at
this point will share the same start time and will also have a current time of 0
when the ready promise is resolved.

In Chrome and Firefox, animations created during a page rendering update will have
their start time set to the timeline time of that same update, even though their
ready promise may be resolved at a later time, for instance during the next page
rendering update. This means that the current time of animations will likely not
be 0 when the ready promise is resolved.

This is particularly visible for CSS-originated animations which may be created
during a page rendering update as styles are recalculated and layout is updated
a few steps after animations are updated. As such, WebKit typically is one rendering
frame behind Chrome and Firefox when dealing with CSS Transitions and CSS Animations.

This behavior is not actually a spec violation since the start time and time where
the ready promise is resolved is left as implementation-dependent [1].

However, this is proving to be a web compatibility issue since we found that captions
may flicker on YouTube for instance, and this is due to the behavior described above.
In fact, for CSS Transitions, we introduced some ad-hoc current time computation code
in 226359@main and 226577@main to deal with some compatibility issues (which we will
remove in a followup to this patch).

In light of this further web compatibility issue, we change how we determine the start
time of animations to align with Chrome and Firefox.

When we cache the current time during a page rendering update, we enqueue a task in
`AnimationTimelinesController::cacheCurrentTime()` to run once page rendering update
is done. Any animation that is created in this interval is added to a list of pending
animations, and when our queued that task is performed we set the &quot;pending start time&quot;
of those pending animations.

Then during the next page rendering update, as `WebAnimation::tick()` is called, we
check whether we have a &quot;pending start time&quot; and use that time to be the animation&apos;s
committed start time.

This now means that any animation created during a page rendering update, including
`requestAnimationFrame()` callbacks and code responding to animation events, will
have its pending start time set to the timeline time used for that page rendering
update. During the _next_ page rendering update, those animations will be marked as
&quot;ready&quot; and their start time will be set to the recorded pending start time.

If an animation was created any time after the page rendering update steps had
completed, for instance in a `setTimeout()` call within a `requestAnimationFrame()`
callback, that animation will have its start time set to match the next page rendering
update and will be marked as ready during the following page rendering update.

This behavior is now tested with an additional subtest in the existing WPT test
`web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html`.
While that behavior isn&apos;t technically normative, as noted above, it seems like important
enough for Web compatibility that it should be part of the WPT suite.

The subtle changes in timing required some adaptation of WebKit-specific tests. For the
compositing tests, because animations and transitions start a frame sooner, we had to update
those tests to have an animation transform in the output and to make sure the animations were
longer to yield a stable animated first frame in the output.

[0] <a href="https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events">https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#waiting-for-the-associated-effect">https://drafts.csswg.org/web-animations-1/#waiting-for-the-associated-effect</a>

* LayoutTests/compositing/backing/backface-visibility-flip-expected.txt:
* LayoutTests/compositing/backing/backface-visibility-flip.html:
* LayoutTests/compositing/backing/backing-store-attachment-empty-keyframe.html:
* LayoutTests/compositing/backing/transition-extent-expected.txt:
* LayoutTests/compositing/backing/transition-extent.html:
* LayoutTests/compositing/layer-creation/overlap-animation-clipping.html:
* LayoutTests/compositing/layer-creation/overlap-animation-container.html:
* LayoutTests/compositing/layer-creation/overlap-animation-expected.txt:
* LayoutTests/compositing/layer-creation/overlap-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html:
* LayoutTests/platform/ios/compositing/backing/transition-extent-expected.txt:
* LayoutTests/platform/mac/compositing/visible-rect/animated-from-none-expected.txt:
* LayoutTests/webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html:
* LayoutTests/webanimations/custom-effect/custom-effect.html:
* LayoutTests/webanimations/offset-anchor-animation-yields-compositing.html:
* LayoutTests/webanimations/offset-distance-animation-yields-compositing.html:
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::detachFromDocument):
(WebCore::AnimationTimelinesController::addPendingAnimation):
(WebCore::AnimationTimelinesController::cacheCurrentTime):
(WebCore::AnimationTimelinesController::processPendingAnimations):
(WebCore::AnimationTimelinesController::maybeClearCachedCurrentTime): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::removeReplacedAnimations): Use the live current time instead
of the cached current time so that we can guarantee that &quot;remove&quot; events are dispatched
after &quot;finish&quot; events for the same animation.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::runPendingPlayTask): use the &quot;pending start time&quot; if set.
(WebCore::WebAnimation::runPendingPauseTask): use the &quot;pending start time&quot; if set.
(WebCore::WebAnimation::tick):
(WebCore::WebAnimation::maybeMarkAsReady): move &quot;ready&quot; logic into a dedicated method.
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::setPendingStartTime):

Canonical link: <a href="https://commits.webkit.org/294049@main">https://commits.webkit.org/294049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c58aba7e104ecff0250df942a58bcb44691fbb5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10656 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/105842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/33716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/105842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/8968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/9043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/108197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28186 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/87162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/108197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/29884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21813 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27758 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/33011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->