### PR TITLE
RTC encoded frame timestamp should be persistent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
@@ -1,11 +1,11 @@
 
 
-FAIL audio metadata: timestamp assert_equals: timestamp matches (for sender before and after write) expected 0 but got 2587289961
+PASS audio metadata: timestamp
 PASS audio metadata: synchronizationSource
 PASS audio metadata: payloadType
 PASS audio metadata: contributingSources
 PASS audio metadata: sequenceNumber
-FAIL video metadata: timestamp assert_equals: timestamp matches (for sender before and after write) expected 0 but got 3109625852
+PASS video metadata: timestamp
 PASS video metadata: ssrc
 PASS video metadata: csrcs
 PASS video metadata: width and height

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -978,7 +978,6 @@ webkit.org/b/206708 fast/animation/request-animation-frame-iframe.html [ Pass Fa
 [ Release ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html [ Pass Failure ]
 
 #rdar://92833592 ([ Ventura ] 4x imported/w3c/web-platform-tests/webrtc-encoded-transform/ are flaky text failures)
-imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp
@@ -39,11 +39,6 @@ RTCEncodedAudioFrame::RTCEncodedAudioFrame(Ref<RTCRtpTransformableFrame>&& frame
 
 RTCEncodedAudioFrame::~RTCEncodedAudioFrame() = default;
 
-uint64_t RTCEncodedAudioFrame::timestamp() const
-{
-    return m_frame->timestamp();
-}
-
 const RTCEncodedAudioFrame::Metadata& RTCEncodedAudioFrame::getMetadata()
 {
     if (!m_metadata)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.h
@@ -39,8 +39,6 @@ public:
     using Metadata = RTCEncodedAudioFrameMetadata;
     const Metadata& getMetadata();
 
-    uint64_t timestamp() const;
-
 private:
     explicit RTCEncodedAudioFrame(Ref<RTCRtpTransformableFrame>&&);
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -50,6 +50,13 @@ void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
     m_data = &buffer;
 }
 
+uint64_t RTCEncodedFrame::timestamp() const
+{
+    if (!m_timestamp)
+        m_timestamp = m_frame->timestamp();
+    return *m_timestamp;
+}
+
 Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame(JSC::VM& vm, ShouldNeuter shouldNeuter)
 {
     ASSERT(!m_isNeutered);

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
@@ -49,6 +49,8 @@ public:
     enum class ShouldNeuter : bool { No, Yes };
     Ref<RTCRtpTransformableFrame> rtcFrame(JSC::VM&, ShouldNeuter = ShouldNeuter::Yes);
 
+    uint64_t timestamp() const;
+
     Ref<RTCRtpTransformableFrame> serialize();
 
 protected:
@@ -57,6 +59,7 @@ protected:
     Ref<RTCRtpTransformableFrame> m_frame;
     mutable RefPtr<JSC::ArrayBuffer> m_data;
     bool m_isNeutered { false };
+    mutable std::optional<uint64_t> m_timestamp;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp
@@ -40,11 +40,6 @@ RTCEncodedVideoFrame::RTCEncodedVideoFrame(Ref<RTCRtpTransformableFrame>&& frame
 
 RTCEncodedVideoFrame::~RTCEncodedVideoFrame() = default;
 
-uint64_t RTCEncodedVideoFrame::timestamp() const
-{
-    return m_frame->timestamp();
-}
-
 const RTCEncodedVideoFrame::Metadata& RTCEncodedVideoFrame::getMetadata()
 {
     if (!m_metadata)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.h
@@ -42,8 +42,6 @@ public:
     using Metadata = RTCEncodedVideoFrameMetadata;
     const Metadata& getMetadata();
 
-    uint64_t timestamp() const;
-
 private:
     explicit RTCEncodedVideoFrame(Ref<RTCRtpTransformableFrame>&&);
 


### PR DESCRIPTION
#### c294012da6fc4b01cc1f97be8c19a4d1b8701d47
<pre>
RTC encoded frame timestamp should be persistent
<a href="https://rdar.apple.com/148580865">rdar://148580865</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291067">https://bugs.webkit.org/show_bug.cgi?id=291067</a>

Reviewed by Jean-Yves Avenard.

Timestamp should persist after write, we apply the same strategy as for metadata and move it to RTCEncodedFrame since it applies for both audio and video.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp:
(WebCore::RTCEncodedAudioFrame::timestamp const): Deleted.
* Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.h:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::timestamp const):
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.h:
* Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp:
(WebCore::RTCEncodedVideoFrame::timestamp const): Deleted.
* Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/293238@main">https://commits.webkit.org/293238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84af0a7b11a8a71ef9f5b2313abb978297f0934a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48857 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26410 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48299 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25415 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19059 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25373 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->