### PR TITLE
Do not immediately recreate invalidated VideoToolbox session when the application has been backgrounded

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5162,10 +5162,8 @@ MediaSourcePrefersDecompressionSession:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(IOS)": false
       default: true
     WebCore:
-      "PLATFORM(IOS)": false
       default: true
   sharedPreferenceForWebProcess: true
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -169,6 +169,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if PLATFORM(IOS_FAMILY)
     void sceneIdentifierDidChange() final;
+    void applicationWillResignActive() final;
+    void applicationDidBecomeActive() final;
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1917,6 +1917,18 @@ void MediaPlayerPrivateMediaSourceAVFObjC::sceneIdentifierDidChange()
     updateSpatialTrackingLabel();
 #endif
 }
+
+void MediaPlayerPrivateMediaSourceAVFObjC::applicationWillResignActive()
+{
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->applicationWillResignActive();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::applicationDidBecomeActive()
+{
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->applicationDidBecomeActive();
+}
 #endif
 
 void MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -89,6 +89,11 @@ public:
     void videoRendererWillReconfigure(VideoMediaSampleRenderer&);
     void videoRendererDidReconfigure(VideoMediaSampleRenderer&);
 
+#if PLATFORM(IOS_FAMILY)
+    void applicationWillResignActive();
+    void applicationDidBecomeActive();
+#endif
+
     void flushActiveSourceBuffersIfNeeded();
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -234,6 +234,20 @@ void MediaSourcePrivateAVFObjC::flushActiveSourceBuffersIfNeeded()
         downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->flushIfNeeded();
 }
 
+#if PLATFORM(IOS_FAMILY)
+void MediaSourcePrivateAVFObjC::applicationWillResignActive()
+{
+    for (auto* sourceBuffer : m_activeSourceBuffers)
+        downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->applicationWillResignActive();
+}
+
+void MediaSourcePrivateAVFObjC::applicationDidBecomeActive()
+{
+    for (auto* sourceBuffer : m_activeSourceBuffers)
+        downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->applicationDidBecomeActive();
+}
+#endif
+
 #if ENABLE(ENCRYPTED_MEDIA)
 void MediaSourcePrivateAVFObjC::cdmInstanceAttached(CDMInstance& instance)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -124,6 +124,11 @@ public:
     void flush();
     void flushIfNeeded();
 
+#if PLATFORM(IOS_FAMILY)
+    void applicationWillResignActive();
+    void applicationDidBecomeActive();
+#endif
+
     void registerForErrorNotifications(SourceBufferPrivateAVFObjCErrorClient*);
     void unregisterForErrorNotifications(SourceBufferPrivateAVFObjCErrorClient*);
 
@@ -196,6 +201,7 @@ private:
     bool requiresFlush() const;
     void flushVideo();
     void setLayerRequiresFlush();
+
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     RetainPtr<AVSampleBufferAudioRenderer> audioRendererForTrackID(TrackID) const;
     void flushAudio(AVSampleBufferAudioRenderer *);
@@ -233,6 +239,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     const Ref<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
     bool m_displayLayerWasInterrupted { false };
+    bool m_applicationIsActive { true };
 #endif
     RetainPtr<NSError> m_hdcpError;
     Box<BinarySemaphore> m_hasSessionSemaphore;
@@ -276,7 +283,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 #endif
-
     ProcessIdentity m_resourceOwner;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -955,9 +955,28 @@ void SourceBufferPrivateAVFObjC::setLayerRequiresFlush()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_layerRequiresFlush = true;
-    // FIXME: Do not immediately flush the layer if the process is now backgrounded on iOS.
+#if PLATFORM(IOS_FAMILY)
+    if (m_applicationIsActive)
+        flushIfNeeded();
+#else
+    flushIfNeeded();
+#endif
+}
+
+#if PLATFORM(IOS_FAMILY)
+void SourceBufferPrivateAVFObjC::applicationWillResignActive()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_applicationIsActive = false;
+}
+
+void SourceBufferPrivateAVFObjC::applicationDidBecomeActive()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_applicationIsActive = true;
     flushIfNeeded();
 }
+#endif
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 RetainPtr<AVSampleBufferAudioRenderer> SourceBufferPrivateAVFObjC::audioRendererForTrackID(TrackID trackID) const

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -287,6 +287,8 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     void sceneIdentifierDidChange() final;
+    void applicationWillResignActive() final;
+    void applicationDidBecomeActive() final;
 #endif
 
     void isInFullscreenOrPictureInPictureChanged(bool) final;
@@ -373,6 +375,7 @@ private:
     uint32_t m_pendingAppends { 0 };
 #if PLATFORM(IOS_FAMILY)
     bool m_displayLayerWasInterrupted { false };
+    bool m_applicationIsActive { true };
 #endif
     bool m_hasAudio { false };
     bool m_hasVideo { false };

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -2027,6 +2027,19 @@ void MediaPlayerPrivateWebM::sceneIdentifierDidChange()
     updateSpatialTrackingLabel();
 #endif
 }
+
+void MediaPlayerPrivateWebM::applicationWillResignActive()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_applicationIsActive = false;
+}
+
+void MediaPlayerPrivateWebM::applicationDidBecomeActive()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_applicationIsActive = true;
+    flushIfNeeded();
+}
 #endif
 
 void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
@@ -2046,9 +2059,11 @@ void MediaPlayerPrivateWebM::setLayerRequiresFlush()
     ALWAYS_LOG(LOGIDENTIFIER);
 #if PLATFORM(IOS_FAMILY)
     m_displayLayerWasInterrupted = true;
-#endif
-    // FIXME: Do not immediately flush the layer if the process is now backgrounded on iOS.
+    if (m_applicationIsActive)
+        flushIfNeeded();
+#else
     flushIfNeeded();
+#endif
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateWebM::videoPlaybackQualityMetrics()


### PR DESCRIPTION
#### 28e62ba18030598368751e8f23f46f1d8d0a9beb
<pre>
Do not immediately recreate invalidated VideoToolbox session when the application has been backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=291189">https://bugs.webkit.org/show_bug.cgi?id=291189</a>
<a href="https://rdar.apple.com/148732453">rdar://148732453</a>

Reviewed by Jer Noble.

If the WebCoreDecompressionSession got invalidated, only flush the SourceBuffer
and re-create a new WebCoreDecompressionSession once the UIP goes back
into the foreground.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Re-enable pref now that the root cause for disabling it has been resolved.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::applicationWillResignActive):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::applicationDidBecomeActive):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::applicationWillResignActive):
(WebCore::MediaSourcePrivateAVFObjC::applicationDidBecomeActive):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setLayerRequiresFlush):
(WebCore::SourceBufferPrivateAVFObjC::applicationWillResignActive):
(WebCore::SourceBufferPrivateAVFObjC::applicationDidBecomeActive):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setLayerRequiresFlush):
(WebCore::MediaPlayerPrivateWebM::applicationWillResignActive):
(WebCore::MediaPlayerPrivateWebM::applicationDidBecomeActive):

Canonical link: <a href="https://commits.webkit.org/293403@main">https://commits.webkit.org/293403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3045fc6877665b4274fb7751171475e0c2e857b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75250 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32383 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48812 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91533 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106338 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97473 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25940 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21203 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28365 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25893 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121089 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25713 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33864 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->