### PR TITLE
[WPE] WPE Platform: convert WPEToplevel get_max_views vfunc into a construct only property

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -50,6 +50,7 @@
  */
 struct _WPEToplevelPrivate {
     GWeakPtr<WPEDisplay> display;
+    unsigned maxViews;
     ListHashSet<WPEView*> views;
 
     int width;
@@ -73,6 +74,7 @@ enum {
     PROP_0,
 
     PROP_DISPLAY,
+    PROP_MAX_VIEWS,
 
     N_PROPERTIES
 };
@@ -116,6 +118,9 @@ static void wpeToplevelSetProperty(GObject* object, guint propId, const GValue* 
     case PROP_DISPLAY:
         toplevel->priv->display.reset(WPE_DISPLAY(g_value_get_object(value)));
         break;
+    case PROP_MAX_VIEWS:
+        toplevel->priv->maxViews = g_value_get_uint(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
     }
@@ -128,6 +133,9 @@ static void wpeToplevelGetProperty(GObject* object, guint propId, GValue* value,
     switch (propId) {
     case PROP_DISPLAY:
         g_value_set_object(value, wpe_toplevel_get_display(toplevel));
+        break;
+    case PROP_MAX_VIEWS:
+        g_value_set_uint(value, wpe_toplevel_get_max_views(toplevel));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -152,6 +160,19 @@ static void wpe_toplevel_class_init(WPEToplevelClass* toplevelClass)
             "display",
             nullptr, nullptr,
             WPE_TYPE_DISPLAY,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WPEToplevel:max-views:
+     *
+     * The maximum number of #WPEView that can be added to the #WPEToplevel.
+     * A value of 0 means no limit.
+     */
+    sObjProperties[PROP_MAX_VIEWS] =
+        g_param_spec_uint(
+            "max-views",
+            nullptr, nullptr,
+            0, G_MAXUINT, 1,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
@@ -247,8 +268,7 @@ guint wpe_toplevel_get_max_views(WPEToplevel* toplevel)
 {
     g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), 0);
 
-    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
-    return toplevelClass->get_max_views ? toplevelClass->get_max_views(toplevel) : 1;
+    return toplevel->priv->maxViews;
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
@@ -49,7 +49,6 @@ struct _WPEToplevelClass
 
     void                    (* set_title)                     (WPEToplevel *toplevel,
                                                                const char  *title);
-    guint                   (* get_max_views)                 (WPEToplevel *toplevel);
     WPEScreen              *(* get_screen)                    (WPEToplevel *toplevel);
     gboolean                (* resize)                        (WPEToplevel *toplevel,
                                                                int          width,

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -561,8 +561,11 @@ void wpe_view_set_toplevel(WPEView* view, WPEToplevel* toplevel)
     if (priv->toplevel == toplevel)
         return;
 
-    if (toplevel && wpe_toplevel_get_n_views(toplevel) == wpe_toplevel_get_max_views(toplevel))
-        return;
+    if (toplevel) {
+        auto maxViews = wpe_toplevel_get_max_views(toplevel);
+        if (maxViews && wpe_toplevel_get_n_views(toplevel) == maxViews)
+            return;
+    }
 
     if (priv->toplevel)
         wpeToplevelRemoveView(priv->toplevel.get(), view);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -434,7 +434,7 @@ static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
     auto* view = wpe_view_wayland_new(displayWayland);
 
     if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
-        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland));
+        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland, 1));
         wpe_view_set_toplevel(view, toplevel.get());
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -882,14 +882,15 @@ struct zwp_linux_surface_synchronization_v1* wpeToplevelWaylandGetSurfaceSync(WP
 /**
  * wpe_toplevel_wayland_new:
  * @display: a #WPEDisplayWayland
+ * @max_views: the maximum number of views allowed, or 0 for no limit
  *
- * Create a new #WPEToplevel on @display.
+ * Create a new #WPEToplevel on @display with @max_views allowed
  *
  * Returns: (transfer full): a #WPEToplevel
  */
-WPEToplevel* wpe_toplevel_wayland_new(WPEDisplayWayland* display)
+WPEToplevel* wpe_toplevel_wayland_new(WPEDisplayWayland* display, guint maxViews)
 {
-    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_WAYLAND, "display", display, nullptr));
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_WAYLAND, "display", display, "max-views", maxViews, nullptr));
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
@@ -40,7 +40,8 @@ G_BEGIN_DECLS
 #define WPE_TYPE_TOPLEVEL_WAYLAND (wpe_toplevel_wayland_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelWayland, wpe_toplevel_wayland, WPE, TOPLEVEL_WAYLAND, WPEToplevel)
 
-WPE_API WPEToplevel       *wpe_toplevel_wayland_new            (WPEDisplayWayland  *display);
+WPE_API WPEToplevel       *wpe_toplevel_wayland_new            (WPEDisplayWayland  *display,
+                                                                guint               max_views);
 WPE_API struct wl_surface *wpe_toplevel_wayland_get_wl_surface (WPEToplevelWayland *toplevel);
 
 G_END_DECLS


### PR DESCRIPTION
#### a2d7a9a4769db9936912bf0600bd34b096724ac0
<pre>
[WPE] WPE Platform: convert WPEToplevel get_max_views vfunc into a construct only property
<a href="https://bugs.webkit.org/show_bug.cgi?id=291080">https://bugs.webkit.org/show_bug.cgi?id=291080</a>

Reviewed by Patrick Griffis.

Because not only the platform needs to support the multiple views, but
also the applications. When applications want to handle the toplevel
themselves they need to decide the maximum view allowed.

* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpeToplevelSetProperty):
(wpeToplevelGetProperty):
(wpe_toplevel_class_init):
(wpe_toplevel_get_max_views):
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_set_toplevel):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandCreateView):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpe_toplevel_wayland_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h:

Canonical link: <a href="https://commits.webkit.org/293405@main">https://commits.webkit.org/293405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4401b139229e7d2dcb693377ae950f01c05c2bff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26934 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32384 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55612 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48816 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106342 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25944 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83715 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28366 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19658 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25897 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->