### PR TITLE
Fix forward declaration for WTF::Function in Forward.h

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -104,7 +104,7 @@ template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
 template<typename, typename = EmbeddedFixedVectorMalloc> class FixedVector;
 template<typename, size_t = 8, typename = SegmentedVectorMalloc> class SegmentedVector;
-template<typename> class Function;
+template<typename, typename...> class Function;
 template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
 template<typename, typename = AnyThreadsAccessTraits> class LazyNeverDestroyed;

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -45,7 +45,7 @@ inline RetainPtr<NSData> toNSData(std::span<const uint8_t> span)
 }
 #endif // #ifdef __OBJC__
 
-template<typename> class Function;
+template<typename, typename...> class Function;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
#### f2e0a1fab06ab74581c15955b22ffad00bcd4755
<pre>
Fix forward declaration for WTF::Function in Forward.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=291124">https://bugs.webkit.org/show_bug.cgi?id=291124</a>

Reviewed by NOBODY (OOPS!).

Fix forward declaration for WTF::Function in Forward.h to match what&apos;s in Function.h.

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2e0a1fab06ab74581c15955b22ffad00bcd4755

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32114 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88926 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55312 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6891 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48431 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105955 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97088 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83402 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28048 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30690 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120707 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25326 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33782 "Found 1 new JSC binary failure: testapi, Found 19751 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_lastindexof.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_length.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice3.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->