### PR TITLE
Adopt the C++ spaceship operator in a few more places

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1104,15 +1104,20 @@ bool spanHasSuffix(std::span<T, TExtent> span, std::span<U, UExtent> suffix)
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
-int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
+std::strong_ordering compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 {
     static_assert(sizeof(T) == sizeof(U));
     static_assert(std::has_unique_object_representations_v<T>);
     static_assert(std::has_unique_object_representations_v<U>);
     int result = memcmp(a.data(), b.data(), std::min(a.size_bytes(), b.size_bytes())); // NOLINT
-    if (!result && a.size() != b.size())
-        result = (a.size() > b.size()) ? 1 : -1;
-    return result;
+    if (result) {
+        if (result < 0)
+            return std::strong_ordering::less;
+        return std::strong_ordering::greater;
+    }
+    if (a.size() != b.size())
+        return a.size() > b.size() ? std::strong_ordering::greater : std::strong_ordering::less;
+    return std::strong_ordering::equal;
 }
 
 // Returns the index of the first occurrence of |needed| in |haystack| or notFound if not present.

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -289,7 +289,7 @@ AXTextMarkerRange::AXTextMarkerRange(const std::optional<SimpleRange>& range)
 
 AXTextMarkerRange::AXTextMarkerRange(const AXTextMarker& start, const AXTextMarker& end)
 {
-    std::partial_ordering order = partialOrder(start, end);
+    auto order = start <=> end;
     if (order == std::partial_ordering::unordered) {
         m_start = { };
         m_end = { };
@@ -303,7 +303,7 @@ AXTextMarkerRange::AXTextMarkerRange(const AXTextMarker& start, const AXTextMark
 
 AXTextMarkerRange::AXTextMarkerRange(AXTextMarker&& start, AXTextMarker&& end)
 {
-    std::partial_ordering order = partialOrder(start, end);
+    auto order = start <=> end;
     if (order == std::partial_ordering::unordered) {
         m_start = { };
         m_end = { };
@@ -465,7 +465,7 @@ String AXTextMarkerRange::debugDescription() const
         ", end: {"_s, m_end.debugDescription(), '}');
 }
 
-std::partial_ordering partialOrder(const AXTextMarker& marker1, const AXTextMarker& marker2)
+std::partial_ordering operator<=>(const AXTextMarker& marker1, const AXTextMarker& marker2)
 {
     if (marker1.objectID() == marker2.objectID() && LIKELY(marker1.treeID() == marker2.treeID())) {
         if (LIKELY(marker1.m_data.characterOffset < marker2.m_data.characterOffset))
@@ -1467,7 +1467,7 @@ AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const
         endMarker = nextWordEnd();
         startMarker = endMarker.previousWordStart();
         // Don't return a right word if the word start is more than a position away from current text marker (e.g., there's a space between the word and current marker).
-        std::partial_ordering order = partialOrder(startMarker, *this);
+        auto order = startMarker <=> *this;
         if (order == std::partial_ordering::unordered)
             return { };
         if (is_gt(order))
@@ -1476,7 +1476,7 @@ AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const
         startMarker = previousWordStart();
         endMarker = startMarker.nextWordEnd();
         // Don't return a left word if the word end is more than a position away from current text marker.
-        std::partial_ordering order = partialOrder(endMarker, *this);
+        auto order = endMarker <=> *this;
         if (order == std::partial_ordering::unordered)
             return { };
         if (is_lt(order))

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -227,7 +227,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXTextMarker);
 class AXTextMarker {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXTextMarker);
     friend class AXTextMarkerRange;
-    friend std::partial_ordering partialOrder(const AXTextMarker&, const AXTextMarker&);
+    friend std::partial_ordering operator<=>(const AXTextMarker&, const AXTextMarker&);
 public:
     // Constructors
     AXTextMarker(const VisiblePosition&, TextMarkerOrigin = TextMarkerOrigin::Unknown);
@@ -358,6 +358,8 @@ public:
     AXTextMarkerRange markerRangeForLineIndex(unsigned lineIndex) const;
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
+    friend bool operator==(const AXTextMarker& a, const AXTextMarker& b) { return a.isEqual(b); }
+
 private:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     const AXTextRuns* runs() const;
@@ -376,7 +378,7 @@ private:
 
 class AXTextMarkerRange {
     WTF_MAKE_TZONE_ALLOCATED(AXTextMarkerRange);
-    friend bool operator==(const AXTextMarkerRange&, const AXTextMarkerRange&);
+    friend bool operator==(const AXTextMarkerRange&, const AXTextMarkerRange&) = default;
     friend bool operator<(const AXTextMarkerRange&, const AXTextMarkerRange&);
     friend bool operator>(const AXTextMarkerRange&, const AXTextMarkerRange&);
 public:
@@ -441,31 +443,14 @@ inline AXTextMarkerRange::AXTextMarkerRange(std::optional<AXID> treeID, std::opt
     : AXTextMarkerRange(treeID, objectID, range.location, range.location + range.length)
 { }
 
-inline bool operator==(const AXTextMarker& marker1, const AXTextMarker& marker2)
-{
-    return marker1.isEqual(marker2);
-}
-
-inline bool operator==(const AXTextMarkerRange& range1, const AXTextMarkerRange& range2)
-{
-    return range1.m_start == range2.m_start && range1.m_end == range2.m_end;
-}
-
-inline bool operator!=(const AXTextMarkerRange& range1, const AXTextMarkerRange& range2)
-{
-    return !(range1 == range2);
-}
-
 inline bool operator<(const AXTextMarkerRange& range1, const AXTextMarkerRange& range2)
 {
-    return is_lt(partialOrder(range1.m_start, range2.m_start))
-        || is_lt(partialOrder(range1.m_end, range2.m_end));
+    return is_lt(range1.m_start <=> range2.m_start) || is_lt(range1.m_end <=> range2.m_end);
 }
 
 inline bool operator>(const AXTextMarkerRange& range1, const AXTextMarkerRange& range2)
 {
-    return is_gt(partialOrder(range1.m_start, range2.m_start))
-        || is_gt(partialOrder(range1.m_end, range2.m_end));
+    return is_gt(range1.m_start <=> range2.m_start) || is_gt(range1.m_end <=> range2.m_end);
 }
 
 inline bool operator<=(const AXTextMarkerRange& range1, const AXTextMarkerRange& range2)

--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -202,28 +202,10 @@ WebAnimationTime& WebAnimationTime::operator-=(const WebAnimationTime& other)
     return *this;
 }
 
-bool WebAnimationTime::operator<(const WebAnimationTime& other) const
+std::partial_ordering operator<=>(const WebAnimationTime& a, const WebAnimationTime& b)
 {
-    ASSERT(m_type == other.m_type);
-    return m_value < other.m_value;
-}
-
-bool WebAnimationTime::operator<=(const WebAnimationTime& other) const
-{
-    ASSERT(m_type == other.m_type);
-    return m_value <= other.m_value;
-}
-
-bool WebAnimationTime::operator>(const WebAnimationTime& other) const
-{
-    ASSERT(m_type == other.m_type);
-    return m_value > other.m_value;
-}
-
-bool WebAnimationTime::operator>=(const WebAnimationTime& other) const
-{
-    ASSERT(m_type == other.m_type);
-    return m_value >= other.m_value;
+    ASSERT(a.m_type == b.m_type);
+    return a.m_value <=> b.m_value;
 }
 
 WebAnimationTime WebAnimationTime::operator+(const Seconds& other) const

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -62,11 +62,9 @@ public:
     double operator/(const WebAnimationTime&) const;
     WebAnimationTime& operator+=(const WebAnimationTime&);
     WebAnimationTime& operator-=(const WebAnimationTime&);
-    bool operator<(const WebAnimationTime&) const;
-    bool operator<=(const WebAnimationTime&) const;
-    bool operator>(const WebAnimationTime&) const;
-    bool operator>=(const WebAnimationTime&) const;
+
     friend bool operator==(const WebAnimationTime&, const WebAnimationTime&) = default;
+    friend std::partial_ordering operator<=>(const WebAnimationTime&, const WebAnimationTime&);
 
     WebAnimationTime operator+(const Seconds&) const;
     WebAnimationTime operator-(const Seconds&) const;

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -406,7 +406,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
 
     if (parsedUnits.isEmpty()) {
         std::sort(values.begin(), values.end(), [](auto& a, auto& b) {
-            return compareSpans(downcast<CSSUnitValue>(a)->unitSerialization().span(), downcast<CSSUnitValue>(b)->unitSerialization().span()) < 0;
+            return is_lt(compareSpans(downcast<CSSUnitValue>(a)->unitSerialization().span(), downcast<CSSUnitValue>(b)->unitSerialization().span()));
         });
         return CSSMathSum::create(WTFMove(values));
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1858,7 +1858,7 @@ static inline unsigned short compareDetachedElementsPosition(Node& firstNode, No
     SHA1::Digest firstHash = hashPointer(&firstNode);
     SHA1::Digest secondHash = hashPointer(&secondNode);
 
-    unsigned short direction = compareSpans(std::span { firstHash }, std::span { secondHash }) > 0 ? Node::DOCUMENT_POSITION_PRECEDING : Node::DOCUMENT_POSITION_FOLLOWING;
+    unsigned short direction = is_gt(compareSpans(std::span { firstHash }, std::span { secondHash })) ? Node::DOCUMENT_POSITION_PRECEDING : Node::DOCUMENT_POSITION_FOLLOWING;
 
     return Node::DOCUMENT_POSITION_DISCONNECTED | Node::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC | direction;
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -821,11 +821,6 @@ private:
 
 bool connectedInSameTreeScope(const Node*, const Node*);
 
-// FIXME: We should remove these but std::is_eq() / std::is_neq() are not available in
-// some of our SDKs yet (rdar://87314077).
-constexpr bool is_eq(std::partial_ordering cmp) { return cmp == 0; }
-constexpr bool is_neq(std::partial_ordering cmp) { return cmp != 0; }
-
 enum TreeType { Tree, ShadowIncludingTree, ComposedTree };
 template<TreeType = Tree> ContainerNode* parent(const Node&);
 template<TreeType = Tree> Node* commonInclusiveAncestor(const Node&, const Node&);

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1642,7 +1642,7 @@ template<TreeType treeType> std::partial_ordering treeOrder(const Position& a, c
     return treeOrder<treeType>(*makeBoundaryPoint(a), *makeBoundaryPoint(b));
 }
 
-std::partial_ordering documentOrder(const Position& a, const Position& b)
+std::partial_ordering operator<=>(const Position& a, const Position& b)
 {
     return treeOrder<ComposedTree>(a, b);
 }

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -223,11 +223,7 @@ private:
 bool operator==(const Position&, const Position&);
 
 template<TreeType treeType> std::partial_ordering treeOrder(const Position&, const Position&);
-WEBCORE_EXPORT std::partial_ordering documentOrder(const Position&, const Position&);
-bool operator<(const Position&, const Position&);
-bool operator>(const Position&, const Position&);
-bool operator>=(const Position&, const Position&);
-bool operator<=(const Position&, const Position&);
+WEBCORE_EXPORT std::partial_ordering operator<=>(const Position&, const Position&);
 
 Position makeContainerOffsetPosition(RefPtr<Node>&&, unsigned offset);
 WEBCORE_EXPORT Position makeContainerOffsetPosition(const BoundaryPoint&);
@@ -279,26 +275,6 @@ inline Position makeDeprecatedLegacyPosition(RefPtr<Node>&& node, unsigned offse
 inline bool operator==(const Position& a, const Position& b)
 {
     return a.anchorNode() == b.anchorNode() && a.deprecatedEditingOffset() == b.deprecatedEditingOffset() && a.anchorType() == b.anchorType();
-}
-
-inline bool operator<(const Position& a, const Position& b)
-{
-    return is_lt(documentOrder(a, b));
-}
-
-inline bool operator>(const Position& a, const Position& b) 
-{
-    return is_gt(documentOrder(a, b));
-}
-
-inline bool operator>=(const Position& a, const Position& b) 
-{
-    return is_gteq(documentOrder(a, b));
-}
-
-inline bool operator<=(const Position& a, const Position& b) 
-{
-    return is_lteq(documentOrder(a, b));
 }
 
 // positionBeforeNode and positionAfterNode return neighbor-anchored positions, construction is O(1)

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -198,7 +198,7 @@ ExceptionOr<short> Range::comparePoint(Node& container, unsigned offset) const
     auto ordering = treeOrder({ container, offset }, makeSimpleRange(*this));
     if (is_lt(ordering))
         return -1;
-    if (WebCore::is_eq(ordering))
+    if (is_eq(ordering))
         return 0;
     if (is_gt(ordering))
         return 1;
@@ -266,7 +266,7 @@ ExceptionOr<short> Range::compareBoundaryPoints(unsigned short how, const Range&
     auto ordering = treeOrder(makeBoundaryPoint(*thisPoint), makeBoundaryPoint(*otherPoint));
     if (is_lt(ordering))
         return -1;
-    if (WebCore::is_eq(ordering))
+    if (is_eq(ordering))
         return 0;
     if (is_gt(ordering))
         return 1;

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -807,7 +807,7 @@ VisiblePositionRange makeVisiblePositionRange(const std::optional<SimpleRange>& 
     return { makeContainerOffsetPosition(range->start), makeContainerOffsetPosition(range->end) };
 }
 
-std::partial_ordering documentOrder(const VisiblePosition& a, const VisiblePosition& b)
+std::partial_ordering operator<=>(const VisiblePosition& a, const VisiblePosition& b)
 {
     // FIXME: Should two positions with different affinity be considered equivalent or not?
     return treeOrder<ComposedTree>(a.deepEquivalent(), b.deepEquivalent());

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -107,11 +107,7 @@ private:
 
 bool operator==(const VisiblePosition&, const VisiblePosition&);
 
-WEBCORE_EXPORT std::partial_ordering documentOrder(const VisiblePosition&, const VisiblePosition&);
-bool operator<(const VisiblePosition&, const VisiblePosition&);
-bool operator>(const VisiblePosition&, const VisiblePosition&);
-bool operator<=(const VisiblePosition&, const VisiblePosition&);
-bool operator>=(const VisiblePosition&, const VisiblePosition&);
+WEBCORE_EXPORT std::partial_ordering operator<=>(const VisiblePosition&, const VisiblePosition&);
 
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPoint(const VisiblePosition&);
 
@@ -153,26 +149,6 @@ inline bool operator==(const VisiblePosition& a, const VisiblePosition& b)
 {
     // FIXME: Is it correct and helpful for this to be ignoring differences in affinity?
     return a.deepEquivalent() == b.deepEquivalent();
-}
-
-inline bool operator<(const VisiblePosition& a, const VisiblePosition& b)
-{
-    return is_lt(documentOrder(a, b));
-}
-
-inline bool operator>(const VisiblePosition& a, const VisiblePosition& b)
-{
-    return is_gt(documentOrder(a, b));
-}
-
-inline bool operator<=(const VisiblePosition& a, const VisiblePosition& b)
-{
-    return is_lteq(documentOrder(a, b));
-}
-
-inline bool operator>=(const VisiblePosition& a, const VisiblePosition& b)
-{
-    return is_gteq(documentOrder(a, b));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -376,52 +376,6 @@ Decimal Decimal::operator/(const Decimal& rhs) const
     return Decimal(resultSign, resultExponent, result);
 }
 
-bool Decimal::operator!=(const Decimal& rhs) const
-{
-    if (m_data == rhs.m_data)
-        return false;
-    const Decimal result = compareTo(rhs);
-    if (result.isNaN())
-        return false;
-    return !result.isZero();
-}
-
-bool Decimal::operator<(const Decimal& rhs) const
-{
-    const Decimal result = compareTo(rhs);
-    if (result.isNaN())
-        return false;
-    return !result.isZero() && result.isNegative();
-}
-
-bool Decimal::operator<=(const Decimal& rhs) const
-{
-    if (m_data == rhs.m_data)
-        return true;
-    const Decimal result = compareTo(rhs);
-    if (result.isNaN())
-        return false;
-    return result.isZero() || result.isNegative();
-}
-
-bool Decimal::operator>(const Decimal& rhs) const
-{
-    const Decimal result = compareTo(rhs);
-    if (result.isNaN())
-        return false;
-    return !result.isZero() && result.isPositive();
-}
-
-bool Decimal::operator>=(const Decimal& rhs) const
-{
-    if (m_data == rhs.m_data)
-        return true;
-    const Decimal result = compareTo(rhs);
-    if (result.isNaN())
-        return false;
-    return result.isZero() || !result.isNegative();
-}
-
 Decimal Decimal::abs() const
 {
     Decimal result(*this);

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -71,35 +71,18 @@ public:
     const struct in_addr& ipv4Address() const { return std::get<struct in_addr>(m_address); }
     const struct in6_addr& ipv6Address() const { return std::get<struct in6_addr>(m_address); }
 
-    enum class ComparisonResult : uint8_t {
-        CannotCompare,
-        Less,
-        Equal,
-        Greater
-    };
-
-    ComparisonResult compare(const IPAddress& other) const
+    friend std::partial_ordering operator<=>(const IPAddress& a, const IPAddress& b)
     {
-        auto comparisonResult = [](int result) {
-            if (!result)
-                return ComparisonResult::Equal;
-            if (result < 0)
-                return ComparisonResult::Less;
-            return ComparisonResult::Greater;
-        };
+        if (a.isIPv4() && b.isIPv4())
+            return compareSpans(asByteSpan(a.ipv4Address()), asByteSpan(b.ipv4Address()));
 
-        if (isIPv4() && other.isIPv4())
-            return comparisonResult(compareSpans(asByteSpan(ipv4Address()), asByteSpan(other.ipv4Address())));
+        if (a.isIPv6() && b.isIPv6())
+            return compareSpans(asByteSpan(a.ipv6Address()), asByteSpan(b.ipv6Address()));
 
-        if (isIPv6() && other.isIPv6())
-            return comparisonResult(compareSpans(asByteSpan(ipv6Address()), asByteSpan(other.ipv6Address())));
-
-        return ComparisonResult::CannotCompare;
+        return std::partial_ordering::unordered;
     }
 
-    bool operator<(const IPAddress& other) const { return compare(other) == ComparisonResult::Less; }
-    bool operator>(const IPAddress& other) const { return compare(other) == ComparisonResult::Greater; }
-    bool operator==(const IPAddress& other) const { return compare(other) == ComparisonResult::Equal; }
+    friend bool operator==(const IPAddress& a, const IPAddress& b) { return is_eq(a <=> b); }
 
 private:
     std::variant<WTF::HashTableEmptyValueType, struct in_addr, struct in6_addr> m_address;

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -270,7 +270,7 @@ struct SubtagComparison {
     size_t keyContinue;
     size_t rangeLength;
     size_t rangeContinue;
-    int comparison;
+    std::strong_ordering comparison { std::strong_ordering::equal };
 };
 
 static SubtagComparison subtagCompare(std::span<const char> key, std::span<const char> range)
@@ -299,7 +299,7 @@ static SubtagComparison subtagCompare(std::span<const char> key, std::span<const
     return result;
 }
 
-static int quoteTableLanguageComparisonFunction(const QuotesForLanguage& key, std::span<const QuotesForLanguage> range)
+static std::strong_ordering quoteTableLanguageComparisonFunction(const QuotesForLanguage& key, std::span<const QuotesForLanguage> range)
 {
     // These strings need to be compared according to "Extended Filtering", as in Section 3.3.2 in RFC4647.
     // https://tools.ietf.org/html/rfc4647#page-10
@@ -316,13 +316,13 @@ static int quoteTableLanguageComparisonFunction(const QuotesForLanguage& key, st
     if (firstSubtagComparison.keyLength != firstSubtagComparison.rangeLength)
         return firstSubtagComparison.comparison;
 
-    if (firstSubtagComparison.comparison)
+    if (is_neq(firstSubtagComparison.comparison))
         return firstSubtagComparison.comparison;
 
     for (auto& checkFurtherRange : range.subspan(1)) {
-        if (!quoteTableLanguageComparisonFunction(key, singleElementSpan(checkFurtherRange))) {
+        if (is_eq(quoteTableLanguageComparisonFunction(key, singleElementSpan(checkFurtherRange)))) {
             // Tell the binary search to check later in the array of ranges, to eventually find the match we just found here.
-            return 1;
+            return std::strong_ordering::greater;
         }
     }
 
@@ -331,7 +331,7 @@ static int quoteTableLanguageComparisonFunction(const QuotesForLanguage& key, st
 
         if (!nextSubtagComparison.rangeLength) {
             // E.g. The key is "zh-Hans" and the range is "zh".
-            return 0;
+            return std::strong_ordering::equal;
         }
 
         if (!nextSubtagComparison.keyLength) {
@@ -342,12 +342,12 @@ static int quoteTableLanguageComparisonFunction(const QuotesForLanguage& key, st
         if (nextSubtagComparison.keyLength == 1) {
             // E.g. the key is "zh-x-Hant" and the range is "zh-Hant".
             // We want to try to find the range "zh", so tell the binary search to check earlier in the array of ranges.
-            return -1;
+            return std::strong_ordering::less;
         }
 
-        if (nextSubtagComparison.keyLength == nextSubtagComparison.rangeLength && !nextSubtagComparison.comparison) {
+        if (nextSubtagComparison.keyLength == nextSubtagComparison.rangeLength && is_eq(nextSubtagComparison.comparison)) {
             // E.g. the key is "de-Latn-ch" and the range is "de-ch".
-            return 0;
+            return std::strong_ordering::equal;
         }
 
         keyOffset += nextSubtagComparison.keyContinue;
@@ -360,10 +360,10 @@ static const QuotesForLanguage* binaryFindQuotes(const QuotesForLanguage& key, s
         return nullptr;
 
     auto& middle = subrange[subrange.size() / 2];
-    int comparison = quoteTableLanguageComparisonFunction(key, std::span { quoteTable }.subspan(&middle - quoteTable.data(), 1 + middle.checkFurther));
-    if (!comparison)
+    auto comparison = quoteTableLanguageComparisonFunction(key, std::span { quoteTable }.subspan(&middle - quoteTable.data(), 1 + middle.checkFurther));
+    if (is_eq(comparison))
         return &middle;
-    if (comparison < 0)
+    if (is_lt(comparison))
         return binaryFindQuotes(key, subrange.first(subrange.size() / 2));
     return binaryFindQuotes(key, subrange.subspan(subrange.size() / 2 + 1));
 }
@@ -382,7 +382,7 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
 
         for (unsigned i = 0; i < std::size(quoteTable); ++i) {
             if (i)
-                ASSERT(compareSpans(quoteTable[i - 1].language, quoteTable[i].language) < 0);
+                ASSERT(is_lt(compareSpans(quoteTable[i - 1].language, quoteTable[i].language)));
 
             for (auto character : quoteTable[i].language)
                 ASSERT(isASCIILower(character) || character == '-');

--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -83,11 +83,8 @@ private:
 
 inline bool operator==(const SMILTime& a, const SMILTime& b) { return a.isFinite() && a.value() == b.value(); }
 inline bool operator!(const SMILTime& a) { return !a.isFinite() || !a.value(); }
-inline bool operator>(const SMILTime& a, const SMILTime& b) { return a.value() > b.value(); }
-inline bool operator<(const SMILTime& a, const SMILTime& b) { return a.value() < b.value(); }
-inline bool operator>=(const SMILTime& a, const SMILTime& b) { return a.value() > b.value() || operator==(a, b); }
-inline bool operator<=(const SMILTime& a, const SMILTime& b) { return a.value() < b.value() || operator==(a, b); }
-inline bool operator<(const SMILTimeWithOrigin& a, const SMILTimeWithOrigin& b) { return a.time() < b.time(); }
+inline auto operator<=>(const SMILTime& a, const SMILTime& b) { return a.value() <=> b.value(); }
+inline auto operator<=>(const SMILTimeWithOrigin& a, const SMILTimeWithOrigin& b) { return a.time() <=> b.time(); }
 
 SMILTime operator+(const SMILTime&, const SMILTime&);
 SMILTime operator-(const SMILTime&, const SMILTime&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7441,7 +7441,7 @@ constexpr ASCIILiteral string(std::partial_ordering ordering)
         return "less"_s;
     if (is_gt(ordering))
         return "greater"_s;
-    if (WebCore::is_eq(ordering))
+    if (is_eq(ordering))
         return "equivalent"_s;
     return "unordered"_s;
 }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -306,16 +306,6 @@ Seconds OperatingDate::secondsSinceEpoch() const
     return Seconds { dateToDaysFrom1970(m_year, m_month, m_monthDay) * secondsPerDay };
 }
 
-bool OperatingDate::operator<(const OperatingDate& other) const
-{
-    return secondsSinceEpoch() < other.secondsSinceEpoch();
-}
-
-bool OperatingDate::operator<=(const OperatingDate& other) const
-{
-    return secondsSinceEpoch() <= other.secondsSinceEpoch();
-}
-
 static DataRemovalFrequency toDataRemovalFrequency(int value)
 {
     switch (value) {

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -66,8 +66,7 @@ public:
     int monthDay() const { return m_monthDay; }
 
     friend bool operator==(const OperatingDate&, const OperatingDate&) = default;
-    bool operator<(const OperatingDate& other) const;
-    bool operator<=(const OperatingDate& other) const;
+    friend auto operator<=>(const OperatingDate& a, const OperatingDate& b) { return a.secondsSinceEpoch() <=> b.secondsSinceEpoch(); }
     
     OperatingDate(int year, int month, int monthDay)
         : m_year(year)

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -569,16 +569,14 @@ public:
         else {
             while (upper - lower > 1) {
                 auto middle = (lower + upper) / 2;
-                switch (address.compare(list[middle].m_network)) {
-                case WebCore::IPAddress::ComparisonResult::Equal:
+                auto compareResult = address <=> list[middle].m_network;
+                if (is_eq(compareResult))
                     return &list[middle];
-                case WebCore::IPAddress::ComparisonResult::Less:
+                if (is_lt(compareResult))
                     upper = middle;
-                    break;
-                case WebCore::IPAddress::ComparisonResult::Greater:
+                else if (is_gt(compareResult))
                     lower = middle;
-                    break;
-                case WebCore::IPAddress::ComparisonResult::CannotCompare:
+                else {
                     ASSERT_NOT_REACHED();
                     return nullptr;
                 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
@@ -43,7 +43,7 @@
 // FIXME(https://webkit.org/b/228175): Expose the functions tested here in WebKit internals object, then replace this test with one written in JavaScript.
 // FIXME: When doing the above, don't forget to remove the many WEBCORE_EXPORT that were added so we could compile and link this test.
 
-#define EXPECT_BOTH(a, b, forward, reversed) do { EXPECT_STREQ(string(documentOrder(a, b)), forward); EXPECT_STREQ(string(documentOrder(b, a)), reversed); } while (0)
+#define EXPECT_BOTH(a, b, forward, reversed) do { EXPECT_STREQ(string(a <=> b), forward); EXPECT_STREQ(string(b <=> a), reversed); } while (0)
 #define EXPECT_EQUIVALENT(a, b) EXPECT_BOTH(a, b, "equivalent", "equivalent")
 #define EXPECT_LESS(a, b) EXPECT_BOTH(a, b, "less", "greater")
 #define EXPECT_UNORDERED(a, b) EXPECT_BOTH(a, b, "unordered", "unordered")
@@ -71,7 +71,7 @@ static constexpr ASCIILiteral string(std::partial_ordering ordering)
         return "less"_s;
     if (is_gt(ordering))
         return "greater"_s;
-    if (WebCore::is_eq(ordering))
+    if (is_eq(ordering))
         return "equivalent"_s;
     return "unordered"_s;
 }
@@ -145,10 +145,10 @@ static CString allPositionTypeFailures(const Position& a, Node* nodeB, unsigned 
 {
     Vector<String> failures;
     for (auto& b : allPositionTypes(nodeB, offsetB)) {
-        auto result = string(documentOrder(a, b));
+        auto result = string(a <=> b);
         if (strcmp(result, string(expectedResult)))
             failures.append(makeString("order(b"_s, typeStringSuffix(b), ")="_s, result, "<expected:"_s, string(expectedResult), '>'));
-        result = string(documentOrder(b, a));
+        result = string(b <=> a);
         if (strcmp(result, string(-expectedResult)))
             failures.append(makeString("order(b"_s, typeStringSuffix(b), ")="_s, result, "<expected:"_s, string(-expectedResult), '>'));
     }
@@ -160,10 +160,10 @@ static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node* node
     Vector<String> failures;
     for (auto& a : allPositionTypes(nodeA, offsetA)) {
         for (auto& b : allPositionTypes(nodeB, offsetB)) {
-            auto result = string(documentOrder(a, b));
+            auto result = string(a <=> b);
             if (strcmp(result, string(expectedResult)))
                 failures.append(makeString("order(a"_s, typeStringSuffix(a), ",b"_s, typeStringSuffix(b), ")="_s, result, "<expected:"_s, string(expectedResult), '>'));
-            result = string(documentOrder(b, a));
+            result = string(b <=> a);
             if (strcmp(result, string(-expectedResult)))
                 failures.append(makeString("order(b"_s, typeStringSuffix(b), ",a"_s, typeStringSuffix(a), ")="_s, result, "<expected:"_s, string(-expectedResult), '>'));
         }

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
@@ -73,8 +73,8 @@ TEST(IPAddressTests, CompareIPAddresses)
     EXPECT_TRUE(address3 < address4);
     EXPECT_TRUE(address4 > address3);
     EXPECT_TRUE(address1 == WebCore::IPAddress::fromString("17.100.100.255"_s));
-    EXPECT_EQ(address1.compare(address3), WebCore::IPAddress::ComparisonResult::CannotCompare);
-    EXPECT_EQ(address4.compare(address2), WebCore::IPAddress::ComparisonResult::CannotCompare);
+    EXPECT_EQ(address1 <=> address3, std::partial_ordering::unordered);
+    EXPECT_EQ(address4 <=> address2, std::partial_ordering::unordered);
 }
 
 #endif // OS(UNIX)


### PR DESCRIPTION
#### 087241f0f367083ea6f453c487068f1959c07fe4
<pre>
Adopt the C++ spaceship operator in a few more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=291172">https://bugs.webkit.org/show_bug.cgi?id=291172</a>

Reviewed by Darin Adler.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::operator&lt;=&gt;):
(WebCore::AXTextMarker::wordRange const):
(WebCore::partialOrder): Deleted.
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::operator==):
(WebCore::operator&lt;=&gt;):
(WebCore::operator==): Deleted.
(WebCore::operator!=): Deleted.
(WebCore::operator&lt;): Deleted.
(WebCore::operator&gt;): Deleted.
(WebCore::operator&lt;=): Deleted.
(WebCore::operator&gt;=): Deleted.
* Source/WebCore/animation/WebAnimationTime.cpp:
(WebCore::operator&lt;=&gt;):
* Source/WebCore/animation/WebAnimationTime.h:
* Source/WebCore/dom/Position.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::documentOrder): Deleted.
* Source/WebCore/dom/Position.h:
(WebCore::operator&lt;): Deleted.
(WebCore::operator&gt;): Deleted.
(WebCore::operator&gt;=): Deleted.
(WebCore::operator&lt;=): Deleted.
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::documentOrder): Deleted.
* Source/WebCore/editing/VisiblePosition.h:
(WebCore::operator&lt;): Deleted.
(WebCore::operator&gt;): Deleted.
(WebCore::operator&lt;=): Deleted.
(WebCore::operator&gt;=): Deleted.
* Source/WebCore/platform/Decimal.cpp:
(WebCore::Decimal::operator!= const): Deleted.
(WebCore::Decimal::operator&lt; const): Deleted.
(WebCore::Decimal::operator&lt;= const): Deleted.
(WebCore::Decimal::operator&gt; const): Deleted.
(WebCore::Decimal::operator&gt;= const): Deleted.
* Source/WebCore/platform/Decimal.h:
(WebCore::operator==):
(WebCore::operator!=):
(WebCore::operator&lt;=&gt;):
(WebCore::Decimal::operator== const): Deleted.
* Source/WebCore/platform/network/DNS.h:
(WebCore::IPAddress::operator&lt;=&gt;):
(WebCore::IPAddress::operator==):
(WebCore::IPAddress::compare const): Deleted.
(WebCore::IPAddress::operator&lt; const): Deleted.
(WebCore::IPAddress::operator&gt; const): Deleted.
(WebCore::IPAddress::operator== const): Deleted.
* Source/WebCore/svg/animation/SMILTime.h:
(WebCore::operator&lt;=&gt;):
(WebCore::operator&gt;): Deleted.
(WebCore::operator&lt;): Deleted.
(WebCore::operator&gt;=): Deleted.
(WebCore::operator&lt;=): Deleted.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::OperatingDate::operator&lt; const): Deleted.
(WebKit::OperatingDate::operator&lt;= const): Deleted.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
(WebKit::OperatingDate::operator&lt;=&gt;):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::TrackerAddressLookupInfo::find):
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp:
(TestWebKitAPI::TEST(IPAddressTests, CompareIPAddresses)):

Canonical link: <a href="https://commits.webkit.org/293372@main">https://commits.webkit.org/293372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/154d8bb49b738e4d0c5cc0e3d73a36a5cc197370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32300 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48673 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91390 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106199 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97332 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18808 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83613 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30933 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120950 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25569 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33840 "Found 19779 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->