### PR TITLE
[SaferCPP] Use smart pointers in LinkIconCollector

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -33,7 +33,6 @@ dom/QualifiedName.h
 dom/TreeScope.h
 editing/cocoa/HTMLConverter.mm
 html/FormListedElement.cpp
-html/LinkIconCollector.h
 html/MediaElementSession.h
 html/parser/HTMLTreeBuilder.h
 html/track/TrackBase.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -365,7 +365,6 @@ html/ImageBitmap.cpp
 html/ImageInputType.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
-html/LinkIconCollector.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
 html/NumberInputType.cpp

--- a/Source/WebCore/html/LinkIconCollector.cpp
+++ b/Source/WebCore/html/LinkIconCollector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-const unsigned defaultTouchIconWidth = 60;
+constexpr unsigned defaultTouchIconWidth = 60;
 
 static unsigned iconSize(const LinkIcon& icon)
 {
@@ -75,21 +75,21 @@ static int compareIcons(const LinkIcon& a, const LinkIcon& b)
 
 auto LinkIconCollector::iconsOfTypes(OptionSet<LinkIconType> iconTypes) -> Vector<LinkIcon>
 {
-    RefPtr head = m_document.head();
+    RefPtr head = m_document->head();
     if (!head)
         return { };
 
     Vector<LinkIcon> icons;
 
-    for (auto& linkElement : childrenOfType<HTMLLinkElement>(*head)) {
-        if (!linkElement.iconType())
+    for (Ref linkElement : childrenOfType<HTMLLinkElement>(*head)) {
+        if (!linkElement->iconType())
             continue;
 
-        auto iconType = *linkElement.iconType();
+        auto iconType = *linkElement->iconType();
         if (!iconTypes.contains(iconType))
             continue;
 
-        auto url = linkElement.href();
+        auto url = linkElement->href();
         if (!url.protocolIsInHTTPFamily() && !url.protocolIsData())
             continue;
 
@@ -97,18 +97,18 @@ auto LinkIconCollector::iconsOfTypes(OptionSet<LinkIconType> iconTypes) -> Vecto
         // part of the size, "60x70" becomes "60". This is for compatibility reasons
         // and is probably good enough for now.
         std::optional<unsigned> iconSize;
-        if (linkElement.sizes().length())
-            iconSize = parseIntegerAllowingTrailingJunk<unsigned>(linkElement.sizes().item(0));
+        if (linkElement->sizes().length())
+            iconSize = parseIntegerAllowingTrailingJunk<unsigned>(linkElement->sizes().item(0));
 
         Vector<std::pair<String, String>> attributes;
-        if (linkElement.hasAttributes()) {
-            auto linkAttributes = linkElement.attributes();
+        if (linkElement->hasAttributes()) {
+            auto linkAttributes = linkElement->attributes();
             attributes = WTF::map(linkAttributes, [](auto& attribute) -> std::pair<String, String> {
                 return { attribute.localName(), attribute.value() };
             });
         }
 
-        icons.append({ url, iconType, linkElement.type(), iconSize, WTFMove(attributes) });
+        icons.append({ url, iconType, linkElement->type(), iconSize, WTFMove(attributes) });
     }
 
     std::sort(icons.begin(), icons.end(), [](auto& a, auto& b) {

--- a/Source/WebCore/html/LinkIconCollector.h
+++ b/Source/WebCore/html/LinkIconCollector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,15 +35,15 @@ enum class LinkIconType : uint8_t;
 
 class LinkIconCollector {
 public:
-    explicit LinkIconCollector(Document& document)
-        : m_document(document)
+    explicit LinkIconCollector(Ref<Document>&& document)
+        : m_document(WTFMove(document))
     {
     }
 
     WEBCORE_EXPORT Vector<LinkIcon> iconsOfTypes(OptionSet<LinkIconType>);
 
 private:
-    Document& m_document;
+    const Ref<Document> m_document;
 };
 
 }


### PR DESCRIPTION
#### 85b73124f671d6d8fbe2b6dc730b98711b42326d
<pre>
[SaferCPP] Use smart pointers in LinkIconCollector
<a href="https://bugs.webkit.org/show_bug.cgi?id=291134">https://bugs.webkit.org/show_bug.cgi?id=291134</a>
&lt;<a href="https://rdar.apple.com/problem/148648198">rdar://problem/148648198</a>&gt;

Reviewed by Chris Dumez.

Use smart pointers/references in LinkIconCollector.h
and LinkIconCollector.cpp

* Source/WebCore/html/LinkIconCollector.cpp:
(WebCore::LinkIconCollector::iconsOfTypes):
* Source/WebCore/html/LinkIconCollector.h:
(WebCore::LinkIconCollector::LinkIconCollector):

Canonical link: <a href="https://commits.webkit.org/293327@main">https://commits.webkit.org/293327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc4453b7a5fd071d9c61d30984523a981b2fb3b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49140 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100626 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32196 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48552 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18697 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83502 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19355 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25630 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30811 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->