### PR TITLE
Model element's entityTransform property setting fails for some valid values

### DIFF
--- a/LayoutTests/model-element/model-element-entity-transform-expected.txt
+++ b/LayoutTests/model-element/model-element-entity-transform-expected.txt
@@ -8,4 +8,5 @@ PASS <model> gets the updated entityTransform after change
 PASS <model> gets the updated entityTransform after model source change
 PASS <model> gets the identity entityTransform after model source removal
 PASS <model> ignores entityTransform when stagemode is set
+PASS <model> gets the updated entityTransform after rotation
 

--- a/LayoutTests/model-element/model-element-entity-transform.html
+++ b/LayoutTests/model-element/model-element-entity-transform.html
@@ -84,5 +84,24 @@ promise_test(async t => {
     assert_3d_matrix_equals(model.entityTransform, orbitFitTransform);
 }, `<model> ignores entityTransform when stagemode is set`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    await model.ready;
+
+    const angle = 57.64999999999886;
+    const rotationAmount = 10;
+
+    for (var iteration = 0; iteration < 6; ++iteration) {
+        try {
+            const matrix = new DOMMatrixReadOnly();
+            const newMatrix = matrix.translate(0, 0, -10).rotate(0, angle + iteration * rotationAmount, 0);
+            model.entityTransform = newMatrix;
+            assert_3d_matrix_equals(model.entityTransform, newMatrix);
+        } catch (error) {
+            console.error('Error setting transform: ' + error.name);
+        }
+    }
+}, `<model> gets the updated entityTransform after rotation`);
+
 </script>
 </body>


### PR DESCRIPTION
#### 00790bc289856d5ad4930173c7075b7435c075b4
<pre>
Model element&apos;s entityTransform property setting fails for some valid values
<a href="https://bugs.webkit.org/show_bug.cgi?id=291110">https://bugs.webkit.org/show_bug.cgi?id=291110</a>
<a href="https://rdar.apple.com/148495915">rdar://148495915</a>

Reviewed by Mike Wyrzykowski.

Use a bigger tolerance for the comparisons made when
checking whether the transform matrix is valid, as there
could be precision loss in the matrix &lt;-&gt; SRT arithmetic.

* LayoutTests/model-element/model-element-entity-transform-expected.txt:
* LayoutTests/model-element/model-element-entity-transform.html:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::transformSupported):

Canonical link: <a href="https://commits.webkit.org/293418@main">https://commits.webkit.org/293418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0314d23839e3b5c213032e75c98b1a0ae72c49d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75195 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32338 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21213 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31012 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->