### PR TITLE
[SaferCPP] Use smart pointer in StyleScopeRuleSets

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -85,7 +85,6 @@ style/RuleSetBuilder.h
 style/StyleRelations.h
 style/StyleResolver.cpp
 style/StyleScope.h
-style/StyleScopeRuleSets.h
 style/Styleable.h
 svg/properties/SVGPropertyOwnerRegistry.h
 workers/WorkerAnimationController.h

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -76,11 +76,11 @@ void ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded() const
     m_userAgentMediaQueryRuleCountOnUpdate = ruleCount;
 
     // Media queries on user agent sheet need to evaluated in document context. They behave like author sheets in this respect.
-    auto& mediaQueryEvaluator = m_styleResolver.mediaQueryEvaluator();
+    auto& mediaQueryEvaluator = m_styleResolver->mediaQueryEvaluator();
 
     m_userAgentMediaQueryStyle = RuleSet::create();
 
-    RuleSetBuilder builder(*m_userAgentMediaQueryStyle, mediaQueryEvaluator, &m_styleResolver);
+    RuleSetBuilder builder(*m_userAgentMediaQueryStyle, mediaQueryEvaluator, &m_styleResolver.get());
     builder.addRulesFromSheet(*UserAgentStyle::mediaQueryStyleSheet);
 }
 
@@ -92,7 +92,7 @@ RuleSet* ScopeRuleSets::dynamicViewTransitionsStyle() const
 RuleSet* ScopeRuleSets::userStyle() const
 {
     if (m_usesSharedUserStyle)
-        return m_styleResolver.document().styleScope().resolver().ruleSets().userStyle();
+        return m_styleResolver->document().styleScope().resolver().ruleSets().userStyle();
     return m_userStyle.get();
 }
 
@@ -115,21 +115,21 @@ RuleSet* ScopeRuleSets::styleForCascadeLevel(CascadeLevel level)
 
 void ScopeRuleSets::initializeUserStyle()
 {
-    CheckedRef extensionStyleSheets = m_styleResolver.document().extensionStyleSheets();
-    auto& mediaQueryEvaluator = m_styleResolver.mediaQueryEvaluator();
+    CheckedRef extensionStyleSheets = m_styleResolver->document().extensionStyleSheets();
+    auto& mediaQueryEvaluator = m_styleResolver->mediaQueryEvaluator();
 
     auto userStyle = RuleSet::create();
 
     if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet()) {
-        RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver);
+        RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver.get());
         builder.addRulesFromSheet(pageUserSheet->contents());
     }
 
 #if ENABLE(APP_BOUND_DOMAINS)
-    auto* page = m_styleResolver.document().page();
+    auto* page = m_styleResolver->document().page();
     auto* localMainFrame = page ? dynamicDowncast<LocalFrame>(page->mainFrame()) : nullptr;
     if (!extensionStyleSheets->injectedUserStyleSheets().isEmpty() && page && localMainFrame && localMainFrame->loader().client().shouldEnableInAppBrowserPrivacyProtections())
-        m_styleResolver.document().addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Ignoring user style sheet for non-app bound domain."_s);
+        m_styleResolver->document().addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Ignoring user style sheet for non-app bound domain."_s);
     else {
         collectRulesFromUserStyleSheets(extensionStyleSheets->injectedUserStyleSheets(), userStyle, mediaQueryEvaluator);
         if (page && localMainFrame && !extensionStyleSheets->injectedUserStyleSheets().isEmpty())
@@ -146,7 +146,7 @@ void ScopeRuleSets::initializeUserStyle()
 
 void ScopeRuleSets::collectRulesFromUserStyleSheets(const Vector<RefPtr<CSSStyleSheet>>& userSheets, RuleSet& userStyle, const MQ::MediaQueryEvaluator& mediaQueryEvaluator)
 {
-    RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver);
+    RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver.get());
     for (auto& sheet : userSheets) {
         ASSERT(sheet->contents().isUserStyleSheet());
         builder.addRulesFromSheet(sheet->contents());
@@ -248,7 +248,7 @@ std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamic
 
 void ScopeRuleSets::appendAuthorStyleSheets(const Vector<RefPtr<CSSStyleSheet>>& styleSheets, MQ::MediaQueryEvaluator* mediaQueryEvaluator, InspectorCSSOMWrappers& inspectorCSSOMWrappers)
 {
-    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable, RuleSetBuilder::ShouldResolveNesting::Yes);
+    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver.get(), RuleSetBuilder::ShrinkToFit::Enable, RuleSetBuilder::ShouldResolveNesting::Yes);
 
     RefPtr<CSSStyleSheet> previous;
     for (auto& cssSheet : styleSheets) {

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -29,6 +29,8 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
 
 namespace WebCore {
 
@@ -117,7 +119,7 @@ private:
     mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
     RefPtr<RuleSet> m_userStyle;
 
-    Resolver& m_styleResolver;
+    WeakPtr<Resolver> m_styleResolver;
     mutable RuleFeatureSet m_features;
     mutable RefPtr<RuleSet> m_scopeBreakingHasPseudoClassInvalidationRuleSet;
     mutable UncheckedKeyHashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;


### PR DESCRIPTION
#### df57ebc8caf90b4b2906a4a2f3545b8b2d9478e7
<pre>
[SaferCPP] Use smart pointer in StyleScopeRuleSets
<a href="https://bugs.webkit.org/show_bug.cgi?id=291151">https://bugs.webkit.org/show_bug.cgi?id=291151</a>

Reviewed by NOBODY (OOPS!).

Use smart pointer in StyleScopeRuleSets

* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded const):
(WebCore::Style::ScopeRuleSets::userStyle const):
(WebCore::Style::ScopeRuleSets::initializeUserStyle):
(WebCore::Style::ScopeRuleSets::collectRulesFromUserStyleSheets):
(WebCore::Style::ScopeRuleSets::appendAuthorStyleSheets):
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/style/StyleResolver.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df57ebc8caf90b4b2906a4a2f3545b8b2d9478e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99147 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18790 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104268 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49728 "Hash df57ebc8 for PR 43702 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101187 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19079 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27227 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/104268 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/49728 "Hash df57ebc8 for PR 43702 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102152 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/19079 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/104268 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/19079 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49104 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/19079 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106631 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26256 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/27227 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/106631 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26619 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/106631 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/9038 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19969 "Hash df57ebc8 for PR 43702 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26197 "Hash df57ebc8 for PR 43702 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31378 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26018 "Hash df57ebc8 for PR 43702 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29331 "Hash df57ebc8 for PR 43702 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27584 "Hash df57ebc8 for PR 43702 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->