### PR TITLE
RTcRtpScriptTransformer.generateKeyFrame promise should be resolved with the key frame timestamp

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
@@ -1,11 +1,11 @@
 
 
 PASS generateKeyFrame() throws for audio
-FAIL generateKeyFrame(null) resolves for video sender, and throws for video receiver assert_equals: expected "number" but got "undefined"
+PASS generateKeyFrame(null) resolves for video sender, and throws for video receiver
 FAIL generateKeyFrame throws NotAllowedError for invalid rid assert_equals: expected "failure" but got "success"
 FAIL generateKeyFrame throws NotFoundError for unknown rid assert_equals: expected "failure" but got "success"
 PASS generateKeyFrame throws for unset transforms
-FAIL generateKeyFrame timestamp should advance assert_equals: expected "number" but got "undefined"
+PASS generateKeyFrame timestamp should advance
 PASS await generateKeyFrame, await generateKeyFrame should see an increase in count of keyframes
 FAIL generateKeyFrame rejects when the sender is negotiated inactive, and resumes succeeding when negotiated back to active assert_equals: Message: Timed out after waiting for 8000 ms expected "InvalidStateError" but got "TimeoutError"
 PASS generateKeyFrame rejects when the sender is stopped, even without negotiation

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -172,7 +172,7 @@ void RTCRtpScriptTransformer::enqueueFrame(ScriptExecutionContext& context, Ref<
     bool isVideo = m_backend->mediaType() == RTCRtpTransformBackend::MediaType::Video;
     if (isVideo && !m_pendingKeyFramePromises.isEmpty() && frame->isKeyFrame()) {
         for (auto& promise : std::exchange(m_pendingKeyFramePromises, { }))
-            promise->resolve();
+            promise->resolve<IDLUnsignedLongLong>(frame->timestamp());
     }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl
@@ -35,6 +35,6 @@
     [CallWith=CurrentGlobalObject, CachedAttribute] readonly attribute any options;
 
     // FIXME: Add support for RID options.
-    Promise<undefined> generateKeyFrame();
+    Promise<unsigned long long> generateKeyFrame();
     Promise<undefined> sendKeyFrameRequest();
 };


### PR DESCRIPTION
#### 7c8e79fd0f6b3d29d769f627f34fd3cb29425f02
<pre>
RTcRtpScriptTransformer.generateKeyFrame promise should be resolved with the key frame timestamp
<a href="https://rdar.apple.com/148590625">rdar://148590625</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291079">https://bugs.webkit.org/show_bug.cgi?id=291079</a>

Reviewed by Eric Carlson.

Align the implementation to the latest spec which mandates to resolve the RTcRtpScriptTransformer.generateKeyFrame promise with the key frame timestamp.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::enqueueFrame):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl:

Canonical link: <a href="https://commits.webkit.org/293630@main">https://commits.webkit.org/293630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1b982cf43cd42e53aef6cbed395fa6c45d4c067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74849 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32009 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105825 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83828 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83298 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->