### PR TITLE
[JSC] Tweaks `Array#indexOf` / `Array#includes` after 293134@main

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3972,11 +3972,8 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSG
     int32_t int32Value = 0;
     if (searchElement.isInt32AsAnyInt())
         int32Value = searchElement.asInt32AsAnyInt();
-    else {
-        if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
-            OPERATION_RETURN(scope, toUCPUStrictInt32(0));
-        int32Value = 0;
-    }
+    else if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(0));
 
     EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(int32Value));
     auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::find64(std::bit_cast<const uint64_t*>(data + index), encodedSearchElement, length - index));
@@ -4157,11 +4154,8 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSGl
     int32_t int32Value = 0;
     if (searchElement.isInt32AsAnyInt())
         int32Value = searchElement.asInt32AsAnyInt();
-    else {
-        if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
-            OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
-        int32Value = 0;
-    }
+    else if (!searchElement.isNumber() || searchElement.asNumber() != 0.0)
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
 
     EncodedJSValue encodedSearchElement = JSValue::encode(jsNumber(int32Value));
     auto* result = std::bit_cast<const WriteBarrier<Unknown>*>(WTF::find64(std::bit_cast<const uint64_t*>(data + index), encodedSearchElement, length - index));


### PR DESCRIPTION
#### b6e2505ae7dd8424019074aa73b6a67fb7494647
<pre>
[JSC] Tweaks `Array#indexOf` / `Array#includes` after 293134@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=291136">https://bugs.webkit.org/show_bug.cgi?id=291136</a>

Reviewed by Yusuke Suzuki.

This patch changes to tweak `operationArrayIncludesValueInt32` and
`operationArrayIndexOfValueInt32` after <a href="https://commits.webkit.org/293134@main.">https://commits.webkit.org/293134@main.</a>

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/293319@main">https://commits.webkit.org/293319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/905e8c3abc6a196adb136258dffe93965c31fc25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98490 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49023 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48460 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91177 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105984 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97119 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28078 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19239 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30719 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120736 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25356 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33792 "Found 92 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse2.js.default, ChakraCore.yaml/ChakraCore/test/Basics/IdsWithEscapes.js.default, ChakraCore.yaml/ChakraCore/test/Basics/ParameterOrder.js.default, ChakraCore.yaml/ChakraCore/test/Basics/Parameters.js.default, ChakraCore.yaml/ChakraCore/test/Basics/StringFromCharCode.js.default, ChakraCore.yaml/ChakraCore/test/Basics/equal_object.js.default, ChakraCore.yaml/ChakraCore/test/Closures/closure_multiple_1.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectWithPrototype.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->