### PR TITLE
[WPE] WPE Platform: add a setting to allow applications handle the toplevels

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -103,6 +103,7 @@ struct _WPESettingsPrivate {
             { WPE_SETTING_DOUBLE_CLICK_DISTANCE, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(5)) },
             { WPE_SETTING_DOUBLE_CLICK_TIME, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(400)) },
             { WPE_SETTING_DRAG_THRESHOLD, G_VARIANT_TYPE_UINT32, g_variant_ref_sink(g_variant_new_uint32(8)) },
+            { WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, G_VARIANT_TYPE_BOOLEAN, g_variant_ref_sink(g_variant_new_boolean(true)) },
         };
 
         for (auto& setting : defaultSettings)

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
  * @WPE_SETTINGS_ERROR_NOT_REGISTERED: Key has not been registered
  * @WPE_SETTINGS_ERROR_ALREADY_REGISTERED: Key has already been registered
  * @WPE_SETTINGS_ERROR_INVALID_VALUE: Failed to parse a value from a keyfile
- * 
+ *
  * #WPESettings errors
  */
 typedef enum {
@@ -64,6 +64,7 @@ WPE_API GQuark wpe_settings_error_quark(void);
  * Default: Sans 10
  */
 #define WPE_SETTING_FONT_NAME "/wpe-platform/font-name"
+
 /**
  * WPE_SETTING_DARK_MODE:
  *
@@ -74,6 +75,7 @@ WPE_API GQuark wpe_settings_error_quark(void);
  * Default: false
  */
 #define WPE_SETTING_DARK_MODE "/wpe-platform/dark-mode"
+
 /**
  * WPE_SETTING_DISABLE_ANIMATIONS:
  *
@@ -84,6 +86,7 @@ WPE_API GQuark wpe_settings_error_quark(void);
  * Default: false
  */
 #define WPE_SETTING_DISABLE_ANIMATIONS "/wpe-platform/disable-animations"
+
 /**
  * WPE_SETTING_FONT_ANTIALIAS:
  *
@@ -94,6 +97,7 @@ WPE_API GQuark wpe_settings_error_quark(void);
  * Default: true
  */
 #define WPE_SETTING_FONT_ANTIALIAS "/wpe-platform/font-antialias"
+
 /**
  * WPESettingsHintingStyle:
  * @WPE_SETTINGS_HINTING_STYLE_NONE
@@ -107,6 +111,7 @@ typedef enum {
     WPE_SETTINGS_HINTING_STYLE_MEDIUM,
     WPE_SETTINGS_HINTING_STYLE_FULL,
 } WPESettingsHintingStyle;
+
 /**
  * WPE_SETTING_FONT_HINTING_STYLE:
  *
@@ -117,6 +122,7 @@ typedef enum {
  * Default: WPE_SETTINGS_HINTING_STYLE_SLIGHT
  */
 #define WPE_SETTING_FONT_HINTING_STYLE "/wpe-platform/font-hinting-style"
+
 /**
  * WPESettingsSubpixelLayout:
  * @WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB
@@ -130,6 +136,7 @@ typedef enum {
     WPE_SETTINGS_SUBPIXEL_LAYOUT_VRGB,
     WPE_SETTINGS_SUBPIXEL_LAYOUT_VBGR,
 } WPESettingsSubpixelLayout;
+
 /**
  * WPE_SETTING_FONT_SUBPIXEL_LAYOUT:
  *
@@ -140,6 +147,7 @@ typedef enum {
  * Default: WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB
  */
 #define WPE_SETTING_FONT_SUBPIXEL_LAYOUT "/wpe-platform/font-subpixel-layout"
+
 /**
  * WPE_SETTING_FONT_DPI:
  *
@@ -150,6 +158,7 @@ typedef enum {
  * Default: 96.0
  */
 #define WPE_SETTING_FONT_DPI "/wpe-platform/font-dpi"
+
 /**
  * WPE_SETTING_CURSOR_BLINK_TIME:
  *
@@ -162,6 +171,7 @@ typedef enum {
  * Default: 1200
  */
 #define WPE_SETTING_CURSOR_BLINK_TIME "/wpe-platform/cursor-blink-time"
+
 /**
  * WPE_SETTING_TOPLEVEL_DEFAULT_SIZE:
  *
@@ -173,6 +183,7 @@ typedef enum {
  * Default: (1024, 768)
  */
 #define WPE_SETTING_TOPLEVEL_DEFAULT_SIZE "/wpe-platform/toplevel-default-size"
+
 /**
  * WPE_SETTING_DOUBLE_CLICK_DISTANCE:
  *
@@ -184,6 +195,7 @@ typedef enum {
  * Default: 5
  */
 #define WPE_SETTING_DOUBLE_CLICK_DISTANCE "/wpe-platform/events/double-click/distance"
+
 /**
  * WPE_SETTING_DOUBLE_CLICK_TIME:
  *
@@ -195,6 +207,7 @@ typedef enum {
  * Default: 400
  */
 #define WPE_SETTING_DOUBLE_CLICK_TIME "/wpe-platform/events/double-click/time"
+
 /**
  * WPE_SETTING_DRAG_THRESHOLD:
  *
@@ -205,6 +218,7 @@ typedef enum {
  * Default: 8
  */
 #define WPE_SETTING_DRAG_THRESHOLD "/wpe-platform/events/gestures/drag-thresold"
+
 /**
  * WPE_SETTING_KEY_REPEAT_DELAY:
  *
@@ -216,6 +230,7 @@ typedef enum {
  * Default: 400
  */
 #define WPE_SETTING_KEY_REPEAT_DELAY "/wpe-platform/events/key-repeat/delay"
+
 /**
  * WPE_SETTING_KEY_REPEAT_INTERVAL:
  *
@@ -227,6 +242,20 @@ typedef enum {
  * Default: 80
  */
 #define WPE_SETTING_KEY_REPEAT_INTERVAL "/wpe-platform/events/key-repeat/interval"
+
+/**
+ * WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL:
+ *
+ * By default, when a #WPEView is created, a #WPEToplevel is also created and set
+ * as the toplevel of the newly created view. This setting allows to create
+ * views wihtout a toplevel set, for applications that want to handle the toplevels
+ * themselves, for example to create a multiview toplevel.
+ *
+ * VariantType: boolean
+ *
+ * Default: true
+ */
+#define WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL "/wpe-platform/create-views-with-a-toplevel"
 
 /**
  * WPESettingsSource:

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -374,8 +374,10 @@ static WPEView* wpeDisplayDRMCreateView(WPEDisplay* display)
     auto* displayDRM = WPE_DISPLAY_DRM(display);
     auto* view = wpe_view_drm_new(displayDRM);
 
-    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_drm_new(displayDRM));
-    wpe_view_set_toplevel(view, toplevel.get());
+    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
+        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_drm_new(displayDRM));
+        wpe_view_set_toplevel(view, toplevel.get());
+    }
 
     displayDRM->priv->seat->setView(view);
     return view;

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -86,8 +86,10 @@ static gboolean wpeDisplayHeadlessConnect(WPEDisplay*, GError**)
 static WPEView* wpeDisplayHeadlessCreateView(WPEDisplay* display)
 {
     auto* view = wpe_view_headless_new(WPE_DISPLAY_HEADLESS(display));
-    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_headless_new(WPE_DISPLAY_HEADLESS(display)));
-    wpe_view_set_toplevel(view, toplevel.get());
+    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
+        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_headless_new(WPE_DISPLAY_HEADLESS(display)));
+        wpe_view_set_toplevel(view, toplevel.get());
+    }
     return view;
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -433,9 +433,10 @@ static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
     auto* displayWayland = WPE_DISPLAY_WAYLAND(display);
     auto* view = wpe_view_wayland_new(displayWayland);
 
-    // FIXME: create the toplevel conditionally.
-    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland));
-    wpe_view_set_toplevel(view, toplevel.get());
+    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
+        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland));
+        wpe_view_set_toplevel(view, toplevel.get());
+    }
 
     return view;
 }


### PR DESCRIPTION
#### 32bbc113a554ff8c364641a73cf88fc1cab481e8
<pre>
[WPE] WPE Platform: add a setting to allow applications handle the toplevels
<a href="https://bugs.webkit.org/show_bug.cgi?id=291076">https://bugs.webkit.org/show_bug.cgi?id=291076</a>

Reviewed by Patrick Griffis.

We currently always create a WPEToplevel for every WPEView when it&apos;s
created. However, applications might want to handle the WPEToplevel, for
example to add multiple views to the same toplevel. This patch adds
WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL and creates the toplevel
conditionally after WPEView creation depending on this setting.

* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(_WPESettingsPrivate::_WPESettingsPrivate):
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMCreateView):
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
(wpeDisplayHeadlessCreateView):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandCreateView):

Canonical link: <a href="https://commits.webkit.org/293399@main">https://commits.webkit.org/293399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caef7019158056a227ab5d655e679e013c353bb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48853 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74844 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101328 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13819 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13603 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83294 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19054 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16061 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->