### PR TITLE
[SwiftUI] Scrolling to a particular scroll position does not work when specifying a single axis value

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2630,6 +2630,24 @@ void LocalFrameView::scrollElementToRect(const Element& element, const IntRect& 
     setScrollPosition(IntPoint(bounds.x() - centeringOffsetX - rect.x(), bounds.y() - centeringOffsetY - rect.y()));
 }
 
+void LocalFrameView::setScrollOffsetWithOptions(std::optional<int> x, std::optional<int> y, const ScrollPositionChangeOptions& options)
+{
+    if (x && y) {
+        setScrollOffsetWithOptions({ *x, *y }, options);
+        return;
+    }
+
+    auto offset = scrollOffsetFromPosition(scrollPosition());
+
+    if (x)
+        offset.setX(*x);
+
+    if (y)
+        offset.setY(*y);
+
+    setScrollOffsetWithOptions(offset, options);
+}
+
 void LocalFrameView::setScrollOffsetWithOptions(const ScrollOffset& scrollOffset, const ScrollPositionChangeOptions& options)
 {
     LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::setScrollOffset " << scrollOffset << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -270,6 +270,7 @@ public:
 
     WEBCORE_EXPORT void scrollToEdgeWithOptions(WebCore::RectEdges<bool>, const ScrollPositionChangeOptions&);
     WEBCORE_EXPORT void setScrollOffsetWithOptions(const ScrollOffset&, const ScrollPositionChangeOptions&);
+    WEBCORE_EXPORT void setScrollOffsetWithOptions(std::optional<int> x, std::optional<int> y, const ScrollPositionChangeOptions&);
     WEBCORE_EXPORT void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions& = ScrollPositionChangeOptions::createProgrammatic()) final;
     void restoreScrollbar();
     void scheduleScrollToFocusedElement(SelectionRevealMode);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -595,7 +595,7 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 @property (nonatomic, setter=_setAlwaysBounceVertical:) BOOL _alwaysBounceVertical;
 @property (nonatomic, setter=_setAlwaysBounceHorizontal:) BOOL _alwaysBounceHorizontal;
 
-- (void)_setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
+- (void)_setContentOffsetX:(NSNumber *)x y:(NSNumber *)y animated:(BOOL)animated NS_SWIFT_NAME(_setContentOffset(x:y:animated:));
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1370,9 +1370,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->insertText(string, replacementRange);
 }
 
-- (void)_setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated
+- (void)_setContentOffsetX:(NSNumber *)x y:(NSNumber *)y animated:(BOOL)animated
 {
-    _page->setContentOffset(WebCore::IntPoint { contentOffset }, animated ? WebCore::ScrollIsAnimated::Yes : WebCore::ScrollIsAnimated::No);
+    std::optional<int> optionalX = std::nullopt;
+    if (x)
+        optionalX = static_cast<int>([x doubleValue]);
+
+    std::optional<int> optionalY = std::nullopt;
+    if (y)
+        optionalY = static_cast<int>([y doubleValue]);
+
+    _page->setContentOffset(optionalX, optionalY, animated ? WebCore::ScrollIsAnimated::Yes : WebCore::ScrollIsAnimated::No);
 }
 
 #pragma mark - QLPreviewPanelController

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -100,8 +100,11 @@ extension WebPageWebView {
         set { self._allowsMagnification = newValue }
     }
 
-    public func setContentOffset(_ offset: CGPoint, animated: Bool) {
-        scrollView.setContentOffset(offset, animated: animated)
+    public func setContentOffset(x: Double?, y: Double?, animated: Bool) {
+        let currentOffset = scrollView.contentOffset
+        let newOffset = CGPoint(x: x ?? currentOffset.x, y: y ?? currentOffset.y)
+
+        scrollView.setContentOffset(newOffset, animated: animated)
     }
 
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
@@ -128,8 +131,8 @@ extension WebPageWebView {
         set { self._rubberBandingEnabled.formUnion([.left, .right]) }
     }
 
-    public func setContentOffset(_ offset: CGPoint, animated: Bool) {
-        self._setContentOffset(offset, animated: animated)
+    public func setContentOffset(x: Double?, y: Double?, animated: Bool) {
+        self._setContentOffset(x: x.map(NSNumber.init(value:)), y: y.map(NSNumber.init(value:)), animated: animated)
     }
 
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15325,9 +15325,9 @@ void WebPageProxy::scrollToRect(const FloatRect& targetRect, const FloatPoint& o
     send(Messages::WebPage::ScrollToRect(targetRect, origin));
 }
 
-void WebPageProxy::setContentOffset(WebCore::ScrollOffset offset, WebCore::ScrollIsAnimated animated)
+void WebPageProxy::setContentOffset(std::optional<int> x, std::optional<int> y, WebCore::ScrollIsAnimated animated)
 {
-    send(Messages::WebPage::SetContentOffset(offset, animated));
+    send(Messages::WebPage::SetContentOffset(x, y, animated));
 }
 
 void WebPageProxy::scrollToEdge(WebCore::RectEdges<bool> edges, WebCore::ScrollIsAnimated animated)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1214,7 +1214,7 @@ public:
         
     void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
     void scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
-    void setContentOffset(WebCore::ScrollPosition, WebCore::ScrollIsAnimated);
+    void setContentOffset(std::optional<int> x, std::optional<int> y, WebCore::ScrollIsAnimated);
     void scrollToEdge(WebCore::RectEdges<bool>, WebCore::ScrollIsAnimated);
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9495,7 +9495,7 @@ void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::
     frameView->setScrollPosition(IntPoint(targetRect.minXMinYCorner()));
 }
 
-void WebPage::setContentOffset(WebCore::ScrollOffset offset, WebCore::ScrollIsAnimated animated)
+void WebPage::setContentOffset(std::optional<int> x, std::optional<int> y, WebCore::ScrollIsAnimated animated)
 {
     RefPtr frameView = localMainFrameView();
     if (!frameView)
@@ -9504,7 +9504,7 @@ void WebPage::setContentOffset(WebCore::ScrollOffset offset, WebCore::ScrollIsAn
     auto options = WebCore::ScrollPositionChangeOptions::createProgrammatic();
     options.animated = animated;
 
-    frameView->setScrollOffsetWithOptions(offset, options);
+    frameView->setScrollOffsetWithOptions(x, y, options);
 }
 
 void WebPage::scrollToEdge(WebCore::RectEdges<bool> edges, WebCore::ScrollIsAnimated animated)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1442,7 +1442,7 @@ public:
     bool alwaysShowsVerticalScroller() const { return m_alwaysShowsVerticalScroller; };
 
     void scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
-    void setContentOffset(WebCore::ScrollOffset, WebCore::ScrollIsAnimated);
+    void setContentOffset(std::optional<int> x, std::optional<int> y, WebCore::ScrollIsAnimated);
     void scrollToEdge(WebCore::RectEdges<bool>, WebCore::ScrollIsAnimated);
 
     void setMinimumSizeForAutoLayout(const WebCore::IntSize&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -740,7 +740,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
     ScrollToRect(WebCore::FloatRect targetRect, WebCore::FloatPoint origin)
-    SetContentOffset(WebCore::IntPoint position, enum:bool WebCore::ScrollIsAnimated animated)
+    SetContentOffset(std::optional<int> x, std::optional<int> y, enum:bool WebCore::ScrollIsAnimated animated)
     ScrollToEdge(WebCore::RectEdges<bool> edges, enum:bool WebCore::ScrollIsAnimated animated)
 
     NavigateServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier documentIdentifier, URL url) -> (enum:uint8_t WebCore::ScheduleLocationChangeResult result)

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -152,11 +152,16 @@ final class WebViewCoordinator {
         }
 
         view.scrollPosition = scrollPosition
+        let scrollPositionValue = scrollPosition.position?.wrappedValue
 
-        if let point = scrollPosition.position?.wrappedValue.point {
-            webView.setContentOffset(point, animated: context.transaction.isAnimated)
-        } else if let edge = scrollPosition.position?.wrappedValue.edge {
+        if let point = scrollPositionValue?.point {
+            webView.setContentOffset(x: point.x, y: point.y, animated: context.transaction.isAnimated)
+        } else if let edge = scrollPositionValue?.edge {
             webView.scrollTo(edge: NSDirectionalRectEdge(edge), animated: context.transaction.isAnimated)
+        } else if let x = scrollPositionValue?.x {
+            webView.setContentOffset(x: x, y: nil, animated: context.transaction.isAnimated)
+        } else if let y = scrollPositionValue?.y {
+            webView.setContentOffset(x: nil, y: y, animated: context.transaction.isAnimated)
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
@@ -36,7 +36,7 @@
 
 @interface WKWebView (Internal)
 
-- (void)_setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
+- (void)_setContentOffsetX:(NSNumber *)x y:(NSNumber *)y animated:(BOOL)animated;
 
 @end
 
@@ -131,11 +131,17 @@ TEST(ScrollingCoordinatorTests, SetContentOffset)
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView waitForNextPresentationUpdate];
 
-    [webView _setContentOffset:CGPointMake(0, 200) animated:NO];
+    [webView _setContentOffsetX:@0 y:@200 animated:NO];
     [webView waitForNextPresentationUpdate];
 
     RetainPtr scrollY = [webView stringByEvaluatingJavaScript:@"window.scrollY"];
     EXPECT_WK_STREQ("200", scrollY.get());
+
+    [webView _setContentOffsetX:@0 y:nil animated:NO];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr scrollY2 = [webView stringByEvaluatingJavaScript:@"window.scrollY"];
+    EXPECT_WK_STREQ("200", scrollY2.get());
 }
 
 TEST(ScrollingCoordinatorTests, SetContentOffsetHorizontalRTL)
@@ -146,7 +152,7 @@ TEST(ScrollingCoordinatorTests, SetContentOffsetHorizontalRTL)
     [webView synchronouslyLoadTestPageNamed:@"rtl-sideways-scrolling"];
     [webView waitForNextPresentationUpdate];
 
-    [webView _setContentOffset:CGPointMake(0, 0) animated:NO];
+    [webView _setContentOffsetX:@0 y:@0 animated:NO];
     [webView waitForNextPresentationUpdate];
 
     RetainPtr scrollX = [webView stringByEvaluatingJavaScript:@"window.scrollX"];


### PR DESCRIPTION
#### a6f68ea69e73ae1619a17c2a6f4abc4eb8de8105
<pre>
[SwiftUI] Scrolling to a particular scroll position does not work when specifying a single axis value
<a href="https://bugs.webkit.org/show_bug.cgi?id=291161">https://bugs.webkit.org/show_bug.cgi?id=291161</a>
<a href="https://rdar.apple.com/148700838">rdar://148700838</a>

Reviewed by Abrar Rahman Protyasha.

Currently, when using the `.webViewScrollPosition` view modifier on WebView, the following functions
on `ScrollPosition` work properly:

* `.scrollTo(x:y:)`
* `.scrollTo(point:)`
* `.scrollTo(edge:)`

This implements support for the functions that only affect a specific axis:

* `.scrollTo(x:)`
* `.scrollTo(y:)`

so that clients can scroll to a particualr point on one axis and have the other axis unaffected.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setScrollOffsetWithOptions):
* Source/WebCore/page/LocalFrameView.h:

Implement the main logic to handle reconciling the resolved scroll offset using the specified values,
falling back to the current scroll offset for any axis value that is not specified.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setContentOffsetX:y:animated:]):
(-[WKWebView _setContentOffset:animated:]): Deleted.

Adjust this function to take seperate optional x and y values in the form of nullable NSNumbers with double
values, which are then converted to `std::optional&lt;int&gt;`s.

* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:
(WebPageWebView.setContentOffset(_:y:animated:)):
(WebPageWebView.setContentOffset(_:animated:)): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setContentOffset):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setContentOffset):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewCoordinator.updateScrollPosition(_:context:)):

Propogate the values from the API to the web process.

Canonical link: <a href="https://commits.webkit.org/293345@main">https://commits.webkit.org/293345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26009c106ce973025d7ef9373bd3b04c05997656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55430 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13853 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 10 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7032 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48591 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106115 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18735 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84047 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19401 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25487 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->