### PR TITLE
Improve NSScreen screens error handling across codebase

### DIFF
--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -78,10 +78,9 @@ static PlatformDisplayID displayID(Widget* widget)
 static NSScreen *firstScreen()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    NSArray *screens = [NSScreen screens];
-    if (![screens count])
-        return nil;
-    return [screens objectAtIndex:0];
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
 }
 
 static NSWindow *window(Widget* widget)

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -33,6 +33,7 @@
 #import "FloatRect.h"
 #import "HostWindow.h"
 #import "LocalFrameView.h"
+#import "Logging.h"
 #import "ScreenProperties.h"
 #import "ThermalMitigationNotifier.h"
 #import <ColorSync/ColorSync.h>
@@ -87,10 +88,12 @@ static PlatformDisplayID displayID(Widget* widget)
 static NSScreen *firstScreen()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    NSArray *screens = [NSScreen screens];
-    if (![screens count])
-        return nil;
-    return [screens objectAtIndex:0];
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    // Unlike the callers in the UI process, this can be reached from the Web Content process, which has no
+    // WindowServer session, so log rather than assert and let callers keep degrading gracefully.
+    if (!firstScreen) [[unlikely]]
+        RELEASE_LOG_ERROR(Layout, "firstScreen: No screens found, possibly due to no WindowServer session.");
+    return firstScreen;
 }
 
 static NSWindow *window(Widget* widget)

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -886,6 +886,15 @@ void WebAutomationSession::platformSimulateKeySequence(WebPageProxy& page, const
 
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    // WebDriver sessions can run without a WindowServer session, so log rather than assert.
+    if (!firstScreen) [[unlikely]]
+        RELEASE_LOG_ERROR(Automation, "firstScreen: No screens found, possibly due to no WindowServer session.");
+    return firstScreen;
+}
+
 void WebAutomationSession::platformSimulateWheelInteraction(WebPageProxy& page, const WebCore::IntPoint& locationInViewport, const WebCore::IntSize& delta)
 {
     static constexpr auto scrollWheelCount = 2;
@@ -897,7 +906,7 @@ void WebAutomationSession::platformSimulateWheelInteraction(WebPageProxy& page, 
     // Set the CGEvent location in flipped coords relative to the first screen, which compensates for the behavior of
     // +[NSEvent eventWithCGEvent:] when the event has no associated window. See <rdar://problem/17180591>.
     auto locationOnScreen = [window convertPointToScreen:locationInWindow];
-    locationOnScreen = CGPointMake(locationOnScreen.x, NSScreen.screens.firstObject.frame.size.height - locationOnScreen.y);
+    locationOnScreen = CGPointMake(locationOnScreen.x, [firstScreen() frame].size.height - locationOnScreen.y);
     CGEventSetLocation(cgScrollEvent.get(), locationOnScreen);
 
     RetainPtr<NSEvent> scrollEvent = [[NSEvent eventWithCGEvent:cgScrollEvent.get()] _eventRelativeToWindow:window.get()];

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -366,6 +366,13 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     return adoptCF(CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace.get(), bitmapInfo, provider.get(), 0, shouldInterpolate, intent));
 }
 
+static RetainPtr<NSScreen> getFirstScreen()
+{
+    RetainPtr firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)_continueEnteringFullscreenAfterPostingNotification:(CompletionHandler<void(bool)>&&)completionHandler
 {
     if ([self isFullScreen])
@@ -379,7 +386,7 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     NSRect webViewFrame = convertRectToScreen(retainPtr([webView window]).get(), [webView convertRect:[webView frame] toView:nil]);
 
     // Flip coordinate system:
-    webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
+    webViewFrame.origin.y = NSMaxY([getFirstScreen() frame]) - NSMaxY(webViewFrame);
 
     CGWindowID windowID = [[webView window] windowNumber];
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
@@ -698,7 +705,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     NSRect exitPlaceholderScreenRect = _initialFrame;
-    exitPlaceholderScreenRect.origin.y = NSMaxY(WebCore::safeScreenFrame(retainPtr([[NSScreen screens] objectAtIndex:0]).get())) - NSMaxY(exitPlaceholderScreenRect);
+    exitPlaceholderScreenRect.origin.y = NSMaxY(WebCore::safeScreenFrame(getFirstScreen().get())) - NSMaxY(exitPlaceholderScreenRect);
 
     RetainPtr webView = _webView.get();
     RetainPtr<CGImageRef> webViewContents = takeWindowSnapshot([[webView window] windowNumber], true);

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -365,6 +365,13 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     return adoptCF(CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace.get(), bitmapInfo, provider.get(), 0, shouldInterpolate, intent));
 }
 
+static RetainPtr<NSScreen> firstScreen()
+{
+    RetainPtr firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)_continueEnteringFullscreenAfterPostingNotification:(CompletionHandler<void(bool)>&&)completionHandler
 {
     if ([self isFullScreen])
@@ -378,7 +385,7 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     NSRect webViewFrame = convertRectToScreen(retainPtr([webView window]).get(), [webView convertRect:[webView frame] toView:nil]);
 
     // Flip coordinate system:
-    webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
+    webViewFrame.origin.y = NSMaxY([firstScreen() frame]) - NSMaxY(webViewFrame);
 
     CGWindowID windowID = [[webView window] windowNumber];
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
@@ -719,7 +726,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     NSRect exitPlaceholderScreenRect = _initialFrame;
-    exitPlaceholderScreenRect.origin.y = NSMaxY(WebCore::safeScreenFrame(retainPtr([[NSScreen screens] objectAtIndex:0]).get())) - NSMaxY(exitPlaceholderScreenRect);
+    exitPlaceholderScreenRect.origin.y = NSMaxY(WebCore::safeScreenFrame(firstScreen().get())) - NSMaxY(exitPlaceholderScreenRect);
 
     RetainPtr webView = _webView.get();
     RetainPtr<CGImageRef> webViewContents = takeWindowSnapshot([[webView window] windowNumber], true);

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -159,6 +159,13 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
 #pragma mark -
 #pragma mark Notifications
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)applicationDidResignActive:(NSNotification*)notification
 {   
     NSWindow* fullscreenWindow = [self window];
@@ -167,7 +174,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     // Is the fullscreen screen the main screen? (Note: this covers the case where only a 
     // single screen is available.)  Is the fullscreen screen on the current space? IFF so, 
     // then exit fullscreen mode. 
-    if (fullscreenWindow.screen == [NSScreen screens][0] && fullscreenWindow.onActiveSpace)
+    if (fullscreenWindow.screen == getFirstScreen() && fullscreenWindow.onActiveSpace)
          [self cancelOperation:self];
 }
 
@@ -204,8 +211,8 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     NSRect webViewFrame = convertRectToScreen([_webView window], [_webView convertRect:[_webView frame] toView:nil]);
 
     // Flip coordinate system:
-    webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
-    
+    webViewFrame.origin.y = NSMaxY([getFirstScreen() frame]) - NSMaxY(webViewFrame);
+
     CGWindowID windowID = [[_webView window] windowNumber];
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
 
@@ -420,7 +427,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Auto-hide the menu bar if the fullscreenScreen contains the menu bar:
         // NOTE: if the fullscreenScreen contains the menu bar but not the dock, we must still 
         // auto-hide the dock, or an exception will be thrown.
-        if ([[NSScreen screens] objectAtIndex:0] == fullscreenScreen)
+        if (getFirstScreen() == fullscreenScreen)
             options |= (NSApplicationPresentationAutoHideMenuBar | NSApplicationPresentationAutoHideDock);
         // Check if the current screen contains the dock by comparing the screen's frame to its
         // visibleFrame; if a dock is present, the visibleFrame will differ. If the current screen

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -162,6 +162,13 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
 #pragma mark -
 #pragma mark Notifications
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)applicationDidResignActive:(NSNotification*)notification
 {   
     NSWindow* fullscreenWindow = [self window];
@@ -170,7 +177,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     // Is the fullscreen screen the main screen? (Note: this covers the case where only a 
     // single screen is available.)  Is the fullscreen screen on the current space? IFF so, 
     // then exit fullscreen mode. 
-    if (fullscreenWindow.screen == [NSScreen screens][0] && fullscreenWindow.onActiveSpace)
+    if (fullscreenWindow.screen == firstScreen() && fullscreenWindow.onActiveSpace)
          [self cancelOperation:self];
 }
 
@@ -207,8 +214,8 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     NSRect webViewFrame = convertRectToScreen([_webView window], [_webView convertRect:[_webView frame] toView:nil]);
 
     // Flip coordinate system:
-    webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
-    
+    webViewFrame.origin.y = NSMaxY([firstScreen() frame]) - NSMaxY(webViewFrame);
+
     CGWindowID windowID = [[_webView window] windowNumber];
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
 
@@ -423,7 +430,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Auto-hide the menu bar if the fullscreenScreen contains the menu bar:
         // NOTE: if the fullscreenScreen contains the menu bar but not the dock, we must still 
         // auto-hide the dock, or an exception will be thrown.
-        if ([[NSScreen screens] objectAtIndex:0] == fullscreenScreen)
+        if (firstScreen() == fullscreenScreen)
             options |= (NSApplicationPresentationAutoHideMenuBar | NSApplicationPresentationAutoHideDock);
         // Check if the current screen contains the dock by comparing the screen's frame to its
         // visibleFrame; if a dock is present, the visibleFrame will differ. If the current screen

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -237,6 +237,13 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     return _videoElement->screenRect();
 }
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)applicationDidResignActive:(NSNotification*)notification
 {
     UNUSED_PARAM(notification);
@@ -246,7 +253,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     // Is the fullscreen screen the main screen? (Note: this covers the case where only a
     // single screen is available.)  Is the fullscreen screen on the current space? IFF so,
     // then exit fullscreen mode.
-    if (fullscreenWindow.screen == [NSScreen screens][0] && fullscreenWindow.onActiveSpace)
+    if (fullscreenWindow.screen == getFirstScreen() && fullscreenWindow.onActiveSpace)
         [self _requestExit];
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -235,6 +235,13 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     return _videoElement->screenRect();
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)applicationDidResignActive:(NSNotification*)notification
 {
     UNUSED_PARAM(notification);
@@ -244,7 +251,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     // Is the fullscreen screen the main screen? (Note: this covers the case where only a
     // single screen is available.)  Is the fullscreen screen on the current space? IFF so,
     // then exit fullscreen mode.
-    if (fullscreenWindow.screen == [NSScreen screens][0] && fullscreenWindow.onActiveSpace)
+    if (fullscreenWindow.screen == firstScreen() && fullscreenWindow.onActiveSpace)
         [self _requestExit];
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
@@ -105,9 +105,16 @@ using WebCore::narrowPrecisionToFloat;
     return scaledRect(_finalFrame, _initialFrame, [self currentValue]);
 }
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 static void flipRect(NSRect* rect)
 {
-    rect->origin.y = NSMaxY([(NSScreen *)[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(*rect);
+    rect->origin.y = NSMaxY([getFirstScreen() frame]) - NSMaxY(*rect);
 }
 
 static CGSConnectionID mainWindowServerConnectionID()

--- a/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
@@ -105,9 +105,16 @@ using WebCore::narrowPrecisionToFloat;
     return scaledRect(_finalFrame, _initialFrame, [self currentValue]);
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 static void flipRect(NSRect* rect)
 {
-    rect->origin.y = NSMaxY([(NSScreen *)[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(*rect);
+    rect->origin.y = NSMaxY([firstScreen() frame]) - NSMaxY(*rect);
 }
 
 static CGSConnectionID mainWindowServerConnectionID()

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -702,6 +702,15 @@ static void registerMockScrollbars()
 }
 #endif
 
+#if !PLATFORM(IOS_FAMILY)
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+#endif
+
 RetainPtr<WebView> createWebViewAndOffscreenWindow()
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -747,7 +756,8 @@ RetainPtr<WebView> createWebViewAndOffscreenWindow()
 
     // To make things like certain NSViews, dragging, and plug-ins work, put the WebView a window, but put it off-screen so you don't see it.
     // Put it at -10000, -10000 in "flipped coordinates", since WebCore and the DOM use flipped coordinates.
-    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    NSScreen *firstScreen = getFirstScreen();
+
     NSRect windowRect = (showWebView) ? NSOffsetRect(rect, 100, 100) : NSOffsetRect(rect, -10000, [firstScreen frame].size.height - rect.size.height + 10000);
     mainWindow = adoptNS([[DumpRenderTreeWindow alloc] initWithContentRect:windowRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES]);
     [mainWindow setReleasedWhenClosed:NO];

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -703,6 +703,15 @@ static void registerMockScrollbars()
 }
 #endif
 
+#if !PLATFORM(IOS_FAMILY)
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+#endif
+
 RetainPtr<WebView> createWebViewAndOffscreenWindow()
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -748,11 +757,11 @@ RetainPtr<WebView> createWebViewAndOffscreenWindow()
 
     // To make things like certain NSViews, dragging, and plug-ins work, put the WebView a window, but put it off-screen so you don't see it.
     // Put it at -10000, -10000 in "flipped coordinates", since WebCore and the DOM use flipped coordinates.
-    NSScreen *firstScreen = [[NSScreen screens] firstObject];
-    NSRect windowRect = (showWebView) ? NSOffsetRect(rect, 100, 100) : NSOffsetRect(rect, -10000, [firstScreen frame].size.height - rect.size.height + 10000);
+    NSScreen *screen = firstScreen();
+    NSRect windowRect = (showWebView) ? NSOffsetRect(rect, 100, 100) : NSOffsetRect(rect, -10000, [screen frame].size.height - rect.size.height + 10000);
     mainWindow = adoptNS([[DumpRenderTreeWindow alloc] initWithContentRect:windowRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES]);
     [mainWindow setReleasedWhenClosed:NO];
-    [mainWindow setColorSpace:[firstScreen colorSpace]];
+    [mainWindow setColorSpace:[screen colorSpace]];
     [mainWindow setCollectionBehavior:NSWindowCollectionBehaviorStationary];
     [[mainWindow contentView] addSubview:webView.get()];
     if (showWebView)

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -844,6 +844,15 @@ static NSInteger swizzledEventButtonNumber()
     }
 }
 
+#if !PLATFORM(IOS_FAMILY)
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+#endif
+
 - (void)mouseScrollByX:(int)x andY:(int)y continuously:(BOOL)continuously
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -853,7 +862,7 @@ static NSInteger swizzledEventButtonNumber()
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(lastMousePosition.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - lastMousePosition.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(lastMousePosition.x, [getFirstScreen() frame].size.height - lastMousePosition.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     NSEvent *scrollEvent = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
@@ -929,7 +938,7 @@ static NSInteger swizzledEventButtonNumber()
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint globalMousePosition = CGPointMake(mouseLocation.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - mouseLocation.y);
+    CGPoint globalMousePosition = CGPointMake(mouseLocation.x, [getFirstScreen() frame].size.height - mouseLocation.y);
     CGEventSetLocation(cgScrollEvent.get(), globalMousePosition);
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventScrollPhase, wheelPhase);

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -844,6 +844,15 @@ static NSInteger swizzledEventButtonNumber()
     }
 }
 
+#if !PLATFORM(IOS_FAMILY)
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+#endif
+
 - (void)mouseScrollByX:(int)x andY:(int)y continuously:(BOOL)continuously
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -853,7 +862,7 @@ static NSInteger swizzledEventButtonNumber()
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(lastMousePosition.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - lastMousePosition.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(lastMousePosition.x, [firstScreen() frame].size.height - lastMousePosition.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     NSEvent *scrollEvent = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
@@ -929,7 +938,7 @@ static NSInteger swizzledEventButtonNumber()
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint globalMousePosition = CGPointMake(mouseLocation.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - mouseLocation.y);
+    CGPoint globalMousePosition = CGPointMake(mouseLocation.x, [firstScreen() frame].size.height - mouseLocation.y);
     CGEventSetLocation(cgScrollEvent.get(), globalMousePosition);
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventScrollPhase, wheelPhase);

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -369,8 +369,9 @@
 
 static CGRect coreGraphicsScreenRectForAppKitScreenRect(NSRect rect)
 {
-    NSScreen *firstScreen = [NSScreen screens][0];
-    return CGRectMake(NSMinX(rect), NSHeight(firstScreen.frame) - NSMinY(rect) - NSHeight(rect), NSWidth(rect), NSHeight(rect));
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    NSCAssert(firstScreen, @"No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return CGRectMake(NSMinX(rect), NSHeight([firstScreen frame]) - NSMinY(rect) - NSHeight(rect), NSWidth(rect), NSHeight(rect));
 }
 
 - (NSImage *)sharingService:(NSSharingService *)sharingService transitionImageForShareItem:(id)item contentRect:(NSRect *)contentRect

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -253,9 +253,11 @@ static NSRect frameForWindowFeatures(WKWindowFeatures *features, NSWindow *windo
     if (features.x)
         frameRect.origin.x = features.x.doubleValue;
 
-    if (features.y)
-        frameRect.origin.y = NSMaxY(NSScreen.screens.firstObject.frame) - features.y.doubleValue - NSHeight(frameRect);
-    else
+    if (features.y) {
+        NSScreen *firstScreen = [[NSScreen screens] firstObject];
+        NSCAssert(firstScreen, @"No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+        frameRect.origin.y = NSMaxY([firstScreen frame]) - features.y.doubleValue - NSHeight(frameRect);
+    } else
         frameRect.origin.y = NSMaxY(window.frame) - NSHeight(frameRect);
 
     return [window constrainFrameRect:frameRect toScreen:nil];

--- a/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
+++ b/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
@@ -225,6 +225,13 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
     return dict.autorelease();
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 + (RetainPtr<CGEventRef>)createEventForDictionary:(NSDictionary *)dict inWindow:(NSWindow *)window relativeToTime:(MonotonicTime)referenceTimestamp
 {
     const RetainPtr event = adoptCF(CGEventCreate(NULL));
@@ -244,7 +251,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
     if (dict[@"windowLocation"]) {
         CGPoint windowLocation = NSPointToCGPoint(NSPointFromString(dict[@"windowLocation"]));
         NSPoint screenPoint = [window convertPointToScreen:windowLocation];
-        CGPoint flippedScreenPoint = CGPointMake(screenPoint.x, NSScreen.screens.firstObject.frame.size.height - screenPoint.y);
+        CGPoint flippedScreenPoint = CGPointMake(screenPoint.x, [firstScreen() frame].size.height - screenPoint.y);
 
         CGEventSetLocation(rawEvent, flippedScreenPoint);
         CGEventSetWindowLocation(rawEvent, windowLocation);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -1727,6 +1727,13 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     }
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta
 {
     static constexpr auto phase = static_cast<CGScrollPhase>(0);
@@ -1741,7 +1748,7 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventMomentumPhase, momentumPhase);
 
     CGPoint locationInGlobalScreenCoordinates = [[self window] convertPointToScreen:pointInWindow];
-    locationInGlobalScreenCoordinates.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - locationInGlobalScreenCoordinates.y;
+    locationInGlobalScreenCoordinates.y = [firstScreen() frame].size.height - locationInGlobalScreenCoordinates.y;
     CGEventSetLocation(cgScrollEvent.get(), locationInGlobalScreenCoordinates);
 
     RetainPtr event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -291,8 +291,10 @@ extension WebPage {
 
         // CGEvent locations are in flipped, global screen coordinates.
         let locationInScreen = window.convertPoint(toScreen: location)
-        let primaryScreenHeight = NSScreen.screens.first?.frame.height ?? 0
-        cgEvent.location = CGPoint(x: locationInScreen.x, y: primaryScreenHeight - locationInScreen.y)
+        guard let primaryScreen = NSScreen.screens.first else {
+            preconditionFailure("No screens found, possibly due to no WindowServer session. This configuration is not supported.")
+        }
+        cgEvent.location = CGPoint(x: locationInScreen.x, y: primaryScreen.frame.height - locationInScreen.y)
 
         guard let event = NSEvent(cgEvent: cgEvent) else {
             preconditionFailure("Could not create scroll NSEvent.")

--- a/Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm
@@ -35,12 +35,19 @@
     return [self initWithSize:size isKeyWindow:YES];
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (instancetype)initWithSize:(CGSize)size isKeyWindow:(BOOL)isKeyWindow
 {
     _isKeyWindow = isKeyWindow;
 
     NSRect rect = NSMakeRect(0, 0, size.width, size.height);
-    NSRect windowRect = NSOffsetRect(rect, -10000, [(NSScreen *)[[NSScreen screens] objectAtIndex:0] frame].size.height - rect.size.height + 10000);
+    NSRect windowRect = NSOffsetRect(rect, -10000, [firstScreen() frame].size.height - rect.size.height + 10000);
     self = [super initWithContentRect:windowRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES];
     if (!self)
         return nil;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -1661,12 +1661,19 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     }
 }
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta
 {
     RetainPtr<CGEventRef> cgScrollEvent = adoptCF(CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitPixel, 2, delta.height, delta.width, 0));
 
     CGPoint locationInGlobalScreenCoordinates = [[self window] convertPointToScreen:pointInWindow];
-    locationInGlobalScreenCoordinates.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - locationInGlobalScreenCoordinates.y;
+    locationInGlobalScreenCoordinates.y = [getFirstScreen() frame].size.height - locationInGlobalScreenCoordinates.y;
     CGEventSetLocation(cgScrollEvent.get(), locationInGlobalScreenCoordinates);
     
     NSEvent* event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];

--- a/Tools/TestWebKitAPI/mac/OffscreenWindow.mm
+++ b/Tools/TestWebKitAPI/mac/OffscreenWindow.mm
@@ -35,12 +35,20 @@
     return [self initWithSize:size isKeyWindow:YES];
 }
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 - (instancetype)initWithSize:(CGSize)size isKeyWindow:(BOOL)isKeyWindow
 {
     _isKeyWindow = isKeyWindow;
 
     NSRect rect = NSMakeRect(0, 0, size.width, size.height);
-    NSRect windowRect = NSOffsetRect(rect, -10000, [(NSScreen *)[[NSScreen screens] objectAtIndex:0] frame].size.height - rect.size.height + 10000);
+    NSScreen *firstScreen = getFirstScreen();
+    NSRect windowRect = NSOffsetRect(rect, -10000, [firstScreen frame].size.height - rect.size.height + 10000);
     self = [super initWithContentRect:windowRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES];
     if (!self)
         return nil;

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -730,6 +730,13 @@ void EventSenderProxy::rawKeyUp(WKStringRef key, WKEventModifiers modifiers, uns
     [NSApp _setCurrentEvent:nil];
 }
 
+static NSScreen *getFirstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 void EventSenderProxy::mouseScrollBy(int x, int y)
 {
     auto cgScrollEvent = adoptCF(CGEventCreateScrollWheelEvent2(0, kCGScrollEventUnitLine, 2, y, x, 0));
@@ -737,7 +744,7 @@ void EventSenderProxy::mouseScrollBy(int x, int y)
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - m_position.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [getFirstScreen() frame].size.height - m_position.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     NSEvent *event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
@@ -764,7 +771,7 @@ void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int x, int y, int
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - m_position.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [getFirstScreen() frame].size.height - m_position.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);
@@ -835,7 +842,7 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint flippedWindowMousePosition = CGPointMake(windowX, [[[NSScreen screens] objectAtIndex:0] frame].size.height - windowY);
+    CGPoint flippedWindowMousePosition = CGPointMake(windowX, [getFirstScreen() frame].size.height - windowY);
     CGEventSetLocation(cgScrollEvent.get(), flippedWindowMousePosition);
 
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -607,6 +607,13 @@ void EventSenderProxy::rawKeyUp(WKStringRef key, WKEventModifiers modifiers, uns
     [NSApp _setCurrentEvent:nil];
 }
 
+static NSScreen *firstScreen()
+{
+    NSScreen *firstScreen = [[NSScreen screens] firstObject];
+    RELEASE_ASSERT_WITH_MESSAGE(firstScreen, "No screens found, possibly due to no WindowServer session. This configuration is not supported.");
+    return firstScreen;
+}
+
 void EventSenderProxy::mouseScrollBy(int x, int y)
 {
     auto cgScrollEvent = adoptCF(CGEventCreateScrollWheelEvent2(0, kCGScrollEventUnitLine, 2, y, x, 0));
@@ -614,7 +621,7 @@ void EventSenderProxy::mouseScrollBy(int x, int y)
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - m_position.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [firstScreen() frame].size.height - m_position.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     NSEvent *event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
@@ -636,7 +643,7 @@ void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int x, int y, int
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [[[NSScreen screens] objectAtIndex:0] frame].size.height - m_position.y);
+    CGPoint lastGlobalMousePosition = CGPointMake(m_position.x, [firstScreen() frame].size.height - m_position.y);
     CGEventSetLocation(cgScrollEvent.get(), lastGlobalMousePosition);
 
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);
@@ -702,7 +709,7 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
     // Set the CGEvent location in flipped coords relative to the first screen, which
     // compensates for the behavior of +[NSEvent eventWithCGEvent:] when the event has
     // no associated window. See <rdar://problem/17180591>.
-    CGPoint flippedWindowMousePosition = CGPointMake(windowX, [[[NSScreen screens] objectAtIndex:0] frame].size.height - windowY);
+    CGPoint flippedWindowMousePosition = CGPointMake(windowX, [firstScreen() frame].size.height - windowY);
     CGEventSetLocation(cgScrollEvent.get(), flippedWindowMousePosition);
 
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventIsContinuous, 1);


### PR DESCRIPTION
#### cff850f4a4e81a84fc47ae1708a67741d03a7513
<pre>
Improve NSScreen screens error handling across codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=291147">https://bugs.webkit.org/show_bug.cgi?id=291147</a>
<a href="https://rdar.apple.com/148673358">rdar://148673358</a>

Reviewed by NOBODY (OOPS!).

After bug 291122, I noticed theres a few inconsistencies
in how we query for screens from the AppKit `NSScreen screens` API,
and that in some cases we are not validating if we have a screen.

Make all of the calls consistent, and add release asserts in the
UI process and testing code, where an empty screen list already
meant an out-of-range exception on `[[NSScreen screens] objectAtIndex:0]`.

i.e, use `[[NSScreen screens] firstObject]` as it
returns `nil` if no screens are given.

Two call sites keep returning `nil` instead of asserting, and log
instead: `WebCore::firstScreen()` is reachable from the Web Content
process, which drops all process privileges and so never has a
WindowServer session, and `WebAutomationSession` can drive a
WebDriver session on a machine without one. Both previously
degraded to a zero rect rather than crashing, so keep that behavior
and leave an audit trail in the log.

* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::firstScreen):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::firstScreen):
(WebKit::WebAutomationSession::platformSimulateWheelInteraction):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(firstScreen):
(-[WKFullScreenWindowController _continueEnteringFullscreenAfterPostingNotification:]):
(-[WKFullScreenWindowController _continueExitingFullscreenAfterPostingNotificationAndExitImmediately:]):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(firstScreen):
(-[WebFullScreenController applicationDidResignActive:]):
(-[WebFullScreenController enterFullScreen:willEnterFullscreen:didEnterFullscreen:]):
(-[WebFullScreenController _updateMenuAndDockForFullScreen]):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(firstScreen):
(-[WebVideoFullscreenController applicationDidResignActive:]):
* Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm:
(firstScreen):
(flipRect):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(firstScreen):
(createWebViewAndOffscreenWindow):
* Tools/DumpRenderTree/mac/EventSendingController.mm:
(firstScreen):
(-[EventSendingController mouseScrollByX:andY:continuously:]):
(-[EventSendingController sendScrollEventAt:deltaX:deltaY:units:wheelPhase:momentumPhase:timestamp:]):
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(coreGraphicsScreenRectForAppKitScreenRect):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(frameForWindowFeatures):
* Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm:
(firstScreen):
(+[EventSerializer createEventForDictionary:inWindow:relativeToTime:]):
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(firstScreen):
(-[TestWKWebView wheelEventAtPoint:wheelDelta:]):
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
* Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm:
(firstScreen):
(-[OffscreenWindow initWithSize:isKeyWindow:]):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::firstScreen):
(WTR::EventSenderProxy::mouseScrollBy):
(WTR::EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases):
(WTR::EventSenderProxy::sendWheelEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cff850f4a4e81a84fc47ae1708a67741d03a7513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150277 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa0e9279-f9c3-47cf-b995-16e883850dbc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144980 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100516 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37e3c73b-4dc3-4fd0-9371-b43971a4fee0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86ee399f-ac46-4433-b41f-4c71d542775e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47388 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45444 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45128 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6896 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197794 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59097 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154508 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59806 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154155 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48623 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132159 "Found 1 new failure in UIProcess/Automation/mac/WebAutomationSessionMac.mm") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129057 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58282 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20150 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57655 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->