### PR TITLE
Avoid autoreleasing NSStrings in WebKit/ when not strictly necessary

### DIFF
--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -66,7 +66,7 @@ bool GPUConnectionToWebProcess::setCaptureAttributionString()
     if ([PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)])
         [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionWebsiteString:visibleName.get() auditToken:auditToken.value()];
     else {
-        RetainPtr<NSString> formatString = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ in %%@", "The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only)."), visibleName.get()];
+        RetainPtr formatString = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ in %%@", "The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only)."), visibleName.get()]);
         [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionStringWithFormat:formatString.get() auditToken:auditToken.value()];
     }
 #endif

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -66,7 +66,7 @@ void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParam
 void GPUProcess::updateProcessName()
 {
 #if !PLATFORM(MACCATALYST)
-    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), m_uiProcessName.createNSString().get()];
+    RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), m_uiProcessName.createNSString().get()]);
     auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
     ASSERT_UNUSED(result, result == noErr);
 #endif

--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -58,7 +58,7 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if !PLATFORM(MACCATALYST)
-    RetainPtr applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), parameters.uiProcessName.createNSString().get()];
+    RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), parameters.uiProcessName.createNSString().get()]);
     _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
 #endif
 }

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -34,7 +34,6 @@ UIProcess/API/Cocoa/_WKDownload.mm
 UIProcess/API/Cocoa/_WKInspector.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
 UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.mm
-UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
 UIProcess/API/Cocoa/_WKTextManipulationItem.mm
 UIProcess/API/Cocoa/_WKTextManipulationToken.mm

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -227,7 +227,7 @@ bool hasProhibitedUsageStrings()
 
     for (NSString *prohibitedString : prohibitedStrings) {
         if ([infoDictionary objectForKey:prohibitedString]) {
-            String message = [NSString stringWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", [[NSBundle mainBundle] bundleIdentifier], prohibitedString];
+            String message = adoptNS([[NSString alloc] initWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", [[NSBundle mainBundle] bundleIdentifier], prohibitedString]).get();
             WTFLogAlways(message.utf8().data());
             hasProhibitedUsageStrings = true;
             break;

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -118,13 +118,13 @@ static NSString *constructExpectedMessage(NSString *key, NSString *expected, NSS
     ASSERT(found);
 
     if (inArray && key.length)
-        return [NSString stringWithFormat:@"'%@' is expected to be %@, but %@ was provided in the array", key, expected, found];
+        return [[NSString alloc] initWithFormat:@"'%@' is expected to be %@, but %@ was provided in the array", key, expected, found];
     if (inArray && !key.length)
-        return [NSString stringWithFormat:@"%@ is expected, but %@ was provided in the array", expected, found];
+        return [[NSString alloc] initWithFormat:@"%@ is expected, but %@ was provided in the array", expected, found];
 
     if (key.length)
-        return [NSString stringWithFormat:@"'%@' is expected to be %@, but %@ was provided", key, expected, found];
-    return [NSString stringWithFormat:@"%@ is expected, but %@ was provided", expected, found];
+        return [[NSString alloc] initWithFormat:@"'%@' is expected to be %@, but %@ was provided", key, expected, found];
+    return [[NSString alloc] initWithFormat:@"%@ is expected, but %@ was provided", expected, found];
 }
 
 static bool validateSingleObject(NSString *key, NSObject *value, Class expectedValueType, NSString **outExceptionString)
@@ -168,14 +168,14 @@ static bool validateArray(NSString *key, NSObject *value, NSArray<Class> *validC
     NSArray *arrayValue = dynamic_objc_cast<NSArray>(value);
     if (!arrayValue) {
         if (outExceptionString)
-            *outExceptionString = constructExpectedMessage(key, [NSString stringWithFormat:@"an array of %@", classToClassString(expectedElementType, true)], valueToTypeString(value));
+            *outExceptionString = constructExpectedMessage(key, [[NSString alloc] initWithFormat:@"an array of %@", classToClassString(expectedElementType, true)], valueToTypeString(value));
         return false;
     }
 
     for (NSObject *element in arrayValue) {
         if (!validateSingleObject(nil, element, expectedElementType, nullptr)) {
             if (outExceptionString)
-                *outExceptionString = constructExpectedMessage(key, [NSString stringWithFormat:@"an array of %@", classToClassString(expectedElementType, true)], valueToTypeString(element), true);
+                *outExceptionString = constructExpectedMessage(key, [[NSString alloc] initWithFormat:@"an array of %@", classToClassString(expectedElementType, true)], valueToTypeString(element), true);
             return false;
         }
     }
@@ -250,14 +250,14 @@ static NSString *formatList(NSArray<NSString *> *list)
         return @"";
 
     if (count == 1)
-        return [NSString stringWithFormat:@"'%@'", list.firstObject];
+        return [[NSString alloc] initWithFormat:@"'%@'", list.firstObject];
 
     if (count == 2)
-        return [NSString stringWithFormat:@"'%@' and '%@'", list.firstObject, list.lastObject];
+        return [[NSString alloc] initWithFormat:@"'%@' and '%@'", list.firstObject, list.lastObject];
 
     auto *allButLast = [list subarrayWithRange:NSMakeRange(0, count - 1)];
     auto *formattedInitialItems = [allButLast componentsJoinedByString:@"', '"];
-    return [NSString stringWithFormat:@"'%@', and '%@'", formattedInitialItems, list.lastObject];
+    return [[NSString alloc] initWithFormat:@"'%@', and '%@'", formattedInitialItems, list.lastObject];
 }
 
 bool validateDictionary(NSDictionary<NSString *, id> *dictionary, NSString *sourceKey, NSArray<NSString *> *requiredKeys, NSDictionary<NSString *, id> *keyTypes, NSString **outExceptionString)
@@ -294,7 +294,7 @@ bool validateDictionary(NSDictionary<NSString *, id> *dictionary, NSString *sour
     // Prioritize type errors over missing required key errors, since the dictionary *might* actually have
     // all the required keys, but we stopped checking. We do know for sure that the type is wrong though.
     if (remainingRequiredKeys.count && !errorString)
-        errorString = [NSString stringWithFormat:@"it is missing required keys: %@", formatList(remainingRequiredKeys.allObjects)];
+        errorString = [[NSString alloc] initWithFormat:@"it is missing required keys: %@", formatList(remainingRequiredKeys.allObjects)];
 
     if (errorString && outExceptionString)
         *outExceptionString = toErrorString(nullString(), sourceKey, errorString);

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -53,7 +53,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
 
     for (NSString *key in keys) {
         NSString *keyWithSingleQuotesEscaped = [key stringByReplacingOccurrencesOfString:@"'" withString:@"''"];
-        [escapedAndQuotedKeys addObject:[NSString stringWithFormat:@"'%@'", keyWithSingleQuotesEscaped]];
+        [escapedAndQuotedKeys addObject:[[NSString alloc] initWithFormat:@"'%@'", keyWithSingleQuotesEscaped]];
     }
 
     return [escapedAndQuotedKeys componentsJoinedByString:@","];
@@ -117,7 +117,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
         ASSERT(!errorMessage.length);
         ASSERT(strongSelf->_database);
 
-        auto result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"DELETE FROM registered_scripts WHERE key in (%@)", rowFilterStringFromRowKeys(ids)]);
+        auto result = SQLiteDatabaseExecute(strongSelf->_database, [[NSString alloc] initWithFormat:@"DELETE FROM registered_scripts WHERE key in (%@)", rowFilterStringFromRowKeys(ids)]);
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to delete scripts for extension %{private}@.", strongSelf->_uniqueIdentifier);
             errorMessage = @"Failed to delete scripts from registered content scripts storage.";

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -59,7 +59,7 @@ using namespace WebKit;
     _directory = [NSURL fileURLWithPath:directory];
     _useInMemoryDatabase = useInMemoryDatabase;
 
-    NSString *extensionDatabaseQueueName = [NSString stringWithFormat:@"com.apple.WebKit.WKWebExtensionSQLiteStore.%@", _uniqueIdentifier];
+    NSString *extensionDatabaseQueueName = [[NSString alloc] initWithFormat:@"com.apple.WebKit.WKWebExtensionSQLiteStore.%@", _uniqueIdentifier];
     _databaseQueue = dispatch_queue_create([extensionDatabaseQueueName cStringUsingEncoding:NSUTF8StringEncoding], DISPATCH_QUEUE_SERIAL);
 
     return self;
@@ -330,7 +330,7 @@ using namespace WebKit;
     dispatch_assert_queue(_databaseQueue);
     ASSERT(_database);
 
-    DatabaseResult result = SQLiteDatabaseExecute(_database, [NSString stringWithFormat:@"PRAGMA user_version = %d", newVersion]);
+    DatabaseResult result = SQLiteDatabaseExecute(_database, [[NSString alloc] initWithFormat:@"PRAGMA user_version = %d", newVersion]);
     if (result != SQLITE_DONE)
         RELEASE_LOG_ERROR(Extensions, "Failed to set database version for extension %{private}@: %{public}@ (%d)", _uniqueIdentifier, _database.lastErrorMessage, result);
 
@@ -366,7 +366,7 @@ using namespace WebKit;
         ASSERT(!errorMessage.length);
         ASSERT(strongSelf->_database);
 
-        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
+        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [[NSString alloc] initWithFormat:@"SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to create storage savepoint for extension %{private}@. %{public}@ (%d)", strongSelf->_uniqueIdentifier, strongSelf->_database.lastErrorMessage, result);
             errorMessage = @"Failed to create savepoint.";
@@ -398,7 +398,7 @@ using namespace WebKit;
         ASSERT(!errorMessage.length);
         ASSERT(strongSelf->_database);
 
-        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"RELEASE SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
+        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [[NSString alloc] initWithFormat:@"RELEASE SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to release storage savepoint for extension %{private}@. %{public}@ (%d)", strongSelf->_uniqueIdentifier, strongSelf->_database.lastErrorMessage, result);
             errorMessage = @"Failed to release savepoint.";
@@ -430,7 +430,7 @@ using namespace WebKit;
         ASSERT(!errorMessage.length);
         ASSERT(strongSelf->_database);
 
-        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"ROLLBACK TO SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
+        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [[NSString alloc] initWithFormat:@"ROLLBACK TO SAVEPOINT %@", [strongSelf _savepointNameFromUUID:savepointIdentifier]]);
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to rollback to storage savepoint for extension %{private}@. %{public}@ (%d)", strongSelf->_uniqueIdentifier, strongSelf->_database.lastErrorMessage, result);
             errorMessage = @"Failed to rollback to savepoint.";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
@@ -78,7 +78,7 @@
     if (!error)
         return nil;
 
-    auto userInfo = @{ NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list parsing failed: %s", error.message().c_str()] };
+    auto userInfo = @{ NSHelpAnchorErrorKey: adoptNS([[NSString alloc] initWithFormat:@"Rule list parsing failed: %s", error.message().c_str()]).get() };
     return [NSError errorWithDomain:WKErrorDomain code:WKErrorContentRuleListStoreCompileFailed userInfo:userInfo];
 #else
     return nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -96,7 +96,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #if ENABLE(CONTENT_EXTENSIONS)
     self._protectedContentListStore->compileContentRuleList(identifier, encodedContentRuleList, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         if (error) {
-            auto userInfo = @{ NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list compilation failed: %s", error.message().c_str()] };
+            auto userInfo = @{ NSHelpAnchorErrorKey: adoptNS([[NSString alloc] initWithFormat:@"Rule list compilation failed: %s", error.message().c_str()]).get() };
 
             // error.value() could have a specific compiler error that is not equal to WKErrorContentRuleListStoreCompileFailed.
             // We want to use error.message, but here we want to only pass on CompileFailed with userInfo from the std::error_code.
@@ -112,7 +112,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #if ENABLE(CONTENT_EXTENSIONS)
     self._protectedContentListStore->lookupContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         if (error) {
-            auto userInfo = @{NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list lookup failed: %s", error.message().c_str()]};
+            auto userInfo = @{ NSHelpAnchorErrorKey: adoptNS([[NSString alloc] initWithFormat:@"Rule list lookup failed: %s", error.message().c_str()]).get() };
             auto wkError = toWKErrorCode(error);
             ASSERT(wkError == WKErrorContentRuleListStoreLookUpFailed || wkError == WKErrorContentRuleListStoreVersionMismatch);
             return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:wkError userInfo:userInfo]);
@@ -137,7 +137,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #if ENABLE(CONTENT_EXTENSIONS)
     self._protectedContentListStore->removeContentRuleList(identifier, [completionHandler = makeBlockPtr(completionHandler)](std::error_code error) {
         if (error) {
-            auto userInfo = @{NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list removal failed: %s", error.message().c_str()]};
+            auto userInfo = @{ NSHelpAnchorErrorKey: adoptNS([[NSString alloc] initWithFormat:@"Rule list removal failed: %s", error.message().c_str()]).get() };
             ASSERT(toWKErrorCode(error) == WKErrorContentRuleListStoreRemoveFailed);
             return completionHandler([NSError errorWithDomain:WKErrorDomain code:WKErrorContentRuleListStoreRemoveFailed userInfo:userInfo]);
         }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3081,7 +3081,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 #if PLATFORM(MAC)
             [extensionView setWantsLayer:YES];
 #endif
-            [extensionView layer].name = [NSString stringWithFormat:@"Fixed color extension fill (%s)", [side] {
+            [extensionView layer].name = adoptNS([[NSString alloc] initWithFormat:@"Fixed color extension fill (%s)", [side] {
                 switch (side) {
                 case WebCore::BoxSide::Top:
                     return "Top";
@@ -3095,7 +3095,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
                     ASSERT_NOT_REACHED();
                     return "";
                 }
-            }()];
+            }()]).get();
             [parentView addSubview:extensionView.get()];
             _fixedColorExtensionViews.setAt(side, extensionView);
         }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -195,7 +195,7 @@ private:
 - (void)printErrorToConsole:(NSString *)error
 {
     // FIXME: This should use a new message source rdar://problem/34658378
-    [self.webView evaluateJavaScript:[NSString stringWithFormat:@"console.error(\"%@\");", error] completionHandler:nil];
+    [self.webView evaluateJavaScript:adoptNS([[NSString alloc] initWithFormat:@"console.error(\"%@\");", error]).get() completionHandler:nil];
 }
 
 // MARK: _WKInspectorPrivate methods

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -335,7 +335,7 @@
 
 - (NSString *)description
 {
-    NSString *description = [NSString stringWithFormat:@"<%@: %p", NSStringFromClass(self.class), self];
+    RetainPtr description = adoptNS([[NSString alloc] initWithFormat:@"<%@: %p", NSStringFromClass(self.class), self]);
 
     if (!_processPoolConfiguration->injectedBundlePath().isEmpty())
         return [description stringByAppendingFormat:@"; injectedBundleURL: \"%@\">", [self injectedBundleURL]];

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
@@ -118,9 +118,8 @@ NSString * const _WKTextManipulationItemErrorItemKey = @"item";
         NSString *description = preservePrivacy ? token.description : token.debugDescription;
         [recursiveDescriptions addObject:description];
     }];
-    NSString *tokenDescription = [NSString stringWithFormat:@"[\n\t%@\n]", [recursiveDescriptions componentsJoinedByString:@",\n\t"]];
-    NSString *description = [NSString stringWithFormat:@"<%@: %p; identifier = %@ tokens = %@>", self.class, self, self.identifier, tokenDescription];
-    return description;
+    RetainPtr tokenDescription = adoptNS([[NSString alloc] initWithFormat:@"[\n\t%@\n]", [recursiveDescriptions componentsJoinedByString:@",\n\t"]]);
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@ tokens = %@>", self.class, self, self.identifier, tokenDescription.get()];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -630,7 +630,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
 
     NSDictionary *options = @{
         // Key type values are string values of numbers, stored as kCFNumberSInt64Type in attributes, but must be passed as string here
-        (id)kSecAttrKeyType: (id)[NSString stringWithFormat:@"%i", (int)keyType],
+        (id)kSecAttrKeyType: (id)adoptNS([[NSString alloc] initWithFormat:@"%i", (int)keyType]).get(),
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @(keySize),
     };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm
@@ -52,12 +52,12 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
     if (pushPartition.length != 32)
         return nil;
 
-    RetainPtr uuidString = [NSString stringWithFormat:@"%@-%@-%@-%@-%@",
+    RetainPtr uuidString = adoptNS([[NSString alloc] initWithFormat:@"%@-%@-%@-%@-%@",
         [pushPartition substringWithRange:NSMakeRange(0, 8)],
         [pushPartition substringWithRange:NSMakeRange(8, 4)],
         [pushPartition substringWithRange:NSMakeRange(12, 4)],
         [pushPartition substringWithRange:NSMakeRange(16, 4)],
-        [pushPartition substringWithRange:NSMakeRange(20, 12)]];
+        [pushPartition substringWithRange:NSMakeRange(20, 12)]]);
     return adoptNS([[NSUUID alloc] initWithUUIDString:uuidString.get()]);
 }
 
@@ -145,14 +145,14 @@ static RetainPtr<NSUUID> uuidFromPushPartition(NSString *pushPartition)
 - (UIBackgroundTaskIdentifier)beginBackgroundTaskForHandling
 {
 #if PLATFORM(IOS)
-    NSString *taskName;
+    RetainPtr<NSString> taskName;
     if (_webClipIdentifier)
-        taskName = [NSString stringWithFormat:@"%@ for %@", self._nameForBackgroundTaskAndLogging, _webClipIdentifier];
+        taskName = adoptNS([[NSString alloc] initWithFormat:@"%@ for %@", self._nameForBackgroundTaskAndLogging, _webClipIdentifier]);
     else
-        taskName = [NSString stringWithFormat:@"%@", self._nameForBackgroundTaskAndLogging];
+        taskName = adoptNS([[NSString alloc] initWithFormat:@"%@", self._nameForBackgroundTaskAndLogging]);
 
-    return [UIApplication.sharedApplication beginBackgroundTaskWithName:taskName expirationHandler:^{
-        RELEASE_LOG_ERROR(Push, "Took too long to handle Web Push action: '%@'", taskName);
+    return [UIApplication.sharedApplication beginBackgroundTaskWithName:taskName.get() expirationHandler:^{
+        RELEASE_LOG_ERROR(Push, "Took too long to handle Web Push action: '%@'", taskName.get());
     }];
 #else
     return 0;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3743,7 +3743,7 @@ static bool isLockdownModeWarningNeeded()
             if (!appDisplayName)
                 appDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
 
-            auto alert = WebKit::createUIAlertController([NSString stringWithFormat:WEB_UI_NSSTRING(@"Lockdown Mode is Turned On For “%@“", "Lockdown Mode alert title"), appDisplayName], message.get());
+            auto alert = WebKit::createUIAlertController(adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Lockdown Mode is Turned On For “%@“", "Lockdown Mode alert title"), appDisplayName]).get(), message.get());
 
             [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
 

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -149,7 +149,7 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
         RetainPtr reportAnError = WEB_UI_NSSTRING(@"report an error", "Action from safe browsing warning");
         RetainPtr visitUnsafeWebsite = WEB_UI_NSSTRING(@"visit this unsafe website", "Action from safe browsing warning");
 
-        RetainPtr attributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@ %@\n\n%@", phishingDescription.get(), learnMore.get(), phishingActions.get()]]);
+        RetainPtr attributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:adoptNS([[NSString alloc] initWithFormat:@"%@ %@\n\n%@", phishingDescription.get(), learnMore.get(), phishingActions.get()]).get()]);
         addLinkAndReplace(attributedString.get(), learnMore.get(), learnMore.get(), learnMoreURL(result));
         replace(attributedString.get(), @"%provider-display-name%", localizedProviderDisplayName(result));
         replace(attributedString.get(), @"%provider%", localizedProviderShortName(result));

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -132,7 +132,7 @@ RetainPtr<NSString> applicationVisibleName()
     return appBundle.get().infoDictionary[bridge_cast(kCFBundleNameKey)];
 }
 
-static NSString *alertMessageText(MediaPermissionReason reason, const WebCore::SecurityOriginData& origin)
+static RetainPtr<NSString> alertMessageText(MediaPermissionReason reason, const WebCore::SecurityOriginData& origin)
 {
     RetainPtr visibleOrigin = applicationVisibleNameFromOrigin(origin);
     if (!visibleOrigin)
@@ -140,19 +140,19 @@ static NSString *alertMessageText(MediaPermissionReason reason, const WebCore::S
 
     switch (reason) {
     case MediaPermissionReason::Camera:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera?", @"Message for user camera access prompt"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera?", @"Message for user camera access prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::CameraAndMicrophone:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera and microphone?", @"Message for user media prompt"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your camera and microphone?", @"Message for user media prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::Microphone:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your microphone?", @"Message for user microphone access prompt"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your microphone?", @"Message for user microphone access prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::ScreenCapture:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe your screen?", @"Message for screen sharing prompt"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe your screen?", @"Message for screen sharing prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::DeviceOrientation:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"“%@” Would Like to Access Motion and Orientation", @"Message for requesting access to the device motion and orientation"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"“%@” Would Like to Access Motion and Orientation", @"Message for requesting access to the device motion and orientation"), visibleOrigin.get()]);
     case MediaPermissionReason::Geolocation:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your current location?", @"Message for geolocation prompt"), visibleOrigin.get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your current location?", @"Message for geolocation prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::SpeechRecognition:
-        return [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to capture your audio and use it for speech recognition?", @"Message for spechrecognition prompt"), visibleDomain(origin.host()).get()];
+        return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to capture your audio and use it for speech recognition?", @"Message for spechrecognition prompt"), visibleDomain(origin.host()).get()]);
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -71,11 +71,11 @@
 
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
 {
-    NSString *viewIdenfier = [NSString stringWithFormat:@"row%ldIdentifier", (long)row];
-    RetainPtr result = [tableView makeViewWithIdentifier:viewIdenfier owner:self];
+    RetainPtr viewIdenfier = adoptNS([[NSString alloc] initWithFormat:@"row%ldIdentifier", (long)row]);
+    RetainPtr result = [tableView makeViewWithIdentifier:viewIdenfier.get() owner:self];
     if (!result) {
         result = adoptNS([[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 100, 300)]);
-        result.get().identifier = viewIdenfier;
+        result.get().identifier = viewIdenfier.get();
     }
     [result setEditable:NO];
     [result setDrawsBackground:NO];
@@ -110,39 +110,38 @@ void presentStorageAccessAlert(WKWebView *webView, const WebCore::RegistrableDom
     auto currentDomain = current.string().createCFString();
 
 #if PLATFORM(MAC)
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Do you want to allow “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), requestingDomain.get(), currentDomain.get()];
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Do you want to allow “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), requestingDomain.get(), currentDomain.get()]);
 #else
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), requestingDomain.get(), currentDomain.get()];
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), requestingDomain.get(), currentDomain.get()]);
 #endif
 
-    NSString *informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), requestingDomain.get()];
+    RetainPtr informativeText = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), requestingDomain.get()]);
 
-    displayStorageAccessAlert(webView, alertTitle, informativeText, nil, nil, WTFMove(completionHandler));
+    displayStorageAccessAlert(webView, alertTitle.get(), informativeText.get(), nil, nil, WTFMove(completionHandler));
 }
 
 void presentStorageAccessAlertQuirk(WKWebView *webView, const WebCore::RegistrableDomain& firstRequesting, const WebCore::RegistrableDomain& secondRequesting, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto firstRequestingDomain = firstRequesting.string().createCFString();
-    auto secondRequestingDomain = secondRequesting.string().createCFString();
-    auto currentDomain = current.string().createCFString();
+    RetainPtr firstRequestingDomain = firstRequesting.string().createCFString();
+    RetainPtr secondRequestingDomain = secondRequesting.string().createCFString();
+    RetainPtr currentDomain = current.string().createCFString();
 
 #if PLATFORM(MAC)
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Do you want to allow “%@” and “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get(), currentDomain.get()];
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Do you want to allow “%@” and “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get(), currentDomain.get()]);
 #else
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” and “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get(), currentDomain.get()];
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” and “%@” to use cookies and website data while browsing “%@”?", @"Message for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get(), currentDomain.get()]);
 #endif
 
-    NSString *informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” and “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get()];
-
-    displayStorageAccessAlert(webView, alertTitle, informativeText, nil, nil, WTFMove(completionHandler));
+    RetainPtr informativeText = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” and “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get()]);
+    displayStorageAccessAlert(webView, alertTitle.get(), informativeText.get(), nil, nil, WTFMove(completionHandler));
 }
 
 void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organizationName, const HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>>& domainPairings, CompletionHandler<void(bool)>&& completionHandler)
 {
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow related %@ websites to share cookies and website data?", @"Message for requesting cross-site cookie and website data access."), organizationName.createCFString().get()];
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow related %@ websites to share cookies and website data?", @"Message for requesting cross-site cookie and website data access."), organizationName.createCFString().get()]);
 
-    NSString *informativeText;;
-    NSString *relatedWebsitesString;
+    RetainPtr<NSString> informativeText;;
+    RetainPtr<NSString> relatedWebsitesString;
     NSMutableArray<NSString *> *accessoryTextList;
 
     HashSet<String> allDomains;
@@ -167,19 +166,19 @@ void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organiz
         if (uniqueDomainList.size() == 2)
             initialListOfSites.append(","_s);
 
-        informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for two sites"), initialListOfSites.toString().utf8().data(), lastSite.utf8().data()];
+        informativeText = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for two sites"), initialListOfSites.toString().utf8().data(), lastSite.utf8().data()]);
         relatedWebsitesString = nil;
         accessoryTextList = nil;
     } else {
-        informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for four or more sites."), uniqueDomainList[0].utf8().data(), uniqueDomainList[1].utf8().data(), uniqueDomainList.size() - 2];
+        informativeText = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for four or more sites."), uniqueDomainList[0].utf8().data(), uniqueDomainList[1].utf8().data(), uniqueDomainList.size() - 2]);
 
-        relatedWebsitesString = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Related %@ websites", @"Label describing the list of related websites controlled by the same organization"), organizationName.createCFString().get()];
+        relatedWebsitesString = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Related %@ websites", @"Label describing the list of related websites controlled by the same organization"), organizationName.createCFString().get()]);
         accessoryTextList = [NSMutableArray arrayWithCapacity:uniqueDomainList.size()];
         for (const auto& domains : uniqueDomainList)
             [accessoryTextList addObject:domains];
     }
 
-    displayStorageAccessAlert(webView, alertTitle, informativeText, relatedWebsitesString, accessoryTextList, WTFMove(completionHandler));
+    displayStorageAccessAlert(webView, alertTitle.get(), informativeText.get(), relatedWebsitesString.get(), accessoryTextList, WTFMove(completionHandler));
 }
 
 void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSString *informativeText, NSString *accessoryLabel, NSArray<NSString *> *accessoryTextList, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -140,7 +140,7 @@ using namespace WebKit;
     NSString *exceptionString;
     if (!validateDictionary(ruleDictionary, nil, requiredKeysInRuleDictionary, keyToExpectedValueTypeInRuleDictionary, &exceptionString)) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
 
         return nil;
     }
@@ -150,14 +150,14 @@ using namespace WebKit;
 
     if (_ruleID < 1) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. Rule id must be non-negative.", (long)_ruleID];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. Rule id must be non-negative.", (long)_ruleID];
 
         return nil;
     }
 
     if (_priority < 1) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. Rule priority must be non-negative.", (long)_ruleID];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. Rule priority must be non-negative.", (long)_ruleID];
 
         return nil;
     }
@@ -177,7 +177,7 @@ using namespace WebKit;
 
     if (!validateDictionary(_action, nil, requiredKeysInActionDictionary, keyToExpectedValueTypeInActionDictionary, &exceptionString)) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
 
         return nil;
     }
@@ -193,7 +193,7 @@ using namespace WebKit;
 
     if (![supportedActionTypes containsObject:_action[declarativeNetRequestRuleActionTypeKey]]) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `%@` is not a supported action type.", (long)_ruleID, _action[declarativeNetRequestRuleActionTypeKey]];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `%@` is not a supported action type.", (long)_ruleID, _action[declarativeNetRequestRuleActionTypeKey]];
 
         return nil;
     }
@@ -216,14 +216,14 @@ using namespace WebKit;
 
     if (!validateDictionary(_condition, nil, @[ ], keyToExpectedValueTypeInConditionDictionary, &exceptionString)) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. %@", (long)_ruleID, exceptionString];
 
         return nil;
     }
 
     if (_condition[declarativeNetRequestRuleConditionRegexFilterKey] && _condition[declarativeNetRequestRuleConditionURLFilterKey]) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. Define only one of the `regexFilter` or `urlFilter` keys.", (long)_ruleID];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. Define only one of the `regexFilter` or `urlFilter` keys.", (long)_ruleID];
 
         return nil;
     }
@@ -231,14 +231,14 @@ using namespace WebKit;
     if (NSString *regexFilter = _condition[declarativeNetRequestRuleConditionRegexFilterKey]) {
         if (![regexFilter canBeConvertedToEncoding:NSASCIIStringEncoding]) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `regexFilter` cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `regexFilter` cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
 
         if (![WKContentRuleList _supportsRegularExpression:regexFilter]) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `regexFilter` is not a supported regular expression.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `regexFilter` is not a supported regular expression.", (long)_ruleID];
 
             return nil;
         }
@@ -247,7 +247,7 @@ using namespace WebKit;
     if (NSString *urlFilter = _condition[declarativeNetRequestRuleConditionURLFilterKey]) {
         if (![urlFilter canBeConvertedToEncoding:NSASCIIStringEncoding]) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `urlFilter` cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `urlFilter` cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -255,7 +255,7 @@ using namespace WebKit;
 
     if (_condition[declarativeNetRequestRuleConditionResourceTypeKey] && _condition[declarativeNetRequestRuleConditionExcludedResourceTypesKey]) {
         if (outErrorString)
-            *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. Define only one of the `resourceTypes` or `excludedResourceTypes` keys.", (long)_ruleID];
+            *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. Define only one of the `resourceTypes` or `excludedResourceTypes` keys.", (long)_ruleID];
 
         return nil;
     }
@@ -264,7 +264,7 @@ using namespace WebKit;
     if (resourceTypes) {
         if (!resourceTypes.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `resourceTypes` cannot be an empty array.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `resourceTypes` cannot be an empty array.", (long)_ruleID];
 
             return nil;
         }
@@ -274,7 +274,7 @@ using namespace WebKit;
 
         if (!resourceTypes.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. The value in the `resourceTypes` array is invalid.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. The value in the `resourceTypes` array is invalid.", (long)_ruleID];
 
             return nil;
         }
@@ -286,7 +286,7 @@ using namespace WebKit;
     if ([_action[declarativeNetRequestRuleActionTypeKey] isEqualToString:declarativeNetRequestRuleActionTypeAllowAllRequests]) {
         if (!resourceTypes) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. A rule with the `allowAllRequests` action type must have the `resourceTypes` key.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. A rule with the `allowAllRequests` action type must have the `resourceTypes` key.", (long)_ruleID];
 
             return nil;
         }
@@ -294,7 +294,7 @@ using namespace WebKit;
         for (NSString *resourceType in resourceTypes) {
             if (![resourceType isEqualToString:@"main_frame"] && ![resourceType isEqualToString:@"sub_frame"]) {
                 if (outErrorString)
-                    *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `%@` is not a valid resource type for the `allowAllRequests` action type.", (long)_ruleID, resourceType];
+                    *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `%@` is not a valid resource type for the `allowAllRequests` action type.", (long)_ruleID, resourceType];
 
                 return nil;
             }
@@ -304,7 +304,7 @@ using namespace WebKit;
     if (NSString *domainType = _condition[declarativeNetRequestRuleConditionDomainTypeKey]) {
         if (![[self _chromeDomainTypeToWebKitDomainType] objectForKey:domainType]) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `%@` is not a valid domain type.", (long)_ruleID, domainType];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `%@` is not a valid domain type.", (long)_ruleID, domainType];
 
             return nil;
         }
@@ -313,7 +313,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *domains = _condition[declarativeNetRequestRuleConditionDomainsKey]) {
         if (!isArrayOfDomainsValid(domains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `domains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `domains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -322,7 +322,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *domains = _condition[ruleConditionRequestDomainsKey]) {
         if (!isArrayOfDomainsValid(domains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `requestDomains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `requestDomains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -331,7 +331,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *excludedDomains = _condition[declarativeNetRequestRuleConditionExcludedDomainsKey]) {
         if (!isArrayOfExcludedDomainsValid(excludedDomains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `excludedDomains` cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `excludedDomains` cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -340,7 +340,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *excludedDomains = _condition[ruleConditionExcludedRequestDomainsKey]) {
         if (!isArrayOfExcludedDomainsValid(excludedDomains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `excludedRequestDomains` cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `excludedRequestDomains` cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -349,7 +349,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *initiatorDomains = _condition[ruleConditionInitiatorDomainsKey]) {
         if (!isArrayOfDomainsValid(initiatorDomains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `initiatorDomains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `initiatorDomains` must be non-empty and cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -358,7 +358,7 @@ using namespace WebKit;
     if (NSArray<NSString *> *excludedInitiatorDomains = _condition[ruleConditionExcludedInitiatorDomainsKey]) {
         if (!isArrayOfExcludedDomainsValid(excludedInitiatorDomains)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `excludedInitiatorDomains` cannot contain non-ASCII characters.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `excludedInitiatorDomains` cannot contain non-ASCII characters.", (long)_ruleID];
 
             return nil;
         }
@@ -374,7 +374,7 @@ using namespace WebKit;
 
         if (!urlString && !extensionPathString && !transformDictionary && !regexSubstitutionString) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` is missing either a `url`, `extensionPath`, `regexSubstitution`, or `transform` key.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` is missing either a `url`, `extensionPath`, `regexSubstitution`, or `transform` key.", (long)_ruleID];
 
             return nil;
         }
@@ -385,14 +385,14 @@ using namespace WebKit;
             NSURL *url = [NSURL URLWithString:urlString];
             if (!url) {
                 if (outErrorString)
-                    *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid or empty `url`.", (long)_ruleID];
+                    *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid or empty `url`.", (long)_ruleID];
 
                 return nil;
             }
 
             if (!URL(url).protocolIsInHTTPFamily()) {
                 if (outErrorString)
-                    *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified a non-HTTP `url`.", (long)_ruleID];
+                    *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified a non-HTTP `url`.", (long)_ruleID];
 
                 return nil;
             }
@@ -401,7 +401,7 @@ using namespace WebKit;
         if (regexSubstitutionString) {
             if (!_condition[declarativeNetRequestRuleConditionRegexFilterKey]) {
                 if (outErrorString)
-                    *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified a `regexSubstitution` without a `regexFilter` condition.", (long)_ruleID];
+                    *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified a `regexSubstitution` without a `regexFilter` condition.", (long)_ruleID];
 
                 return nil;
             }
@@ -409,14 +409,14 @@ using namespace WebKit;
 
         if (extensionPathString && ![extensionPathString hasPrefix:@"/"]) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified an `extensionPath` without a '/' prefix.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified an `extensionPath` without a '/' prefix.", (long)_ruleID];
 
             return nil;
         }
 
         if (transformDictionary && !transformDictionary.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid or empty `transform`.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid or empty `transform`.", (long)_ruleID];
 
             return nil;
         }
@@ -435,7 +435,7 @@ using namespace WebKit;
 
         if (transformDictionary && !validateDictionary(transformDictionary, nil, @[ ], keyToExpectedValueTypeInTransformDictionary, &exceptionString)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid `transform`. %@", (long)_ruleID, exceptionString];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `redirect` specified an invalid `transform`. %@", (long)_ruleID, exceptionString];
 
             return nil;
         }
@@ -443,7 +443,7 @@ using namespace WebKit;
         NSDictionary<NSString *, id> *queryTransformDictionary = objectForKey<NSDictionary>(transformDictionary, declarativeNetRequestRuleURLTransformQueryTransform, false);
         if (queryTransformDictionary && !queryTransformDictionary.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `transform` specified an invalid or empty `queryTransform`.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `transform` specified an invalid or empty `queryTransform`.", (long)_ruleID];
 
             return nil;
         }
@@ -455,7 +455,7 @@ using namespace WebKit;
 
         if (queryTransformDictionary && !validateDictionary(queryTransformDictionary, nil, @[ ], keyToExpectedValueTypeInQueryTransformDictionary, &exceptionString)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `transform` specified an invalid `queryTransform`. %@", (long)_ruleID, exceptionString];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `transform` specified an invalid `queryTransform`. %@", (long)_ruleID, exceptionString];
 
             return nil;
         }
@@ -463,7 +463,7 @@ using namespace WebKit;
         NSArray<NSString *> *removeParamsArray = queryTransformDictionary[declarativeNetRequestRuleQueryTransformRemoveParams];
         if (removeParamsArray && !removeParamsArray.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid or empty `removeParams`.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid or empty `removeParams`.", (long)_ruleID];
 
             return nil;
         }
@@ -482,7 +482,7 @@ using namespace WebKit;
         NSArray<NSDictionary<NSString *, id> *> *addOrReplaceParamsArray = queryTransformDictionary[declarativeNetRequestRuleQueryTransformAddOrReplaceParams];
         if (addOrReplaceParamsArray && !addOrReplaceParamsArray.count) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid or empty `addOrReplaceParams`.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid or empty `addOrReplaceParams`.", (long)_ruleID];
 
             return nil;
         }
@@ -490,7 +490,7 @@ using namespace WebKit;
         for (NSDictionary<NSString *, id> *addOrReplaceParamsDictionary in addOrReplaceParamsArray) {
             if (!validateDictionary(addOrReplaceParamsDictionary, nil, requiredKeysInAddOrReplaceDictionary, keyToExpectedValueTypeInAddOrReplaceDictionary, &exceptionString)) {
                 if (outErrorString)
-                    *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid `addOrReplaceParams`. %@", (long)_ruleID, exceptionString];
+                    *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `queryTransform` specified an invalid `addOrReplaceParams`. %@", (long)_ruleID, exceptionString];
 
                 return nil;
             }
@@ -503,14 +503,14 @@ using namespace WebKit;
 
         if (!requestHeadersInfo && !responseHeadersInfo) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. A modifyHeaders rule must have `requestHeaders` or `responseHeaders` set.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. A modifyHeaders rule must have `requestHeaders` or `responseHeaders` set.", (long)_ruleID];
 
             return nil;
         }
 
         if ((requestHeadersInfo && !requestHeadersInfo.count) || (responseHeadersInfo && !responseHeadersInfo.count)) {
             if (outErrorString)
-                *outErrorString = [NSString stringWithFormat:@"Rule with id %ld is invalid. The arrays specified by `requestHeaders` or `responseHeaders` must be non-empty.", (long)_ruleID];
+                *outErrorString = [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. The arrays specified by `requestHeaders` or `responseHeaders` must be non-empty.", (long)_ruleID];
 
             return nil;
         }
@@ -554,7 +554,7 @@ using namespace WebKit;
 
     NSString *exceptionString;
     if (!validateDictionary(headerInfo, nil, requiredKeysInModifyHeadersDictionary, keyToExpectedValueTypeInHeadersDictionary, &exceptionString))
-        return [NSString stringWithFormat:@"Rule with id %ld is invalid. One of the headers dictionaries is not formatted correctly. %@", (long)_ruleID, exceptionString];
+        return [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. One of the headers dictionaries is not formatted correctly. %@", (long)_ruleID, exceptionString];
 
     NSString *operationType = headerInfo[declarativeNetRequestRuleHeaderOperationKey];
     BOOL isSetOperation = [operationType isEqual:declarativeNetRequestRuleHeaderOperationValueSet];
@@ -562,18 +562,18 @@ using namespace WebKit;
     BOOL isRemoveOperation = [operationType isEqual:declarativeNetRequestRuleHeaderOperationValueRemove];
 
     if (!isSetOperation && !isAppendOperation && !isRemoveOperation)
-        return [NSString stringWithFormat:@"Rule with id %ld is invalid. `%@` is not a recognized header operation.", (long)_ruleID, operationType];
+        return [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. `%@` is not a recognized header operation.", (long)_ruleID, operationType];
 
     NSString *headerName = headerInfo[declarativeNetRequestRuleHeaderKey];
     if (!isHeaderNameValid(headerName))
-        return [NSString stringWithFormat:@"Rule with id %ld is invalid. The header `%@` is not recognized.", (long)_ruleID, headerName];
+        return [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. The header `%@` is not recognized.", (long)_ruleID, headerName];
 
     NSString *headerValue = headerInfo[declarativeNetRequestRuleHeaderValueKey];
     if (isRemoveOperation && headerValue)
-        return [NSString stringWithFormat:@"Rule with id %ld is invalid. Do not provide a value when removing a header.", (long)_ruleID];
+        return [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. Do not provide a value when removing a header.", (long)_ruleID];
 
     if ((isSetOperation || isAppendOperation) && !headerValue)
-        return [NSString stringWithFormat:@"Rule with id %ld is invalid. You must provide a value when modifying a header.", (long)_ruleID];
+        return [[NSString alloc] initWithFormat:@"Rule with id %ld is invalid. You must provide a value when modifying a header.", (long)_ruleID];
 
     return nil;
 }
@@ -1143,7 +1143,7 @@ static NSInteger priorityForRuleType(NSString *ruleType)
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@:%p %@>", self.class, self, @{
+    return [[NSString alloc] initWithFormat:@"<%@:%p %@>", self.class, self, @{
         @"id" : @(_ruleID),
         @"priority" : @(_priority),
         @"action": _action,

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
@@ -111,7 +111,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 
         ASSERT(rulesIDs.count);
 
-        _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(strongSelf->_database, [NSString stringWithFormat:@"SELECT id FROM %@ WHERE id in (%@)", strongSelf->_tableName, [rulesIDs componentsJoinedByString:@", "]]);
+        _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(strongSelf->_database, [[NSString alloc] initWithFormat:@"SELECT id FROM %@ WHERE id in (%@)", strongSelf->_tableName, [rulesIDs componentsJoinedByString:@", "]]);
 
         NSMutableArray<NSNumber *> *existingRuleIDs = [NSMutableArray array];
         for (_WKWebExtensionSQLiteRow *row in rows)
@@ -167,7 +167,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
         ASSERT(!errorMessage.length);
         ASSERT(strongSelf->_database);
 
-        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"DELETE FROM %@ WHERE id in (%@)", strongSelf->_tableName, [ruleIDs componentsJoinedByString:@", "]]);
+        DatabaseResult result = SQLiteDatabaseExecute(strongSelf->_database, [[NSString alloc] initWithFormat:@"DELETE FROM %@ WHERE id in (%@)", strongSelf->_tableName, [ruleIDs componentsJoinedByString:@", "]]);
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to delete rules for extension %{private}@.", strongSelf->_uniqueIdentifier);
             errorMessage = [NSString stringWithFormat:@"Failed to delete rules from %@ rules storage.", strongSelf->_storageType];
@@ -217,7 +217,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
             [bindings addObject:@"?"];
 
         auto *joinedBindings = [bindings componentsJoinedByString:@", "];
-        auto *query = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE id IN (%@)", _tableName, joinedBindings];
+        auto *query = [[NSString alloc] initWithFormat:@"SELECT * FROM %@ WHERE id IN (%@)", _tableName, joinedBindings];
         auto *statement = [[_WKWebExtensionSQLiteStatement alloc] initWithDatabase:_database query:query];
 
         for (NSUInteger i = 0; i < ruleIDs.count; i++)
@@ -225,7 +225,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 
         rows = [statement fetch];
     } else
-        rows = SQLiteDatabaseFetch(_database, [NSString stringWithFormat:@"SELECT * FROM %@", _tableName]);
+        rows = SQLiteDatabaseFetch(_database, [[NSString alloc] initWithFormat:@"SELECT * FROM %@", _tableName]);
 
     return [self _getKeysAndValuesFromRowEnumerator:rows];
 }
@@ -258,7 +258,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     NSNumber *ruleID = objectForKey<NSNumber>(rule, @"id");
     ASSERT(ruleID);
 
-    DatabaseResult result = SQLiteDatabaseExecute(database, [NSString stringWithFormat:@"INSERT INTO %@ (id, rule) VALUES (?, ?)", _tableName], ruleID.integerValue, ruleAsData);
+    DatabaseResult result = SQLiteDatabaseExecute(database, [[NSString alloc] initWithFormat:@"INSERT INTO %@ (id, rule) VALUES (?, ?)", _tableName], ruleID.integerValue, ruleAsData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert dynamic declarative net request rule for extension %{private}@.", _uniqueIdentifier);
         return [NSString stringWithFormat:@"Failed to add %@ rule.", _storageType];
@@ -290,7 +290,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     dispatch_assert_queue(_databaseQueue);
     ASSERT(_database);
 
-    DatabaseResult result = SQLiteDatabaseExecute(_database, [NSString stringWithFormat:@"CREATE TABLE %@ (id INTEGER PRIMARY KEY NOT NULL, rule BLOB NOT NULL)", _tableName]);
+    DatabaseResult result = SQLiteDatabaseExecute(_database, [[NSString alloc] initWithFormat:@"CREATE TABLE %@ (id INTEGER PRIMARY KEY NOT NULL, rule BLOB NOT NULL)", _tableName]);
     if (result != SQLITE_DONE)
         RELEASE_LOG_ERROR(Extensions, "Failed to create %@ database for extension %{private}@: %{public}@ (%d)", _tableName, _uniqueIdentifier, _database.lastErrorMessage, result);
 
@@ -302,7 +302,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     dispatch_assert_queue(_databaseQueue);
     ASSERT(_database);
 
-    DatabaseResult result = SQLiteDatabaseExecute(_database, [NSString stringWithFormat:@"DROP TABLE IF EXISTS %@", _tableName]);
+    DatabaseResult result = SQLiteDatabaseExecute(_database, [[NSString alloc] initWithFormat:@"DROP TABLE IF EXISTS %@", _tableName]);
     if (result != SQLITE_DONE)
         RELEASE_LOG_ERROR(Extensions, "Failed to reset %@ database schema for extension %{private}@: %{public}@ (%d)", _tableName, _uniqueIdentifier, _database.lastErrorMessage, result);
 
@@ -314,7 +314,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     dispatch_assert_queue(_databaseQueue);
     ASSERT(_database);
 
-    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, [NSString stringWithFormat:@"SELECT COUNT(*) FROM %@", _tableName]);
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, [[NSString alloc] initWithFormat:@"SELECT COUNT(*) FROM %@", _tableName]);
     return ![[rows nextObject] int64AtIndex:0];
 }
 

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
@@ -104,15 +104,15 @@
 
         RetainPtr<NSMutableDictionary> headerFields = adoptNS(@{
             @"Access-Control-Allow-Origin": @"*",
-            @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)fileData.length],
+            @"Content-Length": adoptNS([[NSString alloc] initWithFormat:@"%zu", (size_t)fileData.length]).get(),
             @"Content-Type": mimeType,
         }.mutableCopy);
 
         // Allow fetches for resources that use a registered custom URL scheme.
         if (_allowedURLSchemesForCSP && [self.mainResourceURLsForCSP containsObject:requestURL]) {
-            NSString *listOfCustomProtocols = [NSString stringWithFormat:@"%@:", [_allowedURLSchemesForCSP.get().allObjects componentsJoinedByString:@": "]];
-            NSString *stringForCSPPolicy = [NSString stringWithFormat:@"connect-src * %@; img-src * file: blob: resource: %@", listOfCustomProtocols, listOfCustomProtocols];
-            [headerFields setObject:stringForCSPPolicy forKey:@"Content-Security-Policy"];
+            RetainPtr listOfCustomProtocols = adoptNS([[NSString alloc] initWithFormat:@"%@:", [_allowedURLSchemesForCSP.get().allObjects componentsJoinedByString:@": "]]);
+            RetainPtr stringForCSPPolicy = adoptNS([[NSString alloc] initWithFormat:@"connect-src * %@; img-src * file: blob: resource: %@", listOfCustomProtocols.get(), listOfCustomProtocols.get()]);
+            [headerFields setObject:stringForCSPPolicy.get() forKey:@"Content-Security-Policy"];
         }
 
         RetainPtr<NSHTTPURLResponse> urlResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:urlSchemeTask.request.URL statusCode:200 HTTPVersion:nil headerFields:headerFields.get()]);

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -201,7 +201,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
 
 + (NSURL *)URLForInspectorResource:(NSString *)resource
 {
-    return [NSURL URLWithString:[NSString stringWithFormat:@"%@:///%@", WKInspectorResourceScheme, resource]].URLByStandardizingPath;
+    return [NSURL URLWithString:adoptNS([[NSString alloc] initWithFormat:@"%@:///%@", WKInspectorResourceScheme, resource]).get()].URLByStandardizingPath;
 }
 
 // MARK: WKUIDelegate methods

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -354,11 +354,11 @@ void WebInspectorUIProxy::updateInspectorWindowTitle() const
 
     unsigned level = inspectionLevel();
     if (level > 1) {
-        NSString *debugTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector [%d] — %@", "Web Inspector window title when inspecting Web Inspector"), level, m_urlString.createNSString().get()];
-        [m_inspectorWindow setTitle:debugTitle];
+        RetainPtr debugTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Web Inspector [%d] — %@", "Web Inspector window title when inspecting Web Inspector"), level, m_urlString.createNSString().get()]);
+        [m_inspectorWindow setTitle:debugTitle.get()];
     } else {
-        NSString *title = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Web Inspector — %@", "Web Inspector window title"), m_urlString.createNSString().get()];
-        [m_inspectorWindow setTitle:title];
+        RetainPtr title = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Web Inspector — %@", "Web Inspector window title"), m_urlString.createNSString().get()]);
+        [m_inspectorWindow setTitle:title.get()];
     }
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -260,7 +260,7 @@ RemoteLayerTreeNode* RemoteLayerTreeNode::forCALayer(CALayer *layer)
 NSString *RemoteLayerTreeNode::appendLayerDescription(NSString *description, CALayer *layer)
 {
     auto layerID = WebKit::RemoteLayerTreeNode::layerID(layer);
-    RetainPtr layerDescription = [NSString stringWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, layer.name ? layer.name : @""];
+    RetainPtr layerDescription = adoptNS([[NSString alloc] initWithFormat:@" layerID = %llu \"%@\"", layerID ? layerID->object().toUInt64() : 0, layer.name ? layer.name : @""]);
     return [description stringByAppendingString:layerDescription.get()];
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -151,9 +151,9 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     if (experimentalFeatureEnabled(WebPreferencesKey::isFirstPartyWebsiteDataRemovalDisabledKey()))
         firstPartyWebsiteDataRemovalMode = WebCore::FirstPartyWebsiteDataRemovalMode::None;
     else {
-        if ([defaults boolForKey:[NSString stringWithFormat:@"InternalDebug%@", WebPreferencesKey::isFirstPartyWebsiteDataRemovalReproTestingEnabledKey().createCFString().get()]])
+        if ([defaults boolForKey:adoptNS([[NSString alloc] initWithFormat:@"InternalDebug%@", WebPreferencesKey::isFirstPartyWebsiteDataRemovalReproTestingEnabledKey().createCFString().get()]).get()])
             firstPartyWebsiteDataRemovalMode = WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookiesReproTestingTimeout;
-        else if ([defaults boolForKey:[NSString stringWithFormat:@"InternalDebug%@", WebPreferencesKey::isFirstPartyWebsiteDataRemovalLiveOnTestingEnabledKey().createCFString().get()]])
+        else if ([defaults boolForKey:adoptNS([[NSString alloc] initWithFormat:@"InternalDebug%@", WebPreferencesKey::isFirstPartyWebsiteDataRemovalLiveOnTestingEnabledKey().createCFString().get()]).get()])
             firstPartyWebsiteDataRemovalMode = WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookiesLiveOnTestingTimeout;
         else
             firstPartyWebsiteDataRemovalMode = WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookies;
@@ -824,7 +824,7 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         bool isSafari = false;
 #if PLATFORM(MAC)
         isSafari = WTF::MacApplication::isSafari();
-        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:[[NSString stringWithFormat:@"/Library/Managed Preferences/%@/%@.plist", NSUserName(), kManagedSitesIdentifier] stringByStandardizingPath]]);
+        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:[adoptNS([[NSString alloc] initWithFormat:@"/Library/Managed Preferences/%@/%@.plist", NSUserName(), kManagedSitesIdentifier]) stringByStandardizingPath]]);
         crossSiteTrackingPreventionRelaxedDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedDomainsKey];
         crossSiteTrackingPreventionRelaxedApps = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedAppsKey];
 #elif !PLATFORM(MACCATALYST)

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -501,8 +501,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!externalApplicationName)
         return YES;
 
-    NSString *openInExternalApplicationTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Open in “%@”", "Title for Open in External Application Link action button"), externalApplicationName];
-    _WKElementAction *openInExternalApplicationAction = [_WKElementAction _elementActionWithType:_WKElementActionTypeOpenInExternalApplication title:openInExternalApplicationTitle actionHandler:^(_WKActivatedElementInfo *) {
+    RetainPtr openInExternalApplicationTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Open in “%@”", "Title for Open in External Application Link action button"), externalApplicationName]);
+    _WKElementAction *openInExternalApplicationAction = [_WKElementAction _elementActionWithType:_WKElementActionTypeOpenInExternalApplication title:openInExternalApplicationTitle.get() actionHandler:^(_WKActivatedElementInfo *) {
 #if HAVE(APP_LINKS_WITH_ISENABLED)
         appLink.enabled = YES;
         [appLink openWithCompletionHandler:nil];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9925,8 +9925,8 @@ static String fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls(WebCor
 - (void)actionSheetAssistant:(WKActionSheetAssistant *)assistant shareElementWithImage:(UIImage *)image rect:(CGRect)boundingRect
 {
     WebCore::ShareDataWithParsedURL shareData;
-    NSString* fileName = [NSString stringWithFormat:@"%@.png", (NSString*)WEB_UI_STRING("Shared Image", "Default name for the file created for a shared image with no explicit name.")];
-    shareData.files = { { fileName, WebCore::SharedBuffer::create(UIImagePNGRepresentation(image)) } };
+    RetainPtr fileName = adoptNS([[NSString alloc] initWithFormat:@"%@.png", (NSString*)WEB_UI_STRING("Shared Image", "Default name for the file created for a shared image with no explicit name.")]);
+    shareData.files = { { fileName.get(), WebCore::SharedBuffer::create(UIImagePNGRepresentation(image)) } };
     shareData.originator = WebCore::ShareDataOriginator::User;
     [self _showShareSheet:shareData inRect: { [self convertRect:boundingRect toView:self.webView] } completionHandler:nil];
 }

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -616,7 +616,7 @@ static NSStringCompareOptions stringCompareOptions(_WKFindOptions findOptions)
 
 - (NSURL *)_URLWithPageIndex:(NSInteger)pageIndex
 {
-    return [NSURL URLWithString:[NSString stringWithFormat:@"#page%ld", (long)pageIndex + 1] relativeToURL:[_webView URL]];
+    return [NSURL URLWithString:adoptNS([[NSString alloc] initWithFormat:@"#page%ld", (long)pageIndex + 1]).get() relativeToURL:[_webView URL]];
 }
 
 - (void)_goToURL:(NSURL *)url atLocation:(CGPoint)location

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -170,20 +170,20 @@ struct PermissionRequest {
         }
 
         NSString *applicationName = appDisplayName();
-        NSString *message;
+        RetainPtr<NSString> message;
 
     IGNORE_WARNINGS_BEGIN("format-nonliteral")
-        NSString *title = [NSString stringWithFormat:WEB_UI_STRING("“%@” would like to use your current location.", "Prompt for a webpage to request location access. The parameter is the domain for the webpage."), _activeChallenge->token.get()];
+        RetainPtr title = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("“%@” would like to use your current location.", "Prompt for a webpage to request location access. The parameter is the domain for the webpage."), _activeChallenge->token.get()]);
         if (appHasPreciseLocationPermission())
-            message = [NSString stringWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data"), applicationName];
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data"), applicationName]);
         else
-            message = [NSString stringWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data"), applicationName];
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data"), applicationName]);
     IGNORE_WARNINGS_END
 
         NSString *allowActionTitle = WEB_UI_STRING("Allow", "Action authorizing a webpage to access the user’s location.");
         NSString *denyActionTitle = WEB_UI_STRING_KEY("Don’t Allow", "Don’t Allow (website location dialog)", "Action denying a webpage access to the user’s location.");
 
-        auto alert = WebKit::createUIAlertController(title, message);
+        RetainPtr alert = WebKit::createUIAlertController(title.get(), message.get());
         UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
             if (auto strongSelf = weakSelf.get())
                 [strongSelf _finishActiveChallenge:NO];

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -388,8 +388,8 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
 - (void)setHour:(NSInteger)hour minute:(NSInteger)minute
 {
-    NSString *timeString = [NSString stringWithFormat:@"%.2ld:%.2ld", (long)hour, (long)minute];
-    [_datePicker setDate:[[self dateFormatterForPicker] dateFromString:timeString]];
+    RetainPtr timeString = adoptNS([[NSString alloc] initWithFormat:@"%.2ld:%.2ld", (long)hour, (long)minute]);
+    [_datePicker setDate:[[self dateFormatterForPicker] dateFromString:timeString.get()]];
     [self _dateChanged];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -48,7 +48,7 @@ static NSString* WKPopoverTableViewCellReuseIdentifier  = @"WKPopoverTableViewCe
 - (CGRect)contentRectForBounds:(CGRect)bounds;
 @end
 
-static NSString *stringWithWritingDirection(NSString *string, NSWritingDirection writingDirection, bool override)
+static RetainPtr<NSString> stringWithWritingDirection(NSString *string, NSWritingDirection writingDirection, bool override)
 {
     if (![string length] || writingDirection == NSWritingDirectionNatural)
         return string;
@@ -72,7 +72,7 @@ static NSString *stringWithWritingDirection(NSString *string, NSWritingDirection
     else
         directionalFormattingCharacter = (override ? rightToLeftOverride : rightToLeftEmbedding);
     
-    return [NSString stringWithFormat:@"%C%@%C", directionalFormattingCharacter, string, popDirectionalFormatting];
+    return adoptNS([[NSString alloc] initWithFormat:@"%C%@%C", directionalFormattingCharacter, string, popDirectionalFormatting]);
 }
 
 @class WKSelectPopover;
@@ -134,7 +134,7 @@ static NSString *stringWithWritingDirection(NSString *string, NSWritingDirection
     // For that reason we have to override what the system thinks.
     if (writingDirection == NSWritingDirectionRightToLeft)
         self.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    [self setTitle:stringWithWritingDirection(_contentView.focusedElementInformation.title, writingDirection, override)];
+    [self setTitle:stringWithWritingDirection(_contentView.focusedElementInformation.title, writingDirection, override).get()];
 
     return self;
 }

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -725,7 +725,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _location = location;
 
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
-    [_bannerLabel setText:[NSString stringWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]];
+    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]).get()];
     [_bannerLabel sizeToFit];
 #endif
 }
@@ -833,7 +833,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_bannerLabel setNumberOfLines:0];
     [_bannerLabel setLineBreakMode:NSLineBreakByWordWrapping];
     [_bannerLabel setTextAlignment:NSTextAlignmentCenter];
-    [_bannerLabel setText:[NSString stringWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]];
+    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]).get()];
 
     auto banner = adoptNS([[WKFullscreenStackView alloc] init]);
     [banner addArrangedSubview:_bannerLabel.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
@@ -1126,9 +1126,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    NSString *alertTitle = WEB_UI_STRING("It looks like you are typing while in full screen", "Full Screen Deceptive Website Warning Sheet Title");
-    NSString *alertMessage = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Typing is not allowed in full screen websites. “%@” may be showing a fake keyboard to trick you into disclosing personal or financial information.", "Full Screen Deceptive Website Warning Sheet Content Text"), (NSString *)self.location];
-    auto alert = WebKit::createUIAlertController(alertTitle, alertMessage);
+    RetainPtr alertTitle = WEB_UI_STRING("It looks like you are typing while in full screen", "Full Screen Deceptive Website Warning Sheet Title").createNSString();
+    RetainPtr alertMessage = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Typing is not allowed in full screen websites. “%@” may be showing a fake keyboard to trick you into disclosing personal or financial information.", "Full Screen Deceptive Website Warning Sheet Content Text"), (NSString *)self.location]);
+    RetainPtr alert = WebKit::createUIAlertController(alertTitle.get(), alertMessage.get());
 
     if (page) {
         page->suspendAllMediaPlayback([] { });

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -64,21 +64,21 @@ void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, c
     if (!visibleOrigin)
         visibleOrigin = applicationVisibleName();
 
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe one of your windows or screens?", "Message for window and screen sharing prompt"), visibleOrigin.get()];
-    auto *allowWindowButtonString = WEB_UI_NSSTRING(@"Allow to Share Window", "Allow window button title in window and screen sharing prompt");
-    auto *allowScreenButtonString = WEB_UI_NSSTRING(@"Allow to Share Screen", "Allow screen button title in window and screen sharing prompt");
-    auto *doNotAllowButtonString = WEB_UI_NSSTRING_KEY(@"Don’t Allow", @"Don’t Allow (window and screen sharing)", "Disallow button title in window and screen sharing prompt");
+    RetainPtr alertTitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe one of your windows or screens?", "Message for window and screen sharing prompt"), visibleOrigin.get()]);
+    RetainPtr<NSString> allowWindowButtonString = WEB_UI_NSSTRING(@"Allow to Share Window", "Allow window button title in window and screen sharing prompt");
+    RetainPtr<NSString> allowScreenButtonString = WEB_UI_NSSTRING(@"Allow to Share Screen", "Allow screen button title in window and screen sharing prompt");
+    RetainPtr<NSString> doNotAllowButtonString = WEB_UI_NSSTRING_KEY(@"Don’t Allow", @"Don’t Allow (window and screen sharing)", "Disallow button title in window and screen sharing prompt");
 
-    auto alert = adoptNS([[NSAlert alloc] init]);
-    [alert setMessageText:alertTitle];
+    RetainPtr alert = adoptNS([[NSAlert alloc] init]);
+    [alert setMessageText:alertTitle.get()];
 
-    auto *button = [alert addButtonWithTitle:allowWindowButtonString];
+    auto *button = [alert addButtonWithTitle:allowWindowButtonString.get()];
     button.keyEquivalent = @"";
 
-    button = [alert addButtonWithTitle:allowScreenButtonString];
+    button = [alert addButtonWithTitle:allowScreenButtonString.get()];
     button.keyEquivalent = @"";
 
-    button = [alert addButtonWithTitle:doNotAllowButtonString];
+    button = [alert addButtonWithTitle:doNotAllowButtonString.get()];
     button.keyEquivalent = @"\E";
 
     [alert beginSheetModalForWindow:[webView window] completionHandler:[completionBlock = makeBlockPtr(WTFMove(completionHandler))](NSModalResponse returnCode) {

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -477,7 +477,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
 
     // Notify accessibility clients of datalist becoming visible.
     RetainPtr currentSelectedString = [self currentSelectedString].createNSString();
-    RetainPtr info = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Suggestions list visible, %@", "Accessibility announcement that the suggestions list became visible. The format argument is for the first option in the list."), currentSelectedString.get()];
+    RetainPtr info = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Suggestions list visible, %@", "Accessibility announcement that the suggestions list became visible. The format argument is for the first option in the list."), currentSelectedString.get()]);
     [self notifyAccessibilityClients:info.get()];
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -413,7 +413,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionar
         }
 
         NSString *path = input[key];
-        if (!validateObject(path, [NSString stringWithFormat:@"%@[%@]", inputKey, key], NSString.class, outExceptionString))
+        if (!validateObject(path, adoptNS([[NSString alloc] initWithFormat:@"%@[%@]", inputKey, key]).get(), NSString.class, outExceptionString))
             return nil;
 
         result[key] = parseIconPath(path, baseURL);
@@ -439,7 +439,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDicti
         }
 
         id value = input[key];
-        if (!validateObject(value, [NSString stringWithFormat:@"%@[%@]", inputKey, key], JSValue.class, outExceptionString))
+        if (!validateObject(value, adoptNS([[NSString alloc] initWithFormat:@"%@[%@]", inputKey, key]).get(), JSValue.class, outExceptionString))
             return nil;
 
         auto *dataURLString = dataURLFromImageData(value, nullptr, key, outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -81,15 +81,15 @@ static std::variant<std::monostate, String, SidebarError> parseDetailsStringFrom
 
     if ([maybeValue isKindOfClass:NSNull.class]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' is required", key]).get()) };
         return std::monostate();
     }
 
     RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
     if (!nsStringValue]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]) };
-        return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
+            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string'", key]).get()) };
+        return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string' or 'null'", key]).get()) };
     }
 
     return String(nsStringValue.get());
@@ -269,7 +269,7 @@ void WebExtensionAPISidebarAction::setIcon(NSDictionary *details, Ref<WebExtensi
 {
     // FIXME: <https://webkit.org/b/276833> Implement icon-related functionality
     static NSString * const apiName = @"sidebarAction.setIcon()";
-    callback->reportError([NSString stringWithFormat:@"'%@' is unimplemented", apiName]);
+    callback->reportError(adoptNS([[NSString alloc] initWithFormat:@"'%@' is unimplemented", apiName]).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -182,12 +182,12 @@ void WebExtensionAPIStorageArea::set(WebPageProxyIdentifier webPageProxyIdentifi
     });
 
     if (keyWithError) {
-        *outExceptionString = toErrorString(nullString(), [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it is not JSON-serializable");
+        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it is not JSON-serializable");
         return;
     }
 
     if (m_type == WebExtensionDataType::Sync && anyItemsExceedQuota(serializedData, webExtensionStorageAreaSyncQuotaBytesPerItem, &keyWithError)) {
-        *outExceptionString = toErrorString(nullString(), [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it exceeded maximum size for a single item");
+        *outExceptionString = toErrorString(nullString(), adoptNS([[NSString alloc] initWithFormat:@"items[`%@`]", keyWithError]).get(), @"it exceeded maximum size for a single item");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -302,7 +302,7 @@ JSValue *WebExtensionAPITest::assertResolves(JSContextRef context, JSValue *prom
         }
 
         JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
-        fail(context, combineMessages(message, [NSString stringWithFormat:@"Promise rejected with an error: %@", debugString(errorMessageValue)]));
+        fail(context, combineMessages(message, adoptNS([[NSString alloc] initWithFormat:@"Promise rejected with an error: %@", debugString(errorMessageValue)]).get()));
 
         [resolveCallback callWithArguments:nil];
     }];
@@ -353,7 +353,7 @@ JSValue *WebExtensionAPITest::assertSafe(JSContextRef context, JSValue *function
     function.context.exception = nil;
 
     JSValue *exceptionMessageValue = exceptionValue.isObject && [exceptionValue hasProperty:@"message"] ? exceptionValue[@"message"] : exceptionValue;
-    fail(context, combineMessages(message, [NSString stringWithFormat:@"Function threw an exception: %@", debugString(exceptionMessageValue)]));
+    fail(context, combineMessages(message, adoptNS([[NSString alloc] initWithFormat:@"Function threw an exception: %@", debugString(exceptionMessageValue)]).get()));
 
     return [JSValue valueWithUndefinedInContext:function.context];
 }
@@ -439,7 +439,7 @@ void WebExtensionAPITest::startNextTest()
     auto testComplete = [this, protectedThis = Ref { *this }, test](JSValue *result, JSValue *error) {
         if (error || m_hitAssertion) {
             JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
-            WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(test.testName, false, [NSString stringWithFormat:@"Promise rejected with an error: %@", debugString(errorMessageValue)], test.location.first, test.location.second), test.webExtensionControllerIdentifier);
+            WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(test.testName, false, adoptNS([[NSString alloc] initWithFormat:@"Promise rejected with an error: %@", debugString(errorMessageValue)]).get(), test.location.first, test.location.second), test.webExtensionControllerIdentifier);
             [test.rejectCallback callWithArguments:nil];
         } else {
             WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(test.testName, true, @"Promise resolved without an error.", test.location.first, test.location.second), test.webExtensionControllerIdentifier);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -268,7 +268,7 @@ static NSMutableDictionary *webRequestDetailsForResourceLoad(const ResourceLoadI
     NSMutableDictionary *result = [@{
         frameIdKey: resourceLoad.parentFrameID ? @(toWebAPI(toWebExtensionFrameIdentifier(resourceLoad.frameID))) : @(toWebAPI(WebExtensionFrameConstants::MainFrameIdentifier)),
         parentFrameIdKey: resourceLoad.parentFrameID ? @(toWebAPI(toWebExtensionFrameIdentifier(resourceLoad.parentFrameID))) : @(toWebAPI(WebExtensionFrameConstants::NoneIdentifier)),
-        requestIdKey: [NSString stringWithFormat:@"%llu", resourceLoad.resourceLoadID.toUInt64()],
+        requestIdKey: adoptNS([[NSString alloc] initWithFormat:@"%llu", resourceLoad.resourceLoadID.toUInt64()]).get(),
         timeStampKey: @(floor(resourceLoad.eventTimestamp.approximateWallTime().secondsSinceEpoch().milliseconds())),
         urlKey: resourceLoad.originalURL.string(),
         tabIdKey: @(toWebAPI(tabIdentifier)),

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -175,7 +175,7 @@ static NSString * const portsKey = @"ports";
         NSUInteger count = dynamic_objc_cast<NSArray>(rawValue).count;
         for (NSUInteger i = 0; i < count; ++i) {
             id portOrRange = rawValue[i];
-            if (!validateObject(portOrRange, [NSString stringWithFormat:@"%@[%lu]", portsKey, i], expectedPortOrRangeTypes, outErrorMessage))
+            if (!validateObject(portOrRange, adoptNS([[NSString alloc] initWithFormat:@"%@[%lu]", portsKey, i]).get(), expectedPortOrRangeTypes, outErrorMessage))
                 return nil;
 
             if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -301,7 +301,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         if ([attribute isEqualToString:@"AXDataDetectorTypeAtPoint"]) {
             String stringValue;
             if (protectedSelf->m_page->corePage()->pageOverlayController().copyAccessibilityAttributeStringValueForPoint(attribute, point, stringValue))
-                value = [NSString stringWithString:stringValue];
+                value = adoptNS([[NSString alloc] initWithString:stringValue]);
         }
         return value;
     }).autorelease();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -652,19 +652,19 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
     RetainPtr<NSString> applicationName;
     switch (m_processType) {
     case ProcessType::Inspector:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
+        applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
         break;
     case ProcessType::ServiceWorker:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), m_uiProcessName.createNSString().get(), m_registrableDomain.string().createNSString().get()];
+        applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), m_uiProcessName.createNSString().get(), m_registrableDomain.string().createNSString().get()]).get();
         break;
     case ProcessType::PrewarmedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
+        applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
         break;
     case ProcessType::CachedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
+        applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
         break;
     case ProcessType::WebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()];
+        applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
         break;
     }
 

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -139,7 +139,7 @@ static RetainPtr<NSString> platformDefaultActionBundleIdentifier(const WebCore::
 
 static RetainPtr<NSString> platformNotificationCenterBundleIdentifier(String pushPartition)
 {
-    return [NSString stringWithFormat:@"com.apple.WebKit.PushBundle.%@", pushPartition.createNSString().get()];
+    return adoptNS([[NSString alloc] initWithFormat:@"com.apple.WebKit.PushBundle.%@", pushPartition.createNSString().get()]);
 }
 
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
@@ -1025,7 +1025,7 @@ void WebPushDaemon::showNotification(const WebCore::PushSubscriptionSetIdentifie
 #endif
 
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    content.get().subtitle = [NSString stringWithFormat:WEB_UI_STRING("from %@", "Web Push Notification string to indicate the name of the Web App/Web Site a notification was sent from, such as 'from Wikipedia'").createNSString().get(), notificationSourceForDisplay];
+    content.get().subtitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("from %@", "Web Push Notification string to indicate the name of the Web App/Web Site a notification was sent from, such as 'from Wikipedia'").createNSString().get(), notificationSourceForDisplay]).get();
 ALLOW_NONLITERAL_FORMAT_END
 
     content.get().userInfo = notificationData.dictionaryRepresentation();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -260,7 +260,7 @@ int WebPushToolMain(int, char **)
             else if ([argument isEqualToString:@"injectPushMessage"]) {
                 auto pushMessage = pushMessageFromArguments(enumerator);
                 if (!pushMessage)
-                    printUsageAndTerminate([NSString stringWithFormat:@"Invalid push arguments specified"]);
+                    printUsageAndTerminate(adoptNS([[NSString alloc] initWithFormat:@"Invalid push arguments specified"]).get());
                 verb = makeUnique<InjectPushMessageVerb>(WTFMove(*pushMessage));
             } else if ([argument isEqualToString:@"getPushPermissionState"]) {
                 String scope { [enumerator nextObject] };
@@ -269,7 +269,7 @@ int WebPushToolMain(int, char **)
                 String scope { [enumerator nextObject] };
                 verb = makeUnique<RequestPushPermissionVerb>(scope);
             } else
-                printUsageAndTerminate([NSString stringWithFormat:@"Invalid option provided: %@", argument]);
+                printUsageAndTerminate(adoptNS([[NSString alloc] initWithFormat:@"Invalid option provided: %@", argument]).get());
 
             argument = [enumerator nextObject];
         }


### PR DESCRIPTION
#### fea7751ece731c11ca96ae202e371108766c9fdd
<pre>
Avoid autoreleasing NSStrings in WebKit/ when not strictly necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=291104">https://bugs.webkit.org/show_bug.cgi?id=291104</a>

Reviewed by Geoffrey Garen.

Avoid autoreleasing NSStrings when possible is good practice due to:
- Performance reasons:
  - Cleaning up objects from all over the memory space in an autorelease pool
    can be slow.
  - Relying on autorelease pool draining to free objects can lead to temporary
    memory spikes, as clean up work is delayed.
- Safety:
  - Holding a RetainPtr to the object makes lifetime clearer, whereas autorelease
    pool draining is not as clear and can result in use-after-free bugs.
- Easier debugging:
  - Memory corruption bugs are harder to debug when it happens during autorelease
    pool drain.

* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setCaptureAttributionString):
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::updateProcessName):
* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::initializeProcessName):
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::hasProhibitedUsageStrings):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::constructExpectedMessage):
(WebKit::validateArray):
(WebKit::formatList):
(WebKit::validateDictionary):
* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm:
(rowFilterStringFromRowKeys):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore deleteScriptsWithIDs:completionHandler:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _setDatabaseSchemaVersion:]):
(-[_WKWebExtensionSQLiteStore createSavepointWithCompletionHandler:]):
(-[_WKWebExtensionSQLiteStore commitSavepoint:completionHandler:]):
(-[_WKWebExtensionSQLiteStore rollbackToSavepoint:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm:
(+[WKContentRuleList _parseRuleList:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore compileContentRuleListForIdentifier:encodedContentRuleList:completionHandler:]):
(-[WKContentRuleListStore lookUpContentRuleListForIdentifier:completionHandler:]):
(-[WKContentRuleListStore removeContentRuleListForIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector printErrorToConsole:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration description]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm:
(-[_WKTextManipulationItem _descriptionPreservingPrivacy:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(uuidFromPushPartition):
(-[_WKWebPushAction beginBackgroundTaskForHandling]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _presentLockdownMode]):
* Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm:
(WebKit::WebAutomationSession::platformSimulateKeyboardInteraction):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::platformSimulateKeyboardInteraction):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertMessageText):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(-[_WKSSOSiteList tableView:viewForTableColumn:row:]):
(WebKit::presentStorageAccessAlert):
(WebKit::presentStorageAccessAlertQuirk):
(WebKit::presentStorageAccessAlertSSOQuirk):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(WebKit::if):
(-[_WKWebExtensionDeclarativeNetRequestRule _validateHeaderInfoDictionary:]):
(-[_WKWebExtensionDeclarativeNetRequestRule description]):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm:
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore addRules:completionHandler:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore deleteRules:completionHandler:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _getRulesWithRuleIDs:errorMessage:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _insertRule:inDatabase:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _createFreshDatabaseSchema]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _resetDatabaseSchema]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _isDatabaseEmpty]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm:
(-[WKInspectorResourceURLSchemeHandler webView:startURLSchemeTask:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(+[WKInspectorViewController URLForInspectorResource:]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::updateInspectorWindowTitle const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::appendLayerDescription):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
(WebKit::WebsiteDataStore::initializeManagedDomains):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _appendAppLinkOpenActionsForURL:actions:elementInfo:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView actionSheetAssistant:shareElementWithImage:rect:]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView _URLWithPageIndex:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker setHour:minute:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(stringWithWritingDirection):
(-[WKSelectTableViewController initWithView:hasGroups:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController setLocation:]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _showPhishingAlert]):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::alertForGetDisplayMedia):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(linkDestinationName):
(-[WKPrintingView _drawPDFDocument:page:atPoint:]):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController showSuggestionsDropdown:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::pathWithUniqueFilenameForPath):
(WebKit::WebViewImpl::namesOfPromisedFilesDroppedAtDestination):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseDetailsStringFromKey):
(WebKit::WebExtensionAPISidebarAction::setIcon):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::set):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::assertResolves):
(WebKit::WebExtensionAPITest::assertSafe):
(WebKit::WebExtensionAPITest::startNextTest):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::webRequestDetailsForResourceLoad):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityDataDetectorValue:point:]):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::updateProcessName):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformNotificationCenterBundleIdentifier):
(WebPushD::WebPushDaemon::showNotification):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/293324@main">https://commits.webkit.org/293324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1022fd5532aa72e8c2a63e2a95a92f72d94c09c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8434 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/103688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26651 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/103688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89016 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/103688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13802 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48537 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106061 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25657 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83485 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5807 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25615 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->