### PR TITLE
WPT webrtc-encoded-transform/script-metadata-transform.https.html frameId subtest is wrong

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
@@ -11,6 +11,6 @@ PASS video metadata: csrcs
 PASS video metadata: width and height
 PASS video metadata: spatial and temporal index
 PASS video metadata: dependencies
-FAIL video metadata: frameId assert_equals: frameId matches (for sender and receiver) expected (undefined) undefined but got (number) 1
+PASS video metadata: frameId
 PASS video metadata: type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html
@@ -271,10 +271,11 @@ promise_test(async (test) => {
     assert_equals(data.senderBeforeWrite.metadata.frameId,
       data.senderAfterWrite.metadata.frameId,
       'frameId matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.frameId,
-      data.receiverBeforeWrite.metadata.frameId,
+
+    assert_true(data.senderBeforeWrite.metadata.frameId == data.receiverBeforeWrite.metadata.frameId ||
+      data.receiverBeforeWrite.metadata.frameId == undefined,
       'frameId matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.frameId,
+    assert_equals(data.receiverBeforeWrite.metadata.frameId,
       data.receiverAfterWrite.metadata.frameId,
       'frameId matches (for receiver before and after write)');
 }, 'video metadata: frameId');


### PR DESCRIPTION
#### a642222124a9acb6cb135499e4d9264fbe4b487a
<pre>
WPT webrtc-encoded-transform/script-metadata-transform.https.html frameId subtest is wrong
<a href="https://rdar.apple.com/148581747">rdar://148581747</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291069">https://bugs.webkit.org/show_bug.cgi?id=291069</a>

Reviewed by Jean-Yves Avenard.

frameId is present on receiver side only if the Dependency Descriptor Header Extension is present, as per spec.
This is not guaranteed here so we loosen the check to account for the undefined value.
This aligns the test with all implementations.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html:

Canonical link: <a href="https://commits.webkit.org/293239@main">https://commits.webkit.org/293239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/941397a1d0d6595d16b464fde8f068a60a1cb393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74829 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83283 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21037 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25359 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30533 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->