### PR TITLE
Unreviewed non-unified source build fix 2025-04 (part 4)

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -34,6 +34,8 @@
 #include "HTMLImageElement.h"
 
 namespace WebCore {
+
+using namespace HTMLNames;
     
 AccessibilityImageMapLink::AccessibilityImageMapLink(AXID axID, HTMLAreaElement& element)
     : AccessibilityNodeObject(axID, &element)

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "AccessibilityMockObject.h"
+#include "AccessibilityNodeObject.h"
 #include "HTMLAreaElement.h"
 #include "HTMLMapElement.h"
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -57,6 +57,7 @@
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "GeometryUtilities.h"
+#include "HTMLAreaElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDataListElement.h"
 #include "HTMLDetailsElement.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+URL.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+URL.cpp
@@ -30,6 +30,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+KeywordDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserConsumer+String.h"
 #include "CSSPropertyParserState.h"
 #include "CSSURLValue.h"

--- a/Source/WebCore/svg/graphics/SVGResourceImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGResourceImage.cpp
@@ -30,7 +30,6 @@
 #include "LegacyRenderSVGResourceMasker.h"
 #include "ReferencedSVGResources.h"
 #include "RenderSVGResourceMasker.h"
-#include "StyleURL.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/graphics/SVGResourceImage.h
+++ b/Source/WebCore/svg/graphics/SVGResourceImage.h
@@ -27,14 +27,11 @@
 #pragma once
 
 #include "GeneratedImage.h"
+#include "StyleURL.h"
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-
-namespace Style {
-struct URL;
-}
 
 class LegacyRenderSVGResourceContainer;
 class RenderElement;


### PR DESCRIPTION
#### ddf40c5ae8c7b0b18397a31dae4f48f527da06e8
<pre>
Unreviewed non-unified source build fix 2025-04 (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=290868">https://bugs.webkit.org/show_bug.cgi?id=290868</a>

Added a missing #include.

* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+URL.cpp:
* Source/WebCore/svg/graphics/SVGResourceImage.cpp:
* Source/WebCore/svg/graphics/SVGResourceImage.h:

Canonical link: <a href="https://commits.webkit.org/293303@main">https://commits.webkit.org/293303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ebd9ce723aa7cb76ce73977b4c242a526888f2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26575 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/74975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32133 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/13969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13749 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/6919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105985 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25581 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/83946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83431 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19242 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30720 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->