### PR TITLE
[WGSL] Continue statement inside loop can incorrectly emit a break instead

### DIFF
--- a/LayoutTests/fast/webgpu/loop-break-continuing-no-switch-expected.txt
+++ b/LayoutTests/fast/webgpu/loop-break-continuing-no-switch-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: 1000
+CONSOLE MESSAGE: no validation error
+

--- a/LayoutTests/fast/webgpu/loop-break-continuing-no-switch.html
+++ b/LayoutTests/fast/webgpu/loop-break-continuing-no-switch.html
@@ -1,0 +1,51 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  globalThis.testRunner?.dumpAsText();
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read_write> buffer0: u32;
+
+@compute @workgroup_size(1)
+fn compute0() {
+  var i = 0x555u;
+  loop {
+    if i < 0x1000 { continue; }
+    break;
+    continuing { i += 1u; }
+  }
+  buffer0 = i;
+}
+`,
+    });
+    let bindGroupLayout0 = device.createBindGroupLayout({entries: [{binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}}]});
+    let storageBuffer0 = device.createBuffer({size: 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC});
+    let commandEncoder0 = device.createCommandEncoder({});
+    let computePassEncoder0 = commandEncoder0.beginComputePass();
+    let pipeline0 = device.createComputePipeline({layout: device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]}), compute: {module}});
+    computePassEncoder0.setPipeline(pipeline0);
+    let bindGroup0 = device.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 0, resource: {buffer: storageBuffer0}}]});
+    computePassEncoder0.setBindGroup(0, bindGroup0);
+    computePassEncoder0.dispatchWorkgroups(1);
+    computePassEncoder0.end();
+    let outputBuffer0 = device.createBuffer({size: storageBuffer0.size, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST});
+    commandEncoder0.copyBufferToBuffer(storageBuffer0, 0, outputBuffer0, 0, outputBuffer0.size);
+    let commandBuffer0 = commandEncoder0.finish();
+    device.queue.submit([commandBuffer0]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer0.mapAsync(GPUMapMode.READ);
+    console.log([...new Uint32Array(outputBuffer0.getMappedRange())].map(x => x.toString(0x10)).join(' '));
+    outputBuffer0.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      console.log(error.message);
+    } else {
+      console.log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -2118,10 +2118,13 @@ Behaviors TypeChecker::analyze(AST::Statement& statement)
         return Behavior::Return;
     case AST::NodeKind::ContinueStatement: {
         bool hasLoopTarget = false;
+        bool hasSwitchTarget = false;
         for (int i = m_breakTargetStack.size() - 1; i >= 0; --i) {
             auto& target = m_breakTargetStack[i];
-            if (std::holds_alternative<AST::SwitchStatement*>(target))
+            if (std::holds_alternative<AST::SwitchStatement*>(target)) {
+                hasSwitchTarget = true;
                 continue;
+            }
 
             hasLoopTarget = true;
 
@@ -2131,7 +2134,7 @@ Behaviors TypeChecker::analyze(AST::Statement& statement)
             }
 
             if (auto** loop = std::get_if<AST::LoopStatement*>(&target)) {
-                if ((*loop)->continuing().has_value()) {
+                if (hasSwitchTarget && (*loop)->continuing().has_value()) {
                     (*loop)->setContainsSwitch();
                     auto& continueStatement = downcast<AST::ContinueStatement>(statement);
                     continueStatement.setIsFromSwitchToContinuing();


### PR DESCRIPTION
#### ee80df8e018a921050cc91e9993252732bd8e6e2
<pre>
[WGSL] Continue statement inside loop can incorrectly emit a break instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=291098">https://bugs.webkit.org/show_bug.cgi?id=291098</a>
<a href="https://rdar.apple.com/148613938">rdar://148613938</a>

Reviewed by Mike Wyrzykowski.

In 280178@main, some logic was added to detect continue statements inside switch
statements that targeted a loop. However, although that fixed the CTS test, the
logic was missing a check to determine that there actually is a switch between
the continue and the loop.

* LayoutTests/fast/webgpu/loop-break-continuing-no-switch-expected.txt: Added.
* LayoutTests/fast/webgpu/loop-break-continuing-no-switch.html: Added.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::analyze):

Canonical link: <a href="https://commits.webkit.org/293359@main">https://commits.webkit.org/293359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fb1812249a9319c2d1bf9b3470753f22ee1f569

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48907 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74888 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30603 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->