### PR TITLE
Leverage the spaceship operator in more places to simplify the code

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -147,27 +147,7 @@ public:
         return m_callee == deletedToken();
     }
     
-    friend bool operator==(const CallVariant&, const CallVariant&) = default;
-    
-    bool operator<(const CallVariant& other) const
-    {
-        return m_callee < other.m_callee;
-    }
-    
-    bool operator>(const CallVariant& other) const
-    {
-        return other < *this;
-    }
-    
-    bool operator<=(const CallVariant& other) const
-    {
-        return !(*this < other);
-    }
-    
-    bool operator>=(const CallVariant& other) const
-    {
-        return other <= *this;
-    }
+    friend auto operator<=>(const CallVariant&, const CallVariant&) = default;
     
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -64,11 +64,7 @@ public:
     void dump(PrintStream&) const;
     
     // Comparison methods useful for bisection.
-    friend bool operator==(const CodeBlockHash&, const CodeBlockHash&) = default;
-    bool operator<(const CodeBlockHash& other) const { return hash() < other.hash(); }
-    bool operator>(const CodeBlockHash& other) const { return hash() > other.hash(); }
-    bool operator<=(const CodeBlockHash& other) const { return hash() <= other.hash(); }
-    bool operator>=(const CodeBlockHash& other) const { return hash() >= other.hash(); }
+    friend auto operator<=>(const CodeBlockHash&, const CodeBlockHash&) = default;
     
 private:
     unsigned m_hash;

--- a/Source/JavaScriptCore/bytecode/VirtualRegister.h
+++ b/Source/JavaScriptCore/bytecode/VirtualRegister.h
@@ -78,11 +78,7 @@ public:
     int offset() const { return m_virtualRegister; }
     int offsetInBytes() const { return m_virtualRegister * sizeof(Register); }
 
-    friend bool operator==(const VirtualRegister&, const VirtualRegister&) = default;
-    bool operator<(VirtualRegister other) const { return m_virtualRegister < other.m_virtualRegister; }
-    bool operator>(VirtualRegister other) const { return m_virtualRegister > other.m_virtualRegister; }
-    bool operator<=(VirtualRegister other) const { return m_virtualRegister <= other.m_virtualRegister; }
-    bool operator>=(VirtualRegister other) const { return m_virtualRegister >= other.m_virtualRegister; }
+    friend auto operator<=>(const VirtualRegister&, const VirtualRegister&) = default;
 
     VirtualRegister operator+(int value) const
     {

--- a/Source/JavaScriptCore/dfg/DFGEpoch.h
+++ b/Source/JavaScriptCore/dfg/DFGEpoch.h
@@ -81,27 +81,7 @@ public:
         *this = next();
     }
     
-    friend bool operator==(const Epoch&, const Epoch&) = default;
-    
-    bool operator<(const Epoch& other) const
-    {
-        return m_epoch < other.m_epoch;
-    }
-    
-    bool operator>(const Epoch& other) const
-    {
-        return other < *this;
-    }
-    
-    bool operator<=(const Epoch& other) const
-    {
-        return !(*this > other);
-    }
-    
-    bool operator>=(const Epoch& other) const
-    {
-        return !(*this < other);
-    }
+    friend auto operator<=>(const Epoch&, const Epoch&) = default;
     
     void dump(PrintStream&) const;
     

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -137,27 +137,7 @@ public:
             MacroAssembler::firstFPRegister() + (m_index - MacroAssembler::numberOfRegisters()));
     }
 
-    friend constexpr bool operator==(const Reg&, const Reg&) = default;
-
-    constexpr bool operator<(const Reg& other) const
-    {
-        return m_index < other.m_index;
-    }
-
-    constexpr bool operator>(const Reg& other) const
-    {
-        return m_index > other.m_index;
-    }
-
-    constexpr bool operator<=(const Reg& other) const
-    {
-        return m_index <= other.m_index;
-    }
-
-    constexpr bool operator>=(const Reg& other) const
-    {
-        return m_index >= other.m_index;
-    }
+    friend constexpr auto operator<=>(const Reg&, const Reg&) = default;
 
     constexpr unsigned hash() const
     {

--- a/Source/JavaScriptCore/runtime/GenericOffset.h
+++ b/Source/JavaScriptCore/runtime/GenericOffset.h
@@ -61,23 +61,7 @@ public:
         return m_offset;
     }
     
-    friend bool operator==(const GenericOffset&, const GenericOffset&) = default;
-    bool operator<(const GenericOffset& other) const
-    {
-        return m_offset < other.m_offset;
-    }
-    bool operator>(const GenericOffset& other) const
-    {
-        return m_offset > other.m_offset;
-    }
-    bool operator<=(const GenericOffset& other) const
-    {
-        return m_offset <= other.m_offset;
-    }
-    bool operator>=(const GenericOffset& other) const
-    {
-        return m_offset >= other.m_offset;
-    }
+    friend auto operator<=>(const GenericOffset&, const GenericOffset&) = default;
     
     T operator+(int value) const
     {

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -149,23 +149,7 @@ public:
         return m_epochNanoseconds >= ExactTime::minValue && m_epochNanoseconds <= ExactTime::maxValue;
     }
 
-    constexpr bool operator<(ExactTime other) const
-    {
-        return m_epochNanoseconds < other.m_epochNanoseconds;
-    }
-    constexpr bool operator<=(ExactTime other) const
-    {
-        return m_epochNanoseconds <= other.m_epochNanoseconds;
-    }
-    friend constexpr bool operator==(const ExactTime&, const ExactTime&) = default;
-    constexpr bool operator>=(ExactTime other) const
-    {
-        return m_epochNanoseconds >= other.m_epochNanoseconds;
-    }
-    constexpr bool operator>(ExactTime other) const
-    {
-        return m_epochNanoseconds > other.m_epochNanoseconds;
-    }
+    friend constexpr auto operator<=>(const ExactTime&, const ExactTime&) = default;
 
     std::optional<ExactTime> add(Duration) const;
     Int128 difference(ExactTime other, unsigned increment, TemporalUnit, RoundingMode) const;

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -94,10 +94,8 @@ public:
         return m_pageCount != UINT_MAX;
     }
 
-    bool operator<(const PageCount& other) const { return m_pageCount < other.m_pageCount; }
-    bool operator>(const PageCount& other) const { return m_pageCount > other.m_pageCount; }
-    bool operator>=(const PageCount& other) const { return m_pageCount >= other.m_pageCount; }
-    friend bool operator==(const PageCount&, const PageCount&) = default;
+    friend auto operator<=>(const PageCount&, const PageCount&) = default;
+
     PageCount operator+(const PageCount& other) const
     {
         if (sumOverflows<uint32_t>(m_pageCount, other.m_pageCount))

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -88,27 +88,7 @@ public:
         return Seconds(m_value - other.m_value);
     }
 
-    friend constexpr bool operator==(GenericTimeMixin, GenericTimeMixin) = default;
-
-    constexpr bool operator<(const GenericTimeMixin& other) const
-    {
-        return m_value < other.m_value;
-    }
-
-    constexpr bool operator>(const GenericTimeMixin& other) const
-    {
-        return m_value > other.m_value;
-    }
-
-    constexpr bool operator<=(const GenericTimeMixin& other) const
-    {
-        return m_value <= other.m_value;
-    }
-
-    constexpr bool operator>=(const GenericTimeMixin& other) const
-    {
-        return m_value >= other.m_value;
-    }
+    friend constexpr auto operator<=>(GenericTimeMixin, GenericTimeMixin) = default;
 
     DerivedTime isolatedCopy() const
     {

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -678,22 +678,17 @@ inline UInt128Impl::operator long double() const {
 
 // Comparison operators.
 
-constexpr bool operator==(UInt128Impl lhs, UInt128Impl rhs) {
-  return (UInt128Low64(lhs) == UInt128Low64(rhs) &&
-          UInt128High64(lhs) == UInt128High64(rhs));
+constexpr bool operator==(UInt128Impl lhs, UInt128Impl rhs)
+{
+    return UInt128Low64(lhs) == UInt128Low64(rhs) && UInt128High64(lhs) == UInt128High64(rhs);
 }
 
-constexpr bool operator<(UInt128Impl lhs, UInt128Impl rhs) {
-  return (UInt128High64(lhs) == UInt128High64(rhs))
-             ? (UInt128Low64(lhs) < UInt128Low64(rhs))
-             : (UInt128High64(lhs) < UInt128High64(rhs));
+constexpr std::strong_ordering operator<=>(UInt128Impl lhs, UInt128Impl rhs)
+{
+    if (auto cmp = UInt128High64(lhs) <=> UInt128High64(rhs); cmp != std::strong_ordering::equal)
+        return cmp;
+    return UInt128Low64(lhs) <=> UInt128Low64(rhs);
 }
-
-constexpr bool operator>(UInt128Impl lhs, UInt128Impl rhs) { return rhs < lhs; }
-
-constexpr bool operator<=(UInt128Impl lhs, UInt128Impl rhs) { return !(rhs < lhs); }
-
-constexpr bool operator>=(UInt128Impl lhs, UInt128Impl rhs) { return !(lhs < rhs); }
 
 // Unary operators.
 
@@ -1104,26 +1099,17 @@ inline Int128Impl::operator long double() const {
 
 // Comparison operators.
 
-constexpr bool operator==(Int128Impl lhs, Int128Impl rhs) {
-  return (Int128Low64(lhs) == Int128Low64(rhs) &&
-          Int128High64(lhs) == Int128High64(rhs));
+constexpr bool operator==(Int128Impl lhs, Int128Impl rhs)
+{
+    return Int128Low64(lhs) == Int128Low64(rhs) && Int128High64(lhs) == Int128High64(rhs);
 }
 
-constexpr bool operator<(Int128Impl lhs, Int128Impl rhs) {
-  return (Int128High64(lhs) == Int128High64(rhs))
-             ? (Int128Low64(lhs) < Int128Low64(rhs))
-             : (Int128High64(lhs) < Int128High64(rhs));
+constexpr std::strong_ordering operator<=>(Int128Impl lhs, Int128Impl rhs)
+{
+    if (auto cmp = Int128High64(lhs) <=> Int128High64(rhs); cmp != std::strong_ordering::equal)
+        return cmp;
+    return Int128Low64(lhs) <=> Int128Low64(rhs);
 }
-
-constexpr bool operator>(Int128Impl lhs, Int128Impl rhs) {
-  return (Int128High64(lhs) == Int128High64(rhs))
-             ? (Int128Low64(lhs) > Int128Low64(rhs))
-             : (Int128High64(lhs) > Int128High64(rhs));
-}
-
-constexpr bool operator<=(Int128Impl lhs, Int128Impl rhs) { return !(lhs > rhs); }
-
-constexpr bool operator>=(Int128Impl lhs, Int128Impl rhs) { return !(lhs < rhs); }
 
 // Unary operators.
 

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -203,27 +203,7 @@ public:
     WTF_EXPORT_PRIVATE ContinuousApproximateTime operator-(ContinuousApproximateTime) const;
     WTF_EXPORT_PRIVATE TimeWithDynamicClockType operator-(const TimeWithDynamicClockType&) const;
     
-    friend constexpr bool operator==(Seconds, Seconds) = default;
-    
-    constexpr bool operator<(Seconds other) const
-    {
-        return m_value < other.m_value;
-    }
-    
-    constexpr bool operator>(Seconds other) const
-    {
-        return m_value > other.m_value;
-    }
-    
-    constexpr bool operator<=(Seconds other) const
-    {
-        return m_value <= other.m_value;
-    }
-    
-    constexpr bool operator>=(Seconds other) const
-    {
-        return m_value >= other.m_value;
-    }
+    friend constexpr auto operator<=>(Seconds, Seconds) = default;
     
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
     

--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -226,11 +226,6 @@ bool WebAnimationTime::operator>=(const WebAnimationTime& other) const
     return m_value >= other.m_value;
 }
 
-bool WebAnimationTime::operator==(const WebAnimationTime& other) const
-{
-    return m_type == other.m_type && m_value == other.m_value;
-}
-
 WebAnimationTime WebAnimationTime::operator+(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -66,7 +66,7 @@ public:
     bool operator<=(const WebAnimationTime&) const;
     bool operator>(const WebAnimationTime&) const;
     bool operator>=(const WebAnimationTime&) const;
-    bool operator==(const WebAnimationTime&) const;
+    friend bool operator==(const WebAnimationTime&, const WebAnimationTime&) = default;
 
     WebAnimationTime operator+(const Seconds&) const;
     WebAnimationTime operator-(const Seconds&) const;

--- a/Source/WebCore/layout/LayoutUnits.h
+++ b/Source/WebCore/layout/LayoutUnits.h
@@ -52,15 +52,10 @@ using InlineLayoutRect = LayoutRect;
 
 struct Position {
     operator LayoutUnit() const { return value; }
-    friend bool operator==(Position, Position) = default;
+    friend auto operator<=>(Position, Position) = default;
 
     LayoutUnit value;
 };
-
-inline bool operator<(const Position& a, const Position& b)
-{
-    return a.value < b.value;
-}
 
 struct Point {
     // FIXME: Use Position<Horizontal>, Position<Vertical> to avoid top/left vs. x/y confusion.

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -87,7 +87,7 @@ public:
     LayoutUnit& operator=(const LayoutUnit&) = default;
     LayoutUnit& operator=(const float& other) { return *this = LayoutUnit(other); }
 
-    friend bool operator==(LayoutUnit, LayoutUnit) = default;
+    friend auto operator<=>(LayoutUnit, LayoutUnit) = default;
 
     static LayoutUnit fromFloatCeil(float value)
     {
@@ -246,11 +246,6 @@ private:
     int m_value;
 };
 
-inline bool operator<=(const LayoutUnit& a, const LayoutUnit& b)
-{
-    return a.rawValue() <= b.rawValue();
-}
-
 inline bool operator<=(const LayoutUnit& a, float b)
 {
     return a.toFloat() <= b;
@@ -271,11 +266,6 @@ inline bool operator<=(const int a, const LayoutUnit& b)
     return LayoutUnit(a) <= b;
 }
 
-inline bool operator>=(const LayoutUnit& a, const LayoutUnit& b)
-{
-    return a.rawValue() >= b.rawValue();
-}
-
 inline bool operator>=(const LayoutUnit& a, int b)
 {
     return a >= LayoutUnit(b);
@@ -294,11 +284,6 @@ inline bool operator>=(const LayoutUnit& a, float b)
 inline bool operator>=(const int a, const LayoutUnit& b)
 {
     return LayoutUnit(a) >= b;
-}
-
-inline bool operator<(const LayoutUnit& a, const LayoutUnit& b)
-{
-    return a.rawValue() < b.rawValue();
 }
 
 inline bool operator<(const LayoutUnit& a, int b)
@@ -324,11 +309,6 @@ inline bool operator<(const int a, const LayoutUnit& b)
 inline bool operator<(const float a, const LayoutUnit& b)
 {
     return a < b.toFloat();
-}
-
-inline bool operator>(const LayoutUnit& a, const LayoutUnit& b)
-{
-    return a.rawValue() > b.rawValue();
 }
 
 inline bool operator>(const LayoutUnit& a, double b)

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -199,11 +199,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    friend bool operator==(TimerHeapIterator, TimerHeapIterator) = default;
-    friend bool operator<(TimerHeapIterator, TimerHeapIterator);
-    friend bool operator>(TimerHeapIterator, TimerHeapIterator);
-    friend bool operator<=(TimerHeapIterator, TimerHeapIterator);
-    friend bool operator>=(TimerHeapIterator, TimerHeapIterator);
+    friend auto operator<=>(TimerHeapIterator, TimerHeapIterator) = default;
     
     friend TimerHeapIterator operator+(TimerHeapIterator, size_t);
     friend TimerHeapIterator operator+(size_t, TimerHeapIterator);
@@ -213,11 +209,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     RefPtr<ThreadTimerHeapItem>* m_pointer;
 };
-
-inline bool operator<(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer < b.m_pointer; }
-inline bool operator>(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer > b.m_pointer; }
-inline bool operator<=(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer <= b.m_pointer; }
-inline bool operator>=(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer >= b.m_pointer; }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline TimerHeapIterator operator+(TimerHeapIterator a, size_t b) { return TimerHeapIterator(a.m_pointer + b); }

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -66,6 +66,8 @@ public:
     friend constexpr FontSelectionValue operator/(FontSelectionValue, FontSelectionValue);
     friend constexpr FontSelectionValue operator-(FontSelectionValue);
 
+    friend auto operator<=>(FontSelectionValue, FontSelectionValue) = default;
+
     constexpr BackingType rawValue() const { return m_backing; }
 
 private:
@@ -141,26 +143,6 @@ constexpr FontSelectionValue operator/(FontSelectionValue a, FontSelectionValue 
 constexpr FontSelectionValue operator-(FontSelectionValue value)
 {
     return { -value.m_backing, FontSelectionValue::RawTag::RawTag };
-}
-
-constexpr bool operator<(FontSelectionValue a, FontSelectionValue b)
-{
-    return a.rawValue() < b.rawValue();
-}
-
-constexpr bool operator<=(FontSelectionValue a, FontSelectionValue b)
-{
-    return a.rawValue() <= b.rawValue();
-}
-
-constexpr bool operator>(FontSelectionValue a, FontSelectionValue b)
-{
-    return a.rawValue() > b.rawValue();
-}
-
-constexpr bool operator>=(FontSelectionValue a, FontSelectionValue b)
-{
-    return a.rawValue() >= b.rawValue();
 }
 
 constexpr FontSelectionValue italicThreshold()

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.h
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.h
@@ -46,27 +46,7 @@ public:
 
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
 
-    friend bool operator==(MonotonicObjectIdentifier, MonotonicObjectIdentifier) = default;
-
-    bool operator>(const MonotonicObjectIdentifier& other) const
-    {
-        return m_identifier > other.m_identifier;
-    }
-
-    bool operator>=(const MonotonicObjectIdentifier& other) const
-    {
-        return m_identifier >= other.m_identifier;
-    }
-
-    bool operator<(const MonotonicObjectIdentifier& other) const
-    {
-        return m_identifier < other.m_identifier;
-    }
-
-    bool operator<=(const MonotonicObjectIdentifier& other) const
-    {
-        return m_identifier <= other.m_identifier;
-    }
+    friend auto operator<=>(MonotonicObjectIdentifier, MonotonicObjectIdentifier) = default;
 
     MonotonicObjectIdentifier& increment()
     {


### PR DESCRIPTION
#### a5e8dbdc7ef9bedb8e6deacbd94125eaf48a6694
<pre>
Leverage the spaceship operator in more places to simplify the code
<a href="https://bugs.webkit.org/show_bug.cgi?id=291155">https://bugs.webkit.org/show_bug.cgi?id=291155</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/bytecode/CallVariant.h:
(JSC::CallVariant::operator&lt; const): Deleted.
(JSC::CallVariant::operator&gt; const): Deleted.
(JSC::CallVariant::operator&lt;= const): Deleted.
(JSC::CallVariant::operator&gt;= const): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlockHash.h:
(JSC::CodeBlockHash::operator&lt; const): Deleted.
(JSC::CodeBlockHash::operator&gt; const): Deleted.
(JSC::CodeBlockHash::operator&lt;= const): Deleted.
(JSC::CodeBlockHash::operator&gt;= const): Deleted.
* Source/JavaScriptCore/bytecode/VirtualRegister.h:
(JSC::VirtualRegister::operator&lt; const): Deleted.
(JSC::VirtualRegister::operator&gt; const): Deleted.
(JSC::VirtualRegister::operator&lt;= const): Deleted.
(JSC::VirtualRegister::operator&gt;= const): Deleted.
* Source/JavaScriptCore/dfg/DFGEpoch.h:
(JSC::DFG::Epoch::operator&lt; const): Deleted.
(JSC::DFG::Epoch::operator&gt; const): Deleted.
(JSC::DFG::Epoch::operator&lt;= const): Deleted.
(JSC::DFG::Epoch::operator&gt;= const): Deleted.
* Source/JavaScriptCore/jit/Reg.h:
(JSC::Reg::operator&lt; const): Deleted.
(JSC::Reg::operator&gt; const): Deleted.
(JSC::Reg::operator&lt;= const): Deleted.
(JSC::Reg::operator&gt;= const): Deleted.
* Source/JavaScriptCore/runtime/GenericOffset.h:
(JSC::GenericOffset::operator&lt; const): Deleted.
(JSC::GenericOffset::operator&gt; const): Deleted.
(JSC::GenericOffset::operator&lt;= const): Deleted.
(JSC::GenericOffset::operator&gt;= const): Deleted.
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::operator&lt; const): Deleted.
(JSC::PageCount::operator&gt; const): Deleted.
(JSC::PageCount::operator&gt;= const): Deleted.
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::operator&lt; const): Deleted.
(WTF::GenericTimeMixin::operator&gt; const): Deleted.
(WTF::GenericTimeMixin::operator&lt;= const): Deleted.
(WTF::GenericTimeMixin::operator&gt;= const): Deleted.
* Source/WTF/wtf/Seconds.h:
* Source/WebCore/animation/WebAnimationTime.cpp:
* Source/WebCore/animation/WebAnimationTime.h:
* Source/WebCore/layout/LayoutUnits.h:
(WebCore::Layout::operator&lt;): Deleted.
* Source/WebCore/platform/LayoutUnit.h:
* Source/WebCore/platform/Timer.cpp:
(WebCore::operator&lt;): Deleted.
(WebCore::operator&gt;): Deleted.
(WebCore::operator&lt;=): Deleted.
(WebCore::operator&gt;=): Deleted.
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
(WebCore::operator&lt;): Deleted.
(WebCore::operator&lt;=): Deleted.
(WebCore::operator&gt;): Deleted.
(WebCore::operator&gt;=): Deleted.
* Source/WebKit/Shared/MonotonicObjectIdentifier.h:
(WebKit::MonotonicObjectIdentifier::operator&gt; const): Deleted.
(WebKit::MonotonicObjectIdentifier::operator&gt;= const): Deleted.
(WebKit::MonotonicObjectIdentifier::operator&lt; const): Deleted.
(WebKit::MonotonicObjectIdentifier::operator&lt;= const): Deleted.

Canonical link: <a href="https://commits.webkit.org/293330@main">https://commits.webkit.org/293330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee01f9751796c815fdbd6f2ed79ba29a82e647d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98580 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75042 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6993 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48550 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91267 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106074 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83501 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5819 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19353 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15977 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30809 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120827 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25446 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33813 "Found 19735 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_lastindexof.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->