### PR TITLE
Use scrollMargin for lazy load intersection observer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-horizontal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-horizontal-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-2-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-3-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-5-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test that lazy-loaded images load when near viewport. assert_unreached: Timed out while waiting for image to load. Reached unreachable code
+PASS Test that lazy-loaded images load when near viewport.
 

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -93,8 +93,8 @@ IntersectionObserver* LazyLoadImageObserver::intersectionObserver(Document& docu
 {
     if (!m_observer) {
         auto callback = LazyImageLoadIntersectionObserverCallback::create(document);
-        static NeverDestroyed<const String> lazyLoadingRootMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
-        IntersectionObserver::Init options { &document, lazyLoadingRootMarginFallback, emptyString(), { } };
+        static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
+        IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
         auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
         if (observer.hasException())
             return nullptr;


### PR DESCRIPTION
#### 19ed0f7d93d1f3cb7b43c38642f4e78c68dcf3f7
<pre>
Use scrollMargin for lazy load intersection observer
<a href="https://bugs.webkit.org/show_bug.cgi?id=264864">https://bugs.webkit.org/show_bug.cgi?id=264864</a>

Reviewed by Tim Nguyen.

Update to follow step 2 (options) in &quot;start intersection-observing a lazy loading element&quot;:
- switch from using rootMargin to using scrollMargin in the IntersectionObserverInit dictionary.
- remove document from the IntersectionObserverInit dictionary

<a href="https://html.spec.whatwg.org/#start-intersection-observing-a-lazy-loading-element">https://html.spec.whatwg.org/#start-intersection-observing-a-lazy-loading-element</a>

This will allow images in scroll containers to load when they are near the viewport,
in stead of when they are intersecting the viewport.

This PR does not change the lazy load scroll margin, that will stay at 100%.

* Source/WebCore/html/LazyLoadImageObserver.cpp:
(WebCore::LazyLoadImageObserver::intersectionObserver):

Canonical link: <a href="https://commits.webkit.org/293552@main">https://commits.webkit.org/293552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49ceac51394e6284032d038d422de018ef4603c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75532 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32626 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7576 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6339 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20067 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31467 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->