### PR TITLE
RTcRtpScriptTransformer.generateKeyFrame can take a rid parameter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
@@ -2,8 +2,8 @@
 
 PASS generateKeyFrame() throws for audio
 PASS generateKeyFrame(null) resolves for video sender, and throws for video receiver
-FAIL generateKeyFrame throws NotAllowedError for invalid rid assert_equals: expected "failure" but got "success"
-FAIL generateKeyFrame throws NotFoundError for unknown rid assert_equals: expected "failure" but got "success"
+PASS generateKeyFrame throws NotAllowedError for invalid rid
+PASS generateKeyFrame throws NotFoundError for unknown rid
 PASS generateKeyFrame throws for unset transforms
 PASS generateKeyFrame timestamp should advance
 PASS await generateKeyFrame, await generateKeyFrame should see an increase in count of keyframes

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -68,7 +68,7 @@ public:
     ExceptionOr<Ref<WritableStream>> writable();
     JSC::JSValue options(JSC::JSGlobalObject&);
 
-    void generateKeyFrame(Ref<DeferredPromise>&&);
+    void generateKeyFrame(const String&, Ref<DeferredPromise>&&);
     void sendKeyFrameRequest(Ref<DeferredPromise>&&);
 
     void startPendingActivity() { m_pendingActivity = makePendingActivity(*this); }

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl
@@ -35,6 +35,6 @@
     [CallWith=CurrentGlobalObject, CachedAttribute] readonly attribute any options;
 
     // FIXME: Add support for RID options.
-    Promise<unsigned long long> generateKeyFrame();
+    Promise<unsigned long long> generateKeyFrame(optional DOMString rid);
     Promise<undefined> sendKeyFrameRequest();
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class Exception;
 class RTCRtpTransformableFrame;
 
 class RTCRtpTransformBackend : public ThreadSafeRefCounted<RTCRtpTransformBackend, WTF::DestructionThread::Main> {
@@ -47,7 +48,7 @@ public:
     enum class Side { Receiver, Sender };
     virtual Side side() const = 0;
 
-    virtual void requestKeyFrame() = 0;
+    virtual bool requestKeyFrame(const String&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
@@ -48,10 +48,11 @@ void GStreamerRtpReceiverTransformBackend::setTransformableFrameCallback(Callbac
     notImplemented();
 }
 
-void GStreamerRtpReceiverTransformBackend::requestKeyFrame()
+bool GStreamerRtpReceiverTransformBackend::requestKeyFrame(const String&)
 {
     ASSERT(mediaType() == MediaType::Video);
     notImplemented();
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.h
@@ -38,7 +38,7 @@ private:
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
-    void requestKeyFrame() final;
+    bool requestKeyFrame(const String&) final;
 
     GRefPtr<GstWebRTCRTPReceiver> m_rtcReceiver;
 };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
@@ -51,10 +51,11 @@ void GStreamerRtpSenderTransformBackend::setTransformableFrameCallback(Callback&
     notImplemented();
 }
 
-void GStreamerRtpSenderTransformBackend::requestKeyFrame()
+bool GStreamerRtpSenderTransformBackend::requestKeyFrame(const String&)
 {
     ASSERT(mediaType() == MediaType::Video);
     notImplemented();
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.h
@@ -42,7 +42,7 @@ private:
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
-    void requestKeyFrame() final;
+    bool requestKeyFrame(const String&) final;
 
     GRefPtr<GstWebRTCRTPSender> m_rtcSender;
 };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp
@@ -56,10 +56,12 @@ void LibWebRTCRtpReceiverTransformBackend::setTransformableFrameCallback(Callbac
     m_rtcReceiver->SetDepacketizerToDecoderFrameTransformer(rtc::scoped_refptr<webrtc::FrameTransformerInterface>(this));
 }
 
-void LibWebRTCRtpReceiverTransformBackend::requestKeyFrame()
+bool LibWebRTCRtpReceiverTransformBackend::requestKeyFrame(const String& rid)
 {
     ASSERT(mediaType() == MediaType::Video);
+    ASSERT_UNUSED(rid, rid.isEmpty());
     m_rtcReceiver->GenerateKeyFrame();
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h
@@ -53,7 +53,7 @@ private:
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
-    void requestKeyFrame() final;
+    bool requestKeyFrame(const String&) final;
 
     bool m_isRegistered { false };
     rtc::scoped_refptr<webrtc::RtpReceiverInterface> m_rtcReceiver;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp
@@ -59,10 +59,13 @@ void LibWebRTCRtpSenderTransformBackend::setTransformableFrameCallback(Callback&
     m_rtcSender->SetEncoderToPacketizerFrameTransformer(rtc::scoped_refptr<webrtc::FrameTransformerInterface>(this));
 }
 
-void LibWebRTCRtpSenderTransformBackend::requestKeyFrame()
+bool LibWebRTCRtpSenderTransformBackend::requestKeyFrame(const String& rid)
 {
+    std::vector<std::string> rtcRids;
+    if (!rid.isEmpty())
+        rtcRids.push_back(rid.utf8().toStdString());
     ASSERT(mediaType() == MediaType::Video);
-    m_rtcSender->GenerateKeyFrame({ });
+    return m_rtcSender->GenerateKeyFrame(rtcRids).ok();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h
@@ -57,7 +57,7 @@ private:
 
     // RTCRtpTransformBackend
     void setTransformableFrameCallback(Callback&&) final;
-    void requestKeyFrame() final;
+    bool requestKeyFrame(const String&) final;
 
     bool m_isRegistered { false };
     rtc::scoped_refptr<webrtc::RtpSenderInterface> m_rtcSender;


### PR DESCRIPTION
#### a24b100fb04d585bfea2ff5b972e44fc3e63951d
<pre>
RTcRtpScriptTransformer.generateKeyFrame can take a rid parameter
<a href="https://rdar.apple.com/148592676">rdar://148592676</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291082">https://bugs.webkit.org/show_bug.cgi?id=291082</a>

Reviewed by Eric Carlson.

The spec allows passing rid as a parameter.
We implement this and pass the rid value, after validation to the libwebrtc engine.
We reject with NotAllowedError to match WPT and Firefox, not the spec.
A follow-up might change this.

We should also resolve the promise based on key frames for that particular rid.
A follow-up will fix this.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::enqueueFrame):
(WebCore::validateRid):
(WebCore::RTCRtpScriptTransformer::generateKeyFrame):
(WebCore::RTCRtpScriptTransformer::sendKeyFrameRequest):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.idl:
* Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp:
(WebCore::GStreamerRtpReceiverTransformBackend::requestKeyFrame):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp:
(WebCore::GStreamerRtpSenderTransformBackend::requestKeyFrame):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.cpp:
(WebCore::LibWebRTCRtpReceiverTransformBackend::requestKeyFrame):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverTransformBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.cpp:
(WebCore::LibWebRTCRtpSenderTransformBackend::requestKeyFrame):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderTransformBackend.h:

Canonical link: <a href="https://commits.webkit.org/293633@main">https://commits.webkit.org/293633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4000cd4466351a3047c88891b8201dad0545501b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84177 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6547 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31715 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->