### PR TITLE
Partial revert of 292692@main

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt
@@ -17,5 +17,5 @@ PASS Remote ICE restart should not result in a different ICE transport (DataChan
 TIMEOUT RTCIceTransport should transition to "closed" if the underlying transport is closed because the answer used bundle Test timed out
 NOTRUN RTCIceTransport should synchronously transition to "closed" with no event if the underlying transport is closed due to PC.close()
 NOTRUN RTCIceTransport does not expose remote peer-reflexive candidates.
-PASS Validate selected candidate pair
+FAIL Validate selected candidate pair assert_true: pc1 selected local candidate in pc1 candidates expected true got false
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
@@ -32,13 +32,12 @@
 #include "RTCIceCandidate.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+ALLOW_UNUSED_PARAMETERS_BEGIN
 
 #include <webrtc/api/ice_transport_interface.h>
 #include <webrtc/p2p/base/ice_transport_internal.h>
-#include <webrtc/pc/webrtc_sdp.h>
 
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+ALLOW_UNUSED_PARAMETERS_END
 
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -174,7 +173,7 @@ void LibWebRTCIceTransportBackendObserver::onNetworkRouteChanged(std::optional<r
 
 void LibWebRTCIceTransportBackendObserver::processSelectedCandidatePairChanged(const cricket::Candidate& local, const cricket::Candidate& remote)
 {
-    callOnMainThread([protectedThis = Ref { *this }, localSdp = fromStdString(webrtc::SdpSerializeCandidate(local)).isolatedCopy(), remoteSdp = fromStdString(webrtc::SdpSerializeCandidate(remote)).isolatedCopy(), localFields = convertIceCandidate(local).isolatedCopy(), remoteFields = convertIceCandidate(remote).isolatedCopy()]() mutable {
+    callOnMainThread([protectedThis = Ref { *this }, localSdp = fromStdString(local.ToString()).isolatedCopy(), remoteSdp = fromStdString(remote.ToString()).isolatedCopy(), localFields = convertIceCandidate(local).isolatedCopy(), remoteFields = convertIceCandidate(remote).isolatedCopy()]() mutable {
         if (!protectedThis->m_client)
             return;
 


### PR DESCRIPTION
#### f7b941ac0b9640b5a4e9bc14203ab699a1175d72
<pre>
Partial revert of 292692@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=291086">https://bugs.webkit.org/show_bug.cgi?id=291086</a>
<a href="https://rdar.apple.com/problem/148598179">rdar://problem/148598179</a>

Unreviewed.

This make imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html fail on iOS.
Revert the changes to the Source folder but not the WPT changes since they have been upstreamed.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
(WebCore::LibWebRTCIceTransportBackendObserver::processSelectedCandidatePairChanged):

Canonical link: <a href="https://commits.webkit.org/293302@main">https://commits.webkit.org/293302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/800d3c3f6b19f6750beb757d608ffb5d46dc6950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74959 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->