### PR TITLE
Address Safer CPP warnings in WebKit/Shared/Cocoa/ and WebKit/Shared/cf

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -6,7 +6,6 @@ Platform/IPC/ArgumentCoders.h
 Platform/IPC/Connection.cpp
 Platform/IPC/Connection.h
 Platform/IPC/StreamClientConnection.cpp
-Shared/Cocoa/WKObject.mm
 Shared/JavaScriptEvaluationResult.mm
 UIProcess/API/C/WKAuthenticationChallenge.cpp
 UIProcess/API/C/WKBackForwardListRef.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -8,10 +8,6 @@ Platform/cocoa/WebPrivacyHelpers.mm
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Platform/mac/MenuUtilities.mm
 Platform/mac/StringUtilities.mm
-Shared/Cocoa/APIObject.mm
-Shared/Cocoa/AuxiliaryProcessCocoa.mm
-Shared/Cocoa/CompletionHandlerCallChecker.mm
-Shared/cf/CoreIPCSecKeychainItem.h
 UIProcess/API/Cocoa/APIAttachmentCocoa.mm
 UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
 UIProcess/API/Cocoa/NSAttributedString.mm

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -152,7 +152,7 @@ API::Object& Object::fromWKObjectExtraSpace(id <WKObject> obj)
 
 void* Object::newObject(size_t size, Type type)
 {
-    id <WKObject> wrapper;
+    SUPPRESS_UNRETAINED_LOCAL id<WKObject> wrapper;
 
     // Wrappers that inherit from WKObject store the API::Object in their extra bytes, so they are
     // allocated using NSAllocatedObject. The other wrapper classes contain inline storage for the

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -198,7 +198,7 @@ RetainPtr<id> AuxiliaryProcess::decodePreferenceValue(const std::optional<String
         NSData.class,
         NSMutableData.class,
     nil];
-    NSError *error { nil };
+    SUPPRESS_UNRETAINED_LOCAL NSError *error { nil };
     RetainPtr<id> result = [NSKeyedUnarchiver _strictlyUnarchivedObjectOfClasses:classes.get() fromData:encodedData.get() error:&error];
     ASSERT(!error);
     return result;

--- a/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
+++ b/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
@@ -42,7 +42,7 @@ public:
 private:
     CompletionHandlerCallChecker(Class delegateClass, SEL delegateMethodSelector);
 
-    Class classImplementingDelegateMethod() const;
+    RetainPtr<Class> classImplementingDelegateMethod() const;
 
     Class m_delegateClass;
     SEL m_delegateMethodSelector;

--- a/Source/WebKit/Shared/Cocoa/WKObject.mm
+++ b/Source/WebKit/Shared/Cocoa/WKObject.mm
@@ -55,7 +55,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKObject.class, self))
         return;
 
-    API::Object::fromWKObjectExtraSpace(self).~Object();
+    SUPPRESS_UNCOUNTED_ARG API::Object::fromWKObjectExtraSpace(self).~Object();
 
     [super dealloc];
 }

--- a/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
@@ -66,7 +66,7 @@ public:
             return nullptr;
 
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        SecKeychainItemRef keychainItem = NULL;
+        SUPPRESS_UNRETAINED_LOCAL SecKeychainItemRef keychainItem = NULL;
         SecKeychainItemCopyFromPersistentReference(m_persistentRef.get(), &keychainItem);
         ALLOW_DEPRECATED_DECLARATIONS_END
         return adoptCF(keychainItem);
@@ -88,7 +88,7 @@ private:
             return nullptr;
 
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        CFDataRef data = NULL;
+        SUPPRESS_UNRETAINED_LOCAL CFDataRef data = NULL;
         SecKeychainItemCreatePersistentReference(keychainItem, &data);
         ALLOW_DEPRECATED_DECLARATIONS_END
 


### PR DESCRIPTION
#### cc72b233f6b527255d099e9d45be6b35f9f92145
<pre>
Address Safer CPP warnings in WebKit/Shared/Cocoa/ and WebKit/Shared/cf
<a href="https://bugs.webkit.org/show_bug.cgi?id=291105">https://bugs.webkit.org/show_bug.cgi?id=291105</a>

Reviewed by Ryosuke Niwa and Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::decodePreferenceValue):
* Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h:
* Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.mm:
(WebKit::CompletionHandlerCallChecker::~CompletionHandlerCallChecker):
(WebKit::CompletionHandlerCallChecker::completionHandlerHasBeenCalled const):
(WebKit::CompletionHandlerCallChecker::classImplementingDelegateMethod const):
* Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h:
(WebKit::CoreIPCSecKeychainItem::createSecKeychainItem const):
(WebKit::CoreIPCSecKeychainItem::persistentRefForKeychainItem const):

Canonical link: <a href="https://commits.webkit.org/293299@main">https://commits.webkit.org/293299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc7af31cc22717e113bfd888a59d76e2b8e7555d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74949 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88931 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55309 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28054 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25514 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->