### PR TITLE
[SaferCPP] Address issues in WebCore/html/canvas

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -88,7 +88,6 @@ editing/TypingCommand.cpp
 html/InputType.cpp
 html/NavigatorUserActivation.cpp
 html/canvas/WebGL2RenderingContext.cpp
-html/canvas/WebGLRenderingContextBase.cpp
 html/track/TextTrackCueGeneric.cpp
 inspector/CommandLineAPIModule.cpp
 inspector/agents/InspectorCSSAgent.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -746,7 +746,6 @@ html/canvas/WebGLRenderingContext.cpp
 html/canvas/WebGLRenderingContextBase.cpp
 html/canvas/WebGLSync.cpp
 html/canvas/WebGLTransformFeedback.cpp
-html/canvas/WebGLUtilities.cpp
 html/canvas/WebGLVertexArrayObject.cpp
 html/canvas/WebGLVertexArrayObjectBase.cpp
 html/canvas/WebGLVertexArrayObjectOES.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -81,7 +81,6 @@ html/NumberInputType.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasStyle.cpp
 html/canvas/GPUCanvasContextCocoa.mm
-html/canvas/WebGLRenderingContextBase.cpp
 html/track/LoadableTextTrack.cpp
 html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -397,8 +397,6 @@ html/canvas/WebGLMultiDraw.cpp
 html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
 html/canvas/WebGLPolygonMode.cpp
 html/canvas/WebGLProvokingVertex.cpp
-html/canvas/WebGLRenderingContextBase.cpp
-html/canvas/WebGLUtilities.h
 html/parser/HTMLConstructionSite.cpp
 html/shadow/DateTimeEditElement.cpp
 html/shadow/MediaControlTextTrackContainerElement.cpp

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -64,6 +64,7 @@ public:
     WEBCORE_EXPORT void deref() const;
 
     CanvasBase& canvasBase() const { return m_canvas; }
+    Ref<CanvasBase> protectedCanvasBase() const { return m_canvas.get(); }
 
     bool is2dBase() const { return is2d() || isOffscreen2d() || isPaint(); }
     bool is2d() const { return m_type == Type::CanvasElement2D; }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -233,9 +233,9 @@ bool WebGL2RenderingContext::validateBufferTargetCompatibility(ASCIILiteral func
     return true;
 }
 
-WebGLBuffer* WebGL2RenderingContext::validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage)
+RefPtr<WebGLBuffer> WebGL2RenderingContext::validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage)
 {
-    WebGLBuffer* buffer = validateBufferDataTarget(functionName, target);
+    RefPtr buffer = validateBufferDataTarget(functionName, target);
     if (!buffer)
         return nullptr;
     switch (usage) {
@@ -255,9 +255,9 @@ WebGLBuffer* WebGL2RenderingContext::validateBufferDataParameters(ASCIILiteral f
     return nullptr;
 }
 
-WebGLBuffer* WebGL2RenderingContext::validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target)
+RefPtr<WebGLBuffer> WebGL2RenderingContext::validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target)
 {
-    WebGLBuffer* buffer = nullptr;
+    RefPtr<WebGLBuffer> buffer;
     switch (target) {
     case GraphicsContextGL::ELEMENT_ARRAY_BUFFER:
         buffer = m_boundVertexArrayObject->getElementArrayBuffer();
@@ -291,10 +291,10 @@ WebGLBuffer* WebGL2RenderingContext::validateBufferDataTarget(ASCIILiteral funct
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no buffer"_s);
         return nullptr;
     }
-    if (m_boundTransformFeedback->hasBoundIndexedTransformFeedbackBuffer(buffer)) {
+    if (m_boundTransformFeedback->hasBoundIndexedTransformFeedbackBuffer(buffer.get())) {
         ASSERT(buffer != m_boundVertexArrayObject->getElementArrayBuffer());
         if (m_boundIndexedUniformBuffers.contains(buffer)
-            || m_boundVertexArrayObject->hasArrayBuffer(buffer)
+            || m_boundVertexArrayObject->hasArrayBuffer(buffer.get())
             || buffer == m_boundArrayBuffer
             || buffer == m_boundCopyReadBuffer
             || buffer == m_boundCopyWriteBuffer

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -272,8 +272,8 @@ private:
     void initializeDefaultObjects() final;
     bool validateBufferTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateBufferTargetCompatibility(ASCIILiteral, GCGLenum, WebGLBuffer*);
-    WebGLBuffer* validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;
-    WebGLBuffer* validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target) final;
+    RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;
+    RefPtr<WebGLBuffer> validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*) final;
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -975,7 +975,7 @@ protected:
 
     // Helper function to validate parameters for bufferData.
     // Return the current bound buffer to target, or 0 if parameters are invalid.
-    virtual WebGLBuffer* validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage);
+    virtual RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage);
 
     // Helper function for tex{Sub}Image2D to make sure image is ready.
     ExceptionOr<bool> validateHTMLImageElement(ASCIILiteral functionName, HTMLImageElement&);
@@ -1002,7 +1002,7 @@ protected:
 
     // Helper function to validate the target for bufferData.
     // Return the current bound buffer to target, or 0 if the target is invalid.
-    virtual WebGLBuffer* validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target);
+    virtual RefPtr<WebGLBuffer> validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target);
 
     virtual bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*);
 

--- a/Source/WebCore/html/canvas/WebGLUtilities.cpp
+++ b/Source/WebCore/html/canvas/WebGLUtilities.cpp
@@ -34,7 +34,8 @@ namespace WebCore {
 
 bool ScopedInspectorShaderProgramHighlight::shouldApply(WebGLRenderingContextBase& context)
 {
-    if (LIKELY(!context.m_currentProgram || !InspectorInstrumentation::isWebGLProgramHighlighted(context, *context.m_currentProgram)))
+    RefPtr currentProgram = context.m_currentProgram;
+    if (LIKELY(!currentProgram || !InspectorInstrumentation::isWebGLProgramHighlighted(context, *currentProgram)))
         return false;
     if (context.m_framebufferBinding)
         return false;

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -191,7 +191,7 @@ public:
     ~ScopedWebGLRestoreFramebuffer()
     {
         RefPtr gl = m_context->graphicsContextGL();
-        if (auto* gl2Ccontext = dynamicDowncast<WebGL2RenderingContext>(m_context.get())) {
+        if (RefPtr gl2Ccontext = dynamicDowncast<WebGL2RenderingContext>(m_context.get())) {
             gl->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, objectOrZero(gl2Ccontext->m_readFramebufferBinding));
             gl->bindFramebuffer(GraphicsContextGL::DRAW_FRAMEBUFFER, objectOrZero(gl2Ccontext->m_framebufferBinding));
         } else

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.h
@@ -44,8 +44,13 @@ public:
 private:
     WebGLVertexArrayObject(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
+    ArrayObjectType arrayObjectType() const final { return ArrayObjectType::Object; }
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGLVertexArrayObject)
+    static bool isType(const WebCore::WebGLVertexArrayObjectBase& objectBase) { return objectBase.arrayObjectType() == WebCore::WebGLVertexArrayObjectBase::ArrayObjectType::Object; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -88,6 +88,9 @@ public:
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return m_hasEverBeenBound; }
 
+    enum class ArrayObjectType : uint8_t { Object, ObjectOES };
+    virtual ArrayObjectType arrayObjectType() const = 0;
+
 protected:
     WebGLVertexArrayObjectBase(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override = 0;

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h
@@ -39,8 +39,13 @@ public:
 private:
     WebGLVertexArrayObjectOES(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
+    ArrayObjectType arrayObjectType() const final { return ArrayObjectType::ObjectOES; }
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGLVertexArrayObjectOES)
+    static bool isType(const WebCore::WebGLVertexArrayObjectBase& objectBase) { return objectBase.arrayObjectType() == WebCore::WebGLVertexArrayObjectBase::ArrayObjectType::ObjectOES; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif


### PR DESCRIPTION
#### b50bef42cf2f86954092779f1e2e20d879150de2
<pre>
[SaferCPP] Address issues in WebCore/html/canvas
<a href="https://rdar.apple.com/148673390">rdar://148673390</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291148">https://bugs.webkit.org/show_bug.cgi?id=291148</a>

Reviewed by Chris Dumez.

Address SaferCPP issues across multiple files in WebCore/html/canvas.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::protectedCanvasBase const):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateBufferDataParameters):
(WebCore::WebGL2RenderingContext::validateBufferDataTarget):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::addActiveContext):
(WebCore::WebGLRenderingContextBase::create):
(WebCore::WebGLRenderingContextBase::canvas):
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::validateBufferDataTarget):
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::bufferSubData):
(WebCore::WebGLRenderingContextBase::deleteRenderbuffer):
(WebCore::WebGLRenderingContextBase::deleteTexture):
(WebCore::WebGLRenderingContextBase::framebufferRenderbuffer):
(WebCore::WebGLRenderingContextBase::framebufferTexture2D):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
(WebCore::WebGLRenderingContextBase::printToConsole):
(WebCore::WebGLRenderingContextBase::validateBufferDataParameters):
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
(WebCore::WebGLRenderingContextBase::addDebugMessage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLUtilities.cpp:
(WebCore::ScopedInspectorShaderProgramHighlight::shouldApply):
* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedWebGLRestoreFramebuffer::~ScopedWebGLRestoreFramebuffer):
* Source/WebCore/html/canvas/WebGLVertexArrayObject.h:
(isType):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/293421@main">https://commits.webkit.org/293421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a3553ffa4f5d415e8c24a9c41dfae485869c6d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7234 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84208 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6028 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19646 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->