### PR TITLE
Remove m_viewportDependencyDetectionStyle hack from CSSToLengthConversionData

### DIFF
--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -44,7 +44,6 @@ CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, S
     , m_parentStyle(&builderState.parentStyle())
     , m_renderView(builderState.document().renderView())
     , m_elementForContainerUnitResolution(builderState.element())
-    , m_viewportDependencyDetectionStyle(const_cast<RenderStyle*>(m_style))
     , m_styleBuilderState(&builderState)
 {
 }
@@ -56,7 +55,6 @@ CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, c
     , m_renderView(renderView)
     , m_elementForContainerUnitResolution(elementForContainerUnitResolution)
     , m_zoom(1.f)
-    , m_viewportDependencyDetectionStyle(const_cast<RenderStyle*>(m_style))
 {
 }
 
@@ -87,8 +85,8 @@ float CSSToLengthConversionData::zoom() const
 
 FloatSize CSSToLengthConversionData::defaultViewportFactor() const
 {
-    if (m_viewportDependencyDetectionStyle)
-        m_viewportDependencyDetectionStyle->setUsesViewportUnits();
+    if (m_styleBuilderState)
+        m_styleBuilderState->setUsesViewportUnits();
 
     if (!m_renderView)
         return { };
@@ -98,8 +96,8 @@ FloatSize CSSToLengthConversionData::defaultViewportFactor() const
 
 FloatSize CSSToLengthConversionData::smallViewportFactor() const
 {
-    if (m_viewportDependencyDetectionStyle)
-        m_viewportDependencyDetectionStyle->setUsesViewportUnits();
+    if (m_styleBuilderState)
+        m_styleBuilderState->setUsesViewportUnits();
 
     if (!m_renderView)
         return { };
@@ -109,8 +107,8 @@ FloatSize CSSToLengthConversionData::smallViewportFactor() const
 
 FloatSize CSSToLengthConversionData::largeViewportFactor() const
 {
-    if (m_viewportDependencyDetectionStyle)
-        m_viewportDependencyDetectionStyle->setUsesViewportUnits();
+    if (m_styleBuilderState)
+        m_styleBuilderState->setUsesViewportUnits();
 
     if (!m_renderView)
         return { };
@@ -120,8 +118,8 @@ FloatSize CSSToLengthConversionData::largeViewportFactor() const
 
 FloatSize CSSToLengthConversionData::dynamicViewportFactor() const
 {
-    if (m_viewportDependencyDetectionStyle)
-        m_viewportDependencyDetectionStyle->setUsesViewportUnits();
+    if (m_styleBuilderState)
+        m_styleBuilderState->setUsesViewportUnits();
 
     if (!m_renderView)
         return { };
@@ -131,8 +129,8 @@ FloatSize CSSToLengthConversionData::dynamicViewportFactor() const
 
 void CSSToLengthConversionData::setUsesContainerUnits() const
 {
-    if (m_viewportDependencyDetectionStyle)
-        m_viewportDependencyDetectionStyle->setUsesContainerUnits();
+    if (m_styleBuilderState)
+        m_styleBuilderState->setUsesContainerUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -109,8 +109,6 @@ private:
     RefPtr<const Element> m_elementForContainerUnitResolution;
     std::optional<float> m_zoom;
     std::optional<CSSPropertyID> m_propertyToCompute;
-    // FIXME: Remove this hack.
-    RenderStyle* m_viewportDependencyDetectionStyle { nullptr };
 
     Style::BuilderState* m_styleBuilderState { nullptr };
 };

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -308,6 +308,16 @@ void BuilderState::setCurrentPropertyInvalidAtComputedValueTime()
     m_invalidAtComputedValueTimeProperties.set(cssPropertyID());
 }
 
+void BuilderState::setUsesViewportUnits()
+{
+    m_style.setUsesViewportUnits();
+}
+
+void BuilderState::setUsesContainerUnits()
+{
+    m_style.setUsesContainerUnits();
+}
+
 Ref<Calculation::RandomKeyMap> BuilderState::randomKeyMap(bool perElement) const
 {
     if (perElement) {

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -138,6 +138,9 @@ public:
     bool isCurrentPropertyInvalidAtComputedValueTime() const;
     void setCurrentPropertyInvalidAtComputedValueTime();
 
+    void setUsesViewportUnits();
+    void setUsesContainerUnits();
+
     Ref<Calculation::RandomKeyMap> randomKeyMap(bool perElement) const;
 
     AnchorPositionedStates* anchorPositionedStates() { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }


### PR DESCRIPTION
#### e888c45ca558a6567929a48ea5838fc372d95ddf
<pre>
Remove m_viewportDependencyDetectionStyle hack from CSSToLengthConversionData
<a href="https://bugs.webkit.org/show_bug.cgi?id=291188">https://bugs.webkit.org/show_bug.cgi?id=291188</a>
<a href="https://rdar.apple.com/148731894">rdar://148731894</a>

Reviewed by Tim Nguyen.

We have mutable style builder state available, use that for setting the viewport unit bit.

* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::CSSToLengthConversionData):
(WebCore::CSSToLengthConversionData::defaultViewportFactor const):
(WebCore::CSSToLengthConversionData::smallViewportFactor const):
(WebCore::CSSToLengthConversionData::largeViewportFactor const):
(WebCore::CSSToLengthConversionData::dynamicViewportFactor const):
(WebCore::CSSToLengthConversionData::setUsesContainerUnits const):
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::setUsesViewportUnits):
(WebCore::Style::BuilderState::setUsesContainerUnits):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::styleForElementWithCachedMatchResult):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::applyMatchedProperties):

Move setting the document bit to a single place.

Canonical link: <a href="https://commits.webkit.org/293350@main">https://commits.webkit.org/293350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f7dbab8fa84c2c787fcd2a616a64f277d6f6d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75110 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101658 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83570 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19454 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30884 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->