### PR TITLE
[GTK] Pass available input devices from UI process to web process for Interaction Media Features implementation

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -162,10 +162,8 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
 #if ENABLE(TOUCH_EVENTS)
 #if PLATFORM(GTK)
 WEBCORE_EXPORT bool screenHasTouchDevice();
-WEBCORE_EXPORT bool screenIsTouchPrimaryInputDevice();
 #else
 constexpr bool screenHasTouchDevice() { return true; }
-constexpr bool screenIsTouchPrimaryInputDevice() { return true; }
 #endif
 #endif
 

--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -134,26 +134,13 @@ bool screenSupportsExtendedColor(Widget*)
 #if ENABLE(TOUCH_EVENTS)
 bool screenHasTouchDevice()
 {
+    // FIXME: Pass this from UI process as a screen property.
     auto* display = gdk_display_get_default();
     if (!display)
         return true;
 
     auto* seat = gdk_display_get_default_seat(display);
     return seat ? gdk_seat_get_capabilities(seat) & GDK_SEAT_CAPABILITY_TOUCH : true;
-}
-
-bool screenIsTouchPrimaryInputDevice()
-{
-    auto* display = gdk_display_get_default();
-    if (!display)
-        return true;
-
-    auto* seat = gdk_display_get_default_seat(display);
-    if (!seat)
-        return true;
-
-    auto* device = gdk_seat_get_pointer(seat);
-    return device ? gdk_device_get_source(device) == GDK_SOURCE_TOUCHSCREEN : true;
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -69,6 +69,7 @@ if (USE_GBM)
 endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/DMABufRendererBufferFormat.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/RendererBufferTransportMode.serialization.in

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -558,7 +558,7 @@ def types_that_cannot_be_forward_declared():
 
 def conditions_for_header(header):
     conditions = {
-        '"AvailableInputDevices.h"': ["PLATFORM(WPE)"],
+        '"AvailableInputDevices.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"CoreIPCAuditToken.h"': ["HAVE(AUDIT_TOKEN)"],
         '"DMABufRendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -59,13 +59,10 @@
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
+#include "AvailableInputDevices.h"
 #include "RendererBufferTransportMode.h"
 #include <WebCore/SystemSettings.h>
 #include <wtf/MemoryPressureHandler.h>
-#endif
-
-#if PLATFORM(WPE)
-#include "AvailableInputDevices.h"
 #endif
 
 namespace API {
@@ -236,6 +233,9 @@ struct WebProcessCreationParameters {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     OptionSet<RendererBufferTransportMode> rendererBufferTransportMode;
     WebCore::SystemSettings::State systemSettings;
+    std::optional<MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration;
+    bool disableFontHintingForTesting { false };
+    OptionSet<AvailableInputDevices> availableInputDevices;
 #endif
 
 #if PLATFORM(GTK)
@@ -256,21 +256,12 @@ struct WebProcessCreationParameters {
     bool applicationAccessibilityEnabled { false };
 #endif
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    std::optional<MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration;
-    bool disableFontHintingForTesting { false };
-#endif
-
 #if USE(GLIB)
     String applicationID;
     String applicationName;
 #if ENABLE(REMOTE_INSPECTOR)
     CString inspectorServerAddress;
 #endif
-#endif
-
-#if PLATFORM(WPE)
-    OptionSet<AvailableInputDevices> availableInputDevices;
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -181,6 +181,9 @@
 #if PLATFORM(GTK) || PLATFORM(WPE)
     OptionSet<WebKit::RendererBufferTransportMode> rendererBufferTransportMode;
     WebCore::SystemSettings::State systemSettings;
+    std::optional<WTF::MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration;
+    bool disableFontHintingForTesting;
+    OptionSet<WebKit::AvailableInputDevices> availableInputDevices;
 #endif
 
 #if PLATFORM(GTK)
@@ -201,21 +204,12 @@
     bool applicationAccessibilityEnabled;
 #endif
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    std::optional<WTF::MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration;
-    bool disableFontHintingForTesting;
-#endif
-
 #if USE(GLIB)
     String applicationID;
     String applicationName;
 #endif
 #if USE(GLIB) && ENABLE(REMOTE_INSPECTOR)
     CString inspectorServerAddress;
-#endif
-
-#if PLATFORM(WPE)
-    OptionSet<WebKit::AvailableInputDevices> availableInputDevices;
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebKit/Shared/glib/AvailableInputDevices.h
+++ b/Source/WebKit/Shared/glib/AvailableInputDevices.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 
 namespace WebKit {
 
@@ -37,4 +37,4 @@ enum class AvailableInputDevices : uint8_t {
 
 } // namespace WebKit
 
-#endif // PLATFORM(WPE)
+#endif // PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in
+++ b/Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in
@@ -22,7 +22,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-#if PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 
 [OptionSet] enum class WebKit::AvailableInputDevices : uint8_t {
     Mouse,
@@ -30,4 +30,4 @@
     Touchscreen,
 };
 
-#endif // PLATFORM(WPE)
+#endif // PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -33,12 +33,14 @@
 #include "WebKitUserMessage.h"
 #include "WebKitWebPagePrivate.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcess.h"
 #include "WebProcessExtensionManager.h"
 #include <WebCore/Editor.h>
 #include <WebCore/HTMLInputElement.h>
 #include <WebCore/HTMLTextAreaElement.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/PointerCharacteristics.h>
 #include <WebCore/Range.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/UserAgent.h>
@@ -204,6 +206,37 @@ String WebPage::platformUserAgent(const URL& url) const
         return String();
 
     return WebCore::standardUserAgentForURL(url);
+}
+
+bool WebPage::hoverSupportedByPrimaryPointingDevice() const
+{
+    return WebProcess::singleton().primaryPointingDevice() == AvailableInputDevices::Mouse;
+}
+
+bool WebPage::hoverSupportedByAnyAvailablePointingDevice() const
+{
+    return WebProcess::singleton().availableInputDevices().contains(AvailableInputDevices::Mouse);
+}
+
+std::optional<PointerCharacteristics> WebPage::pointerCharacteristicsOfPrimaryPointingDevice() const
+{
+    const auto& primaryPointingDevice = WebProcess::singleton().primaryPointingDevice();
+    if (primaryPointingDevice == AvailableInputDevices::Mouse)
+        return PointerCharacteristics::Fine;
+    if (primaryPointingDevice == AvailableInputDevices::Touchscreen)
+        return PointerCharacteristics::Coarse;
+    return std::nullopt;
+}
+
+OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailablePointingDevices() const
+{
+    OptionSet<PointerCharacteristics> pointerCharacteristics;
+    const auto& availableInputs = WebProcess::singleton().availableInputDevices();
+    if (availableInputs.contains(AvailableInputDevices::Mouse))
+        pointerCharacteristics.add(PointerCharacteristics::Fine);
+    if (availableInputs.contains(AvailableInputDevices::Touchscreen))
+        pointerCharacteristics.add(PointerCharacteristics::Coarse);
+    return pointerCharacteristics;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
@@ -44,7 +44,6 @@
 #include <WebCore/Page.h>
 #include <WebCore/PlatformKeyboardEvent.h>
 #include <WebCore/PlatformScreen.h>
-#include <WebCore/PointerCharacteristics.h>
 #include <WebCore/RenderTheme.h>
 #include <WebCore/RenderThemeAdwaita.h>
 #include <WebCore/Settings.h>
@@ -64,42 +63,6 @@ bool WebPage::platformCanHandleRequest(const ResourceRequest&)
 {
     notImplemented();
     return false;
-}
-
-bool WebPage::hoverSupportedByPrimaryPointingDevice() const
-{
-#if ENABLE(TOUCH_EVENTS)
-    return !screenIsTouchPrimaryInputDevice();
-#else
-    return true;
-#endif
-}
-
-bool WebPage::hoverSupportedByAnyAvailablePointingDevice() const
-{
-#if ENABLE(TOUCH_EVENTS)
-    return !screenHasTouchDevice();
-#else
-    return true;
-#endif
-}
-
-std::optional<PointerCharacteristics> WebPage::pointerCharacteristicsOfPrimaryPointingDevice() const
-{
-#if ENABLE(TOUCH_EVENTS)
-    if (screenIsTouchPrimaryInputDevice())
-        return PointerCharacteristics::Coarse;
-#endif
-    return PointerCharacteristics::Fine;
-}
-
-OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailablePointingDevices() const
-{
-#if ENABLE(TOUCH_EVENTS)
-    if (screenHasTouchDevice())
-        return PointerCharacteristics::Coarse;
-#endif
-    return PointerCharacteristics::Fine;
 }
 
 void WebPage::collapseSelectionInFrame(FrameIdentifier frameID)

--- a/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
@@ -27,11 +27,8 @@
 #include "WebPage.h"
 
 #include "DrawingArea.h"
-#include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
 #include <WebCore/NotImplemented.h>
-#include <WebCore/PlatformScreen.h>
-#include <WebCore/PointerCharacteristics.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -44,37 +41,6 @@ bool WebPage::platformCanHandleRequest(const ResourceRequest&)
 {
     notImplemented();
     return false;
-}
-
-bool WebPage::hoverSupportedByPrimaryPointingDevice() const
-{
-    return WebProcess::singleton().primaryPointingDevice() == AvailableInputDevices::Mouse;
-}
-
-bool WebPage::hoverSupportedByAnyAvailablePointingDevice() const
-{
-    return WebProcess::singleton().availableInputDevices().contains(AvailableInputDevices::Mouse);
-}
-
-std::optional<PointerCharacteristics> WebPage::pointerCharacteristicsOfPrimaryPointingDevice() const
-{
-    const auto& primaryPointingDevice = WebProcess::singleton().primaryPointingDevice();
-    if (primaryPointingDevice == AvailableInputDevices::Mouse)
-        return PointerCharacteristics::Fine;
-    if (primaryPointingDevice == AvailableInputDevices::Touchscreen)
-        return PointerCharacteristics::Coarse;
-    return std::nullopt;
-}
-
-OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailablePointingDevices() const
-{
-    OptionSet<PointerCharacteristics> pointerCharacteristics;
-    const auto& availableInputs = WebProcess::singleton().availableInputDevices();
-    if (availableInputs.contains(AvailableInputDevices::Mouse))
-        pointerCharacteristics.add(PointerCharacteristics::Fine);
-    if (availableInputs.contains(AvailableInputDevices::Touchscreen))
-        pointerCharacteristics.add(PointerCharacteristics::Coarse);
-    return pointerCharacteristics;
 }
 
 #if USE(GBM) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -74,11 +74,8 @@ OBJC_CLASS NSMutableDictionary;
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-#include "RendererBufferTransportMode.h"
-#endif
-
-#if PLATFORM(WPE)
 #include "AvailableInputDevices.h"
+#include "RendererBufferTransportMode.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -479,14 +476,9 @@ public:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     const OptionSet<RendererBufferTransportMode>& rendererBufferTransportMode() const { return m_rendererBufferTransportMode; }
     void initializePlatformDisplayIfNeeded() const;
-#endif
-
-#if PLATFORM(WPE)
     const OptionSet<AvailableInputDevices>& availableInputDevices() const { return m_availableInputDevices; }
     std::optional<AvailableInputDevices> primaryPointingDevice() const;
-#if ENABLE(WPE_PLATFORM)
     void setAvailableInputDevices(OptionSet<AvailableInputDevices>);
-#endif // ENABLE(WPE_PLATFORM)
 #endif // PLATFORM(WPE)
 
     String mediaKeysStorageDirectory() const { return m_mediaKeysStorageDirectory; }
@@ -847,9 +839,6 @@ private:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     OptionSet<RendererBufferTransportMode> m_rendererBufferTransportMode;
-#endif
-
-#if PLATFORM(WPE)
     OptionSet<AvailableInputDevices> m_availableInputDevices;
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -126,9 +126,6 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     SetScreenProperties(struct WebCore::ScreenProperties screenProperties)
 #endif
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    SetAvailableInputDevices(OptionSet<WebKit::AvailableInputDevices> availableInputDevices)
-#endif
 #if PLATFORM(MAC)
     ScrollerStylePreferenceChanged(bool useOvelayScrollbars)
 #endif
@@ -174,6 +171,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     SendMessageToWebProcessExtension(struct WebKit::UserMessage userMessage)
+    SetAvailableInputDevices(OptionSet<WebKit::AvailableInputDevices> availableInputDevices)
 #endif
 
     SeedResourceLoadStatisticsForTesting(WebCore::RegistrableDomain firstPartyDomain, WebCore::RegistrableDomain thirdPartyDomain, bool shouldScheduleNotification) -> ()

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -196,9 +196,9 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         } else
             initializePlatformDisplayIfNeeded();
     }
+#endif
 
     m_availableInputDevices = parameters.availableInputDevices;
-#endif
 
 #if USE(GSTREAMER)
     WebCore::setGStreamerOptionsFromUIProcess(WTFMove(parameters.gstreamerOptions));
@@ -297,9 +297,7 @@ void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties
     for (auto& page : m_pageMap.values())
         page->screenPropertiesDidChange();
 }
-#endif
 
-#if PLATFORM(WPE)
 std::optional<AvailableInputDevices> WebProcess::primaryPointingDevice() const
 {
     if (m_availableInputDevices.contains(AvailableInputDevices::Mouse))
@@ -309,13 +307,11 @@ std::optional<AvailableInputDevices> WebProcess::primaryPointingDevice() const
     return std::nullopt;
 }
 
-#if ENABLE(WPE_PLATFORM)
 void WebProcess::setAvailableInputDevices(OptionSet<AvailableInputDevices> availableInputDevices)
 {
     m_availableInputDevices = availableInputDevices;
 }
-#endif // ENABLE(WPE_PLATFORM)
-#endif // PLATFORM(WPE)
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 8649273e51fd9658ad0df9caea382b4550e7b4b7
<pre>
[GTK] Pass available input devices from UI process to web process for Interaction Media Features implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=291192">https://bugs.webkit.org/show_bug.cgi?id=291192</a>

Reviewed by Adrian Perez de Castro.

Using the same code added in 293276@main for WPE, but getting the devices using GTK API.

* Source/WebCore/platform/PlatformScreen.h:
(WebCore::screenHasTouchDevice):
(WebCore::screenIsTouchPrimaryInputDevice): Deleted.
* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::screenHasTouchDevice):
(WebCore::screenIsTouchPrimaryInputDevice): Deleted.
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/Scripts/webkit/messages.py:
(conditions_for_header):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/glib/AvailableInputDevices.h:
* Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in:
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::toAvailableInputDevices):
(WebKit::availableInputDevices):
(WebKit::seatDevicesChangedCallback):
(WebKit::WebProcessPool::platformInitialize):
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::platformInvalidateContext):
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::hoverSupportedByPrimaryPointingDevice const):
(WebKit::WebPage::hoverSupportedByAnyAvailablePointingDevice const):
(WebKit::WebPage::pointerCharacteristicsOfPrimaryPointingDevice const):
(WebKit::WebPage::pointerCharacteristicsOfAllAvailablePointingDevices const):
* Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp:
(WebKit::WebPage::hoverSupportedByPrimaryPointingDevice const): Deleted.
(WebKit::WebPage::hoverSupportedByAnyAvailablePointingDevice const): Deleted.
(WebKit::WebPage::pointerCharacteristicsOfPrimaryPointingDevice const): Deleted.
(WebKit::WebPage::pointerCharacteristicsOfAllAvailablePointingDevices const): Deleted.
* Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp:
(WebKit::WebPage::hoverSupportedByPrimaryPointingDevice const): Deleted.
(WebKit::WebPage::hoverSupportedByAnyAvailablePointingDevice const): Deleted.
(WebKit::WebPage::pointerCharacteristicsOfPrimaryPointingDevice const): Deleted.
(WebKit::WebPage::pointerCharacteristicsOfAllAvailablePointingDevices const): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::setScreenProperties):

Canonical link: <a href="https://commits.webkit.org/293352@main">https://commits.webkit.org/293352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbba77a346c88246325e43f53905b3df28967e2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75115 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55472 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98146 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83573 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19461 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30891 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->