### PR TITLE
[iOS] UI process takes MediaPlayback assertions even when Media Capability Grants are enabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4830,6 +4830,7 @@ MediaCapabilityGrantsEnabled:
     WebCore:
       "PLATFORM(IOS_FAMILY_SIMULATOR)": false
       default: true
+  sharedPreferenceForWebProcess: true
 
 MediaCaptionFormatTypesAllowedInLockdownMode:
   type: String

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -717,14 +717,22 @@ void AudioContext::isActiveNowPlayingSessionChanged()
     }
 }
 
-ProcessID AudioContext::presentingApplicationPID() const
+std::optional<ProcessID> AudioContext::mediaSessionPresentingApplicationPID() const
 {
-    if (RefPtr document = this->document()) {
-        if (RefPtr page = document->protectedPage())
-            return page->presentingApplicationPID();
-    }
+    RefPtr document = this->document();
+    if (!document)
+        return std::nullopt;
 
-    return { };
+    RefPtr page = document->page();
+    if (!page)
+        return std::nullopt;
+
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (page->settings().mediaCapabilityGrantsEnabled())
+        return std::nullopt;
+#endif
+
+    return page->presentingApplicationPID();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -150,7 +150,7 @@ private:
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
     WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
     void isActiveNowPlayingSessionChanged() final;
-    ProcessID presentingApplicationPID() const final;
+    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
 
     // MediaCanStartListener.
     void mediaCanStart(Document&) final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9825,12 +9825,18 @@ void HTMLMediaElement::isActiveNowPlayingSessionChanged()
         page->hasActiveNowPlayingSessionChanged();
 }
 
-ProcessID HTMLMediaElement::presentingApplicationPID() const
+std::optional<ProcessID> HTMLMediaElement::mediaSessionPresentingApplicationPID() const
 {
-    if (RefPtr page = protectedDocument()->protectedPage())
-        return page->presentingApplicationPID();
+    RefPtr page = protectedDocument()->page();
+    if (!page)
+        return std::nullopt;
 
-    return { };
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (page->settings().mediaCapabilityGrantsEnabled())
+        return std::nullopt;
+#endif
+
+    return page->presentingApplicationPID();
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -259,7 +259,7 @@ public:
 
     WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
     void isActiveNowPlayingSessionChanged() final;
-    ProcessID presentingApplicationPID() const final;
+    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
 
 // DOM API
 // error state

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5641,6 +5641,11 @@ void Page::setPresentingApplicationAuditToken(std::optional<audit_token_t> prese
 {
     m_presentingApplicationAuditToken = WTFMove(presentingApplicationAuditToken);
 
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (settings().mediaCapabilityGrantsEnabled())
+        return;
+#endif
+
     if (RefPtr mediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         mediaSessionManager->updatePresentingApplicationPIDIfNecessary(presentingApplicationPID());
 }

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -494,9 +494,9 @@ void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSes
     client().isActiveNowPlayingSessionChanged();
 }
 
-ProcessID PlatformMediaSession::presentingApplicationPID() const
+std::optional<ProcessID> PlatformMediaSession::presentingApplicationPID() const
 {
-    return client().presentingApplicationPID();
+    return client().mediaSessionPresentingApplicationPID();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -255,7 +255,7 @@ public:
     bool isActiveNowPlayingSession() const { return m_isActiveNowPlayingSession; }
     void setActiveNowPlayingSession(bool);
 
-    ProcessID presentingApplicationPID() const;
+    std::optional<ProcessID> presentingApplicationPID() const;
 
     virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
 
@@ -339,7 +339,7 @@ public:
 
     virtual void isActiveNowPlayingSessionChanged() = 0;
 
-    virtual ProcessID presentingApplicationPID() const = 0;
+    virtual std::optional<ProcessID> mediaSessionPresentingApplicationPID() const = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -52,10 +52,6 @@ bool PlatformMediaSessionManager::m_vp9DecoderEnabled;
 bool PlatformMediaSessionManager::m_swVPDecodersAlwaysEnabled;
 #endif
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-bool PlatformMediaSessionManager::s_mediaCapabilityGrantsEnabled;
-#endif
-
 static std::unique_ptr<PlatformMediaSessionManager>& sharedPlatformMediaSessionManager()
 {
     static NeverDestroyed<std::unique_ptr<PlatformMediaSessionManager>> platformMediaSessionManager;
@@ -788,18 +784,6 @@ bool PlatformMediaSessionManager::alternateWebMPlayerEnabled()
     return false;
 #endif
 }
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-bool PlatformMediaSessionManager::mediaCapabilityGrantsEnabled()
-{
-    return s_mediaCapabilityGrantsEnabled;
-}
-
-void PlatformMediaSessionManager::setMediaCapabilityGrantsEnabled(bool mediaCapabilityGrantsEnabled)
-{
-    s_mediaCapabilityGrantsEnabled = mediaCapabilityGrantsEnabled;
-}
-#endif
 
 WeakPtr<PlatformMediaSession> PlatformMediaSessionManager::bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>& filterFunction, PlatformMediaSession::PlaybackControlsPurpose purpose)
 {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -68,11 +68,6 @@ public:
     WEBCORE_EXPORT static void setAlternateWebMPlayerEnabled(bool);
     WEBCORE_EXPORT static bool alternateWebMPlayerEnabled();
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-    WEBCORE_EXPORT static bool mediaCapabilityGrantsEnabled();
-    WEBCORE_EXPORT static void setMediaCapabilityGrantsEnabled(bool);
-#endif
-
     virtual ~PlatformMediaSessionManager();
 
     virtual void scheduleSessionStatusUpdate() { }
@@ -267,10 +262,6 @@ private:
 #if ENABLE(VP9)
     static bool m_vp9DecoderEnabled;
     static bool m_swVPDecodersAlwaysEnabled;
-#endif
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-    static bool s_mediaCapabilityGrantsEnabled;
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -88,7 +88,7 @@ protected:
     void clientCharacteristicsChanged(PlatformMediaSession&, bool) final;
     void sessionCanProduceAudioChanged() final;
 
-    virtual void providePresentingApplicationPIDIfNecessary(ProcessID) { }
+    virtual void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) { }
 
     WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -238,6 +238,10 @@ void MediaSessionManagerCocoa::beginInterruption(PlatformMediaSession::Interrupt
 
 void MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequestForPage(Page& page)
 {
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (page.settings().mediaCapabilityGrantsEnabled())
+        return;
+#endif
     providePresentingApplicationPIDIfNecessary(page.presentingApplicationPID());
 }
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -267,11 +267,6 @@ MediaSessionHelperIOS::MediaSessionHelperIOS()
 
 void MediaSessionHelperIOS::providePresentingApplicationPID(int pid, ShouldOverride shouldOverride)
 {
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (PlatformMediaSessionManager::mediaCapabilityGrantsEnabled())
-        return;
-#endif
-
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     if (m_presentedApplicationPID && (*m_presentedApplicationPID == pid || shouldOverride == ShouldOverride::No))
         return;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -67,7 +67,7 @@ private:
 #endif
 
     void configureWirelessTargetMonitoring() final;
-    void providePresentingApplicationPIDIfNecessary(ProcessID) final;
+    void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) final;
     void updatePresentingApplicationPIDIfNecessary(ProcessID) final;
     bool sessionWillBeginPlayback(PlatformMediaSession&) final;
     void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -117,13 +117,13 @@ void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 #endif
 }
 
-void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary(ProcessID pid)
+void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>& pid)
 {
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
-    if (m_havePresentedApplicationPID)
+    if (m_havePresentedApplicationPID || !pid)
         return;
     m_havePresentedApplicationPID = true;
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
+    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(*pid);
 #else
     UNUSED_PARAM(pid);
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -291,11 +291,6 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
         PlatformMediaSessionManager::setAlternateWebMPlayerEnabled(*m_preferences.alternateWebMPlayerEnabled);
 #endif
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (updatePreference(m_preferences.mediaCapabilityGrantsEnabled, preferences.mediaCapabilityGrantsEnabled))
-        PlatformMediaSessionManager::setMediaCapabilityGrantsEnabled(*m_preferences.mediaCapabilityGrantsEnabled);
-#endif
-
 #if ENABLE(VP9)
     if (updatePreference(m_preferences.vp9DecoderEnabled, preferences.vp9DecoderEnabled)) {
         VP9TestingOverrides::singleton().setShouldEnableVP9Decoder(*m_preferences.vp9DecoderEnabled);

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -48,11 +48,6 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
         alternateWebMPlayerEnabled = true;
 #endif
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (webPreferences.mediaCapabilityGrantsEnabled())
-        mediaCapabilityGrantsEnabled = true;
-#endif
-
 #if ENABLE(VP9)
     if (webPreferences.vp9DecoderEnabled())
         vp9DecoderEnabled = true;

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -44,10 +44,6 @@ struct GPUProcessPreferences {
     std::optional<bool> alternateWebMPlayerEnabled;
 #endif
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-    std::optional<bool> mediaCapabilityGrantsEnabled;
-#endif
-
 #if ENABLE(VP9)
     std::optional<bool> vp9DecoderEnabled;
     bool swVPDecodersAlwaysEnabled { false };

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -29,9 +29,6 @@ struct WebKit::GPUProcessPreferences {
 #if ENABLE(ALTERNATE_WEBM_PLAYER)
     std::optional<bool> alternateWebMPlayerEnabled;
 #endif
-#if ENABLE(EXTENSION_CAPABILITIES)
-    std::optional<bool> mediaCapabilityGrantsEnabled;
-#endif
 #if ENABLE(VP9)
     std::optional<bool> vp9DecoderEnabled;
     bool swVPDecodersAlwaysEnabled;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2336,11 +2336,6 @@ void WebProcessPool::clearAudibleActivity()
 
 void WebProcessPool::updateAudibleMediaAssertions()
 {
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (PlatformMediaSessionManager::mediaCapabilityGrantsEnabled())
-        return;
-#endif
-
     if (!m_webProcessWithAudibleMediaCounter.value()) {
         WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "updateAudibleMediaAssertions: Starting timer to clear audible activity in %g seconds because we are no longer playing audio", audibleActivityClearDelay.seconds());
         // We clear the audible activity on a timer for 2 reasons:

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1961,15 +1961,20 @@ String WebProcessProxy::environmentIdentifier() const
 
 void WebProcessProxy::updateAudibleMediaAssertions()
 {
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (PlatformMediaSessionManager::mediaCapabilityGrantsEnabled())
-        return;
-#endif
-
     bool hasAudibleMainPage = WTF::anyOf(pages(), [] (auto& page) {
+#if ENABLE(EXTENSION_CAPABILITIES)
+        if (page->preferences().mediaCapabilityGrantsEnabled())
+            return false;
+#endif
         return page->isPlayingAudio();
     });
     bool hasAudibleRemotePage = WTF::anyOf(remotePages(), [](auto& remotePage) {
+#if ENABLE(EXTENSION_CAPABILITIES)
+        if (RefPtr page = remotePage ? remotePage->protectedPage() : nullptr) {
+            if (page->preferences().mediaCapabilityGrantsEnabled())
+                return false;
+        }
+#endif
         return remotePage ? remotePage->mediaState().contains(MediaProducerMediaState::IsPlayingAudio) : false;
     });
     bool hasAudibleWebPage = hasAudibleMainPage || hasAudibleRemotePage;


### PR DESCRIPTION
#### 877acfb0ac59fc476ff8cd4991d78bbb17dc4aea
<pre>
[iOS] UI process takes MediaPlayback assertions even when Media Capability Grants are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=291102">https://bugs.webkit.org/show_bug.cgi?id=291102</a>
<a href="https://rdar.apple.com/problem/148619135">rdar://problem/148619135</a>

Reviewed by Per Arne Vollan and Eric Carlson.

WebProcessProxy::updateAudibleMediaAssertions() would take MediaPlayback assertions even in cases
where Media Capability Grants were enabled, which was duplicative and unnecessary. 276828@main
attempted to address this, but was unsuccessful since
PlatformMediaSessionManager::mediaCapabilityGrantsEnabled() only returns the correct value in the
GPU process.

Tried again to address this by removing PlatformMediaSessionManager::mediaCapabilityGrantsEnabled()
and using the value in WebPreferences / Settings / SharedPreferencesForWebProcess instead.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
  Added &apos;sharedPreferenceForWebProcess: true&apos; to MediaCapabilityGrantsEnabled so that it can be
  read from the GPU process.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::mediaSessionPresentingApplicationPID const):
  Changed to return an optional and renamed to clarify that this value is meant for a media session.
  When mediaCapabilityGrantsEnabled() is true for the AudioContent&apos;s page, returned std::nullopt.
(WebCore::AudioContext::presentingApplicationPID const): Deleted.
* Source/WebCore/Modules/webaudio/AudioContext.h:

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaSessionPresentingApplicationPID const):
(WebCore::HTMLMediaElement::presentingApplicationPID const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
  Changed to return an optional and renamed to clarify that this value is meant for a media session.
  When mediaCapabilityGrantsEnabled() is true for the AudioContent&apos;s page, returned std::nullopt.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPresentingApplicationAuditToken):
  Skipped calling PlatformMediaSessionManager::updatePresentingApplicationPIDIfNecessary() if
  mediaCapabilityGrantsEnabled() is true.

* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::presentingApplicationPID const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
  Changed to return an optional and call
  PlatformMediaSessionClient::mediaSessionPresentingApplicationPID().

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::mediaCapabilityGrantsEnabled): Deleted.
(WebCore::PlatformMediaSessionManager::setMediaCapabilityGrantsEnabled): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
(WebCore::MediaSessionManagerCocoa::providePresentingApplicationPIDIfNecessary):
  Changed to return an optional so that providing a PID can be skipped when
  mediaCapabilityGrantsEnabled() is true.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequestForPage):
  Skipped calling providePresentingApplicationPIDIfNecessary() when mediaCapabilityGrantsEnabled()
  is true.

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelperIOS::providePresentingApplicationPID):
  Removed the call to PlatformMediaSessionManager::mediaCapabilityGrantsEnabled(); callers are now
  responsible to avoid calling this when mediaCapabilityGrantsEnabled() is true.

* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary):
  Skipped calling MediaSessionHelper::providePresentingApplicationPID() when
  mediaCapabilityGrantsEnabled() is true.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences):
* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::copyEnabledWebPreferences):
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in:
  Removed GPUProcessPreferences::mediaCapabilityGrantsEnabled in favor of using
  SharedPreferencesForWebProcess.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updatePresentingProcesses):
  Removed the call to GPUProcessPreferences::mediaCapabilityGrantsEnabled; instead, checked the
  value of mediaCapabilityGrantsEnabled on each GPUConnectionToWebProcess&apos;
  SharedPreferencesForWebProcess and called AudioSession::setPresentingProcesses() with an array
  containing only the process tokens where mediaCapabilityGrantsEnabled is false.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::updateAudibleMediaAssertions):
  Removed the call to GPUProcessPreferences::mediaCapabilityGrantsEnabled;
  WebProcessProxy::updateAudibleMediaAssertions() will ensure that
  m_webProcessWithAudibleMediaCounter only has a value when there are processes where
  mediaCapabilityGrantsEnabled is false.

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateAudibleMediaAssertions):
  Removed the call to GPUProcessPreferences::mediaCapabilityGrantsEnabled; instead, changed how
  hasAudibleMainPage and hasAudibleRemotePage are defined such that they are only true if a page is
  playing audio while mediaCapabilityGrantsEnabled is false.

Canonical link: <a href="https://commits.webkit.org/293335@main">https://commits.webkit.org/293335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8c4626aaab65a830fc2782942d28cacc2e73b9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74919 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48394 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91107 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105918 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97051 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83894 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5693 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30648 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120670 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25289 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33774 "Found 19723 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_forin.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->