### PR TITLE
Regression(293232@main) imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html is crashing in debug

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -59,8 +59,7 @@ uint64_t RTCEncodedFrame::timestamp() const
 
 Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame(JSC::VM& vm, ShouldNeuter shouldNeuter)
 {
-    ASSERT(!m_isNeutered);
-    if (shouldNeuter == ShouldNeuter::Yes) {
+    if (shouldNeuter == ShouldNeuter::Yes && !m_isNeutered) {
         m_isNeutered = true;
         if (m_data) {
             m_frame->setData(m_data->span());


### PR DESCRIPTION
#### 3babcf544dfea3b5dbdc201d3008973db87ead72
<pre>
Regression(293232@main) imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html is crashing in debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=291211">https://bugs.webkit.org/show_bug.cgi?id=291211</a>
<a href="https://rdar.apple.com/148713897">rdar://148713897</a>

Reviewed by Eric Carlson.

It appears `RTCEncodedFrame::rtcFrame()` can be called when `m_isNeutered` has already
been set, thus hitting the `ASSERT(!m_isNeutered)` assertion. Instead of asserting,
deal at runtime with the frame having already been neutered.

* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::rtcFrame):

Canonical link: <a href="https://commits.webkit.org/293382@main">https://commits.webkit.org/293382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eb1405c6cb921b21a4bf903346e1ff6909a66b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75161 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7129 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84134 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19535 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->