### PR TITLE
REGRESSION(291510@main): Web Inspector: Safari Technology Preview 216 WebContent crash when using Develop menu item "Show JavaScript Console"

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h
@@ -102,12 +102,12 @@ private:
 
     void bringToFront();
 
-    void whenFrontendConnectionEstablished(Function<void()>&&);
+    void whenFrontendConnectionEstablished(Function<void(IPC::Connection&)>&&);
 
     WeakPtr<WebPage> m_page;
 
     RefPtr<IPC::Connection> m_frontendConnection;
-    Vector<Function<void()>> m_frontendConnectionActions;
+    Vector<Function<void(IPC::Connection&)>> m_frontendConnectionActions;
 
     bool m_attached { false };
     bool m_previousCanAttach { false };


### PR DESCRIPTION
#### 8e75a6a076708f3a12e10d8655c15d16eaa4060c
<pre>
REGRESSION(291510@main): Web Inspector: Safari Technology Preview 216 WebContent crash when using Develop menu item &quot;Show JavaScript Console&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=291039">https://bugs.webkit.org/show_bug.cgi?id=291039</a>
<a href="https://rdar.apple.com/148560331">rdar://148560331</a>

Reviewed by Per Arne Vollan and Devin Rousso.

We were doing a null dereference of the frontendConnection in the lambda in the case
where m_frontendConnection was null before `whenFrontendConnectionEstablished()` was
called. This is because we were capturing the frontendConnection pointer as soon as
`whenFrontendConnectionEstablished()` instead of using `m_frontendConnection` when
the lambda actually gets called later on.

I refactored the code to pass the frontend connection to the lambda to make this
less error-prone.

* Source/WebKit/WebProcess/Inspector/WebInspectorInternal.cpp:
(WebKit::WebInspector::setFrontendConnection):
(WebKit::WebInspector::whenFrontendConnectionEstablished):
(WebKit::WebInspector::showConsole):
(WebKit::WebInspector::showResources):
(WebKit::WebInspector::showMainResourceForFrame):
(WebKit::WebInspector::startPageProfiling):
(WebKit::WebInspector::stopPageProfiling):
(WebKit::WebInspector::startElementSelection):
(WebKit::WebInspector::stopElementSelection):
* Source/WebKit/WebProcess/Inspector/WebInspectorInternal.h:

Canonical link: <a href="https://commits.webkit.org/293268@main">https://commits.webkit.org/293268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b38c670b4d0c921b3d426507b61e19a2e00968b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74858 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32021 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101346 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13841 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13623 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25429 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83839 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83309 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21041 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19077 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15946 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25389 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->