### PR TITLE
Remove unnecessary ObjC object instantiation in JavaScriptEvaluationResult conversion to JSValueRef

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -28,13 +28,237 @@
 
 #include "APIArray.h"
 #include "APIDictionary.h"
+#include "APINumber.h"
 #include "APISerializedScriptValue.h"
+#include "APIString.h"
+#include "WKSharedAPICast.h"
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/SerializedScriptValue.h>
 
+namespace WTF {
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<JSC::Strong<JSC::JSCell>> {
+    static unsigned hash(const JSC::Strong<JSC::JSCell>& key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key.get())); }
+    static bool equal(const JSC::Strong<JSC::JSCell>& a, const JSC::Strong<JSC::JSCell>& b) { return a.get() == b.get(); }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+}
+
 namespace WebKit {
 
-#if !PLATFORM(COCOA)
+#if PLATFORM(COCOA)
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, HashMap<JSObjectID, Variant>&& map)
+    : m_map(WTFMove(map))
+    , m_root(root) { }
+
+RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Variant&& root)
+{
+    return WTF::switchOn(WTFMove(root), [] (NullType) -> RefPtr<API::Object> {
+        return nullptr;
+    }, [] (bool value) -> RefPtr<API::Object> {
+        return API::Boolean::create(value);
+    }, [] (double value) -> RefPtr<API::Object> {
+        return API::Double::create(value);
+    }, [] (String&& value) -> RefPtr<API::Object> {
+        return API::String::create(value);
+    }, [] (Seconds value) -> RefPtr<API::Object> {
+        return API::Double::create(value.seconds());
+    }, [&] (Vector<JSObjectID>&& vector) -> RefPtr<API::Object> {
+        Ref array = API::Array::create();
+        m_arrays.append({ WTFMove(vector), array });
+        return { WTFMove(array) };
+    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> RefPtr<API::Object> {
+        Ref dictionary = API::Dictionary::create();
+        m_dictionaries.append({ WTFMove(map), dictionary });
+        return { WTFMove(dictionary) };
+    });
+}
+
+WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK()
+{
+    for (auto [identifier, variant] : std::exchange(m_map, { }))
+        m_instantiatedObjects.add(identifier, toAPI(WTFMove(variant)));
+    for (auto [vector, array] : std::exchange(m_arrays, { })) {
+        for (auto identifier : vector) {
+            if (RefPtr object = m_instantiatedObjects.get(identifier))
+                Ref { array }->append(object.releaseNonNull());
+        }
+    }
+    for (auto [map, dictionary] : std::exchange(m_dictionaries, { })) {
+        for (auto [keyIdentifier, valueIdentifier] : map) {
+            RefPtr key = dynamicDowncast<API::String>(m_instantiatedObjects.get(keyIdentifier));
+            if (!key)
+                continue;
+            RefPtr value = m_instantiatedObjects.get(valueIdentifier);
+            if (!value)
+                continue;
+            Ref { dictionary }->add(key->string(), WTFMove(value));
+        }
+    }
+    return WebKit::toAPI(std::exchange(m_instantiatedObjects, { }).take(m_root).get());
+}
+
+JSObjectID JavaScriptEvaluationResult::addObjectToMap(JSGlobalContextRef context, JSValueRef object)
+{
+    if (!object) {
+        if (!m_nullObjectID) {
+            m_nullObjectID = JSObjectID::generate();
+            m_map.add(*m_nullObjectID, Variant { NullType::NullPointer });
+        }
+        return *m_nullObjectID;
+    }
+
+    JSC::JSGlobalObject* globalObject = ::toJS(context);
+    JSC::JSValue value = ::toJS(globalObject, object);
+    JSC::Strong<JSCell> cell { globalObject->vm(), value.asCell() };
+    if (cell) {
+        auto it = m_jsObjectsInMap.find(cell);
+        if (it != m_jsObjectsInMap.end())
+            return it->value;
+    }
+
+    auto identifier = JSObjectID::generate();
+    if (cell)
+        m_jsObjectsInMap.set(WTFMove(cell), identifier);
+    m_map.add(identifier, toVariant(context, object));
+    return identifier;
+}
+
+static std::optional<JSValueRef> roundTripThroughSerializedScriptValue(JSGlobalContextRef serializationContext, JSGlobalContextRef deserializationContext, JSValueRef value)
+{
+    if (RefPtr serialized = WebCore::SerializedScriptValue::create(serializationContext, value, nullptr))
+        return serialized->deserialize(deserializationContext, nullptr);
+    return std::nullopt;
+}
+
+std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
+{
+    JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
+
+    auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
+    if (!result)
+        return std::nullopt;
+    return { JavaScriptEvaluationResult { deserializationContext.get(), *result } };
+}
+
+// Similar to JSValue's valueToObjectWithoutCopy.
+auto JavaScriptEvaluationResult::toVariant(JSGlobalContextRef context, JSValueRef value) -> Variant
+{
+    if (!JSValueIsObject(context, value)) {
+        if (JSValueIsBoolean(context, value))
+            return JSValueToBoolean(context, value);
+        if (JSValueIsNumber(context, value)) {
+            value = JSValueMakeNumber(context, JSValueToNumber(context, value, 0));
+            return JSValueToNumber(context, value, 0);
+        }
+        if (JSValueIsString(context, value)) {
+            auto* globalObject = ::toJS(context);
+            JSC::JSValue jsValue = ::toJS(globalObject, value);
+            return jsValue.toWTFString(globalObject);
+        }
+        if (JSValueIsNull(context, value))
+            return NullType::NSNull;
+        return NullType::NullPointer;
+    }
+
+    JSObjectRef object = JSValueToObject(context, value, 0);
+
+    if (JSValueIsDate(context, object))
+        return Seconds(JSValueToNumber(context, object, 0) / 1000.0);
+
+    if (JSValueIsArray(context, object)) {
+        SUPPRESS_UNCOUNTED_ARG JSValueRef lengthPropertyName = JSValueMakeString(context, adopt(JSStringCreateWithUTF8CString("length")).get());
+        JSValueRef lengthValue = JSObjectGetPropertyForKey(context, object, lengthPropertyName, nullptr);
+        double lengthDouble = JSValueToNumber(context, lengthValue, nullptr);
+        if (lengthDouble < 0 || lengthDouble > static_cast<double>(std::numeric_limits<size_t>::max()))
+            return NullType::NullPointer;
+
+        size_t length = lengthDouble;
+        Vector<JSObjectID> vector;
+        if (!vector.tryReserveInitialCapacity(length))
+            return NullType::NullPointer;
+
+        for (size_t i = 0; i < length; ++i)
+            vector.append(addObjectToMap(context, JSObjectGetPropertyAtIndex(context, object, i, nullptr)));
+        return WTFMove(vector);
+    }
+
+    JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
+    size_t length = JSPropertyNameArrayGetCount(names);
+    HashMap<JSObjectID, JSObjectID> map;
+    for (size_t i = 0; i < length; i++) {
+        JSRetainPtr<JSStringRef> key = JSPropertyNameArrayGetNameAtIndex(names, i);
+        SUPPRESS_UNCOUNTED_ARG map.add(addObjectToMap(context, JSValueMakeString(context, key.get())), addObjectToMap(context, JSObjectGetPropertyForKey(context, object, JSValueMakeString(context, key.get()), nullptr)));
+    }
+    JSPropertyNameArrayRelease(names);
+    return WTFMove(map);
+}
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef context, JSValueRef value)
+    : m_root(addObjectToMap(context, value))
+{
+    m_jsObjectsInMap.clear();
+    m_nullObjectID = std::nullopt;
+}
+
+JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Variant&& root)
+{
+    return WTF::switchOn(WTFMove(root), [&] (NullType) -> JSValueRef {
+        return JSValueMakeNull(context);
+    }, [&] (bool value) -> JSValueRef {
+        return JSValueMakeBoolean(context, value);
+    }, [&] (double value) -> JSValueRef {
+        return JSValueMakeNumber(context, value);
+    }, [&] (String&& value) -> JSValueRef {
+        auto string = OpaqueJSString::tryCreate(WTFMove(value));
+        return JSValueMakeString(context, string.get());
+    }, [&] (Seconds value) -> JSValueRef {
+        JSValueRef argument = JSValueMakeNumber(context, value.value() * 1000.0);
+        return JSObjectMakeDate(context, 1, &argument, 0);
+    }, [&] (Vector<JSObjectID>&& vector) -> JSValueRef {
+        JSValueRef array = JSObjectMakeArray(context, 0, nullptr, 0);
+        m_jsArrays.append({ WTFMove(vector), array });
+        return array;
+    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> JSValueRef {
+        JSObjectRef dictionary = JSObjectMake(context, 0, 0);
+        m_jsDictionaries.append({ WTFMove(map), dictionary });
+        return dictionary;
+    });
+}
+
+JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
+{
+    for (auto [identifier, variant] : std::exchange(m_map, { }))
+        m_instantiatedJSObjects.add(identifier, toJS(context, WTFMove(variant)));
+    for (auto [vector, array] : std::exchange(m_jsArrays, { })) {
+        JSObjectRef jsArray = JSValueToObject(context, array, 0);
+        for (size_t index = 0; index < vector.size(); ++index) {
+            auto identifier = vector[index];
+            if (JSValueRef element = m_instantiatedJSObjects.get(identifier))
+                JSObjectSetPropertyAtIndex(context, jsArray, index, element, 0);
+        }
+    }
+    for (auto [map, dictionary] : std::exchange(m_jsDictionaries, { })) {
+        for (auto [keyIdentifier, valueIdentifier] : map) {
+            JSValueRef key = m_instantiatedJSObjects.get(keyIdentifier);
+            if (!key)
+                continue;
+            ASSERT(JSValueIsString(context, key));
+            SUPPRESS_UNCOUNTED_ARG auto keyString = adopt(JSValueToStringCopy(context, key, nullptr));
+            if (!keyString)
+                continue;
+            JSValueRef value = m_instantiatedJSObjects.get(valueIdentifier);
+            if (!value)
+                continue;
+            SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, dictionary, keyString.get(), value, 0, 0);
+        }
+    }
+    return std::exchange(m_instantiatedJSObjects, { }).take(m_root);
+}
+
+#else // PLATFORM(COCOA)
+
 Ref<API::SerializedScriptValue> JavaScriptEvaluationResult::legacySerializedScriptValue() const
 {
     return API::SerializedScriptValue::createFromWireBytes(Vector(wireBytes()));
@@ -61,7 +285,8 @@ std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JS
 {
     return JavaScriptEvaluationResult { context, value };
 }
-#endif
+
+#endif // PLATFORM(COCOA)
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JavaScriptEvaluationResult&&) = default;
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -27,16 +27,17 @@
 
 #include "WKRetainPtr.h"
 #include <JavaScriptCore/APICast.h>
-#include <WebCore/SerializedScriptValue.h>
+#include <JavaScriptCore/Strong.h>
 #include <optional>
 #include <wtf/HashMap.h>
 #include <wtf/ObjectIdentifier.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/RetainPtr.h>
-OBJC_CLASS JSValue;
 OBJC_CLASS NSMutableArray;
 OBJC_CLASS NSMutableDictionary;
+#else
+#include <WebCore/SerializedScriptValue.h>
 #endif
 
 namespace API {
@@ -99,10 +100,13 @@ private:
 
     RetainPtr<id> toID(Variant&&);
     RefPtr<API::Object> toAPI(Variant&&);
+    JSValueRef toJS(JSGlobalContextRef, Variant&&);
 
     Variant toVariant(id);
     JSObjectID addObjectToMap(id);
-    Variant jsValueToVariant(JSValue *);
+
+    Variant toVariant(JSGlobalContextRef, JSValueRef);
+    JSObjectID addObjectToMap(JSGlobalContextRef, JSValueRef);
 
     // Used for deserializing from IPC to ObjC
     HashMap<JSObjectID, RetainPtr<id>> m_instantiatedNSObjects;
@@ -115,9 +119,14 @@ private:
     Vector<std::pair<Vector<JSObjectID>, Ref<API::Array>>> m_arrays;
 
     // Used for serializing to IPC
-    HashMap<RetainPtr<JSValue>, JSObjectID> m_jsObjectsInMap;
+    HashMap<JSC::Strong<JSC::JSCell>, JSObjectID> m_jsObjectsInMap;
     HashMap<RetainPtr<id>, JSObjectID> m_objectsInMap;
     std::optional<JSObjectID> m_nullObjectID;
+
+    // Used for deserializing from IPC to JS
+    HashMap<JSObjectID, JSValueRef> m_instantiatedJSObjects;
+    Vector<std::pair<HashMap<JSObjectID, JSObjectID>, JSObjectRef>> m_jsDictionaries;
+    Vector<std::pair<Vector<JSObjectID>, JSValueRef>> m_jsArrays;
 
     // IPC representation
     HashMap<JSObjectID, Variant> m_map;


### PR DESCRIPTION
#### 90da1bac176f6018de9d1ded7482bda821aa8e45
<pre>
Remove unnecessary ObjC object instantiation in JavaScriptEvaluationResult conversion to JSValueRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=291116">https://bugs.webkit.org/show_bug.cgi?id=291116</a>
<a href="https://rdar.apple.com/148630517">rdar://148630517</a>

Reviewed by Ryosuke Niwa.

This not only removes unnecessary work in the conversion process, but it also makes the code
able to be used on platforms that don&apos;t have ObjC.

Covered by many tests, especially AsyncFunction API tests and EvaluateJavaScript.ReturnTypes.

* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WTF::DefaultHash&lt;JSC::Strong&lt;JSC::JSCell&gt;&gt;::hash):
(WTF::DefaultHash&lt;JSC::Strong&lt;JSC::JSCell&gt;&gt;::equal):
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::toJS):
(WebKit::JavaScriptEvaluationResult::jsValueToVariant): Deleted.

Canonical link: <a href="https://commits.webkit.org/297138@main">https://commits.webkit.org/297138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b29ce7fac4f108c497fb277d398e4f885df911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116693 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84150 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/113615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24125 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/60488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/119483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/28011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93114 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/38081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92938 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15706 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/33684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/37603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/43075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/37265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/40604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->