### PR TITLE
REGRESSION(292709@main): Web content process occasionally crashes under PDFScrollingPresentationController::updateForCurrentScrollability() during visible content rect updates

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -308,6 +308,8 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
 
 void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability> scrollability)
 {
+    if (!m_contentsLayer)
+        return;
     if (auto* tiledBacking = m_contentsLayer->tiledBacking())
         tiledBacking->setScrollability(scrollability);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1700,7 +1700,8 @@ void UnifiedPDFPlugin::updateScrollingExtents()
     RefPtr scrollingCoordinator = page->scrollingCoordinator();
     scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(m_scrollingNodeID, *this);
 
-    m_presentationController->updateForCurrentScrollability(computeScrollability());
+    if (m_presentationController)
+        m_presentationController->updateForCurrentScrollability(computeScrollability());
 
     CheckedPtr renderer = m_element->renderer();
     if (!renderer)


### PR DESCRIPTION
#### 57f052036b8df9689c4d76fab4731b66ff73d46f
<pre>
REGRESSION(292709@main): Web content process occasionally crashes under PDFScrollingPresentationController::updateForCurrentScrollability() during visible content rect updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=291186">https://bugs.webkit.org/show_bug.cgi?id=291186</a>
<a href="https://rdar.apple.com/148671570">rdar://148671570</a>

Reviewed by Wenson Hsieh.

Sometimes, during visible content rect updates,  we see a null
dereference under PDFScrollingPresentationController::updateForCurrentScrollability().

```
WebKit::PDFScrollingPresentationController::updateForCurrentScrollability(WTF::OptionSet&lt;WebCore::TiledBackingScrollability&gt;) (WebKit) &lt;==
      WebKit::UnifiedPDFPlugin::updateScrollingExtents() (WebKit)
        WebKit::PluginView::mainFramePageScaleFactorDidChange() (WebKit)
          auto WebKit::WebPage::updateVisibleContentRects(WebKit::VisibleContentRectUpdateInfo const&amp;, WTF::MonotonicTime)::$_0::operator()&lt;WebCore::IntPoint&gt;(float, WebCore::IntPoint const&amp;, bool) const (WebKit)
            WebKit::WebPage::updateVisibleContentRects(WebKit::VisibleContentRectUpdateInfo const&amp;, WTF::MonotonicTime) (WebKit)
```

While not immediately reproducible at desk, I can conceive this
happening if either the presentation controller or its content layer is
not properly set up before the visible content rect update is processed.

In this patch, we make the plugin and presentation controller more
robust against such crashes by introducing null check. This is
appropriate because neither the presentation controller (to the plugin)
nor the contents layer (to the presentation controller) are guaranteed
to be well formed during certain visible content rect updates.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateForCurrentScrollability):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):

Canonical link: <a href="https://commits.webkit.org/293366@main">https://commits.webkit.org/293366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a013ec19fde778095c7030e029c149d3fe2cb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49240 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75104 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101656 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14101 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13883 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83562 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21112 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30882 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->