### PR TITLE
[WGSL] Parser should allow expressions as array count

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -940,14 +940,8 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseArrayType()
 
         if (current().type == TokenType::Comma) {
             consume();
-            // FIXME: According to https://www.w3.org/TR/WGSL/#syntax-element_count_expression
-            // this should be: AdditiveExpression | BitwiseExpression.
-            //
-            // The WGSL grammar doesn't specify expression operator precedence so
-            // until then just parse AdditiveExpression.
             if (current().type != TokenType::TemplateArgsRight) {
-                PARSE(elementCountLHS, UnaryExpression);
-                PARSE(elementCount, AdditiveExpressionPostUnary, WTFMove(elementCountLHS));
+                PARSE(elementCount, Expression);
                 maybeElementCount = &elementCount.get();
 
                 if (current().type == TokenType::Comma)

--- a/Source/WebGPU/WGSL/tests/array-count-expression.wgsl
+++ b/Source/WebGPU/WGSL/tests/array-count-expression.wgsl
@@ -1,0 +1,8 @@
+// RUN: %metal-compile main
+
+struct S { x: array<i32, 1<<2> }
+
+@compute @workgroup_size(1)
+fn main() {
+    var s : S;
+}


### PR DESCRIPTION
#### d3e2a81ae245696180a9fb0136e65e53e3b9205d
<pre>
[WGSL] Parser should allow expressions as array count
<a href="https://bugs.webkit.org/show_bug.cgi?id=291078">https://bugs.webkit.org/show_bug.cgi?id=291078</a>
<a href="https://rdar.apple.com/148249747">rdar://148249747</a>

Reviewed by Mike Wyrzykowski.

There was some code left over from array type had a separate syntax, and didn&apos;t
accept generic expressions as arguments. Eventually we should remove the special
case for array types, but for the time being make the array count an expression.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
* Source/WebGPU/WGSL/tests/array-count-expression.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/293360@main">https://commits.webkit.org/293360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12d05ac80ab64a41d59efb935102167ea26a6dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48858 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13608 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->