### PR TITLE
[SaferCPP] Address issues in WebCore/css/parser

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -25,7 +25,6 @@ css/StyleProperties.h
 css/StyleRuleImport.h
 css/StyleSheetContents.h
 css/StyleSheetList.h
-css/parser/SizesCalcParser.h
 dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -472,9 +472,6 @@ css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
 css/StyleSheetList.cpp
-css/parser/CSSPropertyParser.cpp
-css/parser/CSSPropertyParserConsumer+Grid.cpp
-css/parser/SizesCalcParser.cpp
 css/query/GenericMediaQuerySerialization.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
 css/typedom/CSSStyleImageValue.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -59,7 +59,6 @@ css/CSSValue.cpp
 css/CSSVariableReferenceValue.cpp
 css/SelectorChecker.cpp
 css/StyleRule.cpp
-css/parser/CSSParserImpl.cpp
 dom/ContainerNode.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp

--- a/Source/WebCore/css/RectBase.h
+++ b/Source/WebCore/css/RectBase.h
@@ -30,6 +30,10 @@ public:
     const CSSValue& right() const { return m_right.get(); }
     const CSSValue& bottom() const { return m_bottom.get(); }
     const CSSValue& left() const { return m_left.get(); }
+    Ref<const CSSValue> protectedTop() const { return m_top; }
+    Ref<const CSSValue> protectedRight() const { return m_right; }
+    Ref<const CSSValue> protectedBottom() const { return m_bottom; }
+    Ref<const CSSValue> protectedLeft() const { return m_left; }
 
     bool equals(const RectBase& other) const
     {

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -341,7 +341,7 @@ static CSSParserImpl::AllowedRules computeNewAllowedRules(CSSParserImpl::Allowed
 }
 
 template<typename T>
-bool CSSParserImpl::consumeRuleList(CSSParserTokenRange range, RuleList ruleListType, const T callback)
+bool CSSParserImpl::consumeRuleList(CSSParserTokenRange range, RuleList ruleListType, NOESCAPE const T& callback)
 {
     auto allowedRules = AllowedRules::RegularRules;
     switch (ruleListType) {

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -134,7 +134,7 @@ private:
 
     // Returns whether the first encountered rule was valid
     template<typename T>
-    bool consumeRuleList(CSSParserTokenRange, RuleList, T callback);
+    bool consumeRuleList(CSSParserTokenRange, RuleList, NOESCAPE const T& callback);
 
     // This function updates the range it's given.
     RefPtr<StyleRuleBase> consumeQualifiedRule(CSSParserTokenRange&, AllowedRules);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1525,10 +1525,10 @@ static bool isNumber(const CSSValue& value, double number, CSSUnitType type)
 
 static bool isNumber(const RectBase& quad, double number, CSSUnitType type)
 {
-    return isNumber(quad.top(), number, type)
-        && isNumber(quad.right(), number, type)
-        && isNumber(quad.bottom(), number, type)
-        && isNumber(quad.left(), number, type);
+    return isNumber(quad.protectedTop(), number, type)
+        && isNumber(quad.protectedRight(), number, type)
+        && isNumber(quad.protectedBottom(), number, type)
+        && isNumber(quad.protectedLeft(), number, type);
 }
 
 static bool isValueID(const RectBase& quad, CSSValueID valueID)
@@ -3268,7 +3268,7 @@ bool CSSPropertyParser::consumeAnimationRangeShorthand(CSS::PropertyParserState&
                 end = rangeEndValueForStartValue(*startPrimitiveValue);
             else {
                 RefPtr startPair = downcast<CSSValuePair>(start);
-                end = rangeEndValueForStartValue(startPair->first());
+                end = rangeEndValueForStartValue(startPair->protectedFirst());
             }
         } else {
             end = consumeSingleAnimationRangeEnd(m_range, state);

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -33,7 +33,6 @@
 namespace WebCore {
 
 class CSSCustomPropertyValue;
-class CSSProperty;
 class StylePropertyShorthand;
 
 namespace CSS {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -215,13 +215,14 @@ static bool isGridTrackFixedSized(const CSSPrimitiveValue& primitiveValue)
 
 static bool isGridTrackFixedSized(const CSSValue& value)
 {
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
         return isGridTrackFixedSized(*primitiveValue);
     auto& function = downcast<CSSFunctionValue>(value);
     if (function.name() == CSSValueFitContent || function.length() < 2)
         return false;
-    return isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.item(0)))
-        || isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.item(1)));
+
+    return isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.protectedItem(0)))
+        || isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.protectedItem(1)));
 }
 
 static RefPtr<CSSPrimitiveValue> consumeGridBreadth(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/SizesCalcParser.h
+++ b/Source/WebCore/css/parser/SizesCalcParser.h
@@ -74,7 +74,7 @@ private:
     Vector<SizesCalcValue> m_valueList;
     bool m_isValid;
     float m_result;
-    const Document& m_document;
+    Ref<const Document> m_document;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ec18ba9c09e8820d30ed23177cbdae52d9521d64
<pre>
[SaferCPP] Address issues in WebCore/css/parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=291182">https://bugs.webkit.org/show_bug.cgi?id=291182</a>
<a href="https://rdar.apple.com/148718797">rdar://148718797</a>

Reviewed by Chris Dumez.

Address SaferCPP issues in WebCore/css/parser.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/css/RectBase.h:
(WebCore::RectBase::protectedTop const):
(WebCore::RectBase::protectedRight const):
(WebCore::RectBase::protectedBottom const):
(WebCore::RectBase::protectedLeft const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeRuleList):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::isNumber):
(WebCore::CSSPropertyParser::consumeAnimationRangeShorthand):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
(WebCore::CSSPropertyParserHelpers::isGridTrackFixedSized):
* Source/WebCore/css/parser/SizesCalcParser.h:

Canonical link: <a href="https://commits.webkit.org/293502@main">https://commits.webkit.org/293502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/928114f7a1516cd8f8c13c4285ba228febe20dfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75385 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32510 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7408 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84346 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21283 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6190 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19858 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31260 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->