### PR TITLE
Define a virtual MediaSessionManagerInterface interface and have PlatformMediaSessionManager derive from it

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2011,6 +2011,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/AudioSourceProviderClient.h
     platform/audio/AudioStreamDescription.h
     platform/audio/AudioUtilities.h
+    platform/audio/MediaSessionManagerInterface.h
     platform/audio/NowPlayingInfo.h
     platform/audio/NowPlayingMetadataObserver.h
     platform/audio/PlatformAudioData.h

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -337,8 +337,8 @@ void MediaElementSession::clientDataBufferingTimerFired()
     if (state() != PlatformMediaSession::State::Playing || !m_element.elementIsHidden())
         return;
 
-    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType());
-    if ((restrictions & PlatformMediaSessionManager::BackgroundTabPlaybackRestricted) == PlatformMediaSessionManager::BackgroundTabPlaybackRestricted)
+    auto restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType());
+    if ((restrictions & MediaSessionRestriction::BackgroundTabPlaybackRestricted) == MediaSessionRestriction::BackgroundTabPlaybackRestricted)
         pauseSession();
 }
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaUniqueIdentifier.h"
+#include "NowPlayingMetadataObserver.h"
+#include "PlatformMediaSession.h"
+#include "RemoteCommandListener.h"
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Page;
+struct MediaConfiguration;
+struct NowPlayingInfo;
+struct NowPlayingMetadata;
+
+enum class MediaSessionRestriction : uint32_t {
+    NoRestrictions = 0,
+    ConcurrentPlaybackNotPermitted = 1 << 0,
+    BackgroundProcessPlaybackRestricted = 1 << 1,
+    BackgroundTabPlaybackRestricted = 1 << 2,
+    InterruptedPlaybackNotPermitted = 1 << 3,
+    InactiveProcessPlaybackRestricted = 1 << 4,
+    SuspendedUnderLockPlaybackRestricted = 1 << 5,
+};
+using MediaSessionRestrictions = OptionSet<MediaSessionRestriction>;
+
+class MediaSessionManagerInterface
+#if !RELEASE_LOG_DISABLED
+    : private LoggerHelper
+#endif
+{
+public:
+    WEBCORE_EXPORT MediaSessionManagerInterface() = default;
+    WEBCORE_EXPORT virtual ~MediaSessionManagerInterface() = default;
+
+    virtual void addSession(PlatformMediaSession&) = 0;
+    virtual void removeSession(PlatformMediaSession&) = 0;
+
+    virtual bool activeAudioSessionRequired() const = 0;
+    virtual bool hasActiveAudioSession() const = 0;
+    virtual bool canProduceAudio() const = 0;
+
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const = 0;
+    virtual bool hasActiveNowPlayingSession() const { return false; }
+    virtual String lastUpdatedNowPlayingTitle() const { return emptyString(); }
+    virtual double lastUpdatedNowPlayingDuration() const { return NAN; }
+    virtual double lastUpdatedNowPlayingElapsedTime() const { return NAN; }
+    virtual std::optional<MediaUniqueIdentifier> lastUpdatedNowPlayingInfoUniqueIdentifier() const { return std::nullopt; }
+    virtual void addNowPlayingMetadataObserver(const NowPlayingMetadataObserver&) = 0;
+    virtual void removeNowPlayingMetadataObserver(const NowPlayingMetadataObserver&) = 0;
+    virtual bool hasActiveNowPlayingSessionInGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual bool registeredAsNowPlayingApplication() const { return false; }
+    virtual bool haveEverRegisteredAsNowPlayingApplication() const { return false; }
+    virtual void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() { };
+
+    virtual void prepareToSendUserMediaPermissionRequestForPage(Page&) { }
+
+    virtual bool willIgnoreSystemInterruptions() const = 0;
+    virtual void setWillIgnoreSystemInterruptions(bool) = 0;
+    virtual void beginInterruption(PlatformMediaSession::InterruptionType) = 0;
+    virtual void endInterruption(PlatformMediaSession::EndInterruptionFlags) = 0;
+
+    virtual void applicationWillEnterForeground(bool) = 0;
+    virtual void applicationDidEnterBackground(bool) = 0;
+    virtual void applicationWillBecomeInactive() = 0;
+    virtual void applicationDidBecomeActive() = 0;
+    virtual void processWillSuspend() = 0;
+    virtual void processDidResume() = 0;
+
+    virtual void stopAllMediaPlaybackForProcess() = 0;
+    virtual bool mediaPlaybackIsPaused(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual void pauseAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual void suspendAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual void resumeAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual void suspendAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+    virtual void resumeAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>) = 0;
+
+    virtual void addRestriction(PlatformMediaSession::MediaType, MediaSessionRestrictions) = 0;
+    virtual void removeRestriction(PlatformMediaSession::MediaType, MediaSessionRestrictions) = 0;
+    virtual MediaSessionRestrictions restrictions(PlatformMediaSession::MediaType) = 0;
+    virtual void resetRestrictions() = 0;
+
+    virtual bool sessionWillBeginPlayback(PlatformMediaSession&) = 0;
+    virtual void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) = 0;
+    virtual void sessionStateChanged(PlatformMediaSession&) = 0;
+    virtual void sessionDidEndRemoteScrubbing(PlatformMediaSession&) { }
+    virtual void sessionCanProduceAudioChanged() = 0;
+    virtual void clientCharacteristicsChanged(PlatformMediaSession&, bool) { }
+
+    virtual void configureWirelessTargetMonitoring() { }
+    virtual bool hasWirelessTargetsAvailable() { return false; }
+    virtual bool isMonitoringWirelessTargets() const { return false; }
+    virtual void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSession&) = 0;
+
+    virtual void setCurrentSession(PlatformMediaSession&) = 0;
+    virtual PlatformMediaSession* currentSession() const = 0;
+
+    virtual void setIsPlayingToAutomotiveHeadUnit(bool) = 0;
+    virtual bool isPlayingToAutomotiveHeadUnit() const = 0;
+
+    virtual void setSupportsSpatialAudioPlayback(bool) = 0;
+    virtual std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const MediaConfiguration&) = 0;
+
+    virtual void addAudioCaptureSource(AudioCaptureSource&) = 0;
+    virtual void removeAudioCaptureSource(AudioCaptureSource&) = 0;
+    virtual void audioCaptureSourceStateChanged() = 0;
+    virtual size_t audioCaptureSourceCount() const = 0;
+
+    virtual void processDidReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) = 0;
+    virtual bool processIsSuspended() const = 0;
+    virtual void processSystemWillSleep() = 0;
+    virtual void processSystemDidWake() = 0;
+
+    virtual bool isApplicationInBackground() const = 0;
+    virtual bool isInterrupted() const = 0;
+    virtual bool hasNoSession() const = 0;
+
+    virtual void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType) { };
+    virtual void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType) { };
+    virtual RemoteCommandListener::RemoteCommandsSet supportedCommands() const { return { }; };
+
+    virtual void scheduleSessionStatusUpdate() { }
+    virtual void resetSessionState() { };
+
+    virtual WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose) = 0;
+
+    virtual void updatePresentingApplicationPIDIfNecessary(ProcessID) { }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -132,7 +132,7 @@ class PlatformMediaSession
     , public MediaPlaybackTargetClient
 #endif
 #if !RELEASE_LOG_DISABLED
-    , private LoggerHelper
+    , public LoggerHelper
 #endif
 {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSession);
@@ -263,9 +263,10 @@ public:
     virtual String description() const;
 #endif
 
+    PlatformMediaSessionClient& client() const { return m_client; }
+
 protected:
     PlatformMediaSession(PlatformMediaSessionManager&, PlatformMediaSessionClient&);
-    PlatformMediaSessionClient& client() const { return m_client; }
 
 private:
     bool processClientWillPausePlayback(DelayCallingUpdateNowPlaying);
@@ -286,8 +287,6 @@ private:
     bool m_hasPlayedAudiblySinceLastInterruption { false };
     bool m_preparingToPlay { false };
     bool m_isActiveNowPlayingSession { false };
-
-    friend class PlatformMediaSessionManager;
 };
 
 class PlatformMediaSessionClient {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -25,17 +25,13 @@
 
 #pragma once
 
-#include "MediaUniqueIdentifier.h"
-#include "NowPlayingMetadataObserver.h"
-#include "PlatformMediaSession.h"
-#include "RemoteCommandListener.h"
+#include "MediaSessionManagerInterface.h"
 #include "Timer.h"
 #include <wtf/AggregateLogger.h>
 #include <wtf/CancellableTask.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -45,10 +41,7 @@ struct MediaConfiguration;
 struct NowPlayingInfo;
 struct NowPlayingMetadata;
 
-class PlatformMediaSessionManager
-#if !RELEASE_LOG_DISABLED
-    : private LoggerHelper
-#endif
+class PlatformMediaSessionManager : public MediaSessionManagerInterface
 {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSessionManager);
 public:
@@ -70,129 +63,84 @@ public:
 
     virtual ~PlatformMediaSessionManager();
 
-    virtual void scheduleSessionStatusUpdate() { }
+    void addSession(PlatformMediaSession&) override;
+    void removeSession(PlatformMediaSession&) override;
+    void setCurrentSession(PlatformMediaSession&) override;
+    PlatformMediaSession* currentSession() const final;
 
-    bool has(PlatformMediaSession::MediaType) const;
-    int count(PlatformMediaSession::MediaType) const;
-    bool activeAudioSessionRequired() const;
-    bool hasActiveAudioSession() const;
-    bool canProduceAudio() const;
+    bool activeAudioSessionRequired() const final;
+    bool hasActiveAudioSession() const final;
+    bool canProduceAudio() const final;
 
-    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const;
-    virtual bool hasActiveNowPlayingSession() const { return false; }
-    virtual String lastUpdatedNowPlayingTitle() const { return emptyString(); }
-    virtual double lastUpdatedNowPlayingDuration() const { return NAN; }
-    virtual double lastUpdatedNowPlayingElapsedTime() const { return NAN; }
-    virtual std::optional<MediaUniqueIdentifier> lastUpdatedNowPlayingInfoUniqueIdentifier() const { return std::nullopt; }
-    virtual bool registeredAsNowPlayingApplication() const { return false; }
-    virtual bool haveEverRegisteredAsNowPlayingApplication() const { return false; }
-    virtual void prepareToSendUserMediaPermissionRequestForPage(Page&) { }
+    bool willIgnoreSystemInterruptions() const final { return m_willIgnoreSystemInterruptions; }
+    void setWillIgnoreSystemInterruptions(bool ignore) final { m_willIgnoreSystemInterruptions = ignore; }
 
-    bool willIgnoreSystemInterruptions() const { return m_willIgnoreSystemInterruptions; }
-    void setWillIgnoreSystemInterruptions(bool ignore) { m_willIgnoreSystemInterruptions = ignore; }
+    WEBCORE_EXPORT void beginInterruption(PlatformMediaSession::InterruptionType) override;
+    WEBCORE_EXPORT void endInterruption(PlatformMediaSession::EndInterruptionFlags) final;
 
-    WEBCORE_EXPORT virtual void beginInterruption(PlatformMediaSession::InterruptionType);
-    WEBCORE_EXPORT void endInterruption(PlatformMediaSession::EndInterruptionFlags);
+    WEBCORE_EXPORT void applicationWillBecomeInactive() override;
+    WEBCORE_EXPORT void applicationDidBecomeActive() override;
+    WEBCORE_EXPORT void applicationWillEnterForeground(bool) override;
+    WEBCORE_EXPORT void applicationDidEnterBackground(bool) override;
+    WEBCORE_EXPORT void processWillSuspend() final;
+    WEBCORE_EXPORT void processDidResume() final;
 
-    WEBCORE_EXPORT void applicationWillBecomeInactive();
-    WEBCORE_EXPORT void applicationDidBecomeActive();
-    WEBCORE_EXPORT void applicationWillEnterForeground(bool suspendedUnderLock);
-    WEBCORE_EXPORT void applicationDidEnterBackground(bool suspendedUnderLock);
-    WEBCORE_EXPORT void processWillSuspend();
-    WEBCORE_EXPORT void processDidResume();
+    bool mediaPlaybackIsPaused(std::optional<MediaSessionGroupIdentifier>) final;
+    void pauseAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) final;
+    WEBCORE_EXPORT void stopAllMediaPlaybackForProcess() final;
 
-    bool mediaPlaybackIsPaused(std::optional<MediaSessionGroupIdentifier>);
-    void pauseAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>);
-    WEBCORE_EXPORT void stopAllMediaPlaybackForProcess();
+    void suspendAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) final;
+    void resumeAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>) final;
+    void suspendAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>) final;
+    void resumeAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>) final;
 
-    void suspendAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>);
-    void resumeAllMediaPlaybackForGroup(std::optional<MediaSessionGroupIdentifier>);
-    void suspendAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>);
-    void resumeAllMediaBufferingForGroup(std::optional<MediaSessionGroupIdentifier>);
+    WEBCORE_EXPORT void addRestriction(PlatformMediaSession::MediaType, MediaSessionRestrictions) final;
+    WEBCORE_EXPORT void removeRestriction(PlatformMediaSession::MediaType, MediaSessionRestrictions) final;
+    WEBCORE_EXPORT MediaSessionRestrictions restrictions(PlatformMediaSession::MediaType) final;
+    void resetRestrictions() override;
 
-    enum SessionRestrictionFlags {
-        NoRestrictions = 0,
-        ConcurrentPlaybackNotPermitted = 1 << 0,
-        BackgroundProcessPlaybackRestricted = 1 << 1,
-        BackgroundTabPlaybackRestricted = 1 << 2,
-        InterruptedPlaybackNotPermitted = 1 << 3,
-        InactiveProcessPlaybackRestricted = 1 << 4,
-        SuspendedUnderLockPlaybackRestricted = 1 << 5,
-    };
-    typedef unsigned SessionRestrictions;
+    bool sessionWillBeginPlayback(PlatformMediaSession&) override;
+    void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) override;
+    void sessionStateChanged(PlatformMediaSession&) override;
+    void sessionCanProduceAudioChanged() override;
 
-    WEBCORE_EXPORT void addRestriction(PlatformMediaSession::MediaType, SessionRestrictions);
-    WEBCORE_EXPORT void removeRestriction(PlatformMediaSession::MediaType, SessionRestrictions);
-    WEBCORE_EXPORT SessionRestrictions restrictions(PlatformMediaSession::MediaType);
-    virtual void resetRestrictions();
+    void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSession&) final;
 
-    virtual bool sessionWillBeginPlayback(PlatformMediaSession&);
+    WEBCORE_EXPORT void setIsPlayingToAutomotiveHeadUnit(bool) final;
+    bool isPlayingToAutomotiveHeadUnit() const final { return m_isPlayingToAutomotiveHeadUnit; }
 
-    virtual void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying);
-    virtual void sessionStateChanged(PlatformMediaSession&);
-    virtual void sessionDidEndRemoteScrubbing(PlatformMediaSession&) { };
-    virtual void clientCharacteristicsChanged(PlatformMediaSession&, bool) { }
-    virtual void sessionCanProduceAudioChanged();
-
-#if PLATFORM(IOS_FAMILY)
-    virtual void configureWirelessTargetMonitoring() { }
-#endif
-    virtual bool hasWirelessTargetsAvailable() { return false; }
-    virtual bool isMonitoringWirelessTargets() const { return false; }
-
-    virtual void setCurrentSession(PlatformMediaSession&);
-    PlatformMediaSession* currentSession() const;
-
-    void sessionIsPlayingToWirelessPlaybackTargetChanged(PlatformMediaSession&);
-
-    WEBCORE_EXPORT void setIsPlayingToAutomotiveHeadUnit(bool);
-    bool isPlayingToAutomotiveHeadUnit() const { return m_isPlayingToAutomotiveHeadUnit; }
-
-    WEBCORE_EXPORT void setSupportsSpatialAudioPlayback(bool);
-    virtual std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const MediaConfiguration&);
+    WEBCORE_EXPORT void setSupportsSpatialAudioPlayback(bool) final;
+    std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const MediaConfiguration&) override;
 
     void forEachMatchingSession(NOESCAPE const Function<bool(const PlatformMediaSession&)>& predicate, NOESCAPE const Function<void(PlatformMediaSession&)>& matchingCallback);
 
-    bool processIsSuspended() const { return m_processIsSuspended; }
+    bool processIsSuspended() const final { return m_processIsSuspended; }
 
-    WEBCORE_EXPORT void addAudioCaptureSource(AudioCaptureSource&);
-    WEBCORE_EXPORT void removeAudioCaptureSource(AudioCaptureSource&);
-    void audioCaptureSourceStateChanged() { updateSessionState(); }
-    size_t audioCaptureSourceCount() const { return m_audioCaptureSources.computeSize(); }
+    WEBCORE_EXPORT void addAudioCaptureSource(AudioCaptureSource&) final;
+    WEBCORE_EXPORT void removeAudioCaptureSource(AudioCaptureSource&) final;
+    void audioCaptureSourceStateChanged()  final { updateSessionState(); }
+    size_t audioCaptureSourceCount() const  final { return m_audioCaptureSources.computeSize(); }
 
-    WEBCORE_EXPORT void processDidReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&);
+    WEBCORE_EXPORT void processDidReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) final;
 
-    bool isInterrupted() const { return !!m_currentInterruption; }
-    bool hasNoSession() const;
+    bool isInterrupted() const  final { return !!m_currentInterruption; }
+    bool hasNoSession() const final;
 
-    virtual void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType) { };
-    virtual void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType) { };
-    virtual RemoteCommandListener::RemoteCommandsSet supportedCommands() const { return { }; };
+    WEBCORE_EXPORT void processSystemWillSleep() final;
+    WEBCORE_EXPORT void processSystemDidWake() final;
 
-    WEBCORE_EXPORT void processSystemWillSleep();
-    WEBCORE_EXPORT void processSystemDidWake();
+    bool isApplicationInBackground() const final { return m_isApplicationInBackground; }
 
-    virtual void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() { };
-    virtual void resetSessionState() { };
+    WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
-    bool isApplicationInBackground() const { return m_isApplicationInBackground; }
-
-    WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose);
-
-    WEBCORE_EXPORT void addNowPlayingMetadataObserver(const NowPlayingMetadataObserver&);
-    WEBCORE_EXPORT void removeNowPlayingMetadataObserver(const NowPlayingMetadataObserver&);
-
-    bool hasActiveNowPlayingSessionInGroup(std::optional<MediaSessionGroupIdentifier>);
-
-    virtual void updatePresentingApplicationPIDIfNecessary(ProcessID) { }
+    std::optional<NowPlayingInfo> nowPlayingInfo() const override;
+    WEBCORE_EXPORT void addNowPlayingMetadataObserver(const NowPlayingMetadataObserver&) final;
+    WEBCORE_EXPORT void removeNowPlayingMetadataObserver(const NowPlayingMetadataObserver&) final;
+    bool hasActiveNowPlayingSessionInGroup(std::optional<MediaSessionGroupIdentifier>) final;
 
 protected:
-    friend class PlatformMediaSession;
     static std::unique_ptr<PlatformMediaSessionManager> create();
     PlatformMediaSessionManager();
-
-    virtual void addSession(PlatformMediaSession&);
-    virtual void removeSession(PlatformMediaSession&);
 
     void forEachSession(NOESCAPE const Function<void(PlatformMediaSession&)>&);
     void forEachSessionInGroup(std::optional<MediaSessionGroupIdentifier>, NOESCAPE const Function<void(PlatformMediaSession&)>&);
@@ -220,6 +168,9 @@ protected:
 private:
     friend class Internals;
 
+    bool has(PlatformMediaSession::MediaType) const;
+    int count(PlatformMediaSession::MediaType) const;
+
     void scheduleUpdateSessionState();
     virtual void updateSessionState() { }
 
@@ -231,7 +182,7 @@ private:
     void dumpSessionStates();
 #endif
 
-    std::array<SessionRestrictions, static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1> m_restrictions;
+    std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1> m_restrictions;
     mutable Vector<WeakPtr<PlatformMediaSession>> m_sessions;
 
     std::optional<PlatformMediaSession::InterruptionType> m_currentInterruption;

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -47,10 +47,10 @@ public:
     virtual ~MediaSessionHelperClient() = default;
 
     enum class SuspendedUnderLock : bool { No, Yes };
-    virtual void applicationWillEnterForeground(SuspendedUnderLock) = 0;
-    virtual void applicationDidEnterBackground(SuspendedUnderLock) = 0;
-    virtual void applicationWillBecomeInactive() = 0;
-    virtual void applicationDidBecomeActive() = 0;
+    virtual void uiApplicationWillEnterForeground(SuspendedUnderLock) = 0;
+    virtual void uiApplicationDidEnterBackground(SuspendedUnderLock) = 0;
+    virtual void uiApplicationWillBecomeInactive() = 0;
+    virtual void uiApplicationDidBecomeActive() = 0;
 
     enum class HasAvailableTargets : bool { No, Yes };
     virtual void externalOutputDeviceAvailableDidChange(HasAvailableTargets) = 0;

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -159,25 +159,25 @@ void MediaSessionHelper::activeAudioRouteDidChange(ShouldPause shouldPause)
 void MediaSessionHelper::applicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
     for (auto& client : m_clients)
-        client.applicationWillEnterForeground(suspendedUnderLock);
+        client.uiApplicationWillEnterForeground(suspendedUnderLock);
 }
 
 void MediaSessionHelper::applicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
 {
     for (auto& client : m_clients)
-        client.applicationDidEnterBackground(suspendedUnderLock);
+        client.uiApplicationDidEnterBackground(suspendedUnderLock);
 }
 
 void MediaSessionHelper::applicationWillBecomeInactive()
 {
     for (auto& client : m_clients)
-        client.applicationWillBecomeInactive();
+        client.uiApplicationWillBecomeInactive();
 }
 
 void MediaSessionHelper::applicationDidBecomeActive()
 {
     for (auto& client : m_clients)
-        client.applicationDidBecomeActive();
+        client.uiApplicationDidBecomeActive();
 }
 
 void MediaSessionHelper::externalOutputDeviceAvailableDidChange(HasAvailableTargets hasAvailableTargets)
@@ -453,7 +453,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
         ASSERT(!_routeDetector);
 
-        if (auto callback = _callback.get()) {
+        if (RefPtr callback = _callback.get()) {
             BEGIN_BLOCK_OBJC_EXCEPTIONS
             _routeDetector = adoptNS([PAL::allocAVRouteDetectorInstance() init]);
             [_routeDetector setRouteDetectionEnabled:_monitoringAirPlayRoutes];
@@ -489,7 +489,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
     auto isSuspendedUnderLock = [[[notification userInfo] objectForKey:@"isSuspendedUnderLock"] boolValue] ? SuspendedUnderLock::Yes : SuspendedUnderLock::No;
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), isSuspendedUnderLock]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->applicationWillEnterForeground(isSuspendedUnderLock);
     });
 }
@@ -501,7 +501,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     LOG(Media, "-[WebMediaSessionHelper applicationDidBecomeActive]");
 
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->applicationDidBecomeActive();
     });
 }
@@ -513,7 +513,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     LOG(Media, "-[WebMediaSessionHelper applicationWillResignActive]");
 
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->applicationWillBecomeInactive();
     });
 }
@@ -525,7 +525,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     LOG(Media, "-[WebMediaSessionHelper wirelessRoutesAvailableDidChange]");
 
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        auto callback = _callback.get();
+        RefPtr callback = _callback.get();
         if (callback && _monitoringAirPlayRoutes)
             callback->externalOutputDeviceAvailableDidChange();
     });
@@ -539,7 +539,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
     auto isSuspendedUnderLock = [[[notification userInfo] objectForKey:@"isSuspendedUnderLock"] boolValue] ? SuspendedUnderLock::Yes : SuspendedUnderLock::No;
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), isSuspendedUnderLock]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->applicationDidEnterBackground(isSuspendedUnderLock);
     });
 }
@@ -550,7 +550,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     LOG(Media, "-[WebMediaSessionHelper mediaServerConnectionDied:]");
     UNUSED_PARAM(notification);
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->mediaServerConnectionDied();
     });
 }
@@ -562,7 +562,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
     bool shouldPause = [[notification.userInfo objectForKey:AVAudioSessionRouteChangeReasonKey] unsignedIntegerValue] == AVAudioSessionRouteChangeReasonOldDeviceUnavailable;
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), shouldPause]() {
-        if (auto callback = _callback.get()) {
+        if (RefPtr callback = _callback.get()) {
             callback->updateCarPlayIsConnected();
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS)
             callback->activeAudioRouteDidChange(shouldPause);
@@ -578,7 +578,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 {
     LOG(Media, "-[WebMediaSessionHelper spatialPlaybackCapabilitiesChanged:]");
     callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        if (auto callback = _callback.get())
+        if (RefPtr callback = _callback.get())
             callback->updateActiveAudioRouteSupportsSpatialPlayback();
     });
 }

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -50,18 +50,15 @@ class MediaSessionManageriOS
     , public AudioSessionInterruptionObserver {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManageriOS);
 public:
+    MediaSessionManageriOS();
     virtual ~MediaSessionManageriOS();
 
-    bool hasWirelessTargetsAvailable() override;
-    bool isMonitoringWirelessTargets() const override;
+    bool hasWirelessTargetsAvailable() final;
+    bool isMonitoringWirelessTargets() const final;
 
     USING_CAN_MAKE_WEAKPTR(MediaSessionHelperClient);
 
 private:
-    friend class PlatformMediaSessionManager;
-
-    MediaSessionManageriOS();
-
 #if !PLATFORM(MACCATALYST)
     void resetRestrictions() final;
 #endif
@@ -77,10 +74,10 @@ private:
     void endAudioSessionInterruption(AudioSession::MayResume mayResume) final { endInterruption(mayResume == AudioSession::MayResume::Yes ? PlatformMediaSession::EndInterruptionFlags::MayResumePlaying : PlatformMediaSession::EndInterruptionFlags::NoFlags); }
 
     // MediaSessionHelperClient
-    void applicationWillEnterForeground(SuspendedUnderLock) final;
-    void applicationDidEnterBackground(SuspendedUnderLock) final;
-    void applicationWillBecomeInactive() final;
-    void applicationDidBecomeActive() final;
+    void uiApplicationWillEnterForeground(SuspendedUnderLock) final;
+    void uiApplicationDidEnterBackground(SuspendedUnderLock) final;
+    void uiApplicationWillBecomeInactive() final;
+    void uiApplicationDidBecomeActive() final;
     void externalOutputDeviceAvailableDidChange(HasAvailableTargets) final;
     void activeAudioRouteDidChange(ShouldPause) final;
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -77,12 +77,12 @@ void MediaSessionManageriOS::resetRestrictions()
 
     if (ramSize() < systemMemoryRequiredForVideoInBackgroundTabs) {
         ALWAYS_LOG(LOGIDENTIFIER, "restricting video in background tabs because system memory = ", ramSize());
-        addRestriction(PlatformMediaSession::MediaType::Video, BackgroundTabPlaybackRestricted);
+        addRestriction(PlatformMediaSession::MediaType::Video, MediaSessionRestriction::BackgroundTabPlaybackRestricted);
     }
 
-    addRestriction(PlatformMediaSession::MediaType::Video, BackgroundProcessPlaybackRestricted);
-    addRestriction(PlatformMediaSession::MediaType::WebAudio, BackgroundProcessPlaybackRestricted);
-    addRestriction(PlatformMediaSession::MediaType::VideoAudio, ConcurrentPlaybackNotPermitted | BackgroundProcessPlaybackRestricted | SuspendedUnderLockPlaybackRestricted);
+    addRestriction(PlatformMediaSession::MediaType::Video, MediaSessionRestriction::BackgroundProcessPlaybackRestricted);
+    addRestriction(PlatformMediaSession::MediaType::WebAudio, MediaSessionRestriction::BackgroundProcessPlaybackRestricted);
+    addRestriction(PlatformMediaSession::MediaType::VideoAudio, { MediaSessionRestriction::ConcurrentPlaybackNotPermitted, MediaSessionRestriction::BackgroundProcessPlaybackRestricted, MediaSessionRestriction::SuspendedUnderLockPlaybackRestricted });
 }
 #endif
 
@@ -233,7 +233,7 @@ void MediaSessionManageriOS::activeVideoRouteDidChange(SupportsAirPlayVideo supp
     nowPlayingSession->setShouldPlayToPlaybackTarget(supportsAirPlayVideo == SupportsAirPlayVideo::Yes);
 }
 
-void MediaSessionManageriOS::applicationWillEnterForeground(SuspendedUnderLock isSuspendedUnderLock)
+void MediaSessionManageriOS::uiApplicationWillEnterForeground(SuspendedUnderLock isSuspendedUnderLock)
 {
     if (willIgnoreSystemInterruptions())
         return;
@@ -241,7 +241,7 @@ void MediaSessionManageriOS::applicationWillEnterForeground(SuspendedUnderLock i
     MediaSessionManagerCocoa::applicationWillEnterForeground(isSuspendedUnderLock == SuspendedUnderLock::Yes);
 }
 
-void MediaSessionManageriOS::applicationDidBecomeActive()
+void MediaSessionManageriOS::uiApplicationDidBecomeActive()
 {
     if (willIgnoreSystemInterruptions())
         return;
@@ -249,7 +249,7 @@ void MediaSessionManageriOS::applicationDidBecomeActive()
     MediaSessionManagerCocoa::applicationDidBecomeActive();
 }
 
-void MediaSessionManageriOS::applicationDidEnterBackground(SuspendedUnderLock isSuspendedUnderLock)
+void MediaSessionManageriOS::uiApplicationDidEnterBackground(SuspendedUnderLock isSuspendedUnderLock)
 {
     if (willIgnoreSystemInterruptions())
         return;
@@ -257,7 +257,7 @@ void MediaSessionManageriOS::applicationDidEnterBackground(SuspendedUnderLock is
     MediaSessionManagerCocoa::applicationDidEnterBackground(isSuspendedUnderLock == SuspendedUnderLock::Yes);
 }
 
-void MediaSessionManageriOS::applicationWillBecomeInactive()
+void MediaSessionManageriOS::uiApplicationWillBecomeInactive()
 {
     if (willIgnoreSystemInterruptions())
         return;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4936,21 +4936,21 @@ ExceptionOr<void> Internals::setMediaSessionRestrictions(const String& mediaType
     auto restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType);
     PlatformMediaSessionManager::singleton().removeRestriction(mediaType, restrictions);
 
-    restrictions = PlatformMediaSessionManager::NoRestrictions;
+    restrictions = MediaSessionRestriction::NoRestrictions;
 
     for (StringView restrictionString : restrictionsString.split(',')) {
         if (equalLettersIgnoringASCIICase(restrictionString, "concurrentplaybacknotpermitted"_s))
-            restrictions |= PlatformMediaSessionManager::ConcurrentPlaybackNotPermitted;
+            restrictions |= MediaSessionRestriction::ConcurrentPlaybackNotPermitted;
         if (equalLettersIgnoringASCIICase(restrictionString, "backgroundprocessplaybackrestricted"_s))
-            restrictions |= PlatformMediaSessionManager::BackgroundProcessPlaybackRestricted;
+            restrictions |= MediaSessionRestriction::BackgroundProcessPlaybackRestricted;
         if (equalLettersIgnoringASCIICase(restrictionString, "backgroundtabplaybackrestricted"_s))
-            restrictions |= PlatformMediaSessionManager::BackgroundTabPlaybackRestricted;
+            restrictions |= MediaSessionRestriction::BackgroundTabPlaybackRestricted;
         if (equalLettersIgnoringASCIICase(restrictionString, "interruptedplaybacknotpermitted"_s))
-            restrictions |= PlatformMediaSessionManager::InterruptedPlaybackNotPermitted;
+            restrictions |= MediaSessionRestriction::InterruptedPlaybackNotPermitted;
         if (equalLettersIgnoringASCIICase(restrictionString, "inactiveprocessplaybackrestricted"_s))
-            restrictions |= PlatformMediaSessionManager::InactiveProcessPlaybackRestricted;
+            restrictions |= MediaSessionRestriction::InactiveProcessPlaybackRestricted;
         if (equalLettersIgnoringASCIICase(restrictionString, "suspendedunderlockplaybackrestricted"_s))
-            restrictions |= PlatformMediaSessionManager::SuspendedUnderLockPlaybackRestricted;
+            restrictions |= MediaSessionRestriction::SuspendedUnderLockPlaybackRestricted;
     }
     PlatformMediaSessionManager::singleton().addRestriction(mediaType, restrictions);
     return { };
@@ -4962,24 +4962,24 @@ ExceptionOr<String> Internals::mediaSessionRestrictions(const String& mediaTypeS
     if (mediaType == PlatformMediaSession::MediaType::None)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType);
-    if (restrictions == PlatformMediaSessionManager::NoRestrictions)
+    auto restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType);
+    if (restrictions == MediaSessionRestriction::NoRestrictions)
         return String();
 
     StringBuilder builder;
-    if (restrictions & PlatformMediaSessionManager::ConcurrentPlaybackNotPermitted)
+    if (restrictions & MediaSessionRestriction::ConcurrentPlaybackNotPermitted)
         builder.append("concurrentplaybacknotpermitted"_s);
-    if (restrictions & PlatformMediaSessionManager::BackgroundProcessPlaybackRestricted) {
+    if (restrictions & MediaSessionRestriction::BackgroundProcessPlaybackRestricted) {
         if (!builder.isEmpty())
             builder.append(',');
         builder.append("backgroundprocessplaybackrestricted"_s);
     }
-    if (restrictions & PlatformMediaSessionManager::BackgroundTabPlaybackRestricted) {
+    if (restrictions & MediaSessionRestriction::BackgroundTabPlaybackRestricted) {
         if (!builder.isEmpty())
             builder.append(',');
         builder.append("backgroundtabplaybackrestricted"_s);
     }
-    if (restrictions & PlatformMediaSessionManager::InterruptedPlaybackNotPermitted) {
+    if (restrictions & MediaSessionRestriction::InterruptedPlaybackNotPermitted) {
         if (!builder.isEmpty())
             builder.append(',');
         builder.append("interruptedplaybacknotpermitted"_s);

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -91,25 +91,25 @@ void RemoteMediaSessionHelperProxy::overridePresentingApplicationPIDIfNeeded()
         MediaSessionHelper::sharedHelper().providePresentingApplicationPID(*m_presentingApplicationPID, MediaSessionHelper::ShouldOverride::Yes);
 }
 
-void RemoteMediaSessionHelperProxy::applicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
+void RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
     if (auto connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillEnterForeground(suspendedUnderLock), { });
 }
 
-void RemoteMediaSessionHelperProxy::applicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
+void RemoteMediaSessionHelperProxy::uiApplicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
 {
     if (auto connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidEnterBackground(suspendedUnderLock), { });
 }
 
-void RemoteMediaSessionHelperProxy::applicationWillBecomeInactive()
+void RemoteMediaSessionHelperProxy::uiApplicationWillBecomeInactive()
 {
     if (auto connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillBecomeInactive(), { });
 }
 
-void RemoteMediaSessionHelperProxy::applicationDidBecomeActive()
+void RemoteMediaSessionHelperProxy::uiApplicationDidBecomeActive()
 {
     if (auto connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidBecomeActive(), { });

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -64,10 +64,10 @@ private:
     void providePresentingApplicationPID(int, WebCore::MediaSessionHelper::ShouldOverride);
 
     // MediaSessionHelperClient
-    void applicationWillEnterForeground(SuspendedUnderLock) final;
-    void applicationDidEnterBackground(SuspendedUnderLock) final;
-    void applicationWillBecomeInactive() final;
-    void applicationDidBecomeActive() final;
+    void uiApplicationWillEnterForeground(SuspendedUnderLock) final;
+    void uiApplicationDidEnterBackground(SuspendedUnderLock) final;
+    void uiApplicationWillBecomeInactive() final;
+    void uiApplicationDidBecomeActive() final;
     void externalOutputDeviceAvailableDidChange(HasAvailableTargets) final;
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
     void activeAudioRouteDidChange(ShouldPause) final;


### PR DESCRIPTION
#### 057e00b5eeccc05da0746b9d8bcaff3211bd4d02
<pre>
Define a virtual MediaSessionManagerInterface interface and have PlatformMediaSessionManager derive from it
<a href="https://bugs.webkit.org/show_bug.cgi?id=291107">https://bugs.webkit.org/show_bug.cgi?id=291107</a>
<a href="https://rdar.apple.com/148623827">rdar://148623827</a>

Reviewed by Andy Estes.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::clientDataBufferingTimerFired):

* Source/WebCore/platform/audio/MediaSessionManagerInterface.h: Added.
(WebCore::MediaSessionManagerInterface::scheduleSessionStatusUpdate):
(WebCore::MediaSessionManagerInterface::hasActiveNowPlayingSession const):
(WebCore::MediaSessionManagerInterface::lastUpdatedNowPlayingTitle const):
(WebCore::MediaSessionManagerInterface::lastUpdatedNowPlayingDuration const):
(WebCore::MediaSessionManagerInterface::lastUpdatedNowPlayingElapsedTime const):
(WebCore::MediaSessionManagerInterface::lastUpdatedNowPlayingInfoUniqueIdentifier const):
(WebCore::MediaSessionManagerInterface::registeredAsNowPlayingApplication const):
(WebCore::MediaSessionManagerInterface::haveEverRegisteredAsNowPlayingApplication const):
(WebCore::MediaSessionManagerInterface::resetHaveEverRegisteredAsNowPlayingApplicationForTesting):
(WebCore::MediaSessionManagerInterface::prepareToSendUserMediaPermissionRequestForPage):
(WebCore::MediaSessionManagerInterface::sessionDidEndRemoteScrubbing):
(WebCore::MediaSessionManagerInterface::clientCharacteristicsChanged):
(WebCore::MediaSessionManagerInterface::configureWirelessTargetMonitoring):
(WebCore::MediaSessionManagerInterface::hasWirelessTargetsAvailable):
(WebCore::MediaSessionManagerInterface::isMonitoringWirelessTargets const):
(WebCore::MediaSessionManagerInterface::addSupportedCommand):
(WebCore::MediaSessionManagerInterface::removeSupportedCommand):
(WebCore::MediaSessionManagerInterface::supportedCommands const):
(WebCore::MediaSessionManagerInterface::resetSessionState):
(WebCore::MediaSessionManagerInterface::updatePresentingApplicationPIDIfNecessary):

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::resetRestrictions):
(WebCore::PlatformMediaSessionManager::addRestriction):
(WebCore::PlatformMediaSessionManager::removeRestriction):
(WebCore::PlatformMediaSessionManager::restrictions):
(WebCore::PlatformMediaSessionManager::sessionWillBeginPlayback):
(WebCore::PlatformMediaSessionManager::applicationWillBecomeInactive):
(WebCore::PlatformMediaSessionManager::applicationDidBecomeActive):
(WebCore::PlatformMediaSessionManager::applicationDidEnterBackground):
(WebCore::PlatformMediaSessionManager::applicationWillEnterForeground):
(WebCore::PlatformMediaSessionManager::sessionIsPlayingToWirelessPlaybackTargetChanged):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
(WebCore::PlatformMediaSessionManager::scheduleSessionStatusUpdate): Deleted.
(WebCore::PlatformMediaSessionManager::hasActiveNowPlayingSession const): Deleted.
(WebCore::PlatformMediaSessionManager::lastUpdatedNowPlayingTitle const): Deleted.
(WebCore::PlatformMediaSessionManager::lastUpdatedNowPlayingDuration const): Deleted.
(WebCore::PlatformMediaSessionManager::lastUpdatedNowPlayingElapsedTime const): Deleted.
(WebCore::PlatformMediaSessionManager::lastUpdatedNowPlayingInfoUniqueIdentifier const): Deleted.
(WebCore::PlatformMediaSessionManager::registeredAsNowPlayingApplication const): Deleted.
(WebCore::PlatformMediaSessionManager::haveEverRegisteredAsNowPlayingApplication const): Deleted.
(WebCore::PlatformMediaSessionManager::prepareToSendUserMediaPermissionRequestForPage): Deleted.
(WebCore::PlatformMediaSessionManager::willIgnoreSystemInterruptions const): Deleted.
(WebCore::PlatformMediaSessionManager::setWillIgnoreSystemInterruptions): Deleted.
(WebCore::PlatformMediaSessionManager::sessionDidEndRemoteScrubbing): Deleted.
(WebCore::PlatformMediaSessionManager::clientCharacteristicsChanged): Deleted.
(WebCore::PlatformMediaSessionManager::configureWirelessTargetMonitoring): Deleted.
(WebCore::PlatformMediaSessionManager::hasWirelessTargetsAvailable): Deleted.
(WebCore::PlatformMediaSessionManager::isMonitoringWirelessTargets const): Deleted.
(WebCore::PlatformMediaSessionManager::isPlayingToAutomotiveHeadUnit const): Deleted.
(WebCore::PlatformMediaSessionManager::processIsSuspended const): Deleted.
(WebCore::PlatformMediaSessionManager::audioCaptureSourceStateChanged): Deleted.
(WebCore::PlatformMediaSessionManager::audioCaptureSourceCount const): Deleted.
(WebCore::PlatformMediaSessionManager::isInterrupted const): Deleted.
(WebCore::PlatformMediaSessionManager::addSupportedCommand): Deleted.
(WebCore::PlatformMediaSessionManager::removeSupportedCommand): Deleted.
(WebCore::PlatformMediaSessionManager::supportedCommands const): Deleted.
(WebCore::PlatformMediaSessionManager::resetHaveEverRegisteredAsNowPlayingApplicationForTesting): Deleted.
(WebCore::PlatformMediaSessionManager::resetSessionState): Deleted.
(WebCore::PlatformMediaSessionManager::isApplicationInBackground const): Deleted.
(WebCore::PlatformMediaSessionManager::updatePresentingApplicationPIDIfNecessary): Deleted.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::ensureCodecsRegistered):

* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h

* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::resetRestrictions):

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMediaSessionRestrictions):
(WebCore::Internals::mediaSessionRestrictions const):

* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationDidEnterBackground):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationWillBecomeInactive):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationDidBecomeActive):
(WebKit::RemoteMediaSessionHelperProxy::applicationWillEnterForeground): Deleted.
(WebKit::RemoteMediaSessionHelperProxy::applicationDidEnterBackground): Deleted.
(WebKit::RemoteMediaSessionHelperProxy::applicationWillBecomeInactive): Deleted.
(WebKit::RemoteMediaSessionHelperProxy::applicationDidBecomeActive): Deleted.
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:

Canonical link: <a href="https://commits.webkit.org/293485@main">https://commits.webkit.org/293485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31b16bc15d28b7b081f649c4d0a7258af0925f08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75384 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32511 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89431 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55745 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19046 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84345 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83848 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19857 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31265 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->