### PR TITLE
Reduce use of (NSURL *) casting to construct a NSURL from a WTF::URL

### DIFF
--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
@@ -112,7 +112,7 @@ Ref<SceneKitModelLoader> loadSceneKitModel(Model& modelSource, SceneKitModelLoad
 
     auto loader = SceneKitModelLoaderFailure::create([NSError errorWithDomain:@"SceneKitModelLoader" code:-1 userInfo:@{
         NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unsupported MIME type: %s.", modelSource.mimeType().utf8().data()],
-        NSURLErrorFailingURLErrorKey: (NSURL *)modelSource.url()
+        NSURLErrorFailingURLErrorKey: modelSource.url().createNSURL().get()
     }]);
 
     dispatch_async(dispatch_get_main_queue(), [weakClient = WeakPtr { client }, loader] {

--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -80,7 +80,7 @@ NSDictionary *NotificationPayload::dictionaryRepresentation() const
     id nsOptions = options ? options->dictionaryRepresentation() : [NSNull null];
 
     return @{
-        WebNotificationDefaultActionKey : (NSURL *)defaultActionURL,
+        WebNotificationDefaultActionKey : defaultActionURL.createNSURL().get(),
         WebNotificationTitleKey : (NSString *)title,
         WebNotificationAppBadgeKey : nsAppBadge,
         WebNotificationOptionsKey : nsOptions,

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -348,7 +348,7 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
     }, [] (const RetainPtr<NSPresentationIntent>& value) -> RetainPtr<id> {
         return value;
     }, [] (const URL& value) -> RetainPtr<id> {
-        return (NSURL *)value;
+        return value.createNSURL();
     }, [] (const Vector<String>& value) -> RetainPtr<id> {
         return createNSArray(value, [] (const String& string) {
             return (NSString *)string;

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2614,7 +2614,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     if (linkURL.isEmpty())
         [attributes removeObjectForKey:NSLinkAttributeName];
     else
-        [attributes setObject:(NSURL *)linkURL forKey:NSLinkAttributeName];
+        [attributes setObject:linkURL.createNSURL().get() forKey:NSLinkAttributeName];
 
 }
 

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -907,11 +907,11 @@ bool WebContentReader::readURL(const URL& url, const String& title)
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This code shouldn't be accessing selection and changing the behavior.
     if (!frame->editor().client()->hasRichlyEditableSelection()) {
-        if (readPlainText([(NSURL *)url absoluteString]))
+        if (readPlainText([url.createNSURL() absoluteString]))
             return true;
     }
 
-    if ([(NSURL *)url isFileURL])
+    if ([url.createNSURL() isFileURL])
         return false;
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -780,7 +780,7 @@ String PlatformPasteboard::readString(size_t index, const String& type) const
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (type == String(kUTTypeURL)) {
         String title;
-        return [(NSURL *)readURL(index, title) absoluteString];
+        return [readURL(index, title).createNSURL() absoluteString];
     }
 
     if ((NSInteger)index < 0 || (NSInteger)index >= [m_pasteboard numberOfItems])

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -409,11 +409,11 @@ int64_t PlatformPasteboard::setBufferForType(SharedBuffer* buffer, const String&
 
 int64_t PlatformPasteboard::setURL(const PasteboardURL& pasteboardURL)
 {
-    auto urlString = [(NSURL *)pasteboardURL.url absoluteString];
+    RetainPtr urlString = [pasteboardURL.url.createNSURL() absoluteString];
     if (!urlString)
         return 0;
 
-    NSArray *urlWithTitle = @[ @[ urlString ], @[ pasteboardURL.title ] ];
+    NSArray *urlWithTitle = @[ @[ urlString.get() ], @[ pasteboardURL.title ] ];
     NSString *pasteboardType = [NSString stringWithUTF8String:WebURLsWithTitlesPboardType];
     BOOL didWriteData = [m_pasteboard setPropertyList:urlWithTitle forType:pasteboardType];
     if (!didWriteData)

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -134,25 +134,25 @@ Cookie::operator NSHTTPCookie * _Nullable () const
     RetainPtr properties = adoptNS([[NSMutableDictionary alloc] initWithCapacity:14]);
 
     if (!comment.isNull())
-        [properties setObject:(NSString *)comment forKey:NSHTTPCookieComment];
+        [properties setObject:comment.createNSString().get() forKey:NSHTTPCookieComment];
 
     if (!commentURL.isNull())
-        [properties setObject:(NSURL *)commentURL forKey:NSHTTPCookieCommentURL];
+        [properties setObject:commentURL.createNSURL().get() forKey:NSHTTPCookieCommentURL];
 
     if (!domain.isNull())
-        [properties setObject:(NSString *)domain forKey:NSHTTPCookieDomain];
+        [properties setObject:domain.createNSString().get() forKey:NSHTTPCookieDomain];
 
     if (!name.isNull())
-        [properties setObject:(NSString *)name forKey:NSHTTPCookieName];
+        [properties setObject:name.createNSString().get() forKey:NSHTTPCookieName];
 
     if (!path.isNull())
-        [properties setObject:(NSString *)path forKey:NSHTTPCookiePath];
+        [properties setObject:path.createNSString().get() forKey:NSHTTPCookiePath];
 
     if (!partitionKey.isNull())
-        [properties setObject:(NSString *)partitionKey forKey:@"StoragePartition"];
+        [properties setObject:partitionKey.createNSString().get() forKey:@"StoragePartition"];
 
     if (!value.isNull())
-        [properties setObject:(NSString *)value forKey:NSHTTPCookieValue];
+        [properties setObject:value.createNSString().get() forKey:NSHTTPCookieValue];
 
     if (expires) {
         RetainPtr expirationDate = [NSDate dateWithTimeIntervalSince1970:*expires / 1000.0];

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -83,7 +83,7 @@ void NetworkStorageSession::setCookies(const Vector<Cookie>& cookies, const URL&
     });
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [nsCookieStorage() setCookies:nsCookies.get() forURL:(NSURL *)url mainDocumentURL:(NSURL *)mainDocumentURL];
+    [nsCookieStorage() setCookies:nsCookies.get() forURL:url.createNSURL().get() mainDocumentURL:mainDocumentURL.createNSURL().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -125,7 +125,7 @@ Vector<Cookie> NetworkStorageSession::getAllCookies()
 Vector<Cookie> NetworkStorageSession::getCookies(const URL& url)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-    return nsCookiesToCookieVector([nsCookieStorage() cookiesForURL:(NSURL *)url]);
+    return nsCookiesToCookieVector([nsCookieStorage() cookiesForURL:url.createNSURL().get()]);
 }
 
 void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
@@ -545,7 +545,7 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
     if (!nshttpCookie)
         return false;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], (NSURL *)url, firstParty, sameSiteInfo);
+    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty, sameSiteInfo);
     return true;
 
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -104,8 +104,8 @@ static RetainPtr<NSError> createNSErrorFromResourceErrorBase(const ResourceError
 
     if (!resourceError.failingURL().isEmpty()) {
         [userInfo setValue:(NSString *)resourceError.failingURL().string() forKey:@"NSErrorFailingURLStringKey"];
-        if (NSURL *cocoaURL = (NSURL *)resourceError.failingURL())
-            [userInfo setValue:cocoaURL forKey:@"NSErrorFailingURLKey"];
+        if (RetainPtr cocoaURL = (NSURL *)resourceError.failingURL().createNSURL())
+            [userInfo setValue:cocoaURL.get() forKey:@"NSErrorFailingURLKey"];
     }
 
     return adoptNS([[NSError alloc] initWithDomain:resourceError.domain() code:resourceError.errorCode() userInfo:userInfo.get()]);

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -154,7 +154,7 @@ void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmark
         RELEASE_LOG(Network, "Unable to create bookmark URL, error = %@", error);
 
     if (enableModernDownloadProgress()) {
-        RetainPtr<NSURL> publishURL = (NSURL *)url;
+        RetainPtr publishURL = url.createNSURL();
         if (!publishURL) {
             RELEASE_LOG_ERROR(Network, "Download::publishProgress: Invalid publish URL");
             return;
@@ -169,7 +169,7 @@ void Download::publishProgress(const URL& url, std::span<const uint8_t> bookmark
         if (!isUsingPlaceholder)
             startUpdatingProgress();
     } else {
-        m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url sandboxExtension:nullptr]);
+        m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:url.createNSURL().get() sandboxExtension:nullptr]);
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)
         [m_progress _publish];
 #else
@@ -302,7 +302,7 @@ void Download::publishProgress(const URL& url, SandboxExtension::Handle&& sandbo
     if (!sandboxExtension)
         return;
 
-    m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url sandboxExtension:sandboxExtension]);
+    m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:url.createNSURL().get() sandboxExtension:sandboxExtension]);
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)
     [m_progress _publish];
 #else

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -93,7 +93,7 @@ NSDictionary *WebPushMessage::toDictionary() const
 
     return @{
         WebKitPushDataKey : nsData ? nsData.get() : [NSNull null],
-        WebKitPushRegistrationURLKey : (NSURL *)registrationURL,
+        WebKitPushRegistrationURLKey : registrationURL.createNSURL().get(),
         WebKitPushPartitionKey : pushPartitionString.createNSString().get(),
         WebKitNotificationPayloadKey : nsPayload ? nsPayload.get() : [NSNull null]
     };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -227,12 +227,13 @@ private:
         if (bookmarkResolvingError || bookmarkDataIsStale)
             RELEASE_LOG_ERROR(Network, "Failed to resolve URL from bookmark data");
 
-        NSURL *placeholderURL = urlFromBookmark ? urlFromBookmark.get() : (NSURL *)url;
+        if (!urlFromBookmark)
+            urlFromBookmark = url.createNSURL();
 
         if (m_respondsToDidReceivePlaceholderURL)
-            [m_delegate _download:wrapper(download) didReceivePlaceholderURL:placeholderURL completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+            [m_delegate _download:wrapper(download) didReceivePlaceholderURL:urlFromBookmark.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
         else
-            [m_delegate download:wrapper(download) didReceivePlaceholderURL:placeholderURL completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+            [m_delegate download:wrapper(download) didReceivePlaceholderURL:urlFromBookmark.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
     }
 
     void didReceiveFinalURL(WebKit::DownloadProxy& download, const WTF::URL& url, std::span<const uint8_t> bookmarkData) final
@@ -247,12 +248,13 @@ private:
         if (bookmarkResolvingError || bookmarkDataIsStale)
             RELEASE_LOG_ERROR(Network, "Failed to resolve URL from bookmark data");
 
-        NSURL *finalURL = urlFromBookmark.get() ?: (NSURL *)url;
+        if (!urlFromBookmark)
+            urlFromBookmark = url.createNSURL();
 
         if (m_respondsToDidReceiveFinalURL)
-            [m_delegate _download:wrapper(download) didReceiveFinalURL:finalURL];
+            [m_delegate _download:wrapper(download) didReceiveFinalURL:urlFromBookmark.get()];
         else
-            [m_delegate download:wrapper(download) didReceiveFinalURL:finalURL];
+            [m_delegate download:wrapper(download) didReceiveFinalURL:urlFromBookmark.get()];
     }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3392,7 +3392,7 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
 
     auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:3]);
     if (!info->documentURL.isNull())
-        [result setObject:(NSURL *)info->documentURL forKey:_WKTextManipulationTokenUserInfoDocumentURLKey];
+        [result setObject:info->documentURL.createNSURL().get() forKey:_WKTextManipulationTokenUserInfoDocumentURLKey];
     if (!info->tagName.isNull())
         [result setObject:info->tagName.createNSString().get() forKey:_WKTextManipulationTokenUserInfoTagNameKey];
     if (!info->roleAttribute.isNull())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -192,9 +192,9 @@ private:
             callback(newWebView._page.get());
         });
 
-        auto nsURL = (NSURL *)URL { url };
+        RetainPtr nsURL = URL { url }.createNSURL();
         auto apiOrigin = API::SecurityOrigin::create(serviceWorkerOrigin);
-        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() openWindow:nsURL fromServiceWorkerOrigin:wrapper(apiOrigin.get()) completionHandler:completionHandler.get()];
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() openWindow:nsURL.get() fromServiceWorkerOrigin:wrapper(apiOrigin.get()) completionHandler:completionHandler.get()];
     }
 
     void reportServiceWorkerConsoleMessage(const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String& message, unsigned long)
@@ -278,7 +278,7 @@ private:
         if (!m_hasNavigateToNotificationActionURLSelector || !m_delegate || !m_dataStore)
             return;
 
-        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() navigateToNotificationActionURL:(NSURL *)url];
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() navigateToNotificationActionURL:url.createNSURL().get()];
     }
 
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
@@ -41,7 +41,7 @@
     if (!(self = [super init]))
         return nil;
 
-    _url = (NSURL *)linkIcon.url;
+    _url = linkIcon.url.createNSURL();
     _mimeType = linkIcon.mimeType.createNSString();
 
     if (linkIcon.size)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -168,7 +168,7 @@
 {
     RetainPtr result = adoptNS([NSMutableSet<NSURL *> new]);
     for (auto& url : _info->mediaAndLinkURLs())
-        [result addObject:(NSURL *)url];
+        [result addObject:url.createNSURL().get()];
     return result.autorelease();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -155,7 +155,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
             // If the download happened instantly, the call to finish might have come before this
             // loadHandler. In that case, call the completionHandler here.
             if (!strongSelf->_downloadedURL.isEmpty())
-                completionHandler((NSURL *)strongSelf->_downloadedURL, nil);
+                completionHandler(strongSelf->_downloadedURL.createNSURL().get(), nil);
             else
                 [strongSelf setCompletionHandler:completionHandler];
         }
@@ -174,7 +174,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     _downloadedURL = url;
 
     if (self.completionHandler)
-        self.completionHandler((NSURL *)url, nil);
+        self.completionHandler(url.createNSURL().get(), nil);
 }
 
 - (void)failWithError:(NSError *)error
@@ -629,8 +629,8 @@ void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uin
 
 NSArray *SystemPreviewController::localFileURLs() const
 {
-    NSURL *nsurl = (NSURL *)m_localFileURL;
-    return nsurl ? @[ nsurl ] : @[];
+    RetainPtr nsurl = m_localFileURL.createNSURL();
+    return nsurl ? @[ nsurl.get() ] : @[];
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -301,29 +301,29 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
         [shareDataArray addObject:(NSString *)data.shareData.text];
     
     if (data.url) {
-        NSURL *url = (NSURL *)data.url.value();
-        NSString *title = nil;
+        RetainPtr url = data.url.value().createNSURL();
+        RetainPtr<NSString> title;
         if (!data.shareData.title.isEmpty())
             title = data.shareData.title;
 
         if (data.originator == WebCore::ShareDataOriginator::Web) {
 #if PLATFORM(IOS_FAMILY)
-            auto item = adoptNS([[WKShareSheetURLItemProvider alloc] initWithURL:url title:title]);
+            auto item = adoptNS([[WKShareSheetURLItemProvider alloc] initWithURL:url.get() title:title.get()]);
 #else
-            auto item = adoptNS([[NSPreviewRepresentingActivityItem alloc] initWithItem:url linkMetadata:placeholderMetadataWithURLAndTitle(url, title).get()]);
+            auto item = adoptNS([[NSPreviewRepresentingActivityItem alloc] initWithItem:url.get() linkMetadata:placeholderMetadataWithURLAndTitle(url.get(), title.get()).get()]);
 #endif
             if (item)
                 [shareDataArray addObject:item.get()];
         } else {
 #if HAVE(NSURL_TITLE)
-            [url _web_setTitle:title];
+            [url _web_setTitle:title.get()];
 #endif
-            [shareDataArray addObject:url];
+            [shareDataArray addObject:url.get()];
         }
     }
     
     if (!data.shareData.title.isEmpty() && ![shareDataArray count])
-        [shareDataArray addObject:(NSString *)data.shareData.title];
+        [shareDataArray addObject:data.shareData.title.createNSString().get()];
 
     _completionHandler = WTFMove(completionHandler);
 

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -588,7 +588,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     ASSERT([link isKindOfClass:[NSURL class]]);
-    _completionHandler((NSURL *)link);
+    _completionHandler(link);
 }
 
 - (BOOL)forMainFrameNavigation

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -292,7 +292,7 @@ bool WebExtensionController::load(WebExtensionContext& extensionContext, NSError
     }
 
     if (!m_extensionContextBaseURLMap.add(extensionContext.baseURL().protocolHostAndPort(), extensionContext)) {
-        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded with same base URL: %{private}@", (NSURL *)extensionContext.baseURL());
+        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded with same base URL: %{private}@", extensionContext.baseURL().createNSURL().get());
         m_extensionContexts.remove(extensionContext);
         if (outError)
             *outError = extensionContext.createError(WebExtensionContext::Error::BaseURLAlreadyInUse);

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -184,8 +184,8 @@ void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier id
             if (!mediaUsageInfo.isPlaying)
                 return;
 
-            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstance() initWithBundleIdentifier:session->bundleIdentifier URL:(NSURL *)session->pageURL
-                mediaURL:(NSURL *)mediaUsageInfo.mediaURL videoMetadata:metadata]);
+            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstance() initWithBundleIdentifier:session->bundleIdentifier URL:session->pageURL.createNSURL().get()
+                mediaURL:mediaUsageInfo.mediaURL.createNSURL().get() videoMetadata:metadata]);
             ASSERT(session->usageTracker);
             if (!session->usageTracker)
                 return;

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -395,7 +395,7 @@ void DragDropInteractionState::updatePreviewsForActiveDragSources()
             continue;
 
         if (source.action.contains(DragSourceAction::Link)) {
-            dragItem.previewProvider = [title = source.linkTitle.createNSString(), url = retainPtr((NSURL *)source.linkURL)] () -> UIDragPreview * {
+            dragItem.previewProvider = [title = source.linkTitle.createNSString(), url = source.linkURL.createNSURL()] () -> UIDragPreview * {
                 RetainPtr preview = [UIDragPreview previewForURL:url.get() title:title.get()];
 #if PLATFORM(VISION)
                 // FIXME: This is a slightly unfortunate since we end up copying the preview parameters,

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9968,7 +9968,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_positionInformation.isLink || !_positionInformation.isInPlugin)
         return NO;
 
-    RetainPtr urlToCopy = (NSURL *)_positionInformation.url;
+    RetainPtr urlToCopy = _positionInformation.url.createNSURL();
     if (!urlToCopy)
         return NO;
 
@@ -14707,7 +14707,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // Previously, UIPreviewItemController would detect the case where there was no previewViewController
         // and create one. We need to replicate this code for the new API.
-        if (!previewViewController || [(NSURL *)url iTunesStoreURL]) {
+        if (!previewViewController || [url.createNSURL() iTunesStoreURL]) {
             auto ddContextMenuActionClass = PAL::getDDContextMenuActionClass();
             BEGIN_BLOCK_OBJC_EXCEPTIONS
             NSDictionary *context = [self dataDetectionContextForPositionInformation:_positionInformation];
@@ -14725,7 +14725,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _contextMenuLegacyMenu = menuFromLegacyPreviewOrDefaultActions(previewViewController.get(), defaultActionsFromAssistant, elementInfo);
 
     } else if (_positionInformation.isImage && _positionInformation.image) {
-        NSURL *nsURL = (NSURL *)url;
+        RetainPtr nsURL = url.createNSURL();
         RetainPtr<NSDictionary> imageInfo;
         auto cgImage = _positionInformation.image->makeCGImageCopy();
         auto uiImage = adoptNS([[UIImage alloc] initWithCGImage:cgImage.get()]);
@@ -14743,7 +14743,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         RetainPtr<NSArray<_WKElementAction *>> defaultActionsFromAssistant = [_actionSheetAssistant defaultActionsForImageSheet:elementInfo.get()];
 
         if (imageInfo && [uiDelegate respondsToSelector:@selector(_webView:previewViewControllerForImage:alternateURL:defaultActions:elementInfo:)])
-            previewViewController = [uiDelegate _webView:self.webView previewViewControllerForImage:uiImage.get() alternateURL:nsURL defaultActions:defaultActionsFromAssistant.get() elementInfo:elementInfo.get()];
+            previewViewController = [uiDelegate _webView:self.webView previewViewControllerForImage:uiImage.get() alternateURL:nsURL.get() defaultActions:defaultActionsFromAssistant.get() elementInfo:elementInfo.get()];
         else
             previewViewController = adoptNS([[WKImagePreviewViewController alloc] initWithCGImage:cgImage defaultActions:defaultActionsFromAssistant.get() elementInfo:elementInfo.get()]);
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -14902,7 +14902,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
 #if ENABLE(DATA_DETECTION)
-    if ([(NSURL *)linkURL iTunesStoreURL]) {
+    if ([linkURL.createNSURL() iTunesStoreURL]) {
         [self continueContextMenuInteractionWithDataDetectors:continueWithContextMenuConfiguration];
         return;
     }
@@ -15141,7 +15141,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                 if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                     return;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                [uiDelegate _webView:self.webView commitPreviewedImageWithURL:(NSURL *)imageURL];
+                [uiDelegate _webView:self.webView commitPreviewedImageWithURL:imageURL.createNSURL().get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
             }
             return;
@@ -15282,7 +15282,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         id <WKUIDelegatePrivate> uiDelegate = static_cast<id <WKUIDelegatePrivate>>([_webView UIDelegate]);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if ([uiDelegate respondsToSelector:@selector(webView:shouldPreviewElement:)]) {
-            auto previewElementInfo = adoptNS([[WKPreviewElementInfo alloc] _initWithLinkURL:(NSURL *)linkURL]);
+            auto previewElementInfo = adoptNS([[WKPreviewElementInfo alloc] _initWithLinkURL:linkURL.createNSURL().get()]);
             return [uiDelegate webView:self.webView shouldPreviewElement:previewElementInfo.get()];
         }
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -15337,9 +15337,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (canShowLinkPreview) {
         *type = UIPreviewItemTypeLink;
         if (useImageURLForLink)
-            dataForPreview.get()[UIPreviewDataLink] = (NSURL *)_positionInformation.imageURL;
+            dataForPreview.get()[UIPreviewDataLink] = _positionInformation.imageURL.createNSURL().get();
         else
-            dataForPreview.get()[UIPreviewDataLink] = (NSURL *)linkURL;
+            dataForPreview.get()[UIPreviewDataLink] = linkURL.createNSURL().get();
 #if ENABLE(DATA_DETECTION)
         if (isDataDetectorLink) {
             NSDictionary *context = nil;
@@ -15368,10 +15368,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif // ENABLE(DATA_DETECTION)
     } else if (canShowImagePreview) {
         *type = UIPreviewItemTypeImage;
-        dataForPreview.get()[UIPreviewDataLink] = (NSURL *)_positionInformation.imageURL;
+        dataForPreview.get()[UIPreviewDataLink] = _positionInformation.imageURL.createNSURL().get();
     } else if (canShowAttachmentPreview) {
         *type = UIPreviewItemTypeAttachment;
-        auto element = adoptNS([[_WKActivatedElementInfo alloc] _initWithType:_WKActivatedElementTypeAttachment URL:(NSURL *)linkURL image:nil information:_positionInformation]);
+        auto element = adoptNS([[_WKActivatedElementInfo alloc] _initWithType:_WKActivatedElementTypeAttachment URL:linkURL.createNSURL().get() image:nil information:_positionInformation]);
         NSUInteger index = [uiDelegate _webView:self.webView indexIntoAttachmentListForElement:element.get()];
         if (index != NSNotFound) {
             BOOL sourceIsManaged = NO;
@@ -15495,7 +15495,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                 return;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [uiDelegate _webView:self.webView commitPreviewedImageWithURL:(NSURL *)imageURL];
+            [uiDelegate _webView:self.webView commitPreviewedImageWithURL:imageURL.createNSURL().get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
             return;
         }

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -699,7 +699,7 @@ static NSStringCompareOptions stringCompareOptions(_WKFindOptions findOptions)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     NSDictionary *representations = @{
         (NSString *)kUTTypeUTF8PlainText : (NSString *)_positionInformation.url.string(),
-        (NSString *)kUTTypeURL : (NSURL *)_positionInformation.url,
+        (NSString *)kUTTypeURL : _positionInformation.url.createNSURL().get(),
     };
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -479,13 +479,13 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
     if (!hitTestData.absoluteLinkURL.isEmpty()) {
         auto absoluteLinkURL = URL({ }, hitTestData.absoluteLinkURL);
         if (!absoluteLinkURL.isEmpty())
-            [items addObject:(NSURL *)absoluteLinkURL];
+            [items addObject:absoluteLinkURL.createNSURL().get()];
     }
 
     if (hitTestData.isDownloadableMedia && !hitTestData.absoluteMediaURL.isEmpty()) {
         auto downloadableMediaURL = URL({ }, hitTestData.absoluteMediaURL);
         if (!downloadableMediaURL.isEmpty())
-            [items addObject:(NSURL *)downloadableMediaURL];
+            [items addObject:downloadableMediaURL.createNSURL().get()];
     }
 
     bool usePlaceholder = type == ShareMenuItemType::Placeholder;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -881,18 +881,19 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore:
     WebView *webView = getWebView(m_webFrame.get());
     BOOL tryAppLink = shouldTryAppLink(webView, action, nullptr);
 
-    NSURL *appLinkURL = nil, *referrerURL = nil;
+    RetainPtr<NSURL> appLinkURL;
+    RetainPtr<NSURL> referrerURL;
     if (tryAppLink) {
-        appLinkURL = (NSURL *)request.url();
+        appLinkURL = request.url().createNSURL();
         if (!request.httpReferrer().isEmpty())
-            referrerURL = (NSURL *)URL(request.httpReferrer());
+            referrerURL = URL(request.httpReferrer()).createNSURL();
     }
 
     [[webView _policyDelegateForwarder] webView:webView
         decidePolicyForNewWindowAction:actionDictionary(action, formState)
         request:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)
         newFrameName:frameName
-        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL, referrerURL).get()];
+        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
 }
 
 void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction& action, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse&, WebCore::FormState* formState, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::IsPerformingHTTPFallback, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&& function)
@@ -900,18 +901,19 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore
     WebView *webView = getWebView(m_webFrame.get());
     BOOL tryAppLink = shouldTryAppLink(webView, action, core(m_webFrame.get()));
 
-    NSURL *appLinkURL = nil, *referrerURL = nil;
+    RetainPtr<NSURL> appLinkURL;
+    RetainPtr<NSURL> referrerURL;
     if (tryAppLink) {
-        appLinkURL = (NSURL *)request.url();
+        appLinkURL = request.url().createNSURL();
         if (!request.httpReferrer().isEmpty())
-            referrerURL = (NSURL *)URL(request.httpReferrer());
+            referrerURL = URL(request.httpReferrer()).createNSURL();
     }
 
     [[webView _policyDelegateForwarder] webView:webView
         decidePolicyForNavigationAction:actionDictionary(action, formState)
         request:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)
         frame:m_webFrame.get()
-        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL, referrerURL).get()];
+        decisionListener:setUpPolicyListener(WTFMove(function), WebCore::PolicyAction::Ignore, appLinkURL.get(), referrerURL.get()).get()];
 }
 
 void WebFrameLoaderClient::cancelPolicyCheck()
@@ -2090,7 +2092,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
         return nil;
 
     _appLinkURL = appLinkURL;
-    _referrerURL = (NSURL *)WebCore::SecurityOrigin::create(URL { referrerURL })->toURL();
+    _referrerURL = WebCore::SecurityOrigin::create(URL { referrerURL })->toURL().createNSURL();
 
     return self;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1939,7 +1939,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicatorData:indicatorData.value() scale:_private->page->deviceScaleFactor()]);
     else
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
-    _private->draggedLinkURL = dragItem.url.isEmpty() ? nil : (NSURL *)dragItem.url;
+    _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
     _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : (NSString *)dragItem.title;
     _private->dragPreviewFrameInRootViewCoordinates = dragItem.dragPreviewFrameInRootViewCoordinates;
     _private->dragSourceAction = kit(dragItem.sourceAction);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -38,6 +38,7 @@
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 static bool didCrash = false;
 static RetainPtr<NSString> alertMessage;
@@ -660,12 +661,12 @@ TEST(IPCTestingAPI, NSURLWithBaseURLInNSSecureCoding)
     EXPECT_EQ(result.count, static_cast<NSUInteger>(1));
     NSString *resultKey = result.allKeys[0];
     EXPECT_TRUE([key isEqual:resultKey]);
-    NSURL *resultValue = (NSURL *)(result.allValues[0]);
+    RetainPtr resultValue = checked_objc_cast<NSURL>(result.allValues[0]);
 
     // Our coder resolves the URL so we end up with an absolute URL instead of base URL + relative string.
-    EXPECT_WK_STREQ(resultValue.baseURL.absoluteString, @"");
-    EXPECT_WK_STREQ(resultValue.baseURL.relativeString, @"");
-    EXPECT_WK_STREQ(resultValue.absoluteString, @"amcomponent://com.xunmeng.pinduoduo/garden_home.html");
+    EXPECT_WK_STREQ(resultValue.get().baseURL.absoluteString, @"");
+    EXPECT_WK_STREQ(resultValue.get().baseURL.relativeString, @"");
+    EXPECT_WK_STREQ(resultValue.get().absoluteString, @"amcomponent://com.xunmeng.pinduoduo/garden_home.html");
     [unarchiver finishDecoding];
     unarchiver.get().delegate = nil;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -34,6 +34,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 static bool didFinishTest;
 static bool didFailProvisionalLoad;
@@ -118,7 +119,7 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
     auto webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     const UInt8 bytes[10] = { 'h', 't', 't', 'p', ':', '/', '/', 0xE2, 0x80, 0x80 };
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:(NSURL *)adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, 10, kCFStringEncodingUTF8, nullptr, true)).get()];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, 10, kCFStringEncodingUTF8, nullptr, true))).get()];
     [request _setProperty:request.URL forKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"];
     [webView loadRequest:request];
     Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -1417,13 +1417,13 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
     Util::run(&navigationCompleted);
 
     // PSON: file:/// => example.com
-    [webView loadRequest:[NSURLRequest requestWithURL:(NSURL *)testURL]];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     navigationCompleted = false;
     // Pass a HTTP 200 response with a html to mimic a SAML response.
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:(NSURL *)testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:samlResponse length:strlen(samlResponse)]).get()];
     Util::run(&navigationCompleted);
 
@@ -1444,7 +1444,7 @@ TEST(SOAuthorizationRedirect, AuthorizationOptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:@"" baseURL:(NSURL *)URL { "http://www.webkit.org"_str }];
+    [webView loadHTMLString:@"" baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
     [delegate setShouldOpenExternalSchemes:true];
@@ -2458,7 +2458,7 @@ TEST(SOAuthorizationPopUp, AuthorizationOptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.webkit.org"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2484,7 +2484,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.webkit.org"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2551,7 +2551,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.webkit.org"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     Util::run(&navigationCompleted);
 
 #if PLATFORM(MAC)
@@ -2595,7 +2595,7 @@ TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.webkit.org"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.
@@ -2882,7 +2882,7 @@ TEST(SOAuthorizationSubFrame, AuthorizationOptions)
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.apple.com"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
     Util::run(&allMessagesReceived);
 
     checkAuthorizationOptions(false, "http://www.apple.com"_s, 2);
@@ -2901,7 +2901,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL { "http://www.apple.com"_str }];
+    [webView loadHTMLString:testHtml baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.
@@ -2959,7 +2959,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
 
-    [webView loadHTMLString:testHtml baseURL:(NSURL *)URL("http://www.apple.com"_s)];
+    [webView loadHTMLString:testHtml baseURL:URL("http://www.apple.com"_s).createNSURL().get()];
     // Try to wait until the iframe load is finished.
     Util::runFor(0.5_s);
     // Make sure we don't intercept the iframe.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -2746,7 +2746,7 @@ TEST(WebPushD, DeclarativeWebPushHandling)
 
     done = false;
 
-    [connection getNotifications:(NSURL *)message.registrationURL tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
+    [connection getNotifications:message.registrationURL.createNSURL().get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(notifications);
         EXPECT_EQ(notifications.count, 1u);


### PR DESCRIPTION
#### 4d1f5e7cf259c6942d678908996914345d96f059
<pre>
Reduce use of (NSURL *) casting to construct a NSURL from a WTF::URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=291125">https://bugs.webkit.org/show_bug.cgi?id=291125</a>

Reviewed by Timothy Hatcher.

* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm:
(WebCore::loadSceneKitModel):
* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm:
(WebCore::NotificationPayload::dictionaryRepresentation const):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(updateAttributes):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readURL):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::readString const):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::setURL):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setCookies):
(WebCore::NetworkStorageSession::getCookies):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::createNSErrorFromResourceErrorBase):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::publishProgress):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::toDictionary const):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(createUserInfo):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm:
(-[_WKLinkIconParameters _initWithLinkIcon:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo mediaAndLinkURLs]):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithParameters:inRect:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(-[_WKWarningView clickedOnLink:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::updateMediaUsage):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _tryToCopyLinkURLFromPlugin]):
(-[WKContentView assignLegacyDataForContextMenuInteraction]):
(-[WKContentView continueContextMenuInteraction:]):
(-[WKContentView contextMenuInteraction:willPerformPreviewActionForMenuWithConfiguration:animator:]):
(-[WKContentView _interactionShouldBeginFromPreviewItemController:forPosition:]):
(-[WKContentView _dataForPreviewItemController:atPosition:type:]):
(-[WKContentView _previewItemController:commitPreview:]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView actionSheetAssistant:performAction:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(-[WebFramePolicyListener initWithFrame:policyFunction:defaultPolicy:appLinkURL:referrerURL:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _startDrag:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(NSURLWithBaseURLInNSSecureCoding)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm:
(TestWebKitAPI::TEST(WebKit, LoadInvalidURLRequestNonASCII)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushD, DeclarativeWebPushHandling)):

Canonical link: <a href="https://commits.webkit.org/293314@main">https://commits.webkit.org/293314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cff96d408155438b4f7b0a4aa27d92b1f8477902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98520 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74998 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21086 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30749 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25386 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->