### PR TITLE
Add null check in _WKRemoteObjectRegistry._invokeMethod like we have in _callReplyWithID

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.h
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.h
@@ -39,7 +39,7 @@ class Dictionary;
 
 @interface WKRemoteObjectDecoder : NSCoder
 
-- (id)initWithInterface:(_WKRemoteObjectInterface *)interface rootObjectDictionary:(const API::Dictionary*)rootObjectDictionary replyToSelector:(SEL)replyToSelector;
+- (id)initWithInterface:(_WKRemoteObjectInterface *)interface rootObjectDictionary:(Ref<API::Dictionary>&&)rootObjectDictionary replyToSelector:(SEL)replyToSelector;
 
 @end
 

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -662,14 +662,14 @@ static NSString *escapeKey(NSString *key)
     const HashSet<CFTypeRef>* _allowedClasses;
 }
 
-- (id)initWithInterface:(_WKRemoteObjectInterface *)interface rootObjectDictionary:(const API::Dictionary*)rootObjectDictionary replyToSelector:(SEL)replyToSelector
+- (id)initWithInterface:(_WKRemoteObjectInterface *)interface rootObjectDictionary:(Ref<API::Dictionary>&&)rootObjectDictionary replyToSelector:(SEL)replyToSelector
 {
     if (!(self = [super init]))
         return nil;
 
     _interface = interface;
 
-    lazyInitialize(_rootDictionary, Ref { *rootObjectDictionary });
+    lazyInitialize(_rootDictionary, WTFMove(rootObjectDictionary));
     _currentDictionary = _rootDictionary;
 
     _replyToSelector = replyToSelector;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -114,8 +114,6 @@ static RetainPtr<TestWKWebView> createWebViewWithIPCTestingAPI()
     return adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get()]);
 }
 
-#if !ASSERT_ENABLED
-
 TEST(IPCTestingAPI, CanDetectNilReplyBlocks)
 {
     auto webView = createWebViewWithIPCTestingAPI();
@@ -167,8 +165,6 @@ TEST(IPCTestingAPI, CanDetectNilReplyBlocks)
     // Make sure sayHello was not called, as the reply block was nil.
     EXPECT_FALSE([delegate.get() sayHelloWasCalled]);
 }
-
-#endif
 
 TEST(IPCTestingAPI, CanSendAlert)
 {


### PR DESCRIPTION
#### aca65fff1223486ef0679a2264ecf9942452aecc
<pre>
Add null check in _WKRemoteObjectRegistry._invokeMethod like we have in _callReplyWithID
<a href="https://rdar.apple.com/148677016">rdar://148677016</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291154">https://bugs.webkit.org/show_bug.cgi?id=291154</a>

Reviewed by Ryosuke Niwa.

And re-enable the test that hits the condition in question.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.h:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectDecoder initWithInterface:rootObjectDictionary:replyToSelector:]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _invokeMethod:]):
(-[_WKRemoteObjectRegistry _callReplyWithID:blockInvocation:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/293427@main">https://commits.webkit.org/293427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/006bb4a1fc988c020106e37ee2b4598dbddb62f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75021 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32178 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106046 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19325 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16076 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->