### PR TITLE
Deduplicate some copied event conversion code between WebCore and WebKit2

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSEventSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSEventSPI.h
@@ -47,6 +47,11 @@ enum {
 - (nullable NSEvent *)_initWithCGEvent:(nullable CGEventRef)cgEvent eventRef:(nullable void*)eventRef;
 - (nullable void*)_eventRef NS_RETURNS_INNER_POINTER;
 - (NSEvent *)_eventRelativeToWindow:(NSWindow *)window;
+
+- (NSInteger)_scrollCount;
+- (CGFloat)_unacceleratedScrollingDeltaX;
+- (CGFloat)_unacceleratedScrollingDeltaY;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.h
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.h
@@ -45,17 +45,30 @@ public:
 // FIXME: This function doesn't really belong in this header.
 WEBCORE_EXPORT NSPoint globalPoint(const NSPoint& windowPoint, NSWindow *);
 
-// FIXME: WebKit2 has a lot of code copied and pasted from PlatformEventFactoryMac in WebEventFactory. More of it should be shared with WebCore.
+WEBCORE_EXPORT MouseButton mouseButtonForEvent(NSEvent *);
+WEBCORE_EXPORT unsigned short currentlyPressedMouseButtons();
+WEBCORE_EXPORT PlatformEvent::Type mouseEventTypeForEvent(NSEvent *);
+WEBCORE_EXPORT int clickCountForEvent(NSEvent *);
+WEBCORE_EXPORT NSPoint globalPointForEvent(NSEvent *);
+WEBCORE_EXPORT IntPoint pointForEvent(NSEvent *, NSView *windowView);
+WEBCORE_EXPORT IntPoint unadjustedMovementForEvent(NSEvent *);
+
+WEBCORE_EXPORT bool isKeyUpEvent(NSEvent *);
 WEBCORE_EXPORT int windowsKeyCodeForKeyEvent(NSEvent *);
 WEBCORE_EXPORT String keyIdentifierForKeyEvent(NSEvent *);
 WEBCORE_EXPORT String keyForKeyEvent(NSEvent *);
 WEBCORE_EXPORT String codeForKeyEvent(NSEvent *);
+WEBCORE_EXPORT UInt8 keyCharForEvent(NSEvent *);
+WEBCORE_EXPORT String textFromEvent(NSEvent *, bool replacesSoftSpace = false);
+WEBCORE_EXPORT String unmodifiedTextFromEvent(NSEvent *, bool replacesSoftSpace = false);
+WEBCORE_EXPORT bool isKeypadEvent(NSEvent *);
+
 WEBCORE_EXPORT WallTime eventTimeStampSince1970(NSTimeInterval);
-WEBCORE_EXPORT IntPoint unadjustedMovementForEvent(NSEvent *);
 
 WEBCORE_EXPORT OptionSet<PlatformEvent::Modifier> modifiersForEvent(NSEvent *);
+WEBCORE_EXPORT OptionSet<PlatformEvent::Modifier> modifiersForModifierFlags(NSEventModifierFlags);
+
 WEBCORE_EXPORT void getWheelEventDeltas(NSEvent *, float& deltaX, float& deltaY, BOOL& continuous);
-WEBCORE_EXPORT UInt8 keyCharForEvent(NSEvent *);
 
 #endif
 

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -38,6 +38,154 @@
 
 namespace WebKit {
 
+WebCore::MouseButton platform(WebMouseEventButton button)
+{
+    switch (button) {
+    case WebMouseEventButton::None:
+        return WebCore::MouseButton::None;
+    case WebMouseEventButton::Left:
+        return WebCore::MouseButton::Left;
+    case WebMouseEventButton::Middle:
+        return WebCore::MouseButton::Middle;
+    case WebMouseEventButton::Right:
+        return WebCore::MouseButton::Right;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+WebMouseEventButton kit(WebCore::MouseButton button)
+{
+    switch (button) {
+    case WebCore::MouseButton::None:
+        return WebMouseEventButton::None;
+    case WebCore::MouseButton::Left:
+        return WebMouseEventButton::Left;
+    case WebCore::MouseButton::Middle:
+        return WebMouseEventButton::Middle;
+    case WebCore::MouseButton::Right:
+        return WebMouseEventButton::Right;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+WebCore::PlatformEvent::Type platform(WebEventType type)
+{
+    switch (type) {
+    // Mouse
+    case WebEventType::MouseDown:
+        return WebCore::PlatformEvent::Type::MousePressed;
+    case WebEventType::MouseUp:
+        return WebCore::PlatformEvent::Type::MouseReleased;
+    case WebEventType::MouseMove:
+        return WebCore::PlatformEvent::Type::MouseMoved;
+    case WebEventType::MouseForceChanged:
+        return WebCore::PlatformEvent::Type::MouseForceChanged;
+    case WebEventType::MouseForceDown:
+        return WebCore::PlatformEvent::Type::MouseForceDown;
+    case WebEventType::MouseForceUp:
+        return WebCore::PlatformEvent::Type::MouseForceUp;
+
+    // Wheel
+    case WebEventType::Wheel:
+        return WebCore::PlatformEvent::Type::Wheel;
+
+    // Keyboard
+    case WebEventType::KeyDown:
+        return WebCore::PlatformEvent::Type::KeyDown;
+    case WebEventType::KeyUp:
+        return WebCore::PlatformEvent::Type::KeyUp;
+    case WebEventType::RawKeyDown:
+        return WebCore::PlatformEvent::Type::RawKeyDown;
+    case WebEventType::Char:
+        return WebCore::PlatformEvent::Type::Char;
+
+#if ENABLE(TOUCH_EVENTS)
+    // Touch
+    case WebEventType::TouchStart:
+        return WebCore::PlatformEvent::Type::TouchStart;
+    case WebEventType::TouchMove:
+        return WebCore::PlatformEvent::Type::TouchMove;
+    case WebEventType::TouchEnd:
+        return WebCore::PlatformEvent::Type::TouchEnd;
+    case WebEventType::TouchCancel:
+        return WebCore::PlatformEvent::Type::TouchCancel;
+#endif
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+    // Gesture
+    case WebEventType::GestureStart:
+        return WebCore::PlatformEvent::Type::GestureStart;
+    case WebEventType::GestureChange:
+        return WebCore::PlatformEvent::Type::GestureChange;
+    case WebEventType::GestureEnd:
+        return WebCore::PlatformEvent::Type::GestureEnd;
+#endif
+
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+WebEventType kit(WebCore::PlatformEvent::Type type)
+{
+    switch (type) {
+    // Mouse
+    case WebCore::PlatformEvent::Type::MousePressed:
+        return WebEventType::MouseDown;
+    case WebCore::PlatformEvent::Type::MouseReleased:
+        return WebEventType::MouseUp;
+    case WebCore::PlatformEvent::Type::MouseMoved:
+        return WebEventType::MouseMove;
+    case WebCore::PlatformEvent::Type::MouseForceChanged:
+        return WebEventType::MouseForceChanged;
+    case WebCore::PlatformEvent::Type::MouseForceDown:
+        return WebEventType::MouseForceDown;
+    case WebCore::PlatformEvent::Type::MouseForceUp:
+        return WebEventType::MouseForceUp;
+
+    // Wheel
+    case WebCore::PlatformEvent::Type::Wheel:
+        return WebEventType::Wheel;
+
+    // Keyboard
+    case WebCore::PlatformEvent::Type::KeyDown:
+        return WebEventType::KeyDown;
+    case WebCore::PlatformEvent::Type::KeyUp:
+        return WebEventType::KeyUp;
+    case WebCore::PlatformEvent::Type::RawKeyDown:
+        return WebEventType::RawKeyDown;
+    case WebCore::PlatformEvent::Type::Char:
+        return WebEventType::Char;
+
+#if ENABLE(TOUCH_EVENTS)
+    // Touch
+    case WebCore::PlatformEvent::Type::TouchStart:
+        return WebEventType::TouchStart;
+    case WebCore::PlatformEvent::Type::TouchMove:
+        return WebEventType::TouchMove;
+    case WebCore::PlatformEvent::Type::TouchEnd:
+        return WebEventType::TouchEnd;
+    case WebCore::PlatformEvent::Type::TouchCancel:
+        return WebEventType::TouchCancel;
+#endif
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+    // Gesture
+    case WebCore::PlatformEvent::Type::GestureStart:
+        return WebEventType::GestureStart;
+    case WebCore::PlatformEvent::Type::GestureChange:
+        return WebEventType::GestureChange;
+    case WebCore::PlatformEvent::Type::GestureEnd:
+        return WebEventType::GestureEnd;
+#endif
+
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
 OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier> modifiers)
 {
     OptionSet<WebCore::PlatformEvent::Modifier> result;
@@ -54,63 +202,53 @@ OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>
     return result;
 }
 
+OptionSet<WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier> modifiers)
+{
+    OptionSet<WebEventModifier> result;
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::ShiftKey))
+        result.add(WebEventModifier::ShiftKey);
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::ControlKey))
+        result.add(WebEventModifier::ControlKey);
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::AltKey))
+        result.add(WebEventModifier::AltKey);
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::MetaKey))
+        result.add(WebEventModifier::MetaKey);
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::CapsLockKey))
+        result.add(WebEventModifier::CapsLockKey);
+    return result;
+}
+
+static double forceForEvent(const WebMouseEvent& webEvent)
+{
+    switch (webEvent.type()) {
+    case WebEventType::MouseDown:
+        return WebCore::ForceAtClick;
+    case WebEventType::MouseForceDown:
+        return WebCore::ForceAtForceClick;
+    case WebEventType::MouseMove:
+    case WebEventType::MouseForceChanged:
+        return webEvent.force();
+    case WebEventType::MouseUp:
+    case WebEventType::MouseForceUp:
+        return 0;
+    default:
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+}
+
 class WebKit2PlatformMouseEvent : public WebCore::PlatformMouseEvent {
 public:
     WebKit2PlatformMouseEvent(const WebMouseEvent& webEvent)
     {
         // PlatformEvent
-        switch (webEvent.type()) {
-        case WebEventType::MouseDown:
-            m_type = WebCore::PlatformEvent::Type::MousePressed;
-            m_force = WebCore::ForceAtClick;
-            break;
-        case WebEventType::MouseUp:
-            m_type = WebCore::PlatformEvent::Type::MouseReleased;
-            m_force = 0;
-            break;
-        case WebEventType::MouseMove:
-            m_type = WebCore::PlatformEvent::Type::MouseMoved;
-            m_force = webEvent.force();
-            break;
-        case WebEventType::MouseForceChanged:
-            m_type = WebCore::PlatformEvent::Type::MouseForceChanged;
-            m_force = webEvent.force();
-            break;
-        case WebEventType::MouseForceDown:
-            m_type = WebCore::PlatformEvent::Type::MouseForceDown;
-            m_force = WebCore::ForceAtForceClick;
-            break;
-        case WebEventType::MouseForceUp:
-            m_type = WebCore::PlatformEvent::Type::MouseForceUp;
-            m_force = 0;
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-        }
-
+        m_type = platform(webEvent.type());
         m_modifiers = platform(webEvent.modifiers());
-
         m_timestamp = webEvent.timestamp();
         m_authorizationToken = webEvent.authorizationToken();
 
         // PlatformMouseEvent
-        switch (webEvent.button()) {
-        case WebMouseEventButton::None:
-            m_button = WebCore::MouseButton::None;
-            break;
-        case WebMouseEventButton::Left:
-            m_button = WebCore::MouseButton::Left;
-            break;
-        case WebMouseEventButton::Middle:
-            m_button = WebCore::MouseButton::Middle;
-            break;
-        case WebMouseEventButton::Right:
-            m_button = WebCore::MouseButton::Right;
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-
+        m_button = platform(webEvent.button());
         m_buttons = webEvent.buttons();
 
         m_position = webEvent.position();
@@ -118,12 +256,14 @@ public:
         m_unadjustedMovementDelta = webEvent.unadjustedMovementDelta();
         m_globalPosition = webEvent.globalPosition();
         m_clickCount = webEvent.clickCount();
+        m_force = forceForEvent(webEvent);
         m_coalescedEvents = WTF::map(webEvent.coalescedEvents(), [&](const auto& event) {
             return platform(event);
         });
         m_predictedEvents = WTF::map(webEvent.predictedEvents(), [&](const auto& event) {
             return platform(event);
         });
+
 #if PLATFORM(MAC)
         m_eventNumber = webEvent.eventNumber();
         m_menuTypeForEvent = webEvent.menuTypeForEvent();
@@ -157,10 +297,8 @@ public:
     WebKit2PlatformWheelEvent(const WebWheelEvent& webEvent)
     {
         // PlatformEvent
-        m_type = PlatformEvent::Type::Wheel;
-
+        m_type = platform(webEvent.type());
         m_modifiers = platform(webEvent.modifiers());
-
         m_timestamp = webEvent.timestamp();
 
         // PlatformWheelEvent
@@ -199,25 +337,8 @@ public:
     WebKit2PlatformKeyboardEvent(const WebKeyboardEvent& webEvent)
     {
         // PlatformEvent
-        switch (webEvent.type()) {
-        case WebEventType::KeyDown:
-            m_type = WebCore::PlatformEvent::Type::KeyDown;
-            break;
-        case WebEventType::KeyUp:
-            m_type = WebCore::PlatformEvent::Type::KeyUp;
-            break;
-        case WebEventType::RawKeyDown:
-            m_type = WebCore::PlatformEvent::Type::RawKeyDown;
-            break;
-        case WebEventType::Char:
-            m_type = WebCore::PlatformEvent::Type::Char;
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-        }
-
+        m_type = platform(webEvent.type());
         m_modifiers = platform(webEvent.modifiers());
-
         m_timestamp = webEvent.timestamp();
 
         // PlatformKeyboardEvent
@@ -337,25 +458,8 @@ public:
     WebKit2PlatformTouchEvent(const WebTouchEvent& webEvent)
     {
         // PlatformEvent
-        switch (webEvent.type()) {
-        case WebEventType::TouchStart:
-            m_type = WebCore::PlatformEvent::Type::TouchStart;
-            break;
-        case WebEventType::TouchMove:
-            m_type = WebCore::PlatformEvent::Type::TouchMove;
-            break;
-        case WebEventType::TouchEnd:
-            m_type = WebCore::PlatformEvent::Type::TouchEnd;
-            break;
-        case WebEventType::TouchCancel:
-            m_type = WebCore::PlatformEvent::Type::TouchCancel;
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-        }
-
+        m_type = platform(webEvent.type());
         m_modifiers = platform(webEvent.modifiers());
-
         m_timestamp = webEvent.timestamp();
 
 #if PLATFORM(IOS_FAMILY)
@@ -398,22 +502,8 @@ class WebKit2PlatformGestureEvent : public WebCore::PlatformGestureEvent {
 public:
     WebKit2PlatformGestureEvent(const WebGestureEvent& webEvent)
     {
-        switch (webEvent.type()) {
-        case WebEventType::GestureStart:
-            m_type = WebCore::PlatformEvent::Type::GestureStart;
-            break;
-        case WebEventType::GestureChange:
-            m_type = WebCore::PlatformEvent::Type::GestureChange;
-            break;
-        case WebEventType::GestureEnd:
-            m_type = WebCore::PlatformEvent::Type::GestureEnd;
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-        }
-
+        m_type = platform(webEvent.type());
         m_modifiers = platform(webEvent.modifiers());
-
         m_timestamp = webEvent.timestamp();
 
         m_gestureScale = webEvent.gestureScale();

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebEventConversion_h
-#define WebEventConversion_h
+#pragma once
 
 #include "WebEventModifier.h"
 #include <WebCore/PlatformKeyboardEvent.h>
@@ -57,8 +56,6 @@ class WebTouchPoint;
 class WebGestureEvent;
 #endif
 
-OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>);
-
 WebCore::PlatformMouseEvent platform(const WebMouseEvent&);
 WebCore::PlatformWheelEvent platform(const WebWheelEvent&);
 WebCore::PlatformKeyboardEvent platform(const WebKeyboardEvent&);
@@ -74,6 +71,13 @@ WebCore::PlatformTouchPoint platform(const WebTouchPoint&);
 WebCore::PlatformGestureEvent platform(const WebGestureEvent&);
 #endif
 
-} // namespace WebKit
+WebCore::MouseButton platform(WebMouseEventButton);
+WebMouseEventButton kit(WebCore::MouseButton);
 
-#endif // WebEventConversion_h
+WebCore::PlatformEvent::Type platform(WebEventType);
+WebEventType kit(WebCore::PlatformEvent::Type);
+
+OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>);
+OptionSet<WebKit::WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier>);
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebMouseEvent.h"
 
+#include "WebEventConversion.h"
 #include <WebCore/MouseEventTypes.h>
 #include <WebCore/NavigationAction.h>
 
@@ -76,27 +77,8 @@ bool WebMouseEvent::isMouseEventType(WebEventType type)
 WebMouseEventButton mouseButton(const WebCore::NavigationAction& navigationAction)
 {
     auto& mouseEventData = navigationAction.mouseEventData();
-    if (mouseEventData && mouseEventData->buttonDown && mouseEventData->isTrusted) {
-        switch (mouseEventData->button) {
-        case MouseButton::None:
-            return WebMouseEventButton::None;
-
-        case MouseButton::Left:
-            return WebMouseEventButton::Left;
-
-        case MouseButton::Middle:
-            return WebMouseEventButton::Middle;
-
-        case MouseButton::Right:
-            return WebMouseEventButton::Right;
-
-        case MouseButton::Other:
-        case MouseButton::PointerHasNotChanged: {
-            ASSERT_NOT_REACHED();
-            return WebMouseEventButton::Left;
-        }
-        }
-    }
+    if (mouseEventData && mouseEventData->buttonDown && mouseEventData->isTrusted)
+        return kit(mouseEventData->button);
     return WebMouseEventButton::None;
 }
 

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -53,7 +53,6 @@ public:
     static bool shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent&);
 
 #if defined(__OBJC__)
-    static OptionSet<WebKit::WebEventModifier> webEventModifiersForNSEventModifierFlags(NSEventModifierFlags);
     static NSEventModifierFlags toNSEventModifierFlags(OptionSet<WebKit::WebEventModifier>);
     static NSInteger toNSButtonNumber(WebKit::WebMouseEventButton);
 #endif

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -30,6 +30,7 @@
 
 #import "Logging.h"
 #import "WebAutomationSessionMacros.h"
+#import "WebEventConversion.h"
 #import "WebEventFactory.h"
 #import "WebInspectorUIProxy.h"
 #import "WebPageProxy.h"
@@ -39,6 +40,7 @@
 #import <Foundation/Foundation.h>
 #import <WebCore/IntPoint.h>
 #import <WebCore/IntSize.h>
+#import <WebCore/PlatformEventFactoryMac.h>
 #import <WebCore/PlatformMouseEvent.h>
 #import <objc/runtime.h>
 #import <pal/spi/mac/NSEventSPI.h>
@@ -188,18 +190,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
     auto locationInWindow = viewportLocationToWindowLocation(locationInViewport, page);
 
-    NSEventModifierFlags modifiers = 0;
-    if (keyModifiers.contains(WebEventModifier::MetaKey))
-        modifiers |= NSEventModifierFlagCommand;
-    if (keyModifiers.contains(WebEventModifier::AltKey))
-        modifiers |= NSEventModifierFlagOption;
-    if (keyModifiers.contains(WebEventModifier::ControlKey))
-        modifiers |= NSEventModifierFlagControl;
-    if (keyModifiers.contains(WebEventModifier::ShiftKey))
-        modifiers |= NSEventModifierFlagShift;
-    if (keyModifiers.contains(WebEventModifier::CapsLockKey))
-        modifiers |= NSEventModifierFlagCapsLock;
-
+    NSEventModifierFlags modifiers = WebEventFactory::toNSEventModifierFlags(keyModifiers);
     NSTimeInterval timestamp = [NSDate timeIntervalSinceReferenceDate];
     NSWindow *window = page.platformWindow();
     NSInteger windowNumber = window.windowNumber;
@@ -285,7 +276,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
 OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers)
 {
-    return WebEventFactory::webEventModifiersForNSEventModifierFlags(modifiers);
+    return kit(WebCore::modifiersForModifierFlags(modifiers));
 }
 
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)


### PR DESCRIPTION
#### e3ece76059110c8d76f28c9e8c143bf20a3051e3
<pre>
Deduplicate some copied event conversion code between WebCore and WebKit2
<a href="https://bugs.webkit.org/show_bug.cgi?id=291097">https://bugs.webkit.org/show_bug.cgi?id=291097</a>
<a href="https://rdar.apple.com/148613835">rdar://148613835</a>

Reviewed by Abrar Rahman Protyasha.

A long time ago, a bunch of event conversion code (especially code to read
properties off of NSEvent) was copied from WebCore to WebKit.

De-duplicate that copy-pasting, propagating changes that were made in only
one place since the divergence.

Add some helpers for converting between WebCore and WebKit enums to make
this sharing easier (mostly factored out of existing places).

Adopt the new helpers in a few other random places that had duplicative code.

* Source/WebCore/PAL/pal/spi/mac/NSEventSPI.h:
* Source/WebCore/platform/mac/PlatformEventFactoryMac.h:
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::globalPointForEvent):
(WebCore::pointForEvent):
(WebCore::currentMouseButton):
(WebCore::mouseButtonForEvent):
(WebCore::currentlyPressedMouseButtons):
(WebCore::mouseEventTypeForEvent):
(WebCore::clickCountForEvent):
(WebCore::textFromEvent):
(WebCore::unmodifiedTextFromEvent):
(WebCore::isKeypadEvent):
(WebCore::isKeyUpEvent):
(WebCore::modifiersForEvent):
(WebCore::modifiersForModifierFlags):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::platform):
(WebKit::kit):
(WebKit::forceForEvent):
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
(WebKit::WebKit2PlatformKeyboardEvent::WebKit2PlatformKeyboardEvent):
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
(WebKit::WebKit2PlatformGestureEvent::WebKit2PlatformGestureEvent):
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/Shared/WebMouseEvent.cpp:
(WebKit::mouseButton):
* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::createWebMouseEvent):
(WebKit::WebEventFactory::createWebWheelEvent):
(WebKit::WebEventFactory::createWebKeyboardEvent):
(WebKit::currentMouseButton): Deleted.
(WebKit::mouseButtonForEvent): Deleted.
(WebKit::currentlyPressedMouseButtons): Deleted.
(WebKit::mouseEventTypeForEvent): Deleted.
(WebKit::clickCountForEvent): Deleted.
(WebKit::globalPointForEvent): Deleted.
(WebKit::pointForEvent): Deleted.
(WebKit::textFromEvent): Deleted.
(WebKit::unmodifiedTextFromEvent): Deleted.
(WebKit::isKeypadEvent): Deleted.
(WebKit::isKeyUpEvent): Deleted.
(WebKit::WebEventFactory::webEventModifiersForNSEventModifierFlags): Deleted.
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
(WebKit::WebAutomationSession::platformWebModifiersFromRaw):

Canonical link: <a href="https://commits.webkit.org/293379@main">https://commits.webkit.org/293379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b5376458b69a42e2ef6908d1aa098e9aa772cba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74890 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83346 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19122 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30606 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->