### PR TITLE
Drop WTF::URL's `operator NSURL *()`

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -234,7 +234,6 @@ public:
 
 #if USE(FOUNDATION)
     WTF_EXPORT_PRIVATE URL(NSURL *);
-    WTF_EXPORT_PRIVATE operator NSURL *() const;
     WTF_EXPORT_PRIVATE RetainPtr<NSURL> createNSURL() const;
     WTF_EXPORT_PRIVATE static NSURL *emptyNSURL();
 #endif

--- a/Source/WTF/wtf/cocoa/URLCocoa.mm
+++ b/Source/WTF/wtf/cocoa/URLCocoa.mm
@@ -43,13 +43,6 @@ URL::URL(NSURL *cocoaURL)
 {
 }
 
-URL::operator NSURL *() const
-{
-    // Creating a toll-free bridged CFURL because creation with NSURL methods would not preserve the original string.
-    // We'll need fidelity when round-tripping via CFURLGetBytes().
-    return createCFURL().bridgingAutorelease();
-}
-
 RetainPtr<NSURL> URL::createNSURL() const
 {
     return bridge_cast(createCFURL());

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1636,7 +1636,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     URL url = self.axBackingObject->url();
     if (url.isNull())
         return nil;
-    return (NSURL*)url;
+    return url.createNSURL().autorelease();
 }
 
 - (CGPoint)_accessibilityConvertPointToViewSpace:(CGPoint)point

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1283,7 +1283,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         URL url = backingObject->url();
         if (url.isNull())
             return nil;
-        return (NSURL*)url;
+        return url.createNSURL().autorelease();
     }
 
     if ([attributeName isEqualToString:NSAccessibilityIncrementButtonAttribute]) {

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -201,7 +201,7 @@ bool DataDetection::canPresentDataDetectorsUIForElement(Element& element)
     if (!isDataDetectorLink(element))
         return false;
     
-    if (PAL::softLink_DataDetectorsCore_DDShouldImmediatelyShowActionSheetForURL(downcast<HTMLAnchorElement>(element).href()))
+    if (PAL::softLink_DataDetectorsCore_DDShouldImmediatelyShowActionSheetForURL(downcast<HTMLAnchorElement>(element).href().createNSURL().get()))
         return true;
     
     auto& resultAttribute = element.attributeWithoutSynchronization(x_apple_data_detectors_resultAttr);

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -259,7 +259,7 @@ void Editor::replaceSelectionWithAttributedString(NSAttributedString *attributed
 
 String Editor::userVisibleString(const URL& url)
 {
-    return WTF::userVisibleString(url);
+    return WTF::userVisibleString(url.createNSURL().get());
 }
 
 RefPtr<SharedBuffer> Editor::dataInRTFDFormat(NSAttributedString *string)

--- a/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
+++ b/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
@@ -66,7 +66,7 @@ using namespace WebCore;
 
 - (NSURL *)URL
 {
-    return resource->url();
+    return resource->url().createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -122,16 +122,16 @@ static NSDictionary *attributesForAttributedStringConversion(bool useInterchange
         [excludedElements addObject:@"object"];
 #endif
 
-    NSURL *baseURL = URL::fakeURLWithRelativePart(emptyString());
+    RetainPtr baseURL = URL::fakeURLWithRelativePart(emptyString()).createNSURL();
 
     // The output base URL needs +1 refcount to work around the fact that NSHTMLReader over-releases it.
-    CFRetain((__bridge CFTypeRef)baseURL);
+    CFRetain((__bridge CFTypeRef)baseURL.get());
 
     return @{
         NSExcludedElementsDocumentAttribute: excludedElements.get(),
         @"InterchangeNewline": @(useInterchangeNewlines),
         @"CoalesceTabSpans": @YES,
-        @"OutputBaseURL": baseURL,
+        @"OutputBaseURL": baseURL.get(),
         @"WebResourceHandler": adoptNS([WebArchiveResourceWebResourceHandler new]).get(),
     };
 }

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -254,7 +254,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
 
     pasteboardImage.url.url = url;
     pasteboardImage.url.title = title;
-    pasteboardImage.url.userVisibleForm = WTF::userVisibleString(pasteboardImage.url.url);
+    pasteboardImage.url.userVisibleForm = WTF::userVisibleString(pasteboardImage.url.url.createNSURL().get());
     if (auto* buffer = cachedImage->resourceBuffer())
         pasteboardImage.resourceData = buffer->makeContiguous();
     pasteboardImage.resourceMIMEType = cachedImage->response().mimeType();

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -190,15 +190,15 @@ struct LinkImageLayout {
 LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
 {
     NSString *title = nsStringNilIfEmpty(titleString);
-    NSURL *cocoaURL = url;
-    NSString *absoluteURLString = [cocoaURL absoluteString];
+    RetainPtr nsURL = url.createNSURL();
+    NSString *absoluteURLString = [nsURL absoluteString];
 
     NSString *domain = absoluteURLString;
 #if HAVE(URL_FORMATTING)
-    domain = [cocoaURL _lp_simplifiedDisplayString];
+    domain = [nsURL _lp_simplifiedDisplayString];
 #else
     if (LinkPresentationLibrary())
-        domain = [cocoaURL _lp_simplifiedDisplayString];
+        domain = [nsURL _lp_simplifiedDisplayString];
 #endif
 
     if ([title isEqualToString:absoluteURLString])

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -534,11 +534,11 @@ void PlatformPasteboard::write(const PasteboardImage& pasteboardImage)
     // associated image URL. However, in the case of an image enclosed by an anchor, we might want to consider the
     // the URL (i.e. the anchor's href attribute) to be a higher fidelity representation.
     auto& pasteboardURL = pasteboardImage.url;
-    if (NSURL *nsURL = pasteboardURL.url) {
+    if (RetainPtr nsURL = pasteboardURL.url.createNSURL()) {
 #if HAVE(NSURL_TITLE)
-        [nsURL _web_setTitle:pasteboardURL.title.isEmpty() ? WTF::userVisibleString(pasteboardURL.url) : (NSString *)pasteboardURL.title];
+        [nsURL _web_setTitle:pasteboardURL.title.isEmpty() ? WTF::userVisibleString(pasteboardURL.url.createNSURL().get()) : (NSString *)pasteboardURL.title];
 #endif
-        [representationsToRegister addRepresentingObject:nsURL];
+        [representationsToRegister addRepresentingObject:nsURL.get()];
     }
 
     registerItemToPasteboard(representationsToRegister.get(), m_pasteboard.get());
@@ -568,12 +568,12 @@ void PlatformPasteboard::write(const PasteboardURL& url)
     auto representationsToRegister = adoptNS([[WebItemProviderRegistrationInfoList alloc] init]);
     [representationsToRegister setPreferredPresentationStyle:WebPreferredPresentationStyleInline];
 
-    if (NSURL *nsURL = url.url) {
+    if (RetainPtr nsURL = url.url.createNSURL()) {
 #if HAVE(NSURL_TITLE)
         if (!url.title.isEmpty())
             [nsURL _web_setTitle:url.title];
 #endif
-        [representationsToRegister addRepresentingObject:nsURL];
+        [representationsToRegister addRepresentingObject:nsURL.get()];
         [representationsToRegister addRepresentingObject:(NSString *)url.url.string()];
     }
 

--- a/Source/WebCore/platform/ios/QuickLook.mm
+++ b/Source/WebCore/platform/ios/QuickLook.mm
@@ -86,7 +86,7 @@ RetainPtr<NSURLRequest> registerQLPreviewConverterIfNeeded(NSURL *url, NSString 
 
         // We use [request URL] here instead of url since it will be
         // the URL that the WebDataSource will see during -dealloc.
-        addQLPreviewConverterWithFileForURL(previewRequest.url(), converter.get(), nil);
+        addQLPreviewConverterWithFileForURL(previewRequest.url().createNSURL().get(), converter.get(), nil);
 
         return previewRequest.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
     }

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -209,11 +209,11 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     
     ASSERT(!pasteboardURL.url.isEmpty());
     
-    NSURL *cocoaURL = pasteboardURL.url;
+    RetainPtr nsURL = pasteboardURL.url.createNSURL();
     NSString *userVisibleString = pasteboardURL.userVisibleForm;
     NSString *title = (NSString *)pasteboardURL.title;
     if (![title length]) {
-        title = [[cocoaURL path] lastPathComponent];
+        title = [[nsURL path] lastPathComponent];
         if (![title length])
             title = userVisibleString;
     }
@@ -223,7 +223,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
         newChangeCount = platformStrategies()->pasteboardStrategy()->setURL(url, pasteboardName, context);
     }
     if (types.contains(String(legacyURLPasteboardType())))
-        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType([cocoaURL absoluteString], legacyURLPasteboardType(), pasteboardName, context);
+        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType([nsURL absoluteString], legacyURLPasteboardType(), pasteboardName, context);
     if (types.contains(WebURLPboardType))
         newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString, WebURLPboardType, pasteboardName, context);
     if (types.contains(WebURLNamePboardType))
@@ -255,7 +255,7 @@ void Pasteboard::write(const Color& color)
 static NSFileWrapper* fileWrapper(const PasteboardImage& pasteboardImage)
 {
     auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:pasteboardImage.resourceData->makeContiguous()->createNSData().get()]);
-    [wrapper setPreferredFilename:suggestedFilenameWithMIMEType(pasteboardImage.url.url, pasteboardImage.resourceMIMEType)];
+    [wrapper setPreferredFilename:suggestedFilenameWithMIMEType(pasteboardImage.url.url.createNSURL().get(), pasteboardImage.resourceMIMEType)];
     return wrapper.autorelease();
 }
 

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -71,31 +71,31 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     if (auto& urlData = data.urlData()) {
-        NSURL *cocoaURL = urlData->url;
+        RetainPtr nsURL = urlData->url.createNSURL();
         NSString *userVisibleString = urlData->userVisibleForm;
         NSString *title = (NSString *)urlData->title;
         if (!title.length) {
-            title = cocoaURL.path.lastPathComponent;
+            title = nsURL.get().path.lastPathComponent;
             if (!title.length)
                 title = userVisibleString;
         }
 
         // WebURLsWithTitlesPboardType.
         // FIXME: This could use StringView (the one that creates NSString) to save an allocation
-        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ cocoaURL.absoluteString ] ], @[ urlData->title.trim(deprecatedIsSpaceOrNewline) ], nil]);
+        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ nsURL.get().absoluteString ] ], @[ urlData->title.trim(deprecatedIsSpaceOrNewline) ], nil]);
         [pasteboardItem setPropertyList:paths.get() forType:toUTI(@"WebURLsWithTitlesPboardType").get()];
 
         // NSURLPboardType.
-        if (NSURL *baseCocoaURL = cocoaURL.baseURL)
-            [pasteboardItem setPropertyList:@[ cocoaURL.relativeString, baseCocoaURL.absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
-        else if (cocoaURL)
-            [pasteboardItem setPropertyList:@[ cocoaURL.absoluteString, @"" ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
+        if (NSURL *baseCocoaURL = nsURL.get().baseURL)
+            [pasteboardItem setPropertyList:@[ nsURL.get().relativeString, baseCocoaURL.absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
+        else if (nsURL)
+            [pasteboardItem setPropertyList:@[ nsURL.get().absoluteString, @"" ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
         else
             [pasteboardItem setPropertyList:@[ @"", @"" ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        if (cocoaURL.fileURL)
-            [pasteboardItem setString:cocoaURL.absoluteString forType:(NSString *)kUTTypeFileURL];
+        if (nsURL.get().fileURL)
+            [pasteboardItem setString:nsURL.get().absoluteString forType:(NSString *)kUTTypeFileURL];
         [pasteboardItem setString:userVisibleString forType:(NSString *)kUTTypeURL];
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -376,7 +376,7 @@ RetainPtr<NSArray> NetworkStorageSession::cookiesForURL(const URL& firstParty, c
     auto thirdPartyCookieBlockingDecision = thirdPartyCookieBlockingDecisionForRequest(firstParty, url, frameID, pageID, shouldRelaxThirdPartyCookieBlocking);
     if (applyTrackingPrevention == ApplyTrackingPrevention::Yes && thirdPartyCookieBlockingDecision == ThirdPartyCookieBlockingDecision::All)
         return nil;
-    return httpCookiesForURL(cookieStorage().get(), firstParty, sameSiteInfo, url, thirdPartyCookieBlockingDecision);
+    return httpCookiesForURL(cookieStorage().get(), firstParty.createNSURL().get(), sameSiteInfo, url.createNSURL().get(), thirdPartyCookieBlockingDecision);
 }
 
 std::pair<String, bool> NetworkStorageSession::cookiesForSession(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, IncludeHTTPOnlyOrNot includeHTTPOnly, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
@@ -526,7 +526,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     if (!cookie)
         return;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty, sameSiteInfo);
+    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty.createNSURL().get(), sameSiteInfo);
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -545,7 +545,7 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
     if (!nshttpCookie)
         return false;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty, sameSiteInfo);
+    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], url.createNSURL().get(), firstParty.createNSURL().get(), sameSiteInfo);
     return true;
 
     END_BLOCK_OBJC_EXCEPTIONS
@@ -595,7 +595,7 @@ void NetworkStorageSession::deleteCookie(const URL& firstParty, const URL& url, 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     RetainPtr<CFHTTPCookieStorageRef> cookieStorage = this->cookieStorage();
-    RetainPtr<NSArray> cookies = httpCookiesForURL(cookieStorage.get(), firstParty, std::nullopt, url, ThirdPartyCookieBlockingDecision::None);
+    RetainPtr<NSArray> cookies = httpCookiesForURL(cookieStorage.get(), firstParty.createNSURL().get(), std::nullopt, url.createNSURL().get(), ThirdPartyCookieBlockingDecision::None);
 
     RetainPtr cookieNameString = cookieName.createNSString();
 

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -274,9 +274,9 @@ void ResourceRequest::doUpdatePlatformRequest()
     auto nsRequest = adoptNS<NSMutableURLRequest *>([m_nsRequest mutableCopy]);
 
     if (nsRequest)
-        [nsRequest setURL:url()];
+        [nsRequest setURL:url().createNSURL().get()];
     else
-        nsRequest = adoptNS([[NSMutableURLRequest alloc] initWithURL:url()]);
+        nsRequest = adoptNS([[NSMutableURLRequest alloc] initWithURL:url().createNSURL().get()]);
 
     configureRequestWithData(nsRequest.get(), m_requestData);
 
@@ -299,7 +299,7 @@ void ResourceRequest::doUpdatePlatformRequest()
         [nsRequest setTimeoutInterval:timeoutInterval];
     // Otherwise, respect NSURLRequest default timeout.
 
-    [nsRequest setMainDocumentURL:firstPartyForCookies()];
+    [nsRequest setMainDocumentURL:firstPartyForCookies().createNSURL().get()];
     if (!httpMethod().isEmpty())
         [nsRequest setHTTPMethod:httpMethod()];
     [nsRequest setHTTPShouldHandleCookies:allowCookies()];
@@ -352,9 +352,9 @@ void ResourceRequest::doUpdatePlatformHTTPBody()
     auto nsRequest = adoptNS<NSMutableURLRequest *>([m_nsRequest mutableCopy]);
 
     if (nsRequest)
-        [nsRequest setURL:url()];
+        [nsRequest setURL:url().createNSURL().get()];
     else
-        nsRequest = adoptNS([[NSMutableURLRequest alloc] initWithURL:url()]);
+        nsRequest = adoptNS([[NSMutableURLRequest alloc] initWithURL:url().createNSURL().get()]);
 
     configureRequestWithData(nsRequest.get(), m_requestData);
 

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -59,7 +59,7 @@ void ResourceResponse::initNSURLResponse() const
             expectedContentLength = static_cast<NSInteger>(m_expectedContentLength);
 
         RetainPtr encodingNSString = nsStringNilIfEmpty(m_textEncodingName);
-        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
+        m_nsResponse = adoptNS([[NSURLResponse alloc] initWithURL:m_url.createNSURL().get() MIMEType:m_mimeType expectedContentLength:expectedContentLength textEncodingName:encodingNSString.get()]);
         return;
     }
 
@@ -68,7 +68,7 @@ void ResourceResponse::initNSURLResponse() const
     for (auto& header : m_httpHeaderFields)
         [headerDictionary setObject:(NSString *)header.value forKey:(NSString *)header.key];
 
-    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary.get()]);
+    m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url.createNSURL().get() statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary.get()]);
 
     // Mime type sniffing doesn't work with a synthesized response.
     [m_nsResponse _setMIMEType:(NSString *)m_mimeType];

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -100,7 +100,7 @@ namespace WebCore {
 
 String Internals::userVisibleString(const DOMURL& url)
 {
-    return WTF::userVisibleString(url.href());
+    return WTF::userVisibleString(url.href().createNSURL().get());
 }
 
 bool Internals::userPrefersContrast() const

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -114,7 +114,7 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
     if (allowedLocalTestServerTrust() && url.host() != "127.0.0.1"_s)
         return callback({ }, { });
 
-    auto request = adoptNS([[NSMutableURLRequest alloc] initWithURL:url]);
+    auto request = adoptNS([[NSMutableURLRequest alloc] initWithURL:url.createNSURL().get()]);
     [request setValue:WebCore::HTTPHeaderValues::maxAge0() forHTTPHeaderField:@"Cache-Control"];
     [request setValue:WebCore::standardUserAgentWithApplicationName({ }) forHTTPHeaderField:@"User-Agent"];
     if (jsonPayload) {

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -38,9 +38,9 @@ namespace WebKit {
 
 static RetainPtr<BEMediaEnvironment> createMediaEnvironment(const URL& webPageURL)
 {
-    NSURL *protocolHostAndPortURL = URL { webPageURL.protocolHostAndPort() };
+    RetainPtr protocolHostAndPortURL = URL { webPageURL.protocolHostAndPort() }.createNSURL();
     RELEASE_ASSERT(protocolHostAndPortURL);
-    return adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:protocolHostAndPortURL]);
+    return adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:protocolHostAndPortURL.get()]);
 }
 
 Ref<MediaCapability> MediaCapability::create(URL&& url)

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -73,7 +73,7 @@ RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const AppleP
         [disbursementRequest setRequiredRecipientContactFields:createNSArray(WTFMove(*requiredRecipientContactFields), platformContactField).get()];
 
     auto disbursementPaymentRequest = adoptNS([PAL::allocPKDisbursementPaymentRequestInstance() initWithDisbursementRequest:disbursementRequest.get()]);
-    [disbursementPaymentRequest setOriginatingURL:originatingURL];
+    [disbursementPaymentRequest setOriginatingURL:originatingURL.createNSURL().get()];
     [disbursementPaymentRequest setAPIType:PKPaymentRequestAPITypeWebPaymentRequest];
     return disbursementPaymentRequest;
 }

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
@@ -51,7 +51,7 @@ static RetainPtr<PKPaymentSetupConfiguration> toPlatformConfiguration(const WebC
 
     auto configuration = adoptNS([PAL::allocPKPaymentSetupConfigurationInstance() init]);
     [configuration setMerchantIdentifier:coreConfiguration.merchantIdentifier];
-    [configuration setOriginatingURL:url];
+    [configuration setOriginatingURL:url.createNSURL().get()];
     [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier];
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     [configuration setSignature:coreConfiguration.signature];

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -300,7 +300,7 @@ RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(c
 {
     auto result = adoptNS([PAL::allocPKPaymentRequestInstance() init]);
 
-    [result setOriginatingURL:originatingURL];
+    [result setOriginatingURL:originatingURL.createNSURL().get()];
 
     [result setThumbnailURLs:createNSArray(linkIconURLs).get()];
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -72,7 +72,7 @@ bool CoreIPCError::hasValidUserInfo(const RetainPtr<CFDictionaryRef>& userInfo)
             RetainPtr failingURLString = dynamic_objc_cast<NSString>(nsErrorFailingURLString.get());
             if (!failingURLString)
                 return false;
-            if (![failingURL isEqual:URL(failingURLString.get())])
+            if (![failingURL isEqual:URL(failingURLString.get()).createNSURL().get()])
                 return false;
         }
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
@@ -45,7 +45,7 @@ public:
     {
     }
 
-    RetainPtr<id> toID() const { return (NSURL *)m_url; }
+    RetainPtr<id> toID() const { return m_url.createNSURL(); }
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCURL, void>;

--- a/Source/WebKit/Shared/Cocoa/WKNSURLExtras.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSURLExtras.mm
@@ -33,7 +33,7 @@
 + (instancetype)_web_URLWithWTFString:(const String&)string
 {
     URL url { URL { }, string };
-    return (NSURL *)url;
+    return url.createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm
@@ -37,7 +37,7 @@
 
 - (NSURL *)URL
 {
-    return downcast<API::URLRequest>(&self._apiObject)->resourceRequest().url();
+    return downcast<API::URLRequest>(&self._apiObject)->resourceRequest().url().createNSURL().autorelease();
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
@@ -47,17 +47,17 @@ static RetainPtr<NSError> createNSError(NSString* domain, int code, NSURL *URL)
 
 ResourceError cancelledError(const ResourceRequest& request)
 {
-    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorCancelled, request.url()).get());
+    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorCancelled, request.url().createNSURL().get()).get());
 }
 
 ResourceError fileDoesNotExistError(const ResourceResponse& response)
 {
-    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorFileDoesNotExist, response.url()).get());
+    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorFileDoesNotExist, response.url().createNSURL().get()).get());
 }
 
 ResourceError decodeError(const URL& url)
 {
-    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorCannotDecodeContentData, url).get());
+    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorCannotDecodeContentData, url.createNSURL().get()).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
@@ -44,7 +44,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSURL *)linkURL
 {
-    return _elementInfo->url();
+    return _elementInfo->url().createNSURL().autorelease();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -179,7 +179,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (NSURL *)_originalURL
 {
-    return Ref { *_navigationAction }->originalURL();
+    return Ref { *_navigationAction }->originalURL().createNSURL().autorelease();
 }
 
 - (BOOL)_isUserInitiated

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -115,7 +115,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (NSURL *)baseURL
 {
-    return Ref { *_webExtensionContext }->baseURL();
+    return Ref { *_webExtensionContext }->baseURL().createNSURL().autorelease();
 }
 
 - (void)setBaseURL:(NSURL *)baseURL
@@ -180,12 +180,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (NSURL *)optionsPageURL
 {
-    return Ref { *_webExtensionContext }->optionsPageURL();
+    return Ref { *_webExtensionContext }->optionsPageURL().createNSURL().autorelease();
 }
 
 - (NSURL *)overrideNewTabPageURL
 {
-    return Ref { *_webExtensionContext }->overrideNewTabPageURL();
+    return Ref { *_webExtensionContext }->overrideNewTabPageURL().createNSURL().autorelease();
 }
 
 static inline WallTime toImpl(NSDate *date)
@@ -841,7 +841,7 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 
 - (NSURL *)_backgroundContentURL
 {
-    return self._protectedWebExtensionContext->backgroundContentURL();
+    return self._protectedWebExtensionContext->backgroundContentURL().createNSURL().autorelease();
 }
 
 - (void)_sendTestMessage:(NSString *)message withArgument:(id)argument

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -299,8 +299,8 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
     [userInfo setObject:@(details->columnNumber) forKey:_WKJavaScriptExceptionColumnNumberErrorKey];
 
     if (!details->sourceURL.isEmpty()) {
-        if (NSURL *url = URL(details->sourceURL))
-            [userInfo setObject:url forKey:_WKJavaScriptExceptionSourceURLErrorKey];
+        if (RetainPtr url = URL(details->sourceURL).createNSURL())
+            [userInfo setObject:url.get() forKey:_WKJavaScriptExceptionSourceURLErrorKey];
     }
 
     return adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:errorCode userInfo:userInfo.get()]);
@@ -1074,7 +1074,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 
 - (NSURL *)_resourceDirectoryURL
 {
-    return _page->currentResourceDirectoryURL();
+    return _page->currentResourceDirectoryURL().createNSURL().autorelease();
 }
 
 - (BOOL)isLoading
@@ -4011,7 +4011,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (NSURL *)_mainFrameURL
 {
     if (RefPtr frame = _page->mainFrame())
-        return frame->url();
+        return frame->url().createNSURL().autorelease();
     return nil;
 }
 
@@ -4554,7 +4554,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
                 return completionHandler(NO, nil);
             }
         }, [&] (URL url) {
-            completionHandler(NO, url);
+            completionHandler(NO, url.createNSURL().get());
         });
     };
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -378,7 +378,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSURL *)_requiredWebExtensionBaseURL
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return self._protectedPageConfiguration->requiredWebExtensionBaseURL();
+    return self._protectedPageConfiguration->requiredWebExtensionBaseURL().createNSURL().autorelease();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -154,7 +154,7 @@ private:
         URL mainFrameURL { topOrigin.toString() };
         URL frameURL { frameOrigin.toString() };
 
-        [m_delegate.getAutoreleased() requestStorageSpace:mainFrameURL frameOrigin:frameURL quota:quota currentSize:currentSize spaceRequired:spaceRequired decisionHandler:decisionHandler.get()];
+        [m_delegate.getAutoreleased() requestStorageSpace:mainFrameURL.createNSURL().get() frameOrigin:frameURL.createNSURL().get() quota:quota currentSize:currentSize spaceRequired:spaceRequired decisionHandler:decisionHandler.get()];
     }
 
     void didReceiveAuthenticationChallenge(Ref<WebKit::AuthenticationChallengeProxy>&& challenge) final
@@ -300,7 +300,7 @@ private:
         URL mainFrameURL { topOrigin.toString() };
         URL frameURL { frameOrigin.toString() };
 
-        [m_delegate.getAutoreleased() requestBackgroundFetchPermission:mainFrameURL frameOrigin:frameURL decisionHandler:decisionHandler.get()];
+        [m_delegate.getAutoreleased() requestBackgroundFetchPermission:mainFrameURL.createNSURL().get() frameOrigin:frameURL.createNSURL().get() decisionHandler:decisionHandler.get()];
     }
 
     void notifyBackgroundFetchChange(const String& backgroundFetchIdentifier, WebKit::BackgroundFetchChange backgroundFetchChange) final
@@ -348,7 +348,7 @@ private:
         if (!m_hasDidAllowPrivateTokenUsageByThirdPartyForTestingSelector)
             return;
 
-        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() didAllowPrivateTokenUsageByThirdPartyForTesting:wasAllowed forResourceURL:resourceURL];
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() didAllowPrivateTokenUsageByThirdPartyForTesting:wasAllowed forResourceURL:resourceURL.createNSURL().get()];
     }
 
     void didExceedMemoryFootprintThreshold(size_t footprint, const String& domain, unsigned pageCount, Seconds processLifetime, bool inForeground, WebCore::WasPrivateRelayed wasPrivateRelayed, CanSuspend canSuspend)
@@ -738,7 +738,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     auto urls = _websiteDataStore->persistedSiteURLs();
     RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity:urls.size()]);
     for (auto& url : urls)
-        [result addObject:url];
+        [result addObject:url.createNSURL().get()];
 
     return result.autorelease();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
@@ -70,8 +70,8 @@
     if (!(self = [super init]))
         return nil;
     
-    _URL = information.url;
-    _imageURL = information.imageURL;
+    _URL = information.url.createNSURL();
+    _imageURL = information.imageURL.createNSURL();
     _imageMIMEType = information.imageMIMEType;
     _interactionLocation = information.request.point;
     _title = information.title;
@@ -106,12 +106,12 @@
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url information:(const WebKit::InteractionInformationAtPosition&)information
 {
-    return [self _initWithType:type URL:url imageURL:information.imageURL information:information];
+    return [self _initWithType:type URL:url imageURL:information.imageURL.createNSURL().get() information:information];
 }
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type image:(WebCore::ShareableBitmap*)image information:(const WebKit::InteractionInformationAtPosition&)information
 {
-    return [self _initWithType:type URL:information.url imageURL:information.imageURL image:image userInfo:nil information:information];
+    return [self _initWithType:type URL:information.url.createNSURL().get() imageURL:information.imageURL.createNSURL().get() image:image userInfo:nil information:information];
 }
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL information:(const WebKit::InteractionInformationAtPosition&)information
@@ -121,7 +121,7 @@
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url image:(WebCore::ShareableBitmap*)image information:(const WebKit::InteractionInformationAtPosition&)information
 {
-    return [self _initWithType:type URL:url imageURL:information.imageURL image:image userInfo:nil information:information];
+    return [self _initWithType:type URL:url imageURL:information.imageURL.createNSURL().get() image:image userInfo:nil information:information];
 }
 
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL userInfo:(NSDictionary *)userInfo information:(const WebKit::InteractionInformationAtPosition&)information

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -119,7 +119,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
         return nil;
 
     if (icon) {
-        _src = adoptNS([icon->src copy]);
+        _src = icon->src.createNSURL();
         _sizes = createNSArray(icon->sizes, [] (auto& size) -> NSString * {
             return size;
         });
@@ -213,7 +213,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
     if (shortcut) {
         _name = adoptNS([shortcut->name copy]);
-        _url = adoptNS([shortcut->url copy]);
+        _url = shortcut->url.createNSURL();
         _icons = createNSArray(shortcut->icons, [] (auto& icon) {
             return adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon]);
         });
@@ -402,7 +402,7 @@ static NSString *nullableNSString(const WTF::String& string)
 
 - (NSURL *)scope
 {
-    return _applicationManifest->applicationManifest().scope;
+    return _applicationManifest->applicationManifest().scope.createNSURL().autorelease();
 }
 
 - (BOOL)isDefaultScope
@@ -412,12 +412,12 @@ static NSString *nullableNSString(const WTF::String& string)
 
 - (NSURL *)manifestURL
 {
-    return _applicationManifest->applicationManifest().manifestURL;
+    return _applicationManifest->applicationManifest().manifestURL.createNSURL().autorelease();
 }
 
 - (NSURL *)startURL
 {
-    return _applicationManifest->applicationManifest().startURL;
+    return _applicationManifest->applicationManifest().startURL.createNSURL().autorelease();
 }
 
 - (WebCore::CocoaColor *)backgroundColor
@@ -497,7 +497,7 @@ static NSString *nullableNSString(const WTF::String& string)
 
 - (NSURL *)manifestId
 {
-    return _applicationManifest->applicationManifest().id;
+    return _applicationManifest->applicationManifest().id.createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -95,8 +95,8 @@ IGNORE_WARNINGS_END
 
 -(NSArray<NSURL *> *)redirectChain
 {
-    return createNSArray(_download->_download->redirectChain(), [] (auto& url) -> NSURL * {
-        return url;
+    return createNSArray(_download->_download->redirectChain(), [] (auto& url) {
+        return url.createNSURL();
     }).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -192,7 +192,7 @@ static NSString *dataKey = @"data";
 
 - (NSURL *)securityOrigin
 {
-    return (NSURL *)(URL { _coreData.originString });
+    return URL { _coreData.originString }.createNSURL().autorelease();
 }
 
 - (void)setServiceWorkerRegistrationURL:(NSURL *)serviceWorkerRegistrationURL
@@ -202,7 +202,7 @@ static NSString *dataKey = @"data";
 
 - (NSURL *)serviceWorkerRegistrationURL
 {
-    return (NSURL *)_coreData.serviceWorkerRegistrationURL;
+    return _coreData.serviceWorkerRegistrationURL.createNSURL().autorelease();
 }
 
 - (NSString *)identifier

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -112,7 +112,7 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
 
 - (NSURL *)originalURL
 {
-    return _info->originalURL();
+    return _info->originalURL().createNSURL().autorelease();
 }
 
 - (NSString *)originalHTTPMethod

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.mm
@@ -36,10 +36,10 @@
     if (!(self = [super init]))
         return nil;
 
-    _sourceURL = [spatialBackdropSource.m_sourceURL copy];
-    _modelURL = [spatialBackdropSource.m_modelURL copy];
+    _sourceURL = [spatialBackdropSource.m_sourceURL.createNSURL() copy];
+    _modelURL = [spatialBackdropSource.m_modelURL.createNSURL() copy];
     if (spatialBackdropSource.m_environmentMapURL)
-        _environmentMapURL = [spatialBackdropSource.m_environmentMapURL.value() copy];
+        _environmentMapURL = [spatialBackdropSource.m_environmentMapURL.value().createNSURL() copy];
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -78,7 +78,7 @@
 
 - (NSURL *)baseURL
 {
-    return _userStyleSheet->userStyleSheet().url();
+    return _userStyleSheet->userStyleSheet().url().createNSURL().autorelease();
 }
 
 - (BOOL)isForMainFrameOnly

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm
@@ -50,7 +50,7 @@
 
 - (NSURL *)scope
 {
-    return _message->scope();
+    return _message->scope().createNSURL().autorelease();
 }
 
 - (NSString *)partition

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm
@@ -41,7 +41,7 @@
 
 - (NSURL *)endpoint
 {
-    return self._protectedData->endpoint();
+    return self._protectedData->endpoint().createNSURL().autorelease();
 }
 
 - (NSData *)applicationServerKey

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -193,7 +193,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)httpProxy
 {
-    return _configuration->httpProxy();
+    return _configuration->httpProxy().createNSURL().autorelease();
 }
 
 - (void)setHTTPProxy:(NSURL *)proxy
@@ -203,7 +203,7 @@ static void checkURLArgument(NSURL *url)
 
 - (NSURL *)httpsProxy
 {
-    return _configuration->httpsProxy();
+    return _configuration->httpsProxy().createNSURL().autorelease();
 }
 
 - (void)setHTTPSProxy:(NSURL *)proxy
@@ -761,7 +761,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
 
 - (NSURL *)standaloneApplicationURL
 {
-    return _configuration->standaloneApplicationURL();
+    return _configuration->standaloneApplicationURL().createNSURL().autorelease();
 }
 
 - (void)setStandaloneApplicationURL:(NSURL *)url

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3982,7 +3982,7 @@ static bool isLockdownModeWarningNeeded()
         return nil;
 
     URL destinationURL { makeString("https://"_s, attribution->destinationDomain) };
-    return adoptNS([[UIEventAttribution alloc] initWithSourceIdentifier:attribution->sourceID destinationURL:destinationURL sourceDescription:attribution->sourceDescription purchaser:attribution->purchaser]).autorelease();
+    return adoptNS([[UIEventAttribution alloc] initWithSourceIdentifier:attribution->sourceID destinationURL:destinationURL.createNSURL().get() sourceDescription:attribution->sourceDescription purchaser:attribution->purchaser]).autorelease();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -73,7 +73,7 @@ GroupActivitiesSessionNotifier::GroupActivitiesSessionNotifier()
         auto result = m_sessions.add(session->fallbackURL(), session.copyRef());
         ASSERT_UNUSED(result, result.isNewEntry);
 
-        [[NSWorkspace sharedWorkspace] openURL:session->fallbackURL()];
+        [[NSWorkspace sharedWorkspace] openURL:session->fallbackURL().createNSURL().get()];
     };
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -181,7 +181,7 @@ void LegacyDownloadClient::legacyDidCancel(DownloadProxy& downloadProxy)
 void LegacyDownloadClient::willSendRequest(DownloadProxy& downloadProxy, WebCore::ResourceRequest&& request, const WebCore::ResourceResponse&, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
     if (m_delegateMethods.downloadDidReceiveServerRedirectToURL)
-        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didReceiveServerRedirectToURL:request.url()];
+        [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didReceiveServerRedirectToURL:request.url().createNSURL().get()];
 
     completionHandler(WTFMove(request));
 }

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -100,7 +100,7 @@ void ModelElementController::takeModelElementFullscreen(ModelIdentifier modelIde
     CGRect initialFrame = [modelView convertRect:modelView.frame toView:nil];
 
     ASVInlinePreview *preview = [modelView preview];
-    [preview setCanonicalWebPageURL:originatingPageURL];
+    [preview setCanonicalWebPageURL:originatingPageURL.createNSURL().get()];
     [preview setUrlFragment:originatingPageURL.fragmentIdentifier().createNSString().get()];
     NSDictionary *previewOptions = @{@"WebKit": @"Model element fullscreen"};
     [preview createFullscreenInstanceWithInitialFrame:initialFrame previewOptions:previewOptions completionHandler:^(UIViewController *remoteViewController, CAFenceHandle *fenceHandle, NSError *creationError) {

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -536,7 +536,7 @@ static void tryInterceptNavigation(Ref<API::NavigationAction>&& navigationAction
         RetainPtr<_LSOpenConfiguration> configuration = adoptNS([[_LSOpenConfiguration alloc] init]);
         configuration.get().referrerURL = referrerURL.get();
 
-        [LSAppLink openWithURL:url configuration:configuration.get() completionHandler:[localCompletionHandler](BOOL success, NSError *) {
+        [LSAppLink openWithURL:url.createNSURL().get() configuration:configuration.get() completionHandler:[localCompletionHandler](BOOL success, NSError *) {
             RunLoop::protectedMain()->dispatch([localCompletionHandler, success] {
                 (*localCompletionHandler)(success);
                 delete localCompletionHandler;
@@ -761,11 +761,11 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
     }
 
     if (notifications && m_navigationState->m_navigationDelegateMethods.webViewURLContentRuleListIdentifiersNotifications)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() URL:url contentRuleListIdentifiers:identifiers.get() notifications:notifications.get()];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() URL:url.createNSURL().get() contentRuleListIdentifiers:identifiers.get() notifications:notifications.get()];
 
     if (m_navigationState->m_navigationDelegateMethods.webViewContentRuleListWithIdentifierPerformedActionForURL) {
         for (auto&& pair : WTFMove(results.results))
-            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url];
+            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url.createNSURL().get()];
     }
 }
 #endif
@@ -882,7 +882,7 @@ void NavigationState::NavigationClient::willPerformClientRedirect(WebPageProxy& 
 
     URL url { urlString };
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() willPerformClientRedirectToURL:url delay:delay];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() willPerformClientRedirectToURL:url.createNSURL().get() delay:delay];
 }
 
 void NavigationState::NavigationClient::didPerformClientRedirect(WebPageProxy& page, const WTF::String& sourceURLString, const WTF::String& destinationURLString)
@@ -901,7 +901,7 @@ void NavigationState::NavigationClient::didPerformClientRedirect(WebPageProxy& p
     URL sourceURL { sourceURLString };
     URL destinationURL { destinationURLString };
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didPerformClientRedirectFromURL:sourceURL toURL:destinationURL];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didPerformClientRedirectFromURL:sourceURL.createNSURL().get() toURL:destinationURL.createNSURL().get()];
 }
 
 void NavigationState::NavigationClient::didCancelClientRedirect(WebPageProxy& page)
@@ -1058,7 +1058,7 @@ void NavigationState::NavigationClient::didBlockLoadToKnownTracker(WebPageProxy&
         return;
 
     if (navigationState->m_navigationDelegateMethods.webViewDidFailLoadDueToNetworkConnectionIntegrityWithURL)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didFailLoadDueToNetworkConnectionIntegrityWithURL:url];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didFailLoadDueToNetworkConnectionIntegrityWithURL:url.createNSURL().get()];
 }
 
 void NavigationState::NavigationClient::didApplyLinkDecorationFiltering(WebPageProxy& page, const URL& originalURL, const URL& adjustedURL)
@@ -1072,7 +1072,7 @@ void NavigationState::NavigationClient::didApplyLinkDecorationFiltering(WebPageP
         return;
 
     if (navigationState->m_navigationDelegateMethods.webViewDidChangeLookalikeCharactersFromURLToURL)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didChangeLookalikeCharactersFromURL:originalURL toURL:adjustedURL];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didChangeLookalikeCharactersFromURL:originalURL.createNSURL().get() toURL:adjustedURL.createNSURL().get()];
 }
 
 void NavigationState::NavigationClient::didPromptForStorageAccess(WebPageProxy&, const String& topFrameDomain, const String& subFrameDomain, bool hasQuirk)
@@ -1233,7 +1233,7 @@ void NavigationState::NavigationClient::didNegotiateModernTLS(const URL& url)
     if (!navigationDelegate)
         return;
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didNegotiateModernTLSForURL:url];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didNegotiateModernTLSForURL:url.createNSURL().get()];
 }
 
 static _WKProcessTerminationReason wkProcessTerminationReason(ProcessTerminationReason reason)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -164,7 +164,7 @@ void PopUpSOAuthorizationSession::completeInternal(const WebCore::ResourceRespon
     }
 
     m_newPageCallback(m_secretWebView->_page.get());
-    [m_secretWebView loadData:data MIMEType:@"text/html" characterEncodingName:@"UTF-8" baseURL:response.url()];
+    [m_secretWebView loadData:data MIMEType:@"text/html" characterEncodingName:@"UTF-8" baseURL:response.url().createNSURL().get()];
 }
 
 void PopUpSOAuthorizationSession::close(WKWebView *webView)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -72,14 +72,14 @@ void SOAuthorizationCoordinator::canAuthorize(const URL& url, CompletionHandler<
         return;
     }
     if ([PAL::getSOAuthorizationClass() respondsToSelector:@selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:)]) {
-        [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:0 callerBundleIdentifier:nil useInternalExtensions:YES completion:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (BOOL result) mutable {
+        [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0 callerBundleIdentifier:nil useInternalExtensions:YES completion:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (BOOL result) mutable {
             ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), result] () mutable {
                 completionHandler(result);
             });
         }).get()];
         return;
     }
-    completionHandler([PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:0]);
+    completionHandler([PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0]);
 }
 
 void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Function<void(bool)>&& completionHandler)
@@ -95,7 +95,7 @@ void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navig
         // SubFrameSOAuthorizationSession should only be allowed for Apple first parties.
         RefPtr targetFrame = navigationAction->targetFrame();
         bool subframeNavigation = targetFrame && !targetFrame->isMainFrame();
-        if (subframeNavigation && (!page->mainFrame() || ![AKAuthorizationController isURLFromAppleOwnedDomain:page->mainFrame()->url()])) {
+        if (subframeNavigation && (!page->mainFrame() || ![AKAuthorizationController isURLFromAppleOwnedDomain:page->mainFrame()->url().createNSURL().get()])) {
             AUTHORIZATIONCOORDINATOR_RELEASE_LOG_ERROR_STATIC("tryAuthorize: Attempting to perform subframe navigation for non-Apple authorization URL.");
             completionHandler(false);
             return;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -181,7 +181,7 @@ void SOAuthorizationSession::start()
     ASSERT((m_state == State::Idle || m_state == State::Waiting) && m_navigationAction);
     m_state = State::Active;
     AUTHORIZATIONSESSION_RELEASE_LOG("start: Moving m_state to Active.");
-    [m_soAuthorization getAuthorizationHintsWithURL:m_navigationAction->request().url() responseCode:0 completion:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationHints *authorizationHints, NSError *error) {
+    [m_soAuthorization getAuthorizationHintsWithURL:m_navigationAction->request().url().createNSURL().get() responseCode:0 completion:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationHints *authorizationHints, NSError *error) {
         auto protectedThis = weakThis.get();
         if (!protectedThis) {
             RELEASE_LOG_ERROR(AppSSO, "SOAuthorizationSession::start (getAuthorizationHintsWithURL completion handler): Returning early because weakThis is now null.");
@@ -330,7 +330,7 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
     }
 
     // Set cookies.
-    auto cookies = toCookieVector([NSHTTPCookie cookiesWithResponseHeaderFields:httpResponse.allHeaderFields forURL:response.url()]);
+    auto cookies = toCookieVector([NSHTTPCookie cookiesWithResponseHeaderFields:httpResponse.allHeaderFields forURL:response.url().createNSURL().get()]);
 
     AUTHORIZATIONSESSION_RELEASE_LOG("complete: (httpStatusCode=%d, hasCookies=%d, hasData=%d)", response.httpStatusCode(), !cookies.isEmpty(), !!data.length);
 

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -133,15 +133,15 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     NSString *contentType = WebCore::UTIFromMIMEType("model/vnd.usdz+zip"_s);
 
 #if HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)
-    auto previewItem = adoptNS([WebKit::allocARQuickLookPreviewItemInstance() initWithFileAtURL:_downloadedURL]);
-    [previewItem setCanonicalWebPageURL:_originatingPageURL];
+    RetainPtr previewItem = adoptNS([WebKit::allocARQuickLookPreviewItemInstance() initWithFileAtURL:_downloadedURL.createNSURL().get()]);
+    [previewItem setCanonicalWebPageURL:_originatingPageURL.createNSURL().get()];
 
     _item = adoptNS([allocARQuickLookWebKitItemInstance() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType previewTitle:@"Preview" fileSize:@(0) previewItem:previewItem.get()]);
     [_item setDelegate:self];
 
     if ([_item respondsToSelector:(@selector(setAdditionalParameters:))]) {
-        NSURL *urlParameter = _originatingPageURL;
-        [_item setAdditionalParameters:@{ _WKARQLWebsiteURLParameterKey: urlParameter }];
+        RetainPtr urlParameter = _originatingPageURL.createNSURL();
+        [_item setAdditionalParameters:@{ _WKARQLWebsiteURLParameterKey: urlParameter.get() }];
     }
 
 #else
@@ -492,7 +492,7 @@ void SystemPreviewController::loadStarted(const URL& localFileURL)
 
 #if PLATFORM(VISION)
     if ([getASVLaunchPreviewClass() respondsToSelector:@selector(beginPreviewApplicationWithURLs:is3DContent:websiteURL:completion:)])
-        [getASVLaunchPreviewClass() beginPreviewApplicationWithURLs:localFileURLs() is3DContent:YES websiteURL:m_downloadURL completion:^(NSError *error) { }];
+        [getASVLaunchPreviewClass() beginPreviewApplicationWithURLs:localFileURLs() is3DContent:YES websiteURL:m_downloadURL.createNSURL().get() completion:^(NSError *error) { }];
 #endif
 
     m_state = State::Loading;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -120,12 +120,12 @@ std::unique_ptr<API::UIClient> UIDelegate::createUIClient()
     return makeUnique<UIClient>(*this);
 }
 
-RetainPtr<id <WKUIDelegate> > UIDelegate::delegate()
+RetainPtr<id<WKUIDelegate> > UIDelegate::delegate()
 {
     return m_delegate.get();
 }
 
-void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
+void UIDelegate::setDelegate(id<WKUIDelegate> delegate)
 {
     m_delegate = delegate;
 
@@ -330,7 +330,7 @@ void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const Web
 #else
     auto modifierFlags = WebKit::WebIOSEventFactory::toUIKeyModifierFlags(modifiers);
 #endif
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() mouseDidMoveOverElement:wrapper(apiHitTestResult.get()) withFlags:modifierFlags userInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() mouseDidMoveOverElement:wrapper(apiHitTestResult.get()) withFlags:modifierFlags userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 #endif
 
@@ -531,7 +531,7 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestStorageAccessPanelForDomain:underCurrentDomain:completionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestStorageAccessPanelForDomain:requestingDomain.string() underCurrentDomain:currentDomain.string() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -597,7 +597,7 @@ void UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance(WebPage
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didResignInputElementStrongPasswordAppearanceWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didResignInputElementStrongPasswordAppearanceWithUserInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 
 bool UIDelegate::UIClient::canRunBeforeUnloadConfirmPanel() const
@@ -656,7 +656,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
 
     if (uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:databaseName:displayName:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName displayName:displayName currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) databaseName:databaseName displayName:displayName currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -666,7 +666,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:wrapper(*securityOrigin) currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](unsigned long long newQuota) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -748,7 +748,7 @@ bool UIDelegate::UIClient::takeFocus(WebPageProxy*, WKFocusDirection direction)
     if (!delegate)
         return false;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() takeFocus:toWKFocusDirection(direction)];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() takeFocus:toWKFocusDirection(direction)];
     return true;
 }
 
@@ -794,7 +794,7 @@ void UIDelegate::UIClient::handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayE
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() handleAutoplayEvent:toWKAutoplayEvent(event) withFlags:toWKAutoplayEventFlags(flags)];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() handleAutoplayEvent:toWKAutoplayEvent(event) withFlags:toWKAutoplayEventFlags(flags)];
 }
 
 void UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest(WebKit::WebPageProxy&, API::SecurityOrigin& securityOrigin, CompletionHandler<void(bool allowed)>&& completionHandler)
@@ -811,7 +811,7 @@ void UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest(WebKit::
         return completionHandler(false);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:wrapper(securityOrigin) decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:wrapper(securityOrigin) decisionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -835,7 +835,7 @@ void UIDelegate::UIClient::requestCookieConsent(CompletionHandler<void(WebCore::
 
     // FIXME: Add support for the 'more info' handler.
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestCookieConsentWithMoreInfoHandler:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestCookieConsentWithMoreInfoHandler:nil decisionHandler:makeBlockPtr([completion = WTFMove(completion), checker = WTFMove(checker)] (BOOL decision) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() requestCookieConsentWithMoreInfoHandler:nil decisionHandler:makeBlockPtr([completion = WTFMove(completion), checker = WTFMove(checker)] (BOOL decision) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -930,7 +930,7 @@ void UIDelegate::UIClient::runModal(WebPageProxy&)
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewRunModal:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _webViewRunModal:uiDelegate->m_webView.get().get()];
 }
 
 float UIDelegate::UIClient::headerHeight(WebPageProxy&, WebFrameProxy& webFrameProxy)
@@ -946,7 +946,7 @@ float UIDelegate::UIClient::headerHeight(WebPageProxy&, WebFrameProxy& webFrameP
     if (!delegate)
         return 0;
     
-    return [(id <WKUIDelegatePrivate>)delegate _webViewHeaderHeight:uiDelegate->m_webView.get().get()];
+    return [(id<WKUIDelegatePrivate>)delegate _webViewHeaderHeight:uiDelegate->m_webView.get().get()];
 }
 
 float UIDelegate::UIClient::footerHeight(WebPageProxy&, WebFrameProxy&)
@@ -962,7 +962,7 @@ float UIDelegate::UIClient::footerHeight(WebPageProxy&, WebFrameProxy&)
     if (!delegate)
         return 0;
     
-    return [(id <WKUIDelegatePrivate>)delegate _webViewFooterHeight:uiDelegate->m_webView.get().get()];
+    return [(id<WKUIDelegatePrivate>)delegate _webViewFooterHeight:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::drawHeader(WebPageProxy&, WebFrameProxy& frame, WebCore::FloatRect&& rect)
@@ -978,7 +978,7 @@ void UIDelegate::UIClient::drawHeader(WebPageProxy&, WebFrameProxy& frame, WebCo
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawHeaderInRect:rect forPageWithTitle:frame.title() URL:frame.url().createNSURL().get()];
 }
 
 void UIDelegate::UIClient::drawFooter(WebPageProxy&, WebFrameProxy& frame, WebCore::FloatRect&& rect)
@@ -994,7 +994,7 @@ void UIDelegate::UIClient::drawFooter(WebPageProxy&, WebFrameProxy& frame, WebCo
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title() URL:frame.url()];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() drawFooterInRect:rect forPageWithTitle:frame.title() URL:frame.url().createNSURL().get()];
 }
 
 void UIDelegate::UIClient::pageDidScroll(WebPageProxy*)
@@ -1010,7 +1010,7 @@ void UIDelegate::UIClient::pageDidScroll(WebPageProxy*)
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidScroll:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _webViewDidScroll:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::focus(WebPageProxy*)
@@ -1026,7 +1026,7 @@ void UIDelegate::UIClient::focus(WebPageProxy*)
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _focusWebView:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _focusWebView:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::unfocus(WebPageProxy*)
@@ -1042,7 +1042,7 @@ void UIDelegate::UIClient::unfocus(WebPageProxy*)
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _unfocusWebView:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _unfocusWebView:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didNotHandleWheelEvent(WebPageProxy*, const NativeWebWheelEvent& event)
@@ -1058,7 +1058,7 @@ void UIDelegate::UIClient::didNotHandleWheelEvent(WebPageProxy*, const NativeWeb
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didNotHandleWheelEvent:event.nativeEvent()];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didNotHandleWheelEvent:event.nativeEvent()];
 }
 
 void UIDelegate::UIClient::setIsResizable(WebKit::WebPageProxy&, bool resizable)
@@ -1074,7 +1074,7 @@ void UIDelegate::UIClient::setIsResizable(WebKit::WebPageProxy&, bool resizable)
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setResizable:resizable];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setResizable:resizable];
 }
 
 void UIDelegate::UIClient::setWindowFrame(WebKit::WebPageProxy&, const WebCore::FloatRect& frame)
@@ -1090,7 +1090,7 @@ void UIDelegate::UIClient::setWindowFrame(WebKit::WebPageProxy&, const WebCore::
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setWindowFrame:frame];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() setWindowFrame:frame];
 }
 
 void UIDelegate::UIClient::windowFrame(WebKit::WebPageProxy&, Function<void(WebCore::FloatRect)>&& completionHandler)
@@ -1106,7 +1106,7 @@ void UIDelegate::UIClient::windowFrame(WebKit::WebPageProxy&, Function<void(WebC
     if (!delegate)
         return completionHandler({ });
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getWindowFrameWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getWindowFrameWithCompletionHandler:))](CGRect frame) {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getWindowFrameWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getWindowFrameWithCompletionHandler:))](CGRect frame) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1127,7 +1127,7 @@ void UIDelegate::UIClient::toolbarsAreVisible(WebPageProxy&, Function<void(bool)
     if (!delegate)
         return completionHandler(true);
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getToolbarsAreVisibleWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getToolbarsAreVisibleWithCompletionHandler:))](BOOL visible) {
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() getToolbarsAreVisibleWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getToolbarsAreVisibleWithCompletionHandler:))](BOOL visible) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1148,7 +1148,7 @@ void UIDelegate::UIClient::didClickAutoFillButton(WebPageProxy&, API::Object* us
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didClickAutoFillButtonWithUserInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didClickAutoFillButtonWithUserInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil];
 }
 
 void UIDelegate::UIClient::showPage(WebPageProxy*)
@@ -1164,7 +1164,7 @@ void UIDelegate::UIClient::showPage(WebPageProxy*)
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _showWebView:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _showWebView:uiDelegate->m_webView.get().get()];
 }
     
 void UIDelegate::UIClient::saveDataToFileInDownloadsFolder(WebPageProxy*, const WTF::String& suggestedFilename, const WTF::String& mimeType, const URL& originatingURL, API::Data& data)
@@ -1180,7 +1180,7 @@ void UIDelegate::UIClient::saveDataToFileInDownloadsFolder(WebPageProxy*, const 
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename mimeType:mimeType originatingURL:originatingURL];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:wrapper(data) suggestedFilename:suggestedFilename mimeType:mimeType originatingURL:originatingURL.createNSURL().get()];
 }
 
 Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1196,7 +1196,7 @@ Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInsp
     if (!delegate)
         return API::InspectorConfiguration::create();
 
-    return downcast<API::InspectorConfiguration>([[(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() configurationForLocalInspector:wrapper(inspector)] _apiObject]);
+    return downcast<API::InspectorConfiguration>([[(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() configurationForLocalInspector:wrapper(inspector)] _apiObject]);
 }
 
 void UIDelegate::UIClient::didAttachLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1212,7 +1212,7 @@ void UIDelegate::UIClient::didAttachLocalInspector(WebPageProxy&, WebInspectorUI
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didAttachLocalInspector:wrapper(inspector)];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() didAttachLocalInspector:wrapper(inspector)];
 }
 
 void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1228,7 +1228,7 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() willCloseLocalInspector:wrapper(inspector)];
+    [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() willCloseLocalInspector:wrapper(inspector)];
 }
 
 #endif
@@ -1278,7 +1278,7 @@ void UIDelegate::UIClient::didChangeFontAttributes(const WebCore::FontAttributes
     if (!needsFontAttributes())
         return;
 
-    auto privateUIDelegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto privateUIDelegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     [privateUIDelegate _webView:uiDelegate->m_webView.get().get() didChangeFontAttributes:fontAttributes.createDictionary().get()];
 }
 
@@ -1326,7 +1326,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
     if (!uiDelegate)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         ensureOnMainRunLoop([protectedRequest = Ref { request }]() {
             protectedRequest->doDefaultAction();
@@ -1423,7 +1423,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         const String& audioDeviceUID = protectedRequest->requiresAudioCapture() ? protectedRequest->audioDeviceUIDs().first() : String();
         protectedRequest->allow(audioDeviceUID, videoDeviceUID);
     });
-    [delegate _webView:uiDelegate->m_webView.get().get() requestUserMediaAuthorizationForDevices:devices url:requestFrameURL mainFrameURL:mainFrameURL decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() requestUserMediaAuthorizationForDevices:devices url:requestFrameURL.createNSURL().get() mainFrameURL:mainFrameURL.createNSURL().get() decisionHandler:decisionHandler.get()];
 #endif
 }
 
@@ -1479,7 +1479,7 @@ void UIDelegate::UIClient::mediaCaptureStateDidChange(WebCore::MediaProducerMedi
     if (!delegate || !uiDelegate->m_delegateMethods.webViewMediaCaptureStateDidChange)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webView:webView.get().get() mediaCaptureStateDidChange:toWKMediaCaptureStateDeprecated(state)];
+    [(id<WKUIDelegatePrivate>)delegate _webView:webView.get().get() mediaCaptureStateDidChange:toWKMediaCaptureStateDeprecated(state)];
 }
 
 void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProxy, const WebCore::FloatSize& pdfFirstPageSize, CompletionHandler<void()>&& completionHandler)
@@ -1495,7 +1495,7 @@ void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProx
     auto handle = API::FrameHandle::create(webFrameProxy.frameID());
     if (uiDelegate->m_delegateMethods.webViewPrintFramePDFFirstPageSizeCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:printFrame:pdfFirstPageSize:completionHandler:));
-        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle) pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTFMove(checker), completionHandler = WTFMove(completionHandler)] () mutable {
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle) pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTFMove(checker), completionHandler = WTFMove(completionHandler)] () mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -1505,7 +1505,7 @@ void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProx
     }
 
     if (uiDelegate->m_delegateMethods.webViewPrintFrame)
-        [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle)];
+        [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() printFrame:wrapper(handle)];
     completionHandler();
 }
 
@@ -1520,7 +1520,7 @@ void UIDelegate::UIClient::close(WebPageProxy*)
         if (!delegate)
             return;
 
-        [(id <WKUIDelegatePrivate>)delegate _webViewClose:uiDelegate->m_webView.get().get()];
+        [(id<WKUIDelegatePrivate>)delegate _webViewClose:uiDelegate->m_webView.get().get()];
         return;
     }
 
@@ -1547,7 +1547,7 @@ void UIDelegate::UIClient::fullscreenMayReturnToInline(WebPageProxy*)
     if (!delegate)
         return;
     
-    [(id <WKUIDelegatePrivate>)delegate _webViewFullscreenMayReturnToInline:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _webViewFullscreenMayReturnToInline:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didEnterFullscreen(WebPageProxy*)
@@ -1563,7 +1563,7 @@ void UIDelegate::UIClient::didEnterFullscreen(WebPageProxy*)
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidEnterFullscreen:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _webViewDidEnterFullscreen:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::didExitFullscreen(WebPageProxy*)
@@ -1579,7 +1579,7 @@ void UIDelegate::UIClient::didExitFullscreen(WebPageProxy*)
     if (!delegate)
         return;
 
-    [(id <WKUIDelegatePrivate>)delegate _webViewDidExitFullscreen:uiDelegate->m_webView.get().get()];
+    [(id<WKUIDelegatePrivate>)delegate _webViewDidExitFullscreen:uiDelegate->m_webView.get().get()];
 }
     
 #if PLATFORM(IOS_FAMILY)
@@ -1597,7 +1597,7 @@ bool UIDelegate::UIClient::shouldIncludeAppLinkActionsForElement(_WKActivatedEle
     if (!delegate)
         return true;
 
-    return [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() shouldIncludeAppLinkActionsForElement:elementInfo];
+    return [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() shouldIncludeAppLinkActionsForElement:elementInfo];
 }
 #endif
 
@@ -1614,7 +1614,7 @@ RetainPtr<NSArray> UIDelegate::UIClient::actionsForElement(_WKActivatedElementIn
     if (!delegate)
         return defaultActions;
 
-    return [(id <WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() actionsForElement:elementInfo defaultActions:defaultActions.get()];
+    return [(id<WKUIDelegatePrivate>)delegate _webView:uiDelegate->m_webView.get().get() actionsForElement:elementInfo defaultActions:defaultActions.get()];
 }
 
 void UIDelegate::UIClient::didNotHandleTapAsClick(const WebCore::IntPoint& point)
@@ -1630,7 +1630,7 @@ void UIDelegate::UIClient::didNotHandleTapAsClick(const WebCore::IntPoint& point
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() didNotHandleTapAsClickAtPoint:point];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() didNotHandleTapAsClickAtPoint:point];
 }
 
 void UIDelegate::UIClient::statusBarWasTapped()
@@ -1646,7 +1646,7 @@ void UIDelegate::UIClient::statusBarWasTapped()
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewStatusBarWasTapped:uiDelegate->m_webView.get().get()];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webViewStatusBarWasTapped:uiDelegate->m_webView.get().get()];
 }
 
 bool UIDelegate::UIClient::setShouldKeepScreenAwake(bool shouldKeepScreenAwake)
@@ -1662,7 +1662,7 @@ bool UIDelegate::UIClient::setShouldKeepScreenAwake(bool shouldKeepScreenAwake)
     if (!delegate)
         return false;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() setShouldKeepScreenAwake:shouldKeepScreenAwake];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() setShouldKeepScreenAwake:shouldKeepScreenAwake];
     return true;
 }
 #endif // PLATFORM(IOS_FAMILY)
@@ -1680,7 +1680,7 @@ PlatformViewController *UIDelegate::UIClient::presentingViewController()
     if (!delegate)
         return nullptr;
 
-    return [static_cast<id <WKUIDelegatePrivate>>(delegate) _presentingViewControllerForWebView:uiDelegate->m_webView.get().get()];
+    return [static_cast<id<WKUIDelegatePrivate>>(delegate) _presentingViewControllerForWebView:uiDelegate->m_webView.get().get()];
 }
 
 std::optional<double> UIDelegate::UIClient::dataDetectionReferenceDate()
@@ -1719,12 +1719,12 @@ void UIDelegate::UIClient::requestPointerLock(WebPageProxy* page)
         return;
 
     if (uiDelegate->m_delegateMethods.webViewRequestPointerLock) {
-        [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewRequestPointerLock:uiDelegate->m_webView.get().get()];
+        [static_cast<id<WKUIDelegatePrivate>>(delegate) _webViewRequestPointerLock:uiDelegate->m_webView.get().get()];
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webViewDidRequestPointerLock:completionHandler:));
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidRequestPointerLock:uiDelegate->m_webView.get().get() completionHandler:makeBlockPtr([checker = WTFMove(checker), page = RefPtr { page }] (BOOL allow) {
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webViewDidRequestPointerLock:uiDelegate->m_webView.get().get() completionHandler:makeBlockPtr([checker = WTFMove(checker), page = RefPtr { page }] (BOOL allow) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1749,7 +1749,7 @@ void UIDelegate::UIClient::didLosePointerLock(WebPageProxy*)
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidLosePointerLock:uiDelegate->m_webView.get().get()];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webViewDidLosePointerLock:uiDelegate->m_webView.get().get()];
 }
 
 #endif
@@ -1767,7 +1767,7 @@ void UIDelegate::UIClient::didShowSafeBrowsingWarning()
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewDidShowSafeBrowsingWarning:uiDelegate->m_webView.get().get()];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webViewDidShowSafeBrowsingWarning:uiDelegate->m_webView.get().get()];
 }
 
 void UIDelegate::UIClient::confirmPDFOpening(WebPageProxy& page, const WTF::URL& fileURL, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
@@ -1784,7 +1784,7 @@ void UIDelegate::UIClient::confirmPDFOpening(WebPageProxy& page, const WTF::URL&
         return completionHandler(true);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:shouldAllowPDFAtURL:toOpenFromFrame:completionHandler:));
-    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL.createNSURL().get() toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1870,7 +1870,7 @@ void UIDelegate::UIClient::hasVideoInPictureInPictureDidChange(WebPageProxy*, bo
     if (!delegate)
         return;
     
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() hasVideoInPictureInPictureDidChange:hasVideoInPictureInPicture];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() hasVideoInPictureInPictureDidChange:hasVideoInPictureInPicture];
 }
 
 void UIDelegate::UIClient::imageOrMediaDocumentSizeChanged(const WebCore::IntSize& newSize)
@@ -1886,7 +1886,7 @@ void UIDelegate::UIClient::imageOrMediaDocumentSizeChanged(const WebCore::IntSiz
     if (!delegate)
         return;
 
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() imageOrMediaDocumentSizeChanged:newSize];
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:uiDelegate->m_webView.get().get() imageOrMediaDocumentSizeChanged:newSize];
 }
 
 void UIDelegate::UIClient::queryPermission(const String& permissionName, API::SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& callback)
@@ -1897,7 +1897,7 @@ void UIDelegate::UIClient::queryPermission(const String& permissionName, API::Se
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         callback(WebCore::PermissionState::Prompt);
         return;
@@ -1936,7 +1936,7 @@ void UIDelegate::UIClient::didEnableInspectorBrowserDomain(WebPageProxy&)
     if (!uiDelegate->m_delegateMethods.webViewDidEnableInspectorBrowserDomain)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -1952,7 +1952,7 @@ void UIDelegate::UIClient::didDisableInspectorBrowserDomain(WebPageProxy&)
     if (!uiDelegate->m_delegateMethods.webViewDidDisableInspectorBrowserDomain)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -1968,7 +1968,7 @@ void UIDelegate::UIClient::updateAppBadge(WebPageProxy&, const WebCore::Security
     if (!uiDelegate->m_delegateMethods.webViewUpdatedAppBadge)
         return;
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate)
         return;
 
@@ -2104,7 +2104,7 @@ void UIDelegate::UIClient::requestPermissionOnXRSessionFeatures(WebPageProxy&, c
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(granted);
         return;
@@ -2161,7 +2161,7 @@ void UIDelegate::UIClient::startXRSession(WebPageProxy&, const PlatformXR::Devic
         return;
     }
 
-    auto delegate = (id <WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
+    auto delegate = (id<WKUIDelegatePrivate>)uiDelegate->m_delegate.get();
     if (!delegate) {
         completionHandler(nil, nil);
         return;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -242,7 +242,7 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, bool forMainFrameNavig
     SSBLookupContext *context = [SSBLookupContext sharedLookupContext];
     if (!context)
         return listener.didReceiveSafeBrowsingResults({ });
-    [context lookUpURL:url completionHandler:makeBlockPtr([listener = Ref { listener }, forMainFrameNavigation, url = url] (SSBLookupResult *result, NSError *error) mutable {
+    [context lookUpURL:url.createNSURL().get() completionHandler:makeBlockPtr([listener = Ref { listener }, forMainFrameNavigation, url = url] (SSBLookupResult *result, NSError *error) mutable {
         RunLoop::protectedMain()->dispatch([listener = WTFMove(listener), result = retainPtr(result), error = retainPtr(error), forMainFrameNavigation, url = WTFMove(url)] {
             if (error) {
                 listener->didReceiveSafeBrowsingResults({ });
@@ -896,7 +896,7 @@ void WebPageProxy::startApplePayAMSUISession(URL&& originatingURL, ApplePayAMSUI
     }
 
     RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[WTFMove(request.engagementRequest) dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
-    [amsRequest setOriginatingURL:WTFMove(originatingURL)];
+    [amsRequest setOriginatingURL:originatingURL.createNSURL().get()];
 
     auto amsBag = retainPtr([getAMSUIEngagementTaskClass() createBagForSubProfile]);
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -101,7 +101,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     configuration.shouldAddToSelection = YES;
     configuration.window = frontmostWindow ? frontmostWindow->delegate() : nil;
     configuration.index = frontmostWindow ? frontmostWindow->tabs().size() : 0;
-    configuration.url = optionsPageURL();
+    configuration.url = optionsPageURL().createNSURL().get();
 
     [delegate webExtensionController:extensionController->wrapper() openNewTabUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id<WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -102,7 +102,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
     }
 
     if (parameters.url)
-        configuration.url = parameters.url.value();
+        configuration.url = parameters.url.value().createNSURL().get();
 
     [delegate webExtensionController:extensionController->wrapper() openNewTabUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -1009,7 +1009,7 @@ WKWebView *WebExtensionAction::popupWebView()
     extensionContext->addPopupPage(Ref { *m_popupWebView.get()._page.get() }, *this);
 
     auto url = URL { extensionContext->baseURL(), popupPath() };
-    [m_popupWebView loadRequest:[NSURLRequest requestWithURL:url]];
+    [m_popupWebView loadRequest:[NSURLRequest requestWithURL:url.createNSURL().get()]];
 
     return m_popupWebView.get();
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -576,7 +576,7 @@ void WebExtensionContext::moveLocalStorageIfNeeded(const URL& previousBaseURL, C
     }
 
     static NSSet<NSString *> *dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeIndexedDBDatabases, WKWebsiteDataTypeLocalStorage, nil];
-    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL to:baseURL() forDataOfTypes:dataTypes completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL.createNSURL().get() to:baseURL().createNSURL().get() forDataOfTypes:dataTypes completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
 void WebExtensionContext::invalidateStorage()
@@ -3484,7 +3484,7 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration(WebViewPurpose
     configuration._corsDisablingPatterns = corsDisablingPatterns();
     configuration._crossOriginAccessControlCheckEnabled = NO;
     configuration._processDisplayName = processDisplayName();
-    configuration._requiredWebExtensionBaseURL = baseURL();
+    configuration._requiredWebExtensionBaseURL = baseURL().createNSURL().get();
     configuration._shouldRelaxThirdPartyCookieBlocking = YES;
 
     if (!configuration.preferences._siteIsolationEnabled) {
@@ -3656,11 +3656,11 @@ void WebExtensionContext::loadBackgroundWebView()
     if (!protectedExtension()->backgroundContentIsServiceWorker()) {
         backgroundProcess->send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageIDInMainFrameProcess()), identifier());
 
-        [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL()]];
+        [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL().createNSURL().get()]];
         return;
     }
 
-    [m_backgroundWebView _loadServiceWorker:backgroundContentURL() usingModules:protectedExtension()->backgroundContentUsesModules() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }](BOOL success) {
+    [m_backgroundWebView _loadServiceWorker:backgroundContentURL().createNSURL().get() usingModules:protectedExtension()->backgroundContentUsesModules() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }](BOOL success) {
         if (!success) {
             m_backgroundContentLoadError = createError(Error::BackgroundContentFailedToLoad);
             recordError(backgroundContentLoadError());
@@ -3997,7 +3997,7 @@ void WebExtensionContext::webViewWebContentProcessDidTerminate(WKWebView *webVie
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (isInspectorBackgroundPage(webView)) {
-        [webView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL()]];
+        [webView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL().createNSURL().get()]];
         return;
     }
 #endif
@@ -4306,7 +4306,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(inspectorBackgroundWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());
 
-        [inspectorBackgroundWebView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL()]];
+        [inspectorBackgroundWebView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL().createNSURL().get()]];
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -166,7 +166,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
             }
 
             for (auto& script : scriptPairs) {
-                [webView _evaluateJavaScript:script.first withSourceURL:script.second inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
+                [webView _evaluateJavaScript:script.first withSourceURL:script.second.createNSURL().get() inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));
                 }).get()];
             }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -643,12 +643,12 @@ void WebExtensionTab::loadURL(URL url, CompletionHandler<void(Expected<void, Web
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToLoadURL) {
-        [webView() loadRequest:[NSURLRequest requestWithURL:url]];
+        [webView() loadRequest:[NSURLRequest requestWithURL:url.createNSURL().get()]];
         completionHandler({ });
         return;
     }
 
-    [m_delegate loadURL:url forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [m_delegate loadURL:url.createNSURL().get() forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for loadURL: %{public}@", privacyPreservingDescription(error));
             completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -125,7 +125,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         auto mimeType = extension->resourceMIMETypeForPath(requestURL.path().toString());
         resourceData = extensionContext->localizedResourceData(resourceData, mimeType);
 
-        auto *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:nil headerFields:@{
+        auto *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL.createNSURL().get() statusCode:200 HTTPVersion:nil headerFields:@{
             @"Access-Control-Allow-Origin": @"*",
             @"Content-Security-Policy": extension->contentSecurityPolicy(),
             @"Content-Length": @(resourceData->size()).stringValue,

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -103,7 +103,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionT
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID newURL:newURL];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() didNavigateTabWithIdentifier:extensionTabID newURL:newURL.createNSURL().get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavigate(const WTF::URL& newURL)
@@ -115,7 +115,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavig
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() inspectedPageDidNavigate:newURL];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate->m_inspectorExtension.get().get() inspectedPageDidNavigate:newURL.createNSURL().get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -542,7 +542,7 @@ void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)
 {
-    [contentView() requestTextRecognition:imageURL imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier targetLanguageIdentifier:targetLanguageIdentifier completionHandler:WTFMove(completion)];
+    [contentView() requestTextRecognition:imageURL.createNSURL().get() imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier targetLanguageIdentifier:targetLanguageIdentifier completionHandler:WTFMove(completion)];
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
@@ -196,7 +196,7 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
     if ([uiDelegate respondsToSelector:@selector(_webView:requestGeolocationAuthorizationForURL:frame:decisionHandler:)]) {
         RetainPtr<WKFrameInfo> frameInfo = wrapper(API::FrameInfo::create(WTFMove(request.frameInfo), request.view->_page.get()));
         auto checker = WebKit::CompletionHandlerCallChecker::create(uiDelegate, @selector(_webView:requestGeolocationAuthorizationForURL:frame:decisionHandler:));
-        [uiDelegate _webView:request.view.get() requestGeolocationAuthorizationForURL:request.url frame:frameInfo.get() decisionHandler:makeBlockPtr([decisionHandler = WTFMove(decisionHandler), checker = WTFMove(checker)](BOOL authorized) {
+        [uiDelegate _webView:request.view.get() requestGeolocationAuthorizationForURL:request.url.createNSURL().get() frame:frameInfo.get() decisionHandler:makeBlockPtr([decisionHandler = WTFMove(decisionHandler), checker = WTFMove(checker)](BOOL authorized) {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -206,7 +206,7 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
     }
 
     auto policyListener = adoptNS([[WKWebAllowDenyPolicyListener alloc] initWithCompletionHandler:WTFMove(decisionHandler)]);
-    [[WKWebGeolocationPolicyDecider sharedPolicyDecider] decidePolicyForGeolocationRequestFromOrigin:WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url) requestingURL:request.url view:request.view.get() listener:policyListener.get()];
+    [[WKWebGeolocationPolicyDecider sharedPolicyDecider] decidePolicyForGeolocationRequestFromOrigin:WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url) requestingURL:request.url.createNSURL().get() view:request.view.get() listener:policyListener.get()];
 }
 
 - (void)geolocationAuthorizationDenied

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -710,7 +710,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)actionSheetAssistant:(WKActionSheetAssistant *)assistant openElementAtLocation:(CGPoint)location
 {
-    [self _goToURL:_positionInformation.url atLocation:location];
+    [self _goToURL:_positionInformation.url.createNSURL().get() atLocation:location];
 }
 
 - (void)actionSheetAssistant:(WKActionSheetAssistant *)assistant shareElementWithURL:(NSURL *)url rect:(CGRect)boundingRect

--- a/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
+++ b/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
@@ -54,8 +54,8 @@
         auto previewOptions = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
         if (imageURL)
             [previewOptions setObject:imageURL forKey:@"imageURL"];
-        if (NSURL *pageURL = URL { page.currentURL() })
-            [previewOptions setObject:pageURL forKey:@"pageURL"];
+        if (RetainPtr pageURL = URL { page.currentURL() }.createNSURL())
+            [previewOptions setObject:pageURL.get() forKey:@"pageURL"];
         [_item setPreviewOptions:previewOptions.get()];
     }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -568,7 +568,7 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
     m_uiClient->confirmPDFOpening(*this, pdfFileURL, WTFMove(frameInfo), [pdfFileURL] (bool allowed) {
         if (!allowed)
             return;
-        [[NSWorkspace sharedWorkspace] openURL:pdfFileURL];
+        [[NSWorkspace sharedWorkspace] openURL:pdfFileURL.createNSURL().get()];
     });
 }
 
@@ -877,7 +877,7 @@ void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap
     if (!CGImageDestinationFinalize(destination.get()))
         return;
 
-    m_quickLookPreviewController = adoptNS([[WKQuickLookPreviewController alloc] initWithPage:*this imageData:(__bridge NSData *)imageData.get() title:tooltip imageURL:imageURL activity:activity]);
+    m_quickLookPreviewController = adoptNS([[WKQuickLookPreviewController alloc] initWithPage:*this imageData:(__bridge NSData *)imageData.get() title:tooltip imageURL:imageURL.createNSURL().get() activity:activity]);
 
     // When presenting the shared QLPreviewPanel, QuickLook will search the responder chain for a suitable panel controller.
     // Make sure that we (by default) start the search at the web view, which knows how to vend the Visual Search preview

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6751,8 +6751,8 @@ int32_t WebViewImpl::processImageAnalyzerRequest(CocoaImageAnalyzerRequest *requ
 static RetainPtr<CocoaImageAnalyzerRequest> createImageAnalyzerRequest(CGImageRef image, const URL& imageURL, const URL& pageURL, VKAnalysisTypes types)
 {
     auto request = createImageAnalyzerRequest(image, types);
-    [request setImageURL:imageURL];
-    [request setPageURL:pageURL];
+    [request setImageURL:imageURL.createNSURL().get()];
+    [request setPageURL:pageURL.createNSURL().get()];
     return request;
 }
 
@@ -6773,7 +6773,7 @@ void WebViewImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::H
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     if (!targetLanguageIdentifier.isEmpty())
-        return requestVisualTranslation(ensureImageAnalyzer(), imageURL, sourceLanguageIdentifier, targetLanguageIdentifier, cgImage.get(), WTFMove(completion));
+        return requestVisualTranslation(ensureImageAnalyzer(), imageURL.createNSURL().get(), sourceLanguageIdentifier, targetLanguageIdentifier, cgImage.get(), WTFMove(completion));
 #else
     UNUSED_PARAM(sourceLanguageIdentifier);
     UNUSED_PARAM(targetLanguageIdentifier);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -103,7 +103,7 @@ NSURL *WebExtensionAPIExtension::getURL(NSString *resourcePath, NSString **outEx
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL
 
-    return URL { extensionContext().baseURL(), resourcePath };
+    return URL { extensionContext().baseURL(), resourcePath }.createNSURL().autorelease();
 }
 
 JSValue *WebExtensionAPIExtension::getBackgroundPage(JSContextRef context)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -171,7 +171,7 @@ NSURL *WebExtensionAPIRuntime::getURL(NSString *resourcePath, NSString **outExce
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL
 
-    return URL { extensionContext().baseURL(), resourcePath };
+    return URL { extensionContext().baseURL(), resourcePath }.createNSURL().autorelease();
 }
 
 NSDictionary *WebExtensionAPIRuntime::getManifest()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -215,27 +215,27 @@ void WebExtensionContextProxy::dispatchWebNavigationEvent(WebExtensionEventListe
         switch (type) {
         case WebExtensionEventListenerType::WebNavigationOnBeforeNavigate:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate
-            webNavigationObject.onBeforeNavigate().invokeListenersWithArgument(navigationDetails, frameURL);
+            webNavigationObject.onBeforeNavigate().invokeListenersWithArgument(navigationDetails, frameURL.createNSURL().get());
             break;
 
         case WebExtensionEventListenerType::WebNavigationOnCommitted:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted
-            webNavigationObject.onCommitted().invokeListenersWithArgument(navigationDetails, frameURL);
+            webNavigationObject.onCommitted().invokeListenersWithArgument(navigationDetails, frameURL.createNSURL().get());
             break;
 
         case WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded
-            webNavigationObject.onDOMContentLoaded().invokeListenersWithArgument(navigationDetails, frameURL);
+            webNavigationObject.onDOMContentLoaded().invokeListenersWithArgument(navigationDetails, frameURL.createNSURL().get());
             break;
 
         case WebExtensionEventListenerType::WebNavigationOnCompleted:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted
-            webNavigationObject.onCompleted().invokeListenersWithArgument(navigationDetails, frameURL);
+            webNavigationObject.onCompleted().invokeListenersWithArgument(navigationDetails, frameURL.createNSURL().get());
             break;
 
         case WebExtensionEventListenerType::WebNavigationOnErrorOccurred:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred
-            webNavigationObject.onErrorOccurred().invokeListenersWithArgument(navigationDetails, frameURL);
+            webNavigationObject.onErrorOccurred().invokeListenersWithArgument(navigationDetails, frameURL.createNSURL().get());
             break;
 
         default:

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -56,7 +56,7 @@ void WebExtensionAPIWebRequestEvent::enumerateListeners(WebExtensionTabIdentifie
 
     for (auto& listener : listenersCopy) {
         auto* filter = listener.filter.get();
-        if (filter && ![filter matchesRequestForResourceOfType:resourceType URL:resourceURL tabID:toWebAPI(tabIdentifier) windowID:toWebAPI(windowIdentifier)])
+        if (filter && ![filter matchesRequestForResourceOfType:resourceType URL:resourceURL.createNSURL().get() tabID:toWebAPI(tabIdentifier) windowID:toWebAPI(windowIdentifier)])
             continue;
 
         function(*listener.callback, listener.extraInfo);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -126,7 +126,7 @@
 
 - (NSURL *)URL
 {
-    return _frame->url();
+    return _frame->url().createNSURL().autorelease();
 }
 
 - (NSArray *)childFrames
@@ -164,8 +164,8 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
     RefPtr document = frame->document();
     if (!document)
         return @[];
-    return createNSArray(WebCore::LinkIconCollector(*document).iconsOfTypes(iconTypes), [] (auto&& icon) -> NSURL * {
-        return icon.url;
+    return createNSArray(WebCore::LinkIconCollector(*document).iconsOfTypes(iconTypes), [] (auto&& icon) {
+        return icon.url.createNSURL();
     });
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -614,7 +614,7 @@ void PDFPluginBase::addArchiveResource()
 
     // Add just enough data for context menu handling and web archives to work.
     NSDictionary* headers = @{ @"Content-Disposition": m_suggestedFilename.createNSString().get(), @"Content-Type" : @"application/pdf" };
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_view->mainResourceURL() statusCode:200 HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headers]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_view->mainResourceURL().createNSURL().get() statusCode:200 HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headers]);
     ResourceResponse synthesizedResponse(response.get());
 
     RetainPtr data = originalData();
@@ -1136,7 +1136,7 @@ void PDFPluginBase::writeItemsToGeneralPasteboard(Vector<PasteboardItem>&& paste
                 .url = sanitizedURL,
                 .title = sanitizedURL.string(),
 #if PLATFORM(MAC)
-                .userVisibleForm = userVisibleString(sanitizedURL),
+                .userVisibleForm = WTF::userVisibleString(sanitizedURL.createNSURL().get()),
 #endif
             };
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -143,7 +143,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
     if (title.isEmpty()) {
         title = url.lastPathComponent().toString();
         if (title.isEmpty())
-            title = WTF::userVisibleString(url);
+            title = WTF::userVisibleString(url.createNSURL().get());
     }
 
     auto archive = LegacyWebArchive::create(element);
@@ -180,7 +180,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
             filename = downloadFilename;
     }
 
-    m_page->send(Messages::WebPageProxy::SetPromisedDataForImage(pasteboardName, WTFMove(*imageHandle), filename, extension, title, String([[response URL] absoluteString]), WTF::userVisibleString(url), WTFMove(*archiveHandle), element.document().originIdentifierForPasteboard()));
+    m_page->send(Messages::WebPageProxy::SetPromisedDataForImage(pasteboardName, WTFMove(*imageHandle), filename, extension, title, String([[response URL] absoluteString]), WTF::userVisibleString(url.createNSURL().get()), WTFMove(*archiveHandle), element.document().originIdentifierForPasteboard()));
 }
 
 #else

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
@@ -40,9 +40,9 @@ namespace WebKit {
 
 static RetainPtr<NSDictionary> policyProperties(const WebCore::SameSiteInfo& sameSiteInfo, const URL& url)
 {
-    NSURL *nsURL = url;
+    RetainPtr nsURL = url.createNSURL();
     NSDictionary *policyProperties = @{
-        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? nsURL : URL::emptyNSURL(),
+        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? nsURL.get() : URL::emptyNSURL(),
         @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation": [NSNumber numberWithBool:sameSiteInfo.isTopSite],
     };
     return policyProperties;
@@ -62,7 +62,7 @@ String WebCookieJar::cookiesInPartitionedCookieStorage(const WebCore::Document& 
         return { };
 
     __block RetainPtr<NSArray> cookies;
-    [m_partitionedStorageForDOMCookies.get() _getCookiesForURL:cookieURL mainDocumentURL:firstPartyURL partition:partition policyProperties:policyProperties(sameSiteInfo, cookieURL).get() completionHandler:^(NSArray *result) {
+    [m_partitionedStorageForDOMCookies.get() _getCookiesForURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() partition:partition policyProperties:policyProperties(sameSiteInfo, cookieURL).get() completionHandler:^(NSArray *result) {
         cookies = result;
     }];
 
@@ -93,11 +93,11 @@ void WebCookieJar::setCookiesInPartitionedCookieStorage(const WebCore::Document&
     if (partition.isEmpty())
         return;
 
-    NSHTTPCookie *cookie = [NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL partition:partition];
+    NSHTTPCookie *cookie = [NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL.createNSURL().get() partition:partition];
     if (!cookie || ![[cookie name] length] || [cookie isHTTPOnly])
         return;
 
-    [ensurePartitionedCookieStorage() _setCookies:@[cookie] forURL:cookieURL mainDocumentURL:firstPartyURL policyProperties:policyProperties(sameSiteInfo, cookieURL).get()];
+    [ensurePartitionedCookieStorage() _setCookies:@[cookie] forURL:cookieURL.createNSURL().get() mainDocumentURL:firstPartyURL.createNSURL().get() policyProperties:policyProperties(sameSiteInfo, cookieURL).get()];
 }
 
 NSHTTPCookieStorage* WebCookieJar::ensurePartitionedCookieStorage()

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -11,7 +11,6 @@ mac/DOM/DOMCounter.mm
 mac/DOM/DOMCustomXPathNSResolver.mm
 mac/DOM/DOMEvent.mm
 mac/DOM/DOMFileList.mm
-mac/DOM/DOMHTML.mm
 mac/DOM/DOMHTMLCollection.mm
 mac/DOM/DOMHTMLInputElement.mm
 mac/DOM/DOMHTMLOptionsCollection.mm

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
@@ -39,12 +39,12 @@ WebCore::ResourceError WebResourceLoadScheduler::pluginWillHandleLoadError(const
 
 WebCore::ResourceError WebResourceLoadScheduler::pluginWillHandleLoadErrorFromResponse(const WebCore::ResourceResponse& response)
 {
-    return [[[NSError alloc] _initWithPluginErrorCode:WebKitErrorPlugInWillHandleLoad contentURL:response.url() pluginPageURL:nil pluginName:nil MIMEType:response.mimeType()] autorelease];
+    return [[[NSError alloc] _initWithPluginErrorCode:WebKitErrorPlugInWillHandleLoad contentURL:response.url().createNSURL().get() pluginPageURL:nil pluginName:nil MIMEType:response.mimeType()] autorelease];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::cancelledError(const WebCore::ResourceRequest& request) const
 {
-    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled URL:request.url()];
+    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled URL:request.url().createNSURL().get()];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::blockedError(const WebCore::ResourceRequest& request) const
@@ -54,7 +54,7 @@ WebCore::ResourceError WebResourceLoadScheduler::blockedError(const WebCore::Res
 
 WebCore::ResourceError WebResourceLoadScheduler::blockedErrorFromRequest(const WebCore::ResourceRequest& request)
 {
-    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorCannotUseRestrictedPort URL:request.url()];
+    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorCannotUseRestrictedPort URL:request.url().createNSURL().get()];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::blockedByContentBlockerError(const WebCore::ResourceRequest& request) const
@@ -64,29 +64,29 @@ WebCore::ResourceError WebResourceLoadScheduler::blockedByContentBlockerError(co
 
 WebCore::ResourceError WebResourceLoadScheduler::cannotShowURLError(const WebCore::ResourceRequest& request) const
 {
-    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorCannotShowURL URL:request.url()];
+    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorCannotShowURL URL:request.url().createNSURL().get()];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::interruptedForPolicyChangeError(const WebCore::ResourceRequest& request) const
 {
-    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorFrameLoadInterruptedByPolicyChange URL:request.url()];
+    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorFrameLoadInterruptedByPolicyChange URL:request.url().createNSURL().get()];
 }
 
 #if ENABLE(CONTENT_FILTERING)
 WebCore::ResourceError WebResourceLoadScheduler::blockedByContentFilterError(const WebCore::ResourceRequest& request) const
 {
-    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorFrameLoadBlockedByContentFilter URL:request.url()];
+    return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorFrameLoadBlockedByContentFilter URL:request.url().createNSURL().get()];
 }
 #endif
 
 WebCore::ResourceError WebResourceLoadScheduler::cannotShowMIMETypeError(const WebCore::ResourceResponse& response) const
 {
-    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:WebKitErrorCannotShowMIMEType URL:response.url()];
+    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:WebKitErrorCannotShowMIMEType URL:response.url().createNSURL().get()];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::fileDoesNotExistError(const WebCore::ResourceResponse& response) const
 {
-    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist URL:response.url()];
+    return [NSError _webKitErrorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist URL:response.url().createNSURL().get()];
 }
 
 WebCore::ResourceError WebResourceLoadScheduler::httpsUpgradeRedirectLoopError(const WebCore::ResourceRequest&) const

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -386,7 +386,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->document().completeURL(link->getAttribute(HTMLNames::hrefAttr));
+    return link->document().completeURL(link->getAttribute(HTMLNames::hrefAttr)).createNSURL().autorelease();
 }
 
 - (NSString *)hrefTarget
@@ -664,7 +664,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSURL *)_getURLAttribute:(NSString *)name
 {
     auto& element = *core(self);
-    return element.document().completeURL(element.getAttribute(name));
+    return element.document().completeURL(element.getAttribute(name)).createNSURL().autorelease();
 }
 
 - (BOOL)isFocused

--- a/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
@@ -178,8 +178,8 @@
 
 - (DOMDocumentFragment *)_createDocumentFragmentWithMarkupString:(NSString *)markupString baseURLString:(NSString *)baseURLString
 {
-    NSURL *baseURL = core(self)->completeURL(baseURLString);
-    return [self createDocumentFragmentWithMarkupString:markupString baseURL:baseURL];
+    RetainPtr baseURL = core(self)->completeURL(baseURLString).createNSURL();
+    return [self createDocumentFragmentWithMarkupString:markupString baseURL:baseURL.get()];
 }
 
 - (DOMDocumentFragment *)_createDocumentFragmentWithText:(NSString *)text

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -164,7 +164,7 @@ using namespace JSC;
 
 - (NSURL *)URLWithAttributeString:(NSString *)string
 {
-    return core(self)->completeURL(string);
+    return core(self)->completeURL(string).createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -480,7 +480,7 @@ WebHistoryItem *kit(HistoryItem* item)
     const URL& url = core(_private)->url();
     if (url.isEmpty())
         return nil;
-    return url;
+    return url.createNSURL().autorelease();
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -221,12 +221,12 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSURL *)_absoluteImageURL
 {
-    return _result->absoluteImageURL();
+    return _result->absoluteImageURL().createNSURL().autorelease();
 }
 
 - (NSURL *)_absoluteMediaURL
 {
-    return _result->absoluteMediaURL();
+    return _result->absoluteMediaURL().createNSURL().autorelease();
 }
 
 - (NSNumber *)_isSelected
@@ -242,7 +242,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSURL *)_absoluteLinkURL
 {
-    return _result->absoluteLinkURL();
+    return _result->absoluteLinkURL().createNSURL().autorelease();
 }
 
 - (WebFrame *)_targetWebFrame

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -103,7 +103,7 @@
 - (NSURL *)_webkit_canonicalize_with_wtf
 {
     auto url = WTF::URL(self);
-    return url.isValid() ? (NSURL *)url : nil;
+    return url.isValid() ? url.createNSURL().autorelease() : nil;
 }
 
 - (NSURL *)_webkit_URLByRemovingFragment 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -89,7 +89,7 @@ WebContextMenuClient::~WebContextMenuClient()
 
 void WebContextMenuClient::downloadURL(const URL& url)
 {
-    [m_webView _downloadURL:url];
+    [m_webView _downloadURL:url.createNSURL().get()];
 }
 
 void WebContextMenuClient::searchWithGoogle(const LocalFrame*)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -205,7 +205,7 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)
 {
     ASSERT(pasteboardName);
-    [[NSPasteboard pasteboardWithName:pasteboardName] _web_declareAndWriteDragImageForElement:kit(&element) URL:url title:title archive:[kit(&element) webArchive] source:getTopHTMLView(frame)];
+    [[NSPasteboard pasteboardWithName:pasteboardName] _web_declareAndWriteDragImageForElement:kit(&element) URL:url.createNSURL().get() title:title archive:[kit(&element) webArchive] source:getTopHTMLView(frame)];
 }
 
 #elif !PLATFORM(IOS_FAMILY) || !ENABLE(DRAG_SUPPORT)

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -355,7 +355,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
     const URL& url = toPrivate(_private)->loader->url();
     if (url.isEmpty())
         return nil;
-    return url;
+    return url.createNSURL().autorelease();
 }
 
 - (WebView *)_webView
@@ -522,7 +522,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
     const URL& unreachableURL = toPrivate(_private)->loader->unreachableURL();
     if (unreachableURL.isEmpty())
         return nil;
-    return unreachableURL;
+    return unreachableURL.createNSURL().autorelease();
 }
 
 - (WebArchive *)webArchive

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -2285,7 +2285,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     String filename = [imageMIMEType stringByReplacingOccurrencesOfString:@"/" withString:@"."];
     auto resource = adoptNS([[WebResource alloc] initWithData:[pasteboard dataForType:pasteboardType]
-        URL:URL::fakeURLWithRelativePart(filename) MIMEType:imageMIMEType textEncodingName:nil frameName:nil]);
+        URL:URL::fakeURLWithRelativePart(filename).createNSURL().get() MIMEType:imageMIMEType textEncodingName:nil frameName:nil]);
     return [[self _dataSource] _documentFragmentWithImageResource:resource.get()];
 }
 
@@ -3580,13 +3580,13 @@ static RetainPtr<NSMenuItem> createShareMenuItem(const WebCore::HitTestResult& h
     auto items = adoptNS([[NSMutableArray alloc] init]);
 
     if (!hitTestResult.absoluteLinkURL().isEmpty()) {
-        NSURL *absoluteLinkURL = hitTestResult.absoluteLinkURL();
-        [items addObject:absoluteLinkURL];
+        RetainPtr absoluteLinkURL = hitTestResult.absoluteLinkURL().createNSURL();
+        [items addObject:absoluteLinkURL.get()];
     }
 
     if (!hitTestResult.absoluteMediaURL().isEmpty() && hitTestResult.isDownloadableMedia()) {
-        NSURL *downloadableMediaURL = hitTestResult.absoluteMediaURL();
-        [items addObject:downloadableMediaURL];
+        RetainPtr downloadableMediaURL = hitTestResult.absoluteMediaURL().createNSURL();
+        [items addObject:downloadableMediaURL.get()];
     }
 
     if (auto* image = hitTestResult.image()) {
@@ -4357,7 +4357,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RetainPtr<NSFileWrapper> wrapper;
-    NSURL *draggingElementURL = nil;
+    RetainPtr<NSURL> draggingElementURL;
 
     if (auto tiffResource = _private->promisedDragTIFFDataSource) {
         if (auto* buffer = tiffResource->resourceBuffer()) {
@@ -4384,9 +4384,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
         const URL& imageURL = page->dragController().draggingImageURL();
         if (!imageURL.isEmpty())
-            draggingElementURL = imageURL;
+            draggingElementURL = imageURL.createNSURL();
 
-        wrapper = [[self _dataSource] _fileWrapperForURL:draggingElementURL];
+        wrapper = [[self _dataSource] _fileWrapperForURL:draggingElementURL.get()];
     }
     
     if (!wrapper) {
@@ -7189,7 +7189,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 
 + (NSURL *)_web_uniqueWebDataURL
 {
-    return URL::fakeURLWithRelativePart(emptyString());
+    return URL::fakeURLWithRelativePart(emptyString()).createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -276,7 +276,7 @@
     if (_contentPreventsDefault)
         return adoptNS([[WebAnimationController alloc] init]).autorelease();
 
-    NSURL *url = _hitTestResult.absoluteLinkURL();
+    RetainPtr url = _hitTestResult.absoluteLinkURL().createNSURL();
     String absoluteURLString = [url absoluteString];
     if (url && _hitTestResult.URLElement()) {
         if (WTF::protocolIs(absoluteURLString, "mailto"_s)) {
@@ -362,7 +362,7 @@
     if (!_webView)
         return nil;
 
-    return _hitTestResult.absoluteLinkURL();
+    return _hitTestResult.absoluteLinkURL().createNSURL().autorelease();
 }
 
 - (NSRectEdge)menuItem:(NSMenuItem *)menuItem preferredEdgeForPoint:(NSPoint)point

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -166,20 +166,20 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     auto* resource = _private->coreResource.get();
 
     RetainPtr<NSData> data;
-    NSURL *url = nil;
+    RetainPtr<NSURL> url;
     NSString *mimeType = nil, *textEncoding = nil, *frameName = nil;
     NSURLResponse *response = nil;
 
     if (resource) {
         data = resource->data().makeContiguous()->createNSData();
-        url = resource->url();
+        url = resource->url().createNSURL();
         mimeType = resource->mimeType();
         textEncoding = resource->textEncoding();
         frameName = resource->frameName();
         response = resource->response().nsURLResponse();
     }
     [encoder encodeObject:data.get() forKey:WebResourceDataKey];
-    [encoder encodeObject:url forKey:WebResourceURLKey];
+    [encoder encodeObject:url.get() forKey:WebResourceURLKey];
     [encoder encodeObject:mimeType forKey:WebResourceMIMETypeKey];
     [encoder encodeObject:textEncoding forKey:WebResourceTextEncodingNameKey];
     [encoder encodeObject:frameName forKey:WebResourceFrameNameKey];
@@ -212,7 +212,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
     if (!_private->coreResource)
         return nil;
-    return _private->coreResource->url();
+    return _private->coreResource->url().createNSURL().autorelease();
 }
 
 - (NSString *)MIMEType

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm
@@ -80,7 +80,7 @@ void WebScriptDebugger::sourceParsed(JSC::JSGlobalObject* lexicalGlobalObject, J
     m_callingDelegate = true;
 
     NSString *nsSource = toNSString(sourceProvider);
-    NSURL *nsURL = sourceProvider->sourceOrigin().url();
+    RetainPtr nsURL = sourceProvider->sourceOrigin().url().createNSURL();
     int firstLine = sourceProvider->startPosition().m_line.oneBasedInt();
 
     JSC::VM& vm = lexicalGlobalObject->vm();
@@ -91,7 +91,7 @@ void WebScriptDebugger::sourceParsed(JSC::JSGlobalObject* lexicalGlobalObject, J
     if (errorLine == -1) {
         if (implementations->didParseSourceFunc) {
             if (implementations->didParseSourceExpectsBaseLineNumber)
-                CallScriptDebugDelegate(implementations->didParseSourceFunc, webView, @selector(webView:didParseSource:baseLineNumber:fromURL:sourceId:forWebFrame:), nsSource, firstLine, nsURL, sourceProvider->asID(), webFrame);
+                CallScriptDebugDelegate(implementations->didParseSourceFunc, webView, @selector(webView:didParseSource:baseLineNumber:fromURL:sourceId:forWebFrame:), nsSource, firstLine, nsURL.get(), sourceProvider->asID(), webFrame);
             else
                 CallScriptDebugDelegate(implementations->didParseSourceFunc, webView, @selector(webView:didParseSource:fromURL:sourceId:forWebFrame:), nsSource, [nsURL absoluteString], sourceProvider->asID(), webFrame);
         }
@@ -110,7 +110,7 @@ void WebScriptDebugger::sourceParsed(JSC::JSGlobalObject* lexicalGlobalObject, J
         auto error = adoptNS([[NSError alloc] initWithDomain:WebScriptErrorDomain code:WebScriptGeneralErrorCode userInfo:info]);
 
         if (implementations->failedToParseSourceFunc)
-            CallScriptDebugDelegate(implementations->failedToParseSourceFunc, webView, @selector(webView:failedToParseSource:baseLineNumber:fromURL:withError:forWebFrame:), nsSource, firstLine, nsURL, error.get(), webFrame);
+            CallScriptDebugDelegate(implementations->failedToParseSourceFunc, webView, @selector(webView:failedToParseSource:baseLineNumber:fromURL:withError:forWebFrame:), nsSource, firstLine, nsURL.get(), error.get(), webFrame);
     }
 
     m_callingDelegate = false;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -6719,7 +6719,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return nil;
 
     // We arbitrarily choose the first icon in the list if there is more than one.
-    return (NSURL *)linkIcons[0].url;
+    return linkIcons[0].url.createNSURL().autorelease();
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -310,19 +310,19 @@ TEST(WTF_URLExtras, URLExtras_ParsingError)
     EXPECT_TRUE(encodedHostName == nil);
 
     WTF::URL url2 { utf16String(u"http://\u2267\u222E\uFE63\u0661\u06F1") };
-    EXPECT_NULL([url2 absoluteString]);
+    EXPECT_NULL([url2.createNSURL() absoluteString]);
 
     std::array<UChar, 2> utf16 { 0xC2, 0xB6 };
     WTF::URL url3 { String(utf16) };
     EXPECT_FALSE(url3.string().is8Bit());
     EXPECT_FALSE(url3.isValid());
-    EXPECT_NULL([url3 absoluteString]);
+    EXPECT_NULL([url3.createNSURL() absoluteString]);
     
     std::array<LChar, 2> latin1 { 0xC2, 0xB6 };
     WTF::URL url4 { String(latin1) };
     EXPECT_FALSE(url4.isValid());
     EXPECT_TRUE(url4.string().is8Bit());
-    EXPECT_NULL([url4 absoluteString]);
+    EXPECT_NULL([url4.createNSURL() absoluteString]);
 
     std::array<char, 100> buffer = { };
     WTF::URL url5 { "file:///A%C3%A7%C3%A3o.html"_str };

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -388,7 +388,7 @@ TEST(RETAIN_PTR_TEST_NAME, URLBridgeCast)
     uintptr_t nsURLPtr;
     @autoreleasepool {
         URL url("https://www.webkit.org"_str);
-        nsURL = static_cast<NSURL *>(url);
+        nsURL = url.createNSURL().get();
         nsURLPtr = reinterpret_cast<uintptr_t>(nsURL.get());
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -678,7 +678,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     // Force App Links with a request.URL that has a different host than the current one (empty host) and ShouldOpenExternalURLsPolicy::ShouldAllow.
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
-    [webView _loadRequest:[NSURLRequest requestWithURL:testURL] shouldOpenExternalURLs:YES];
+    [webView _loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()] shouldOpenExternalURLs:YES];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
@@ -692,7 +692,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -711,7 +711,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     // Force App Links with a request.URL that has a different host than the current one (empty host) and ShouldOpenExternalURLsPolicy::ShouldAllow.
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
-    [webView _loadRequest:[NSURLRequest requestWithURL:testURL] shouldOpenExternalURLs:YES];
+    [webView _loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()] shouldOpenExternalURLs:YES];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
@@ -726,7 +726,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -1116,7 +1116,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
 
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
-    [webView loadRequest:[NSURLRequest requestWithURL:testURL]];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.createNSURL().get()]];
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
@@ -1130,7 +1130,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -1160,7 +1160,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     URL redirectURL { "https://www.example.com"_str };
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:redirectURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : redirectURL.string() }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:redirectURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : redirectURL.string() }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
@@ -2134,7 +2134,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, "window.close();"_s).utf8(); // The pop up closes itself.
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2172,7 +2172,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2210,7 +2210,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2289,7 +2289,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;"}]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2332,7 +2332,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
 
         [messageHandler resetExpectations:@[@"Hello.", @"WindowClosed."]];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
         auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
         // The secret WKWebView needs to be destroyed right the way.
         @autoreleasepool {
@@ -2399,7 +2399,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     }];
     Util::run(&navigationCompleted);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2437,7 +2437,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2527,7 +2527,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHtml(newWindowResponseTemplate, "window.close();"_s).utf8(); // The pop up closes itself.
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2692,7 +2692,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2758,7 +2758,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
     EXPECT_TRUE(policyForAppSSOPerformed);
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello.", @"http://www.example.com", @"Cookies: sessionid=38afes7a8"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;"}]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2789,7 +2789,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"SOAuthorizationDidCancel"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Content-Security-Policy" : @"frame-ancestors 'none';" }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Content-Security-Policy" : @"frame-ancestors 'none';" }]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2820,7 +2820,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"SOAuthorizationDidCancel"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"X-Frame-Options" : @"DENY" }]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"X-Frame-Options" : @"DENY" }]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2858,7 +2858,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 
         [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
         auto iframeHtmlCString = generateHtml(iframeTemplate, emptyString()).utf8();
         [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
         Util::run(&allMessagesReceived);
@@ -2939,7 +2939,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -3061,7 +3061,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHtml(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);


### PR DESCRIPTION
#### d66195dc56b11a4bfb9f60e94755c0a36eca7498
<pre>
Drop WTF::URL&apos;s `operator NSURL *()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291149">https://bugs.webkit.org/show_bug.cgi?id=291149</a>

Reviewed by Darin Adler.

Drop WTF::URL&apos;s `operator NSURL *()` and use URL::createNSURL() instead. `createNSURL()`
is better because it makes it clearer we&apos;re constructing a new NSURL object. It also
returns a RetainPtr&lt;NSURL&gt; instead of an autoreleased object. This is a step towards
reducing the use of autorelease in our codebase.

* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/cocoa/URLCocoa.mm:
(WTF::URL::operator NSURL * const): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::userVisibleString):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_addLinkForElement):
(HTMLConverter::_processElement):
(fileWrapperForURL):
* Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm:
(-[WebArchiveResourceFromNSAttributedString URL]):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::attributesForAttributedStringConversion):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::writeImageToPasteboard):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::LinkImageLayout::LinkImageLayout):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::canonicalURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeURLForTypes):
(WebCore::fileWrapper):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::cookiesForURL const):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
(WebCore::NetworkStorageSession::deleteCookie const):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::initNSURLResponse const):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::userVisibleString):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
(WebKit::platformDisbursementRequest):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm:
(WebKit::toPlatformConfiguration):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::hasValidUserInfo):
* Source/WebKit/Shared/Cocoa/CoreIPCURL.h:
(WebKit::CoreIPCURL::toID const):
* Source/WebKit/Shared/Cocoa/WKNSURLExtras.mm:
(+[NSURL _web_URLWithWTFString:]):
* Source/WebKit/Shared/Cocoa/WKNSURLRequest.mm:
(-[WKNSURLRequest URL]):
* Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm:
(WebKit::cancelledError):
(WebKit::fileDoesNotExistError):
(WebKit::decodeError):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _originalURL]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext baseURL]):
(-[WKWebExtensionContext optionsPageURL]):
(-[WKWebExtensionContext overrideNewTabPageURL]):
(-[WKWebExtensionContext _backgroundContentURL]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(nsErrorFromExceptionDetails):
(-[WKWebView _resourceDirectoryURL]):
(-[WKWebView _mainFrameURL]):
(-[WKWebView _showWarningViewWithURL:title:warning:detailsWithLinks:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _requiredWebExtensionBaseURL]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _persistedSites]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifestIcon initWithCoreIcon:]):
(-[_WKApplicationManifestShortcut initWithCoreShortcut:]):
(-[_WKApplicationManifest scope]):
(-[_WKApplicationManifest manifestURL]):
(-[_WKApplicationManifest startURL]):
(-[_WKApplicationManifest manifestId]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload redirectChain]):
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm:
(-[_WKNotificationData securityOrigin]):
(-[_WKNotificationData serviceWorkerRegistrationURL]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo originalURL]):
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet baseURL]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessage.mm:
(-[_WKWebPushMessage scope]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm:
(-[_WKWebPushSubscriptionData endpoint]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration httpProxy]):
(-[_WKWebsiteDataStoreConfiguration httpsProxy]):
(-[_WKWebsiteDataStoreConfiguration standaloneApplicationURL]):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::reportAnErrorURL):
(WebKit::malwareDetailsURL):
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::willSendRequest):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::tryInterceptNavigation):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::willPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didBlockLoadToKnownTracker):
(WebKit::NavigationState::NavigationClient::didApplyLinkDecorationFiltering):
(WebKit::NavigationState::NavigationClient::didNegotiateModernTLS):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::canAuthorize):
(WebKit::SOAuthorizationCoordinator::tryAuthorize):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::start):
(WebKit::SOAuthorizationSession::complete):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::drawHeader):
(WebKit::UIDelegate::UIClient::drawFooter):
(WebKit::UIDelegate::UIClient::saveDataToFileInDownloadsFolder):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
(WebKit::UIDelegate::UIClient::confirmPDFOpening):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
(WebKit::WebPageProxy::startApplePayAMSUISession):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::popupWebView):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::moveLocalStorageIfNeeded):
(WebKit::WebExtensionContext::webViewConfiguration):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::loadURL):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didNavigateExtensionTab):
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::inspectedPageDidNavigate):
* Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm:
(-[WKQuickLookPreviewController initWithPage:imageData:title:imageURL:activity:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::createImageAnalyzerRequest):
(WebKit::WebViewImpl::requestTextRecognition):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::getURL):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getURL):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::enumerateListeners):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame URL]):
(collectIcons):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::addArchiveResource):
(WebKit::PDFPluginBase::writeItemsToGeneralPasteboard const):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm:
(WebKit::policyProperties):
(WebKit::WebCookieJar::cookiesInPartitionedCookieStorage const):
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm:
(WebResourceLoadScheduler::pluginWillHandleLoadErrorFromResponse):
(WebResourceLoadScheduler::cancelledError const):
(WebResourceLoadScheduler::blockedErrorFromRequest):
(WebResourceLoadScheduler::cannotShowURLError const):
(WebResourceLoadScheduler::interruptedForPolicyChangeError const):
(WebResourceLoadScheduler::blockedByContentFilterError const):
(WebResourceLoadScheduler::cannotShowMIMETypeError const):
(WebResourceLoadScheduler::fileDoesNotExistError const):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMElement _getURLAttribute:]):
* Source/WebKitLegacy/mac/DOM/DOMHTML.mm:
(-[DOMHTMLDocument _createDocumentFragmentWithMarkupString:baseURLString:]):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(-[DOMDocument URLWithAttributeString:]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(-[WebElementDictionary _absoluteImageURL]):
(-[WebElementDictionary _absoluteMediaURL]):
(-[WebElementDictionary _absoluteLinkURL]):
* Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm:
(-[NSURL _webkit_canonicalize_with_wtf]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::downloadURL):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(WebDragClient::declareAndWriteDragImage):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::shouldPaintBrokenImage const):
(WebFrameLoaderClient::dispatchWillPerformClientRedirect):
(WebFrameLoaderClient::startDownload):
(WebFrameLoaderClient::updateGlobalHistory):
(WebFrameLoaderClient::setTitle):
(WebFrameLoaderClient::actionDictionary const):
(WebFrameLoaderClient::objectContentType):
(WebFrameLoaderClient::createPlugin):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(-[WebDataSource _URL]):
(-[WebDataSource unreachableURL]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _loadData:MIMEType:textEncodingName:baseURL:unreachableURL:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _web_documentFragmentFromPasteboard:pasteboardType:imageMIMEType:]):
(createShareMenuItem):
(-[WebHTMLView namesOfPromisedFilesDroppedAtDestination:]):
(+[NSURL _web_uniqueWebDataURL]):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(-[WebImmediateActionController _defaultAnimationController]):
(-[WebImmediateActionController menuItem:previewItemAtPoint:]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(-[WebResource encodeWithCoder:]):
(-[WebResource URL]):
* Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm:
(WebScriptDebugger::sourceParsed):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(WTF_URLExtras, URLExtras_ParsingError)):
* Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, URLBridgeCast)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed2)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed3)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccess)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)):

Canonical link: <a href="https://commits.webkit.org/293338@main">https://commits.webkit.org/293338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a84ad50d5d8bace24a6e4c11d49f74c20b33df6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98604 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75060 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48574 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91291 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106098 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97233 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18719 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83525 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19384 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15987 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30834 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120851 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25470 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33819 "Found 19746 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->