### PR TITLE
[GTK] Pass touchscreen presence flag from UI process to web process as part of ScreenProperties

### DIFF
--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -69,6 +69,9 @@ struct ScreenProperties {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     OptionSet<ContentsFormat> screenContentsFormatsForTesting;
 #endif
+#if ENABLE(TOUCH_EVENTS) && PLATFORM(GTK)
+    bool screenHasTouchDevice { true };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -134,13 +134,7 @@ bool screenSupportsExtendedColor(Widget*)
 #if ENABLE(TOUCH_EVENTS)
 bool screenHasTouchDevice()
 {
-    // FIXME: Pass this from UI process as a screen property.
-    auto* display = gdk_display_get_default();
-    if (!display)
-        return true;
-
-    auto* seat = gdk_display_get_default_seat(display);
-    return seat ? gdk_seat_get_capabilities(seat) & GDK_SEAT_CAPABILITY_TOUCH : true;
+    return getScreenProperties().screenHasTouchDevice;
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2524,6 +2524,9 @@ struct WebCore::ScreenProperties {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     OptionSet<WebCore::ContentsFormat> screenContentsFormatsForTesting;
 #endif
+#if ENABLE(TOUCH_EVENTS) && PLATFORM(GTK)
+    bool screenHasTouchDevice;
+#endif
 };
 
 class WebCore::PlatformTimeRanges {

--- a/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
@@ -118,6 +118,11 @@ ScreenProperties ScreenManager::collectScreenProperties() const
     ScreenProperties properties;
     properties.primaryDisplayID = m_primaryDisplayID;
 
+#if ENABLE(TOUCH_EVENTS)
+    if (auto* seat = gdk_display_get_default_seat(gdk_display_get_default()))
+        properties.screenHasTouchDevice = gdk_seat_get_capabilities(seat) & GDK_SEAT_CAPABILITY_TOUCH;
+#endif
+
     for (const auto& iter : m_screenToDisplayIDMap) {
         GdkMonitor* monitor = iter.key;
         ScreenData data;


### PR DESCRIPTION
#### 31da4b16314913d9a11cabddc35d9e69ff5ff146
<pre>
[GTK] Pass touchscreen presence flag from UI process to web process as part of ScreenProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=291198">https://bugs.webkit.org/show_bug.cgi?id=291198</a>

Reviewed by Adrian Perez de Castro.

Instead of using the GTK API from the web process.

* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::screenHasTouchDevice):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp:
(WebKit::ScreenManager::collectScreenProperties const):

Canonical link: <a href="https://commits.webkit.org/293404@main">https://commits.webkit.org/293404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c90e6a350ec51eee4439525d39b506cde8b1251

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75124 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83580 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19474 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16063 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30903 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->