### PR TITLE
Address Safer cpp failures in NavigationPreloadManager

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -92,7 +92,6 @@ workers/WorkerConsoleClient.h
 workers/WorkerMessagingProxy.h
 workers/WorkerNotificationClient.h
 workers/WorkerOrWorkletGlobalScope.h
-workers/service/NavigationPreloadManager.h
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
 xml/XMLHttpRequestProgressEventThrottle.h
 xml/XMLHttpRequestUpload.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1377,7 +1377,6 @@ workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
 workers/WorkerScriptLoader.cpp
 workers/service/FetchEvent.cpp
-workers/service/NavigationPreloadManager.cpp
 workers/service/ServiceWorker.cpp
 workers/service/ServiceWorkerClientData.cpp
 workers/service/ServiceWorkerContainer.cpp

--- a/Source/WebCore/workers/service/NavigationPreloadManager.cpp
+++ b/Source/WebCore/workers/service/NavigationPreloadManager.cpp
@@ -36,22 +36,26 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationPreloadManager);
 
 void NavigationPreloadManager::enable(Promise&& promise)
 {
-    m_registration.container().enableNavigationPreload(m_registration.identifier(), WTFMove(promise));
+    Ref registration = m_registration.get();
+    registration->protectedContainer()->enableNavigationPreload(registration->identifier(), WTFMove(promise));
 }
 
 void NavigationPreloadManager::disable(Promise&& promise)
 {
-    m_registration.container().disableNavigationPreload(m_registration.identifier(), WTFMove(promise));
+    Ref registration = m_registration.get();
+    registration->protectedContainer()->disableNavigationPreload(registration->identifier(), WTFMove(promise));
 }
 
 void NavigationPreloadManager::setHeaderValue(String&& value, Promise&& promise)
 {
-    m_registration.container().setNavigationPreloadHeaderValue(m_registration.identifier(), WTFMove(value), WTFMove(promise));
+    Ref registration = m_registration.get();
+    registration->protectedContainer()->setNavigationPreloadHeaderValue(registration->identifier(), WTFMove(value), WTFMove(promise));
 }
 
 void NavigationPreloadManager::getState(StatePromise&& promise)
 {
-    m_registration.container().getNavigationPreloadState(m_registration.identifier(), WTFMove(promise));
+    Ref registration = m_registration.get();
+    registration->protectedContainer()->getNavigationPreloadState(registration->identifier(), WTFMove(promise));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/NavigationPreloadManager.h
+++ b/Source/WebCore/workers/service/NavigationPreloadManager.h
@@ -28,8 +28,11 @@
 #include "NavigationPreloadState.h"
 #include "ServiceWorkerRegistration.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
+
+class WeakPtrImplWithEventTargetData;
 
 class NavigationPreloadManager {
     WTF_MAKE_TZONE_ALLOCATED(NavigationPreloadManager);
@@ -44,13 +47,13 @@ public:
     using StatePromise = DOMPromiseDeferred<IDLDictionary<NavigationPreloadState>>;
     void getState(StatePromise&&);
 
-    void ref() { m_registration.ref(); }
-    void deref() { m_registration.deref(); }
+    void ref() { m_registration->ref(); }
+    void deref() { m_registration->deref(); }
 
 private:
     explicit NavigationPreloadManager(ServiceWorkerRegistration&);
 
-    ServiceWorkerRegistration& m_registration;
+    const WeakRef<ServiceWorkerRegistration, WeakPtrImplWithEventTargetData> m_registration;
 };
 
 inline NavigationPreloadManager::NavigationPreloadManager(ServiceWorkerRegistration& registration)


### PR DESCRIPTION
#### dac454a345caca913147a7c98b5fa6f400be62fa
<pre>
Address Safer cpp failures in NavigationPreloadManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=291144">https://bugs.webkit.org/show_bug.cgi?id=291144</a>
<a href="https://rdar.apple.com/problem/148668310">rdar://problem/148668310</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning in NavigationPreloadManager.

* Source/WebCore/workers/service/NavigationPreloadManager.cpp:
(WebCore::NavigationPreloadManager::enable):
(WebCore::NavigationPreloadManager::disable):
(WebCore::NavigationPreloadManager::setHeaderValue):
(WebCore::NavigationPreloadManager::getState):
* Source/WebCore/workers/service/NavigationPreloadManager.h:
(WebCore::NavigationPreloadManager::ref):
(WebCore::NavigationPreloadManager::deref):

Canonical link: <a href="https://commits.webkit.org/293527@main">https://commits.webkit.org/293527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4410dff0d476fe1b7f8429cc701f586e6c01b94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32191 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106071 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84010 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5817 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19350 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30806 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->