### PR TITLE
[HDR] Use CoreGraphics to constrain the brightness of the HDR images

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -82,6 +82,13 @@ OptionSet<ContentsFormat> screenContentsFormatsForTesting()
 }
 #endif
 
+Headroom currentHeadroomForDisplay(PlatformDisplayID displayID)
+{
+    if (auto data = screenData(displayID))
+        return data->currentHeadroom;
+    return Headroom::None;
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -62,6 +62,8 @@ class FloatRect;
 class FloatSize;
 class Widget;
 
+struct Headroom;
+
 using PlatformDisplayID = uint32_t;
 
 using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
@@ -116,6 +118,8 @@ WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
 WEBCORE_EXPORT void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
 OptionSet<ContentsFormat> screenContentsFormatsForTesting();
 #endif
+
+Headroom currentHeadroomForDisplay(PlatformDisplayID);
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -27,6 +27,7 @@
 
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include "ImageTypes.h"
 #include "PlatformScreen.h"
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
@@ -43,6 +44,7 @@ struct ScreenData {
     bool screenSupportsExtendedColor { false };
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
+    Headroom currentHeadroom { Headroom::None };
 #if PLATFORM(MAC)
     FloatSize screenSize; // In millimeters.
     bool screenIsMonochrome { false };

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -97,7 +97,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     auto sizeForDrawing = expandedIntSize(sourceSize * scaleFactorForDrawing);
     auto subsamplingLevel =  m_source->subsamplingLevelForScaleFactor(context, scaleFactorForDrawing, options.allowImageSubsampling());
 
-    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), sizeForDrawing });
+    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), sizeForDrawing, m_source->decodingFormat() });
 
     if (!nativeImage) {
         if (nativeImage.error() != DecodingStatus::Decoding)
@@ -122,7 +122,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             orientation = currentFrameOrientation();
 
         auto headroom = options.headroom();
-        if (headroom == Headroom::FromImage && hasHDRContentForTesting())
+        if (hasHDRContentForTesting())
             fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
         else {
             if (headroom == Headroom::FromImage)

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -362,7 +362,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
         return;
     }
 
-    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, DecodingMode::Asynchronous);
+    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, std::nullopt, decodingFormat() });
     RefPtr frameAnimator = this->frameAnimator();
 
     if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
@@ -376,7 +376,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
 
     if (!isCompatibleNativeImage) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
-        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous });
+        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, std::nullopt, decodingFormat() });
         return;
     }
 
@@ -563,7 +563,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     }
 
     if (!isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options)) {
-        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, DecodingMode::Synchronous);
+        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, { DecodingMode::Synchronous, std::nullopt, decodingFormat() });
 
         RefPtr nativeImage = NativeImage::create(WTFMove(platformImage));
         if (!nativeImage)
@@ -608,12 +608,12 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::currentNativeImage
 {
     startAnimation(subsamplingLevel, options);
 
-    auto effectiveOptions = options;
+    auto effectiveOptions = DecodingOptions { options.decodingMode(), options.sizeForDrawing(), decodingFormat() };
 
     // If frame0 is displayed for the first time, startAnimation() has to request decoding frame1
     // asynchronously. A flicker will occur if we request decoding frame0 also asynchronously.
     if (options.decodingMode() == DecodingMode::Asynchronous && isAnimated() && !hasEverAnimated())
-        effectiveOptions = { DecodingMode::Synchronous, options.sizeForDrawing() };
+        effectiveOptions = { DecodingMode::Synchronous, options.sizeForDrawing(), decodingFormat() };
 
     return nativeImageAtIndexForDrawing(currentFrameIndex(), subsamplingLevel, effectiveOptions);
 }

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,11 +36,17 @@ enum class DecodingMode : uint8_t {
     Asynchronous
 };
 
+enum class DecodingFormat : bool {
+    SDR,
+    HDR
+};
+
 class DecodingOptions {
 public:
-    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
+    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, const std::optional<IntSize>& sizeForDrawing = std::nullopt, DecodingFormat decodingFormat = DecodingFormat::SDR)
         : m_decodingMode(decodingMode)
         , m_sizeForDrawing(sizeForDrawing)
+        , m_decodingFormat(decodingFormat)
     {
     }
 
@@ -69,9 +75,12 @@ public:
         return sizeForDrawing()->maxDimension() >= other.sizeForDrawing()->maxDimension();
     }
 
+    DecodingFormat decodingFormat() const { return m_decodingFormat; }
+
 private:
     DecodingMode m_decodingMode;
     std::optional<IntSize> m_sizeForDrawing;
+    DecodingFormat m_decodingFormat;
 };
 
 TextStream& operator<<(TextStream&, DecodingMode);

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -82,6 +82,7 @@ public:
     virtual std::optional<Color> singlePixelSolidColor() const = 0;
     virtual Headroom headroom() const = 0;
 
+    DecodingFormat decodingFormat() const { return headroom() > Headroom::None ? DecodingFormat::HDR : DecodingFormat::SDR; }
     bool hasSolidColor() const;
 
     virtual String uti() const { return String(); }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -378,21 +378,37 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
     auto oldHeadroom = CGContextGetEDRTargetHeadroom(context);
 
     auto headroom = options.headroom();
-    auto dynamicRangeLimit = options.dynamicRangeLimit();
-
     if (headroom == Headroom::FromImage)
         headroom = nativeImage.headroom();
 
-    // FIXME: Use CoreGraphics to constrain the brightness of the image more appropriately.
-    if (headroom > Headroom::None) {
-        static constexpr float maxConstrainedHeadroom = 2;
-        if (dynamicRangeLimit == PlatformDynamicRangeLimit::standard())
-            headroom = Headroom::None;
-        else if (dynamicRangeLimit == PlatformDynamicRangeLimit::constrainedHigh())
-            headroom = std::max<float>(Headroom::None, std::min<float>(headroom * dynamicRangeLimit.value(), maxConstrainedHeadroom));
-    }
-
     CGContextSetEDRTargetHeadroom(context, headroom);
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    auto oldToneMappingInfo = CGContextGetContentToneMappingInfo(context);
+
+    if (headroom > Headroom::None) {
+        auto dynamicRangeLimit = options.dynamicRangeLimit();
+
+        float edrStrength = dynamicRangeLimit == PlatformDynamicRangeLimit::noLimit() ? 1 : 0;
+        float cdrStrength = dynamicRangeLimit == PlatformDynamicRangeLimit::constrainedHigh() ? 1 : 0;
+        unsigned averageLightLevel = CGImageGetContentAverageLightLevelNits(subImage.get());
+
+        if (!averageLightLevel)
+            averageLightLevel = CGImageCalculateContentAverageLightLevelNits(subImage.get());
+
+        RetainPtr edrStrengthNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &edrStrength));
+        RetainPtr cdrStrengthNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &cdrStrength));
+        RetainPtr averageLightLevelNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &averageLightLevel));
+
+        CFTypeRef toneMappingKeys[] = { kCGContentEDRStrength, kCGContentAverageLightLevel, kCGConstrainedDynamicRange };
+        CFTypeRef toneMappingValues[] = { edrStrengthNumber.get(), averageLightLevelNumber.get(), cdrStrengthNumber.get() };
+
+        RetainPtr toneMappingOptions = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, toneMappingKeys, toneMappingValues, sizeof(toneMappingKeys) / sizeof(toneMappingKeys[0]), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+        CGContentToneMappingInfo toneMappingInfo = { kCGToneMappingDefault, toneMappingOptions.get() };
+        CGContextSetContentToneMappingInfo(context, toneMappingInfo);
+    }
+#endif
 #endif
 
     // Make the origin be at adjustedDestRect.location()
@@ -422,6 +438,9 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
 #endif
         setCGBlendMode(context, oldCompositeOperator, oldBlendMode);
 #if HAVE(SUPPORT_HDR_DISPLAY)
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+        CGContextSetContentToneMappingInfo(context, oldToneMappingInfo);
+#endif
         CGContextSetEDRTargetHeadroom(context, oldHeadroom);
 #endif
     }

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -63,11 +63,12 @@ const CFStringRef WebCoreCGImagePropertyDelayTime = CFSTR("DelayTime");
 const CFStringRef WebCoreCGImagePropertyLoopCount = CFSTR("LoopCount");
 const CFStringRef WebCoreCGImagePropertyHeadroom = CFSTR("Headroom");
 
-const CFStringRef kCGImageSourceEnableRestrictedDecoding = CFSTR("kCGImageSourceEnableRestrictedDecoding");
-
 #if HAVE(IMAGEIO_CREATE_UNPREMULTIPLIED_PNG)
 const CFStringRef kCGImageSourceCreateUnpremultipliedPNG = CFSTR("kCGImageSourceCreateUnpremultipliedPNG");
 #endif
+
+const CFStringRef kCGImageSourceEnableRestrictedDecoding = CFSTR("kCGImageSourceEnableRestrictedDecoding");
+const CFStringRef kCGComputeHDRStats = CFSTR("kCGComputeHDRStats");
 
 static RetainPtr<CFMutableDictionaryRef> createImageSourceOptions()
 {
@@ -127,27 +128,47 @@ static RetainPtr<CFMutableDictionaryRef> appendImageSourceOptions(RetainPtr<CFMu
 {
     if (subsamplingLevel != SubsamplingLevel::Default)
         options = appendImageSourceOption(WTFMove(options), subsamplingLevel);
-    
+
     options = appendImageSourceOption(WTFMove(options), sizeForDrawing);
     return WTFMove(options);
 }
 
-static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplingLevel = SubsamplingLevel::Default)
+static RetainPtr<CFMutableDictionaryRef> appendImageSourceOptions(RetainPtr<CFMutableDictionaryRef>&& options, DecodingFormat decodingFormat)
 {
-    static const auto options = createImageSourceOptions().leakRef();
-    if (subsamplingLevel == SubsamplingLevel::Default)
-        return options;
-    return appendImageSourceOption(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options)), subsamplingLevel);
+    if (decodingFormat == DecodingFormat::SDR)
+        return WTFMove(options);
+
+    RetainPtr decodeRequestOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(decodeRequestOptions.get(), kCGComputeHDRStats, kCFBooleanTrue);
+
+    CFDictionarySetValue(options.get(), kCGImageSourceDecodeRequestOptions, decodeRequestOptions.get());
+    CFDictionarySetValue(options.get(), kCGImageSourceDecodeRequest, kCGImageSourceDecodeToHDR);
+
+    return WTFMove(options);
 }
 
-static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing)
+static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplingLevel = SubsamplingLevel::Default, DecodingFormat decodingFormat = DecodingFormat::SDR)
 {
-    static CFMutableDictionaryRef options;
+    static const auto basicOptions = createImageSourceOptions().leakRef();
+
+    RetainPtr options = appendImageSourceOption(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, basicOptions)), subsamplingLevel);
+    options = appendImageSourceOptions(WTFMove(options), decodingFormat);
+
+    return options;
+}
+
+static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing, DecodingFormat decodingFormat)
+{
+    static CFMutableDictionaryRef basicOptions;
     static std::once_flag initializeThumbnailOptionsOnce;
     std::call_once(initializeThumbnailOptionsOnce, [] {
-        options = createImageSourceThumbnailOptions().leakRef();
+        basicOptions = createImageSourceThumbnailOptions().leakRef();
     });
-    return appendImageSourceOptions(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options)), subsamplingLevel, sizeForDrawing);
+
+    RetainPtr options = appendImageSourceOptions(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, basicOptions)), subsamplingLevel, sizeForDrawing);
+    options = appendImageSourceOptions(WTFMove(options), decodingFormat);
+
+    return options;
 }
 
 static IntSize frameSizeFromProperties(CFDictionaryRef properties)
@@ -587,7 +608,7 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
 
     if (decodingOptions.decodingMode() == DecodingMode::Synchronous) {
         // Decode an image synchronously for its native size.
-        options = imageSourceOptions(subsamplingLevel);
+        options = imageSourceOptions(subsamplingLevel, decodingOptions.decodingFormat());
         image = adoptCF(CGImageSourceCreateImageAtIndex(m_nativeDecoder.get(), index, options.get()));
     } else {
         auto size = frameSizeAtIndex(index, SubsamplingLevel::Default);
@@ -599,7 +620,7 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
                 size = *sizeForDrawing;
         }
 
-        options = imageSourceThumbnailOptions(subsamplingLevel, size);
+        options = imageSourceThumbnailOptions(subsamplingLevel, size, decodingOptions.decodingFormat());
         image = adoptCF(CGImageSourceCreateThumbnailAtIndex(m_nativeDecoder.get(), index, options.get()));
     }
     

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -250,6 +250,7 @@ ScreenProperties collectScreenProperties()
         screenData.screenSupportsExtendedColor = WebCore::screenSupportsExtendedColor(nullptr);
         screenData.screenHasInvertedColors = WebCore::screenHasInvertedColors();
         screenData.screenSupportsHighDynamicRange = WebCore::screenSupportsHighDynamicRange(nullptr);
+        screenData.currentHeadroom = screen.currentEDRHeadroom;
         screenData.scaleFactor = WebCore::screenPPIFactor();
 
         screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -175,6 +175,7 @@ ScreenProperties collectScreenProperties()
         screenData.screenSize = FloatSize { CGDisplayScreenSize(displayID) };
         screenData.scaleFactor = screen.backingScaleFactor;
         screenData.screenSupportsHighDynamicRange = screenSupportsHighDynamicRange(displayID, screenData.preferredDynamicRangeMode);
+        screenData.currentHeadroom = screen.maximumExtendedDynamicRangeColorComponentValue;
 
         screenProperties.screenDataMap.set(displayID, WTFMove(screenData));
         if (!screenProperties.primaryDisplayID)

--- a/Source/WebCore/platform/win/PlatformScreenWin.cpp
+++ b/Source/WebCore/platform/win/PlatformScreenWin.cpp
@@ -111,4 +111,9 @@ bool screenSupportsExtendedColor(Widget*)
     return false;
 }
 
+Headroom currentHeadroomForDisplay(PlatformDisplayID)
+{
+    return Headroom::None;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -31,6 +31,7 @@
 #include "AXObjectCache.h"
 #include "BitmapImage.h"
 #include "CachedImage.h"
+#include "Chrome.h"
 #include "DocumentInlines.h"
 #include "FocusController.h"
 #include "FontCache.h"
@@ -740,6 +741,7 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
 #if USE(SKIA)
         StrictImageClamping::No,
 #endif
+        currentHeadroomForDisplay(page().chrome().displayID()),
         style().dynamicRangeLimit().toPlatformDynamicRangeLimit()
     };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2489,6 +2489,7 @@ header: <WebCore/ScreenProperties.h>
     bool screenSupportsExtendedColor;
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
+    WebCore::Headroom currentHeadroom;
 #if PLATFORM(MAC)
     WebCore::FloatSize screenSize;
     bool screenIsMonochrome;


### PR DESCRIPTION
#### 0b44a002ca8cbd6f43656a1353c098989fdd9f57
<pre>
[HDR] Use CoreGraphics to constrain the brightness of the HDR images
<a href="https://bugs.webkit.org/show_bug.cgi?id=288881">https://bugs.webkit.org/show_bug.cgi?id=288881</a>
<a href="https://rdar.apple.com/145887519">rdar://145887519</a>

Reviewed by NOBODY (OOPS!).

To support the CSS property dynamic-range-limit, CoreGraphics tone-mapping APIs
will be used before drawing the HDR GCImage.

CGContextSetEDRTargetHeadroom() should be called with the display headroom.
Calling it with the image headroom is incorrect since this will not do any
tone-mapping.

* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::currentHeadroomForDisplay):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::currentNativeImageForDrawing):
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::DecodingOptions):
(WebCore::DecodingOptions::decodingFormat const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::decodingFormat const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::appendImageSourceOptions):
(WebCore::imageSourceOptions):
(WebCore::imageSourceThumbnailOptions):
(WebCore::ImageDecoderCG::createFrameImageAtIndex):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::collectScreenProperties):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b44a002ca8cbd6f43656a1353c098989fdd9f57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98792 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75214 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106288 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84180 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83678 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5998 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19601 "Hash 0b44a002 for PR 43668 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->