### PR TITLE
[iPad] TestWebKitAPI.FocusPreservationTests.UserCanDismissInputViewRegardlessOfFocusPreservationCount is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
@@ -76,6 +76,10 @@ TEST(FocusPreservationTests, PreserveAndRestoreFocus)
 
 TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservationCount)
 {
+    // The Done button above the keyboard is only present when using the phone idiom.
+    if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomPhone)
+        return;
+
     bool inputFocused = false;
     auto [webView, delegate] = webViewForTestingFocusPreservation([&inputFocused] (id<_WKFocusedElementInfo>) {
         inputFocused = true;
@@ -89,13 +93,7 @@ TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservatio
     [webView dismissFormAccessoryView];
     [webView waitForNextPresentationUpdate];
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281518 Test is broken on iPad
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)
-        EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"document.activeElement == document.querySelector('input')"] boolValue]);
-    else
-        EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"document.activeElement == document.querySelector('input')"] boolValue]);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"document.activeElement == document.querySelector('input')"] boolValue]);
 }
 
 // FIXME: Re-enable this test once rdar://60644908 is resolved


### PR DESCRIPTION
#### ba305a4b2e70e47a0eb6180b7632c5cdd71d1327
<pre>
[iPad] TestWebKitAPI.FocusPreservationTests.UserCanDismissInputViewRegardlessOfFocusPreservationCount is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=281518">https://bugs.webkit.org/show_bug.cgi?id=281518</a>
<a href="https://rdar.apple.com/137985687">rdar://137985687</a>

Reviewed by Abrar Rahman Protyasha, Richard Robinson, and Wenson Hsieh.

The failing test was added to fix an issue where tapping &quot;Done&quot; sometimes failed
to dismiss the software keyboard after dismissing AutoFill UI (264235@main).

However, the &quot;Done&quot; button is not present on iPads, which means this test does
not make sense to run there. `accessoryDone` to blur the focused element, explicitly
skips iPad, ever since the logic was introduced in 210804@main.

Consequently, skip the test on iPad.

* Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm:
(TestWebKitAPI::TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservationCount)):

Canonical link: <a href="https://commits.webkit.org/293288@main">https://commits.webkit.org/293288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e720330a4c39b6bed6af83c61c88d2dea88a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26448 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74881 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83860 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27973 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19105 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25412 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->