### PR TITLE
[Page color sampling] Add system trace points for fixed container edge detection and sampling

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -116,6 +116,8 @@ enum TracePointCode {
     WebXRSessionFrameCallbacksStart,
     WebXRSessionFrameCallbacksEnd,
     ProgrammaticScroll,
+    FixedContainerEdgeSamplingStart,
+    FixedContainerEdgeSamplingEnd,
 
     WebKitRange = 10000,
     WebHTMLViewPaintStart,

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -194,6 +194,8 @@ public:
         case WebXRLayerEndFrameEnd:
         case WebXRSessionFrameCallbacksEnd:
         case ProgrammaticScroll:
+        case FixedContainerEdgeSamplingStart:
+        case FixedContainerEdgeSamplingEnd:
         case WebHTMLViewPaintEnd:
         case BackingStoreFlushEnd:
         case WaitForCompositionCompletionEnd:
@@ -392,6 +394,9 @@ private:
             return "WebXRSessionFrameCallbacks"_s;
         case ProgrammaticScroll:
             return "ProgrammaticScroll"_s;
+        case FixedContainerEdgeSamplingStart:
+        case FixedContainerEdgeSamplingEnd:
+            return "FixedContainerEdgeSampling"_s;
 
         case WebHTMLViewPaintStart:
         case WebHTMLViewPaintEnd:

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1913,6 +1913,8 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
     if (!document)
         return { };
 
+    TraceScope tracingScope { FixedContainerEdgeSamplingStart, FixedContainerEdgeSamplingEnd };
+
     static constexpr auto sampleRectThickness = 2;
     static constexpr auto sampleRectMargin = 2;
     static constexpr auto thinBorderWidth = 5;

--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -550,6 +550,18 @@
              </dict>
              <dict>
                  <key>Name</key>
+                 <string>Fixed container edge sampling</string>
+                 <key>Type</key>
+                 <string>Interval</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>CodeBegin</key>
+                 <string>5056</string>
+                 <key>CodeEnd</key>
+                 <string>5057</string>
+             </dict>
+             <dict>
+                 <key>Name</key>
                  <string>Paint WebHTMLView</string>
                  <key>Type</key>
                  <string>Interval</string>


### PR DESCRIPTION
#### 923e525b46880c01b28eb7561a135302161d4781
<pre>
[Page color sampling] Add system trace points for fixed container edge detection and sampling
<a href="https://bugs.webkit.org/show_bug.cgi?id=291101">https://bugs.webkit.org/show_bug.cgi?id=291101</a>
<a href="https://rdar.apple.com/148618680">rdar://148618680</a>

Reviewed by Abrar Rahman Protyasha.

Add trace points around the heuristic for detecting and sampling colors along the edges of
viewport-constrained elements.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:

Canonical link: <a href="https://commits.webkit.org/293289@main">https://commits.webkit.org/293289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ac6ec7abf606ca11c5ff53f6e6c42a8337f121d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103549 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/48959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/48959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48398 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91111 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105922 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97055 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25516 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28022 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/5692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25475 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120674 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25293 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/28613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->