### PR TITLE
[JSC] DFG Loop Unrolling: Track and print clone source for debug assertions

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -261,7 +261,12 @@ public:
         ~SSAData();
     };
     std::unique_ptr<SSAData> ssa;
-    
+
+#if ASSERT_ENABLED
+    // Points to the original block this one was cloned from during loop unrolling.
+    BasicBlock* cloneSource { nullptr };
+#endif
+
 private:
     friend class InsertionSet;
     BlockNodeList m_nodes;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -462,8 +462,12 @@ void Graph::dumpBlockHeader(PrintStream& out, const char* prefixStr, BasicBlock*
     Prefix myPrefix(prefixStr);
     Prefix& prefix = prefixStr ? myPrefix : m_prefix;
 
-    out.print(prefix, "Block ", *block, " (", inContext(block->at(0)->origin.semantic, context), "):",
-        block->isReachable ? "" : " (skipped)", block->isOSRTarget ? " (OSR target)" : "", block->isCatchEntrypoint ? " (Catch Entrypoint)" : "", "\n");
+    out.print(prefix, "Block ", *block);
+#if ASSERT_ENABLED
+    if (block->cloneSource)
+        out.print("<-", block->cloneSource);
+#endif
+    out.print(" (", inContext(block->at(0)->origin.semantic, context), "):", block->isReachable ? "" : " (skipped)", block->isOSRTarget ? " (OSR target)" : "", block->isCatchEntrypoint ? " (Catch Entrypoint)" : "", "\n");
     if (block->executionCount == block->executionCount)
         out.print(prefix, "  Execution count: ", block->executionCount, "\n");
     out.print(prefix, "  Predecessors:");

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -461,7 +461,7 @@ public:
 
     void unrollLoop(LoopData& data)
     {
-        dataLogLnIf(Options::verboseLoopUnrolling(), " unroll ", data.shouldFullyUnroll() ?  " with constant iterations" : " partially");
+        dataLogLnIf(Options::verboseLoopUnrolling(), data.shouldFullyUnroll() ?  "Fully" : "Partially", " unrolling...");
 
         BasicBlock* const header = data.header();
         BasicBlock* const tail = data.tail;
@@ -575,6 +575,10 @@ public:
                             successor = blockClones.get(successor);
                     }
                 }
+
+#if ASSERT_ENABLED
+                clone->cloneSource = body;
+#endif
             }
 
             taken = blockClones.get(header);


### PR DESCRIPTION
#### 05c4d7bc6de03c2975f98b4c2916c829b064581d
<pre>
[JSC] DFG Loop Unrolling: Track and print clone source for debug assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=291090">https://bugs.webkit.org/show_bug.cgi?id=291090</a>
<a href="https://rdar.apple.com/148601073">rdar://148601073</a>

Reviewed by Yusuke Suzuki.

This patch enhances loop unrolling debugging by adding support for tracking
the original source block (cloneSource) for each cloned basic block in DFGBasicBlock.
The cloneSource pointer is enabled only under ASSERT_ENABLED to avoid runtime
overhead in release builds.

Additionally, Graph::dumpBlockHeader() now prints the clone source block if
available, improving traceability during debugging and validation of loop
unrolling logic.

After loop unrolling, we might see output like the following, where block 17
is a clone of block 9:

    9 24:   Block #9 (bc#52):
 0  9 24:   D@62:&lt;!0:-&gt;     LoopHint(MustGen, W:SideState, bc#52, ExitValid)
            ...

   17 24:   Block #17&lt;-#9 (bc#52):
 0 17 24:   D@256:&lt;!0:-&gt;        LoopHint(MustGen, W:SideState, bc#52, ExitValid)
            ...

* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dumpBlockHeader):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::unrollLoop):

Canonical link: <a href="https://commits.webkit.org/293265@main">https://commits.webkit.org/293265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/455945a6ee30000a18cd8b4f910890f7e5338213

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48885 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32033 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48327 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91037 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105851 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/96982 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83327 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27965 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25402 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120603 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25221 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33766 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->