### PR TITLE
Fix AudioData.copyTo crashing on memcpy

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
+PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
+PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
@@ -1,0 +1,90 @@
+// META: global=window,worker
+
+test(() => {
+  for (const [formatFrom, formatTo] of [
+    ['f32', 'f32'],
+    ['f32', 'f32-planar'],
+    ['f32-planar', 'f32-planar'],
+    ['f32-planar', 'f32'],
+  ]) {
+    const data = new AudioData({
+      format: formatFrom,
+      sampleRate: 48000,
+      numberOfChannels: 1,
+      numberOfFrames: 5,
+      data: new Float32Array([1, 2, 3, 4, 5]),
+      timestamp: 0,
+    });
+    const output = new Float32Array(5);
+    data.copyTo(output.subarray(1, 4), {
+      planeIndex: 0,
+      frameOffset: 1,
+      frameCount: 3,
+      format: formatTo,
+    });
+    data.close();
+    assert_array_equals(output, [0, 2, 3, 4, 0], `only 3 middle elements are copied in ${formatFrom}->${formatTo} copy`);
+  }
+}, 'Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset');
+
+test(() => {
+  const data = new AudioData({
+    format: 'f32-planar',
+    sampleRate: 48000,
+    numberOfChannels: 2,
+    numberOfFrames: 5,
+    data: new Float32Array([
+      1, 2, 3, 4, 5, // left channel
+      6, 7, 8, 9, 10, // right channel
+    ]),
+    timestamp: 0,
+  });
+  const output = new Float32Array(10);
+  data.copyTo(output.subarray(1, 4), {
+    planeIndex: 0,
+    frameOffset: 1,
+    frameCount: 3,
+  });
+  data.copyTo(output.subarray(data.numberOfFrames + 1, data.numberOfFrames + 4), {
+    planeIndex: 1,
+    frameOffset: 1,
+    frameCount: 3,
+  });
+  data.close();
+  assert_array_equals(output, [
+    0, 2, 3, 4, 0, // left channel
+    0, 7, 8, 9, 0, // right channel
+  ], 'only 3 middle elements are copied in both channels');
+}, 'Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset');
+
+test(() => {
+  const data = new AudioData({
+    format: 'f32',
+    sampleRate: 48000,
+    numberOfChannels: 2,
+    numberOfFrames: 5,
+    data: new Float32Array([
+      1, 6,
+      2, 7,
+      3, 8,
+      4, 9,
+      5, 10,
+    ]),
+    timestamp: 0,
+  });
+  const output = new Float32Array(data.numberOfFrames * data.numberOfChannels);
+  data.copyTo(output.subarray(2, 8), {
+    planeIndex: 0,
+    frameOffset: 1,
+    frameCount: 3,
+    format: 'f32',
+  });
+  data.close();
+  assert_array_equals(output, [
+    0, 0,
+    2, 7,
+    3, 8,
+    4, 9,
+    0, 0,
+  ], 'only 3 middle elements are copied');
+}, 'Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
+PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
+PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->


### PR DESCRIPTION
#### e1a2977e3a8353fa61fcf484fdc10565c1562758
<pre>
Fix AudioData.copyTo crashing on memcpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=291070">https://bugs.webkit.org/show_bug.cgi?id=291070</a>

Reviewed by Philippe Normand and Jean-Yves Avenard.

The memcpy branch of both GStreamer and Cocoa implementations were
not taking into account copyElementCount when calculating subSource.
This was causing overwriting the target if there was enough space
and crashes if the target was just-sized for the requested number
of elements to copy.

Moreover, only mono case for planar data was using memcpy while
stereo was using the unoptimised route. This was inconsistent with
the interleaved mode which was using memcpy for any number of
channels.

Add tests for mono, stereo, planar and interleaved data. Fix writing
beyond requested range and crashes by:

- taking into account copyElementCount when calulating subSource
- taking into account frame size when calculating frameOffsetInBytes
- taking into account sample size when calculating copyLengthInBytes

To unify handling of multichannel data between planar and interleaved
modes, enumerate more cases where it&apos;s safe to use memcpy and handle
the stereo planar case by adding a plane offset to the frame offset.

It&apos;s worth mentioning differences between GStreamer and Cocoa
implementations. While GST_AUDIO_INFO_BPF (&quot;bytes per frame&quot;)
consistenly returns sampleSize * numberOfChannels, Cocoa&apos;s
CAAudioStreamDescription::bytesPerFrame() will be only multiplied
by number of channels in interleaved mode. Hence slight differences
in the way frame size and sample size are calculated in each
implementation.

It&apos;s also worth mentioning for context that copyElementCount is the
original options.frameCount already multiplied by number of channels
in case of interleaved copy. So copyLengthInBytes needs to only be
calculated from sample size, not the frame size.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker.html: Added.
* Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
(WebCore::PlatformRawAudioData::copyTo): Fixed writing out of bounds and crashes.
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::PlatformRawAudioData::copyTo): Fixed writing out of bounds and crashes.

Canonical link: <a href="https://commits.webkit.org/296217@main">https://commits.webkit.org/296217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e3598b4e3a5d577a1dd5177e848379970c304be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81709 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90480 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13183 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30443 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40156 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->