### PR TITLE
[JSC] Use `WTF::find64` for searching int32 from array by `indexOf` / `includes` in runtime

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-indexOf-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-int32.js
@@ -9,3 +9,4 @@ for (var i = 0; i < array.length; i++)
 
 for (var i = 0; i < 1e6; ++i)
     test(array, i % 1024);
+


### PR DESCRIPTION
#### b3adba53257656b5383d7f511f0398d2b1e24a93
<pre>
[JSC] Use `WTF::find64` for searching int32 from array by `indexOf` / `includes` in runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=291135">https://bugs.webkit.org/show_bug.cgi?id=291135</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `WTF::find64` instead of for loop for
searching int32 from array by `Array#indexOf` / `Array#includes`
in runtime (not JIT) using the same approach as
<a href="https://commits.webkit.org/292999@main">https://commits.webkit.org/292999@main</a> .

However, this change showed little performance improvement in
micro-benchmarks. Therefore, this patch is more of a refactoring
aimed at improving code consistency than an optimization:

                                                  TipOfTree                  Patched

array-prototype-includes-int32                122.1570+-1.0730          120.8459+-1.6853          might be 1.0108x faster
array-prototype-indexOf-int32                 122.0494+-1.2063     ^    119.8085+-0.6945        ^ definitely 1.0187x faster

* JSTests/microbenchmarks/array-prototype-includes-int32.js:
* JSTests/microbenchmarks/array-prototype-indexOf-int32.js: Copied from JSTests/microbenchmarks/array-prototype-includes-int32.js.
(test):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastIndexOf):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastIncludes):

Canonical link: <a href="https://commits.webkit.org/293320@main">https://commits.webkit.org/293320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5396f5bdcee4c466d033cbd20b0737815f7a75c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32130 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48459 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91176 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105983 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97118 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83944 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19238 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30718 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120735 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25355 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33791 "Found 98 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/memop_alias.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativeFloatPop.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen4.js.default, ChakraCore.yaml/ChakraCore/test/Array/negindex.js.default, ChakraCore.yaml/ChakraCore/test/Basics/DeleteProperty1.js.default, ChakraCore.yaml/ChakraCore/test/Basics/Parameters.js.default, ChakraCore.yaml/ChakraCore/test/Basics/StringFromCharCode.js.default, ChakraCore.yaml/ChakraCore/test/Basics/TypePromotion.js.default, ChakraCore.yaml/ChakraCore/test/Basics/UndefinedVsNull.js.default, ChakraCore.yaml/ChakraCore/test/Basics/equal.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->