### PR TITLE
Sync `html/obsolete` from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS document.applets should return an empty collection.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>document.applets</title>
+<link rel="help" href="https://html.spec.whatwg.org/C/#dom-document-applets">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<object></object>
+<object type="application/x-java-applet"></object>
+<object type="application/x-java-bean"></object>
+<object type="application/x-java-vm"></object>
+<object><param name="type" value="application/x-java-applet" /></object>
+<object><param name="type" value="application/x-java-bean" /></object>
+<object><param name="type" value="application/x-java-vm" /></object>
+
+<script>
+test(() => {
+  const collection = document.applets;
+  assert_true(collection instanceof HTMLCollection);
+  assert_equals(collection.length, 0, 'The collection should be empty.');
+}, 'document.applets should return an empty collection.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-all.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-02.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-03.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow-expected.txt
@@ -1,0 +1,4 @@
+       
+
+PASS Marquee should have overflow: hidden !important in the UA stylesheet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Marquee forces overflow: hidden</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-marquee-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<marquee style="overflow: visible">&nbsp;</marquee>
+<marquee style="overflow: scroll">&nbsp;</marquee>
+<marquee style="overflow: clip">&nbsp;</marquee>
+<marquee style="overflow: auto">&nbsp;</marquee>
+
+<script>
+test(() => {
+  for (let m of document.querySelectorAll("marquee")) {
+    assert_equals(getComputedStyle(m).overflow, "hidden", m.style);
+  }
+}, "Marquee should have overflow: hidden !important in the UA stylesheet");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log
@@ -20,5 +20,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size.html
+/LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrollamount.html
 /LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html


### PR DESCRIPTION
#### 093095ff2b637ef7c3bd1cc2fa6e66f414a6d7b6
<pre>
Sync `html/obsolete` from WPT

<a href="https://bugs.webkit.org/show_bug.cgi?id=291114">https://bugs.webkit.org/show_bug.cgi?id=291114</a>
<a href="https://rdar.apple.com/148630248">rdar://148630248</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2518df1a574171b618fabe4b7fea56b1e2c03485">https://github.com/web-platform-tests/wpt/commit/2518df1a574171b618fabe4b7fea56b1e2c03485</a>

* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-applets.html:

Canonical link: <a href="https://commits.webkit.org/293294@main">https://commits.webkit.org/293294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61e3336dc18e6fa5ad01924f0dc6ab63ddc06293

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32089 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6862 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48402 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83382 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19174 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25479 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->