### PR TITLE
Use `ASCIILiteral` instead of `const char*` for `NetworkStorageSessionSoup`

### DIFF
--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -173,49 +173,48 @@ void NetworkStorageSession::setCookieObserverHandler(Function<void ()>&& handler
 }
 
 #if USE(LIBSECRET)
-static const char* schemeFromProtectionSpaceServerType(ProtectionSpace::ServerType serverType)
+static ASCIILiteral schemeFromProtectionSpaceServerType(ProtectionSpace::ServerType serverType)
 {
     switch (serverType) {
     case ProtectionSpace::ServerType::HTTP:
     case ProtectionSpace::ServerType::ProxyHTTP:
-        return "http";
+        return "http"_s;
     case ProtectionSpace::ServerType::HTTPS:
     case ProtectionSpace::ServerType::ProxyHTTPS:
-        return "https";
+        return "https"_s;
     case ProtectionSpace::ServerType::FTP:
     case ProtectionSpace::ServerType::ProxyFTP:
-        return "ftp";
+        return "ftp"_s;
     case ProtectionSpace::ServerType::FTPS:
     case ProtectionSpace::ServerType::ProxySOCKS:
         break;
     }
-
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static const char* authTypeFromProtectionSpaceAuthenticationScheme(ProtectionSpace::AuthenticationScheme scheme)
+static ASCIILiteral authTypeFromProtectionSpaceAuthenticationScheme(ProtectionSpace::AuthenticationScheme scheme)
 {
     switch (scheme) {
     case ProtectionSpace::AuthenticationScheme::Default:
     case ProtectionSpace::AuthenticationScheme::HTTPBasic:
-        return "Basic";
+        return "Basic"_s;
     case ProtectionSpace::AuthenticationScheme::HTTPDigest:
-        return "Digest";
+        return "Digest"_s;
     case ProtectionSpace::AuthenticationScheme::NTLM:
-        return "NTLM";
+        return "NTLM"_s;
     case ProtectionSpace::AuthenticationScheme::Negotiate:
-        return "Negotiate";
+        return "Negotiate"_s;
     case ProtectionSpace::AuthenticationScheme::HTMLForm:
     case ProtectionSpace::AuthenticationScheme::ClientCertificateRequested:
     case ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested:
         ASSERT_NOT_REACHED();
         break;
     case ProtectionSpace::AuthenticationScheme::ClientCertificatePINRequested:
-        return "Certificate PIN";
+        return "Certificate PIN"_s;
     case ProtectionSpace::AuthenticationScheme::OAuth:
-        return "OAuth";
+        return "OAuth"_s;
     case ProtectionSpace::AuthenticationScheme::Unknown:
-        return "unknown";
+        return "unknown"_s;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -256,8 +255,8 @@ void NetworkStorageSession::getCredentialFromPersistentStorage(const ProtectionS
         "domain", realm.utf8().data(),
         "server", protectionSpace.host().utf8().data(),
         "port", protectionSpace.port(),
-        "protocol", schemeFromProtectionSpaceServerType(protectionSpace.serverType()),
-        "authtype", authTypeFromProtectionSpaceAuthenticationScheme(protectionSpace.authenticationScheme()),
+        "protocol", schemeFromProtectionSpaceServerType(protectionSpace.serverType()).characters(),
+        "authtype", authTypeFromProtectionSpaceAuthenticationScheme(protectionSpace.authenticationScheme()).characters(),
         nullptr));
     if (!attributes) {
         completionHandler({ });
@@ -316,8 +315,8 @@ void NetworkStorageSession::saveCredentialToPersistentStorage(const ProtectionSp
         "domain", realm.utf8().data(),
         "server", protectionSpace.host().utf8().data(),
         "port", protectionSpace.port(),
-        "protocol", schemeFromProtectionSpaceServerType(protectionSpace.serverType()),
-        "authtype", authTypeFromProtectionSpaceAuthenticationScheme(protectionSpace.authenticationScheme()),
+        "protocol", schemeFromProtectionSpaceServerType(protectionSpace.serverType()).characters(),
+        "authtype", authTypeFromProtectionSpaceAuthenticationScheme(protectionSpace.authenticationScheme()).characters(),
         nullptr));
     if (!attributes)
         return;


### PR DESCRIPTION
#### 05b634a4ae0d5d4bc8f7893a5c4724371c5773e5
<pre>
Use `ASCIILiteral` instead of `const char*` for `NetworkStorageSessionSoup`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291142">https://bugs.webkit.org/show_bug.cgi?id=291142</a>

Reviewed by Patrick Griffis.

Using Safer CPP constructs to enhance run-time performance and memory safety
particularly avoiding out-of-bounds access bugs. Also making the code more concise.

* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::schemeFromProtectionSpaceServerType):
(WebCore::authTypeFromProtectionSpaceAuthenticationScheme):

Canonical link: <a href="https://commits.webkit.org/293401@main">https://commits.webkit.org/293401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c62573bdd63a931e381d3b10dd2d3776d6cc08e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75202 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7161 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48742 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106268 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84159 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5974 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19581 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->