### PR TITLE
computeIntrinsicLogicalWidths return value WIP

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -73,10 +73,8 @@ LayoutUnit formattingContextRootLogicalWidthForType(const Layout::ElementBox& bo
         return renderer.minPreferredLogicalWidth();
     case LogicalWidthType::MaxContent:
     case LogicalWidthType::MinContent: {
-        auto minimunLogicalWidth = LayoutUnit { };
-        auto maximumLogicalWidth = LayoutUnit { };
-        renderer.computeIntrinsicLogicalWidths(minimunLogicalWidth, maximumLogicalWidth);
-        return logicalWidthType == LogicalWidthType::MaxContent ? maximumLogicalWidth : minimunLogicalWidth;
+        auto [minimumLogicalWidth, maximumLogicalWidth] = renderer.computeIntrinsicLogicalWidths();
+        return logicalWidthType == LogicalWidthType::MaxContent ? maximumLogicalWidth : minimumLogicalWidth;
     }
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -210,21 +210,20 @@ static bool shouldScaleColumnsForParent(const RenderTable& table)
     return true;
 }
 
-void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics intrinsics)
+IntrinsicLogicalWidths AutoTableLayout::computeIntrinsicLogicalWidths(TableIntrinsics intrinsics)
 {
     fullRecalc();
 
     float spanMaxLogicalWidth = calcEffectiveLogicalWidth();
-    minWidth = 0;
-    maxWidth = 0;
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     float maxPercent = 0;
     float maxNonPercent = 0;
     bool scaleColumnsForSelf = intrinsics == TableIntrinsics::ForLayout;
 
     float remainingPercent = 100;
     for (size_t i = 0; i < m_layoutStruct.size(); ++i) {
-        minWidth += m_layoutStruct[i].effectiveMinLogicalWidth;
-        maxWidth += m_layoutStruct[i].effectiveMaxLogicalWidth;
+        intrinsicLogicalWidths.minimum += m_layoutStruct[i].effectiveMinLogicalWidth;
+        intrinsicLogicalWidths.maximum += m_layoutStruct[i].effectiveMaxLogicalWidth;
         if (scaleColumnsForSelf) {
             if (m_layoutStruct[i].effectiveLogicalWidth.isPercent()) {
                 float percent = std::min(m_layoutStruct[i].effectiveLogicalWidth.percent(), remainingPercent);
@@ -245,11 +244,12 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
         if (maxNonPercent > 0)
             maxNonPercent = (remainingPercent > 0) ? maxNonPercent * 100 / remainingPercent : tableMaxWidth;
         m_scaledWidthFromPercentColumns = std::min(LayoutUnit(tableMaxWidth), LayoutUnit(std::max(maxPercent, maxNonPercent)));
-        if (m_scaledWidthFromPercentColumns > maxWidth && shouldScaleColumnsForParent(*m_table))
-            maxWidth = m_scaledWidthFromPercentColumns;
+        if (m_scaledWidthFromPercentColumns > intrinsicLogicalWidths.maximum && shouldScaleColumnsForParent(*m_table))
+            intrinsicLogicalWidths.maximum = m_scaledWidthFromPercentColumns;
     }
 
-    maxWidth = std::max(maxWidth, LayoutUnit(spanMaxLogicalWidth));
+    intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.maximum, LayoutUnit(spanMaxLogicalWidth));
+    return intrinsicLogicalWidths;
 }
 
 void AutoTableLayout::applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const

--- a/Source/WebCore/rendering/AutoTableLayout.h
+++ b/Source/WebCore/rendering/AutoTableLayout.h
@@ -29,13 +29,14 @@ namespace WebCore {
 
 class RenderTable;
 class RenderTableCell;
+struct IntrinsicLogicalWidths;
 
 class AutoTableLayout final : public TableLayout {
 public:
     explicit AutoTableLayout(RenderTable*);
     virtual ~AutoTableLayout();
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics) override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths(TableIntrinsics) override;
     LayoutUnit scaledWidthFromPercentColumns() const override { return m_scaledWidthFromPercentColumns; }
     void applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const override;
     void layout() override;

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -173,9 +173,10 @@ float FixedTableLayout::calcWidthArray()
     return usedWidth;
 }
 
-void FixedTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics)
+IntrinsicLogicalWidths FixedTableLayout::computeIntrinsicLogicalWidths(TableIntrinsics)
 {
-    minWidth = maxWidth = calcWidthArray();
+    auto calcWidthArray = LayoutUnit { this->calcWidthArray() };
+    return { calcWidthArray, calcWidthArray };
 }
 
 void FixedTableLayout::applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const

--- a/Source/WebCore/rendering/FixedTableLayout.h
+++ b/Source/WebCore/rendering/FixedTableLayout.h
@@ -28,12 +28,13 @@
 namespace WebCore {
 
 class RenderTable;
+struct IntrinsicLogicalWidths;
 
 class FixedTableLayout final : public TableLayout {
 public:
     explicit FixedTableLayout(RenderTable*);
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics) override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths(TableIntrinsics) override;
     void applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const override;
     void layout() override;
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2345,22 +2345,22 @@ void RenderBlock::offsetForContents(LayoutPoint& offset) const
     offset = flipForWritingMode(offset);
 }
 
-void RenderBlock::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderBlock::computeIntrinsicLogicalWidths() const
 {
     ASSERT(!childrenInline());
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = width.value();
-            maxLogicalWidth = width.value();
+            intrinsicLogicalWidths.minimum = width.value();
+            intrinsicLogicalWidths.maximum = width.value();
         }
     } else if (!shouldApplyInlineSizeContainment())
-        computeBlockPreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        computeBlockPreferredLogicalWidths(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
 
-    maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
+    intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
 
-    int scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    maxLogicalWidth += scrollbarWidth;
-    minLogicalWidth += scrollbarWidth;
+    intrinsicLogicalWidths += intrinsicScrollbarLogicalWidthIncludingGutter();
+    return intrinsicLogicalWidths;
 }
 
 void RenderBlock::computePreferredLogicalWidths()
@@ -2379,8 +2379,11 @@ void RenderBlock::computePreferredLogicalWidths()
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
         m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);
         m_maxPreferredLogicalWidth = std::max(0_lu, m_maxPreferredLogicalWidth);
-    } else 
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    } else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(styleToUse.logicalMinWidth(), styleToUse.logicalMaxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -278,7 +278,7 @@ protected:
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
     
     std::optional<LayoutUnit> firstLineBaseline() const override;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -293,41 +293,41 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
     }
 }
 
-void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderBlockFlow::computeIntrinsicLogicalWidths() const
 {
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     bool needAdjustIntrinsicLogicalWidthsForColumns = true;
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = width.value();
-            maxLogicalWidth = width.value();
+            intrinsicLogicalWidths.minimum = width.value();
+            intrinsicLogicalWidths.maximum = width.value();
             needAdjustIntrinsicLogicalWidthsForColumns = false;
         }
     } else if (childrenInline())
-        computeInlinePreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        computeInlinePreferredLogicalWidths(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
     else
-        computeBlockPreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        computeBlockPreferredLogicalWidths(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
 
-    maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
+    intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
 
     if (needAdjustIntrinsicLogicalWidthsForColumns)
-        adjustIntrinsicLogicalWidthsForColumns(minLogicalWidth, maxLogicalWidth);
+        adjustIntrinsicLogicalWidthsForColumns(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
 
     if (!style().autoWrap() && childrenInline()) {
         // A horizontal marquee with inline children has no minimum width.
         CheckedPtr scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
         if (scrollableArea && scrollableArea->marquee() && scrollableArea->marquee()->isHorizontal())
-            minLogicalWidth = 0;
+            intrinsicLogicalWidths.minimum = 0;
     }
 
     if (auto* cell = dynamicDowncast<RenderTableCell>(*this)) {
         Length tableCellWidth = cell->styleOrColLogicalWidth();
         if (tableCellWidth.isFixed() && tableCellWidth.value() > 0)
-            maxLogicalWidth = std::max(minLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(tableCellWidth));
+            intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.minimum, adjustContentBoxLogicalWidthForBoxSizing(tableCellWidth));
     }
 
-    int scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    maxLogicalWidth += scrollbarWidth;
-    minLogicalWidth += scrollbarWidth;
+    intrinsicLogicalWidths += intrinsicScrollbarLogicalWidthIncludingGutter();
+    return intrinsicLogicalWidths;
 }
 
 bool RenderBlockFlow::recomputeLogicalWidthAndColumnWidth()

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -415,7 +415,7 @@ protected:
 
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     
     bool pushToNextPageWithMinimumLogicalHeight(LayoutUnit& adjustment, LayoutUnit logicalOffset, LayoutUnit minimumLogicalHeight) const;
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2780,15 +2780,15 @@ LayoutUnit RenderBox::computeIntrinsicLogicalWidthUsing(Length logicalWidthLengt
     if (!logicalWidthLength.isMinIntrinsic() && shouldComputeLogicalWidthFromAspectRatio()) {
         minLogicalWidth = maxLogicalWidth = computeLogicalWidthFromAspectRatioInternal() - borderAndPadding;
         if (firstChild()) {
-            LayoutUnit minChildrenLogicalWidth;
-            LayoutUnit maxChildrenLogicalWidth;
-            computeIntrinsicKeywordLogicalWidths(minChildrenLogicalWidth, maxChildrenLogicalWidth);
-            minLogicalWidth = std::max(minLogicalWidth, minChildrenLogicalWidth);
-            maxLogicalWidth = std::max(maxLogicalWidth, maxChildrenLogicalWidth);
+            auto intrinsicLogicalWidths = computeIntrinsicKeywordLogicalWidths();
+            minLogicalWidth = std::max(minLogicalWidth, intrinsicLogicalWidths.minimum);
+            maxLogicalWidth = std::max(maxLogicalWidth, intrinsicLogicalWidths.maximum);
         }
-    } else
-        computeIntrinsicKeywordLogicalWidths(minLogicalWidth, maxLogicalWidth);
-
+    } else {
+        auto intrinsicLogicalWidths = computeIntrinsicKeywordLogicalWidths();
+        minLogicalWidth = intrinsicLogicalWidths.minimum;
+        maxLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
     if (logicalWidthLength.isMinContent() || logicalWidthLength.isMinIntrinsic())
         return minLogicalWidth + borderAndPadding;
 
@@ -4051,10 +4051,8 @@ LayoutUnit RenderBox::computePositionedLogicalWidthUsing(SizeType widthType, Len
     auto originalLogicalWidthType = logicalWidth.type();
     if (widthType == SizeType::MinSize && logicalWidth.isAuto()) {
         if (shouldComputeLogicalWidthFromAspectRatio()) {
-            LayoutUnit minLogicalWidth;
-            LayoutUnit maxLogicalWidth;
-            computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
-            logicalWidth = Length(minLogicalWidth, LengthType::Fixed);
+            auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+            logicalWidth = Length(intrinsicLogicalWidths.minimum, LengthType::Fixed);
         } else
             logicalWidth = Length(0, LengthType::Fixed);
     } else if (widthType == SizeType::MainOrPreferredSize && logicalWidth.isAuto() && shouldComputeLogicalWidthFromAspectRatio())
@@ -5163,6 +5161,13 @@ bool RenderBox::overflowChangesMayAffectLayout() const
 #endif
     return !ScrollbarTheme::theme().usesOverlayScrollbars();
 
+}
+
+IntrinsicLogicalWidths& IntrinsicLogicalWidths::operator+=(LayoutUnit value)
+{
+    minimum += value;
+    maximum += value;
+    return *this;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -46,6 +46,13 @@ enum class ShouldComputePreferred : bool { ComputeActual, ComputePreferred };
 
 enum class StretchingMode { Any, Explicit };
 
+
+struct IntrinsicLogicalWidths {
+    IntrinsicLogicalWidths& operator +=(LayoutUnit);
+    LayoutUnit minimum;
+    LayoutUnit maximum;
+};
+
 class RenderBox : public RenderBoxModelObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RenderBox);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBox);
@@ -271,7 +278,8 @@ public:
 
     LayoutUnit minPreferredLogicalWidth() const override;
     LayoutUnit maxPreferredLogicalWidth() const override;
-    virtual void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const = 0;
+
+    virtual IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const = 0;
 
     std::optional<LayoutUnit> overridingBorderBoxLogicalWidth() const;
     std::optional<LayoutUnit> overridingBorderBoxLogicalHeight() const;
@@ -731,9 +739,9 @@ private:
     LayoutUnit fillAvailableMeasure(LayoutUnit availableLogicalWidth) const;
     LayoutUnit fillAvailableMeasure(LayoutUnit availableLogicalWidth, LayoutUnit& marginStart, LayoutUnit& marginEnd) const;
 
-    virtual void computeIntrinsicKeywordLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+    virtual IntrinsicLogicalWidths computeIntrinsicKeywordLogicalWidths() const
     {
-        computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        return computeIntrinsicLogicalWidths();
     }
 
     // This function calculates the minimum and maximum preferred widths for an object.

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -199,8 +199,9 @@ void RenderDeprecatedFlexibleBox::styleWillChange(StyleDifference diff, const Re
     RenderBlock::styleWillChange(diff, newStyle);
 }
 
-void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths() const
 {
+    LayoutUnit minLogicalWidth, maxLogicalWidth;
     auto addScrollbarWidth = [&]() {
         LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
         maxLogicalWidth += scrollbarWidth;
@@ -213,7 +214,7 @@ void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minL
             maxLogicalWidth = width.value();
         }
         addScrollbarWidth();
-        return;
+        return { minLogicalWidth, maxLogicalWidth };
     }
 
     if (hasMultipleLines() || isVertical()) {
@@ -241,6 +242,7 @@ void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minL
 
     maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
     addScrollbarWidth();
+    return { minLogicalWidth, maxLogicalWidth };
 }
 
 void RenderDeprecatedFlexibleBox::computePreferredLogicalWidths()
@@ -250,8 +252,11 @@ void RenderDeprecatedFlexibleBox::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = 0;
     if (style().width().isFixed() && style().width().value() > 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().width());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().minWidth(), style().maxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -50,7 +50,7 @@ public:
     bool canDropAnonymousBlockChild() const override { return false; }
 
 private:
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
     void layoutSingleClampedFlexItem();
     bool hasClampingAndNoFlexing() const;

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -268,14 +268,12 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
     }
 }
 
-void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderFileUploadControl::computeIntrinsicLogicalWidths() const
 {
     if (shouldApplySizeOrInlineSizeContainment()) {
-        if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = logicalWidth.value();
-            maxLogicalWidth = logicalWidth.value();
-        }
-        return;
+        if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth())
+            return { *logicalWidth, *logicalWidth };
+        return { };
     }
     // Figure out how big the filename space needs to be for a given number of characters
     // (using "0" as the nominal character).
@@ -290,13 +288,16 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
     if (HTMLInputElement* button = uploadButton())
         if (RenderObject* buttonRenderer = button->renderer())
             defaultLabelWidth += buttonRenderer->maxPreferredLogicalWidth() + afterButtonSpacing;
-    maxLogicalWidth = static_cast<int>(ceilf(std::max(minDefaultLabelWidth, defaultLabelWidth)));
+
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
+    intrinsicLogicalWidths.maximum = static_cast<int>(ceilf(std::max(minDefaultLabelWidth, defaultLabelWidth)));
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
+        intrinsicLogicalWidths.minimum = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
     else if (!logicalWidth.isPercent())
-        minLogicalWidth = maxLogicalWidth;
+        intrinsicLogicalWidths.minimum = intrinsicLogicalWidths.maximum;
+    return intrinsicLogicalWidths;
 }
 
 void RenderFileUploadControl::computePreferredLogicalWidths()
@@ -308,8 +309,11 @@ void RenderFileUploadControl::computePreferredLogicalWidths()
 
     if (style().logicalWidth().isFixed() && style().logicalWidth().value() > 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), writingMode().isHorizontal() ? horizontalBorderAndPaddingExtent() : verticalBorderAndPaddingExtent());
 

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -48,7 +48,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderFileUploadControl"_s; }
 
     void updateFromElement() override;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
     void paintObject(PaintInfo&, const LayoutPoint&) override;
     void paintControl(PaintInfo&, const LayoutPoint&);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -101,23 +101,17 @@ ASCIILiteral RenderFlexibleBox::renderName() const
     return "RenderFlexibleBox"_s;
 }
 
-void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderFlexibleBox::computeIntrinsicLogicalWidths() const
 {
-    auto addScrollbarWidth = [&]() {
-        LayoutUnit scrollbarWidth(scrollbarLogicalWidth());
-        maxLogicalWidth += scrollbarWidth;
-        minLogicalWidth += scrollbarWidth;
-    };
-
     if (shouldApplySizeOrInlineSizeContainment()) {
-        if (auto width = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = width.value();
-            maxLogicalWidth = width.value();
-        }
-        addScrollbarWidth();
-        return;
+        auto scrollbarLogicalWidth = this->scrollbarLogicalWidth();
+        auto intrinsicLogicalWidths = IntrinsicLogicalWidths { scrollbarLogicalWidth, scrollbarLogicalWidth };
+        if (auto width = explicitIntrinsicInnerLogicalWidth())
+            intrinsicLogicalWidths += *width;
+        return intrinsicLogicalWidths;
     }
 
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     LayoutUnit flexItemMinWidth;
     LayoutUnit flexItemMaxWidth;
     bool hadExcludedChildren = computePreferredWidthsForExcludedChildren(flexItemMinWidth, flexItemMaxWidth);
@@ -146,39 +140,40 @@ void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
         maxPreferredLogicalWidth += margin;
 
         if (!isColumnFlow()) {
-            maxLogicalWidth += maxPreferredLogicalWidth;
+            intrinsicLogicalWidths.maximum += maxPreferredLogicalWidth;
             if (isMultiline()) {
                 // For multiline, the min preferred width is if you put a break between
                 // each item.
-                minLogicalWidth = std::max(minLogicalWidth, minPreferredLogicalWidth);
+                intrinsicLogicalWidths.minimum = std::max(intrinsicLogicalWidths.minimum, minPreferredLogicalWidth);
             } else
-                minLogicalWidth += minPreferredLogicalWidth;
+                intrinsicLogicalWidths.minimum += minPreferredLogicalWidth;
         } else {
-            minLogicalWidth = std::max(minPreferredLogicalWidth, minLogicalWidth);
-            maxLogicalWidth = std::max(maxPreferredLogicalWidth, maxLogicalWidth);
+            intrinsicLogicalWidths.minimum = std::max(minPreferredLogicalWidth, intrinsicLogicalWidths.minimum);
+            intrinsicLogicalWidths.maximum = std::max(maxPreferredLogicalWidth, intrinsicLogicalWidths.maximum);
         }
     }
 
     if (!isColumnFlow() && numItemsWithNormalLayout > 1) {
         LayoutUnit inlineGapSize = (numItemsWithNormalLayout - 1) * computeGap(GapType::BetweenItems);
-        maxLogicalWidth += inlineGapSize;
+        intrinsicLogicalWidths.maximum += inlineGapSize;
         if (!isMultiline())
-            minLogicalWidth += inlineGapSize;
+            intrinsicLogicalWidths.minimum += inlineGapSize;
     }
 
-    maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
+    intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.minimum, intrinsicLogicalWidths.maximum);
     
     // Due to negative margins, it is possible that we calculated a negative
     // intrinsic width. Make sure that we never return a negative width.
-    minLogicalWidth = std::max(0_lu, minLogicalWidth);
-    maxLogicalWidth = std::max(0_lu, maxLogicalWidth);
+    intrinsicLogicalWidths.minimum = std::max({ }, intrinsicLogicalWidths.minimum);
+    intrinsicLogicalWidths.maximum = std::max({ }, intrinsicLogicalWidths.maximum);
     
     if (hadExcludedChildren) {
-        minLogicalWidth = std::max(minLogicalWidth, flexItemMinWidth);
-        maxLogicalWidth = std::max(maxLogicalWidth, flexItemMaxWidth);
+        intrinsicLogicalWidths.minimum = std::max(intrinsicLogicalWidths.minimum, flexItemMinWidth);
+        intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.maximum, flexItemMaxWidth);
     }
 
-    addScrollbarWidth();
+    intrinsicLogicalWidths += scrollbarLogicalWidth();
+    return intrinsicLogicalWidths;
 }
 
 #define SET_OR_CLEAR_OVERRIDING_SIZE(box, SizeType, size)       \

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -135,7 +135,7 @@ public:
     bool hasModernLayout() const { return m_hasFlexFormattingContextLayout && *m_hasFlexFormattingContextLayout; }
 
 protected:
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     bool shouldResetChildLogicalHeightBeforeLayout(const RenderBox&) const override { return m_shouldResetFlexItemLogicalHeightBeforeLayout; }
 

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -374,14 +374,11 @@ void RenderFragmentContainer::willBeRemovedFromTree()
     detachFragment();
 }
 
-void RenderFragmentContainer::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderFragmentContainer::computeIntrinsicLogicalWidths() const
 {
-    if (!isValid()) {
-        RenderBlockFlow::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
-        return;
-    }
-    maxLogicalWidth = { };
-    minLogicalWidth = { };
+    if (!isValid())
+        return RenderBlockFlow::computeIntrinsicLogicalWidths();
+    return { };
 }
 
 void RenderFragmentContainer::computePreferredLogicalWidths()
@@ -400,8 +397,11 @@ void RenderFragmentContainer::computePreferredLogicalWidths()
     const RenderStyle& styleToUse = style();
     if (styleToUse.logicalWidth().isFixed() && styleToUse.logicalWidth().value() > 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(styleToUse.logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -128,7 +128,7 @@ protected:
     RenderOverflow* overflowForBox(const RenderBox&) const;
 
     void computePreferredLogicalWidths() override;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     LayoutRect overflowRectForFragmentedFlowPortion(const LayoutRect& fragmentedFlowPortionRect, bool isFirstPortion, bool isLastPortion) const;
     void repaintFragmentedFlowContentRectangle(const LayoutRect& repaintRect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0) const;

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -70,7 +70,7 @@ public:
 
 private:
     void element() const = delete;
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override { return { }; }
 
     static const int noSplit = -1;
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -753,7 +753,7 @@ LayoutUnit RenderGrid::guttersSize(GridTrackSizingDirection direction, unsigned 
     return gapAccumulator;
 }
 
-void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderGrid::computeIntrinsicLogicalWidths() const
 {
     GridLayoutState gridLayoutState;
 
@@ -777,33 +777,33 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
         cacheBaselineAlignedGridItems(*this, algorithm, { GridTrackSizingDirection::ForColumns }, emptyCallback, !isSubgridRows());
     }
 
-    computeTrackSizesForIndefiniteSize(algorithm, GridTrackSizingDirection::ForColumns, gridLayoutState, &minLogicalWidth, &maxLogicalWidth);
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
+    computeTrackSizesForIndefiniteSize(algorithm, GridTrackSizingDirection::ForColumns, gridLayoutState, &intrinsicLogicalWidths.minimum, &intrinsicLogicalWidths.maximum);
 
     if (isMasonry(GridTrackSizingDirection::ForColumns)) {
         // The track sizing algorithm will only be run once in this case, since track sizing will not run in the masonry direction.
-        computeTrackSizesForIndefiniteSize(algorithm, GridTrackSizingDirection::ForRows, gridLayoutState, &minLogicalWidth, &maxLogicalWidth);
+        computeTrackSizesForIndefiniteSize(algorithm, GridTrackSizingDirection::ForRows, gridLayoutState, &intrinsicLogicalWidths.minimum, &intrinsicLogicalWidths.maximum);
 
         auto gridAxisTracksCountBeforeAutoPlacement = currentGrid().numTracks(GridTrackSizingDirection::ForRows);
 
         // To determine the width of the grid when we have a masonry layout in the column direction we need to perform a layout with the min and max
         // content sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
         m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns, GridMasonryLayout::MasonryLayoutPhase::MinContentPhase);
-        minLogicalWidth = m_masonryLayout.gridContentSize();
+        intrinsicLogicalWidths.minimum = m_masonryLayout.gridContentSize();
 
         m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns, GridMasonryLayout::MasonryLayoutPhase::MaxContentPhase);
-        maxLogicalWidth = m_masonryLayout.gridContentSize();
+        intrinsicLogicalWidths.maximum = m_masonryLayout.gridContentSize();
     }
 
     m_grid.resetCurrentGrid();
 
     if (hadExcludedChildren) {
-        minLogicalWidth = std::max(minLogicalWidth, gridItemMinWidth);
-        maxLogicalWidth = std::max(maxLogicalWidth, gridItemMaxWidth);
+        intrinsicLogicalWidths.minimum = std::max(intrinsicLogicalWidths.minimum, gridItemMinWidth);
+        intrinsicLogicalWidths.maximum = std::max(intrinsicLogicalWidths.maximum, gridItemMaxWidth);
     }
 
-    LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    minLogicalWidth += scrollbarWidth;
-    maxLogicalWidth += scrollbarWidth;
+    intrinsicLogicalWidths += intrinsicScrollbarLogicalWidthIncludingGutter();
+    return intrinsicLogicalWidths;
 }
 
 void RenderGrid::computeTrackSizesForIndefiniteSize(GridTrackSizingAlgorithm& algorithm, GridTrackSizingDirection direction, GridLayoutState& gridLayoutState, LayoutUnit* minIntrinsicSize, LayoutUnit* maxIntrinsicSize) const

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -165,7 +165,7 @@ private:
     }
 
     ASCIILiteral renderName() const override;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     bool selfAlignmentChangedToStretch(GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
     bool selfAlignmentChangedFromStretch(GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -222,24 +222,26 @@ void RenderListBox::scrollToRevealSelection()
         scrollToRevealElementAtListIndex(firstIndex);
 }
 
-void RenderListBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderListBox::computeIntrinsicLogicalWidths() const
 {
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth())
-            maxLogicalWidth = logicalWidth.value();
+            intrinsicLogicalWidths.maximum = logicalWidth.value();
         else
-            maxLogicalWidth = 2 * optionsSpacingInlineStart;
+            intrinsicLogicalWidths.maximum = 2 * optionsSpacingInlineStart;
     } else
-        maxLogicalWidth = 2 * optionsSpacingInlineStart + m_optionsLogicalWidth;
+        intrinsicLogicalWidths.maximum = 2 * optionsSpacingInlineStart + m_optionsLogicalWidth;
 
     if (m_scrollbar)
-        maxLogicalWidth += m_scrollbar->orientation() == ScrollbarOrientation::Vertical ? m_scrollbar->width() : m_scrollbar->height();
+        intrinsicLogicalWidths.maximum += m_scrollbar->orientation() == ScrollbarOrientation::Vertical ? m_scrollbar->width() : m_scrollbar->height();
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
+        intrinsicLogicalWidths.minimum = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
     else if (!logicalWidth.isPercent())
-        minLogicalWidth = maxLogicalWidth;
+        intrinsicLogicalWidths.minimum = intrinsicLogicalWidths.maximum;
+    return intrinsicLogicalWidths;
 }
 
 void RenderListBox::computePreferredLogicalWidths()
@@ -252,8 +254,11 @@ void RenderListBox::computePreferredLogicalWidths()
 
     if (style().logicalWidth().isFixed() && style().logicalWidth().value() > 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), writingMode().isHorizontal() ? horizontalBorderAndPaddingExtent() : verticalBorderAndPaddingExtent());
 

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -95,7 +95,7 @@ private:
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const override;
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -489,4 +489,11 @@ bool RenderListMarker::widthUsesMetricsOfPrimaryFont() const
     return listType.isCircle() || listType.isDisc() || listType.isSquare();
 }
 
+
+IntrinsicLogicalWidths RenderListMarker::computeIntrinsicLogicalWidths() const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -85,7 +85,7 @@ private:
     bool canBeSelectionLeaf() const final { return true; }
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) final;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { ASSERT_NOT_REACHED(); }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     void element() const = delete;
 

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -335,24 +335,26 @@ LayoutRect RenderMenuList::controlClipRect(const LayoutPoint& additionalOffset) 
     return intersection(outerBox, innerBox);
 }
 
-void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderMenuList::computeIntrinsicLogicalWidths() const
 {
     // FIXME: Fix field-sizing: content with size containment
     // https://bugs.webkit.org/show_bug.cgi?id=269169
     if (style().fieldSizing() == FieldSizing::Content)
-        return RenderFlexibleBox::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        return RenderFlexibleBox::computeIntrinsicLogicalWidths();
 
-    maxLogicalWidth = shouldApplySizeContainment() ? theme().minimumMenuListSize(style()) : std::max(m_optionsWidth, theme().minimumMenuListSize(style()));
-    maxLogicalWidth += m_innerBlock->paddingStart() + m_innerBlock->paddingEnd();
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
+    intrinsicLogicalWidths.maximum = shouldApplySizeContainment() ? theme().minimumMenuListSize(style()) : std::max(m_optionsWidth, theme().minimumMenuListSize(style()));
+    intrinsicLogicalWidths.maximum += m_innerBlock->paddingStart() + m_innerBlock->paddingEnd();
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth())
-            maxLogicalWidth = logicalWidth.value();
+            intrinsicLogicalWidths.maximum = logicalWidth.value();
     }
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
+        intrinsicLogicalWidths.minimum = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
     else if (!logicalWidth.isPercent())
-        minLogicalWidth = maxLogicalWidth;
+        intrinsicLogicalWidths.minimum = intrinsicLogicalWidths.maximum;
+    return intrinsicLogicalWidths;
 }
 
 void RenderMenuList::computePreferredLogicalWidths()
@@ -367,8 +369,11 @@ void RenderMenuList::computePreferredLogicalWidths()
     
     if (style().logicalWidth().isFixed() && style().logicalWidth().value() > 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), writingMode().isHorizontal() ? horizontalBorderAndPaddingExtent() : verticalBorderAndPaddingExtent());
 

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -90,7 +90,7 @@ private:
 
     ASCIILiteral renderName() const override { return "RenderMenuList"_s; }
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -63,4 +63,11 @@ ASCIILiteral RenderMultiColumnSpannerPlaceholder::renderName() const
     return "RenderMultiColumnSpannerPlaceholder"_s;
 }
 
+
+IntrinsicLogicalWidths RenderMultiColumnSpannerPlaceholder::computeIntrinsicLogicalWidths() const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
@@ -48,7 +48,7 @@ private:
     template<class T, class... Args> friend RenderPtr<T> createRenderer(Args&&...);
 
     RenderMultiColumnSpannerPlaceholder(RenderMultiColumnFlow&, RenderBox& spanner, RenderStyle&&);
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { ASSERT_NOT_REACHED(); }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     bool canHaveChildren() const override { return false; }
     void paint(PaintInfo&, const LayoutPoint&) override { }

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -719,9 +719,10 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
     return computeReplacedLogicalHeightRespectingMinMaxHeight(intrinsicLogicalHeight());
 }
 
-void RenderReplaced::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderReplaced::computeIntrinsicLogicalWidths() const
 {
-    minLogicalWidth = maxLogicalWidth = intrinsicLogicalWidth();
+    auto intrinsicLogicalWidth = this->intrinsicLogicalWidth();
+    return { intrinsicLogicalWidth, intrinsicLogicalWidth };
 }
 
 void RenderReplaced::computePreferredLogicalWidths()
@@ -730,9 +731,11 @@ void RenderReplaced::computePreferredLogicalWidths()
 
     // We cannot resolve any percent logical width here as the available logical
     // width may not be set on our containing block.
-    if (style().logicalWidth().isPercentOrCalculated())
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
-    else
+    if (style().logicalWidth().isPercentOrCalculated()) {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    } else
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeReplacedLogicalWidth(ShouldComputePreferred::ComputePreferred);
 
     bool ignoreMinMaxSizes = shouldIgnoreLogicalMinMaxWidthSizes();

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -58,7 +58,7 @@ protected:
 
     void layout() override;
 
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const final;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const final;
 
     virtual LayoutUnit minimumReplacedHeight() const { return 0_lu; }
 

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -85,4 +85,11 @@ void RenderReplica::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         paintMask(paintInfo, adjustedPaintOffset);
 }
 
+
+IntrinsicLogicalWidths RenderReplica::computeIntrinsicLogicalWidths() const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderReplica.h
+++ b/Source/WebCore/rendering/RenderReplica.h
@@ -50,7 +50,7 @@ public:
 private:
     bool canHaveChildren() const override { return false; }
     void computePreferredLogicalWidths() override;
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { ASSERT_NOT_REACHED(); }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -71,21 +71,22 @@ LayoutUnit RenderSlider::baselinePosition(FontBaseline, bool /*firstLine*/, Line
     return height() + marginTop();
 }
 
-void RenderSlider::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderSlider::computeIntrinsicLogicalWidths() const
 {
     if (shouldApplySizeOrInlineSizeContainment()) {
-        if (auto width = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = width.value();
-            maxLogicalWidth = width.value();
-        }
-        return;
+        if (auto width = explicitIntrinsicInnerLogicalWidth())
+            return { *width, *width };
+        return { };
     }
-    maxLogicalWidth = defaultTrackLength * style().usedZoom();
+
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
+    intrinsicLogicalWidths.maximum = defaultTrackLength * style().usedZoom();
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
+        intrinsicLogicalWidths.minimum = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
     else if (!logicalWidth.isPercent())
-        minLogicalWidth = maxLogicalWidth;
+        intrinsicLogicalWidths.minimum = intrinsicLogicalWidths.maximum;
+    return intrinsicLogicalWidths;
 }
 
 void RenderSlider::computePreferredLogicalWidths()
@@ -95,8 +96,11 @@ void RenderSlider::computePreferredLogicalWidths()
 
     if (style().logicalWidth().isFixed())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), writingMode().isHorizontal() ? horizontalBorderAndPaddingExtent() : verticalBorderAndPaddingExtent());
 

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -46,7 +46,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSlider"_s; }
 
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const override;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
 
     bool isFlexibleBoxImpl() const override { return true; }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -909,7 +909,7 @@ void RenderTable::paintMask(PaintInfo& paintInfo, const LayoutPoint& paintOffset
     paintMaskImages(paintInfo, rect);
 }
 
-void RenderTable::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics intrinsics) const
+IntrinsicLogicalWidths RenderTable::computeIntrinsicLogicalWidths(TableIntrinsics intrinsics) const
 {
     recalcSectionsIfNeeded();
     // FIXME: Do the recalc in borderStart/borderEnd and make those const_cast this call.
@@ -917,26 +917,28 @@ void RenderTable::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit
     // of reading out stale values.
     const_cast<RenderTable*>(this)->recalcBordersInRowDirection();
     // FIXME: Restructure the table layout code so that we can make this method const.
-    const_cast<RenderTable*>(this)->m_tableLayout->computeIntrinsicLogicalWidths(minWidth, maxWidth, intrinsics);
+    return const_cast<RenderTable*>(this)->m_tableLayout->computeIntrinsicLogicalWidths(intrinsics);
 
     // FIXME: We should include captions widths here like we do in computePreferredLogicalWidths.
 }
 
-void RenderTable::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth) const
+IntrinsicLogicalWidths RenderTable::computeIntrinsicLogicalWidths() const
 {
-    computeIntrinsicLogicalWidths(minWidth, maxWidth, TableIntrinsics::ForLayout);
+    return computeIntrinsicLogicalWidths(TableIntrinsics::ForLayout);
 }
 
-void RenderTable::computeIntrinsicKeywordLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth) const
+IntrinsicLogicalWidths RenderTable::computeIntrinsicKeywordLogicalWidths() const
 {
-    computeIntrinsicLogicalWidths(minWidth, maxWidth, TableIntrinsics::ForKeyword);
+    return computeIntrinsicLogicalWidths(TableIntrinsics::ForKeyword);
 }
 
 void RenderTable::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+    m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+    m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
 
     LayoutUnit bordersPaddingAndSpacing = bordersPaddingAndSpacingInRowDirection();
     m_minPreferredLogicalWidth += bordersPaddingAndSpacing;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -237,9 +237,9 @@ private:
     void paintBoxDecorations(PaintInfo&, const LayoutPoint&) final;
     void paintMask(PaintInfo&, const LayoutPoint&) final;
     void layout() final;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics) const;
-    void computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth) const final;
-    void computeIntrinsicKeywordLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth) const final;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths(TableIntrinsics) const;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const final;
+    IntrinsicLogicalWidths computeIntrinsicKeywordLogicalWidths() const final;
     void computePreferredLogicalWidths() override;
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -253,4 +253,11 @@ LayoutUnit RenderTableCol::offsetHeight() const
     return table()->offsetHeightForColumn(*this);
 }
 
+
+IntrinsicLogicalWidths RenderTableCol::computeIntrinsicLogicalWidths() const
+{
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 }

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -70,7 +70,7 @@ public:
 private:
     ASCIILiteral renderName() const override { return "RenderTableCol"_s; }
     void computePreferredLogicalWidths() override { ASSERT_NOT_REACHED(); }
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { ASSERT_NOT_REACHED(); }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
 
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -83,7 +83,7 @@ private:
 
     LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext) const override;
     RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override { return { }; }
 
     bool requiresLayer() const final;
     void paint(PaintInfo&, const LayoutPoint&) override;

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -183,7 +183,7 @@ private:
     LayoutUnit verticalRowGroupBorderHeight(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row);
     LayoutUnit horizontalRowGroupBorderWidth(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row, unsigned column);
 
-    void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { }
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override { return { }; }
 
     void imageChanged(WrappedImagePtr, const IntRect* = 0) override;
 

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -160,27 +160,27 @@ float RenderTextControl::scaleEmToUnits(int x) const
     return roundf(style().fontCascade().size() * x / unitsPerEm);
 }
 
-void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
+IntrinsicLogicalWidths RenderTextControl::computeIntrinsicLogicalWidths() const
 {
     // FIXME: Fix field-sizing: content with size containment
     // https://bugs.webkit.org/show_bug.cgi?id=269169
     if (style().fieldSizing() == FieldSizing::Content)
-        return RenderBlockFlow::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+        return RenderBlockFlow::computeIntrinsicLogicalWidths();
 
     if (shouldApplySizeOrInlineSizeContainment()) {
-        if (auto width = explicitIntrinsicInnerLogicalWidth()) {
-            minLogicalWidth = width.value();
-            maxLogicalWidth = width.value();
-        }
-        return;
+        if (auto width = explicitIntrinsicInnerLogicalWidth())
+            return { *width, *width };
     }
+
+    IntrinsicLogicalWidths intrinsicLogicalWidths;
     // Use average character width. Matches IE.
-    maxLogicalWidth = preferredContentLogicalWidth(const_cast<RenderTextControl*>(this)->getAverageCharWidth());
+    intrinsicLogicalWidths.maximum = preferredContentLogicalWidth(const_cast<RenderTextControl*>(this)->getAverageCharWidth());
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
+        intrinsicLogicalWidths.minimum = std::max(0_lu, valueForLength(logicalWidth, 0_lu));
     else if (!logicalWidth.isPercent())
-        minLogicalWidth = maxLogicalWidth;
+        intrinsicLogicalWidths.minimum = intrinsicLogicalWidths.maximum;
+    return intrinsicLogicalWidths;
 }
 
 void RenderTextControl::computePreferredLogicalWidths()
@@ -196,8 +196,11 @@ void RenderTextControl::computePreferredLogicalWidths()
 
     if (style().logicalWidth().isFixed() && style().logicalWidth().value() >= 0)
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
-    else
-        computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+    else {
+        auto intrinsicLogicalWidths = computeIntrinsicLogicalWidths();
+        m_minPreferredLogicalWidth = intrinsicLogicalWidths.minimum;
+        m_maxPreferredLogicalWidth = intrinsicLogicalWidths.maximum;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -70,7 +70,7 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderTextControl"_s; }
-    void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
+    IntrinsicLogicalWidths computeIntrinsicLogicalWidths() const override;
     void computePreferredLogicalWidths() override;
     bool canHaveGeneratedChildren() const override { return false; }
     

--- a/Source/WebCore/rendering/TableLayout.h
+++ b/Source/WebCore/rendering/TableLayout.h
@@ -29,6 +29,7 @@ namespace WebCore {
 class RenderTable;
 
 enum class TableIntrinsics : uint8_t;
+struct IntrinsicLogicalWidths;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(TableLayout);
 class TableLayout {
@@ -42,7 +43,7 @@ public:
 
     virtual ~TableLayout() = default;
 
-    virtual void computeIntrinsicLogicalWidths(LayoutUnit& minWidth, LayoutUnit& maxWidth, TableIntrinsics) = 0;
+    virtual IntrinsicLogicalWidths computeIntrinsicLogicalWidths(TableIntrinsics) = 0;
     virtual LayoutUnit scaledWidthFromPercentColumns() const { return 0_lu; }
     virtual void applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const = 0;
     virtual void layout() = 0;


### PR DESCRIPTION
#### 909e1de8dfc977467ddb47c03b9223b0b2db0aff
<pre>
computeIntrinsicLogicalWidths return value WIP
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/909e1de8dfc977467ddb47c03b9223b0b2db0aff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32082 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6847 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83890 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85083 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83369 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30635 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->