### PR TITLE
[Page color sampler] Add a fast path that avoids snapshotting when computing fixed container edges

### DIFF
--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -309,7 +309,6 @@ std::variant<PredominantColorType, Color> PageColorSampler::predominantColor(Pag
     if (!pixelBuffer)
         return PredominantColorType::None;
 
-    static constexpr auto nearlyTransparentAlphaThreshold = 0.1;
     static constexpr auto sampleCount = 29;
     static constexpr auto minimumSampleCountForPredominantColor = 0.5 * sampleCount;
     static constexpr auto bytesPerPixel = 4;

--- a/Source/WebCore/page/PageColorSampler.h
+++ b/Source/WebCore/page/PageColorSampler.h
@@ -38,6 +38,8 @@ enum class PredominantColorType : uint8_t;
 class PageColorSampler {
 public:
     static std::optional<Color> sampleTop(Page&);
+
+    static constexpr auto nearlyTransparentAlphaThreshold = 0.1;
     static std::variant<PredominantColorType, Color> predominantColor(Page&, const LayoutRect&);
 };
 


### PR DESCRIPTION
#### 92b9c7857ee51709dd45301037020c3b86c24be8
<pre>
[Page color sampler] Add a fast path that avoids snapshotting when computing fixed container edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=291165">https://bugs.webkit.org/show_bug.cgi?id=291165</a>
<a href="https://rdar.apple.com/148602376">rdar://148602376</a>

Reviewed by Richard Robinson.

Augment the heuristics in `LocalFrameView::fixedContainerEdges` to avoid snapshotting in the common
case where a renderer in the hit-tested renderer&apos;s lineage has a visible background color; if we
find multiple background colors, fall back to using `PageColorSampler::predominantColor`. In manual
testing, this allows us to (mostly) avoid all snapshotting in websites with fixed-position content
near the edges of the viewport.

Covered by existing tests in `fast/page-color-sampling`.

Note that this also fixes <a href="https://rdar.apple.com/148175811">rdar://148175811</a>.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::isHiddenOrNearlyTransparent):
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):
* Source/WebCore/page/PageColorSampler.h:

Move a constant definition into the header, so we can reuse it in `fixedContainerEdges` above.

Canonical link: <a href="https://commits.webkit.org/293340@main">https://commits.webkit.org/293340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fe3b55c897d4f9579f4c217894a989138bc79a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32214 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84035 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->