### PR TITLE
TextDecoder raises "RangeError: Bad value" exception after 2GB of text

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -231,6 +231,8 @@ http/tests/security/clipboard/drag-drop-html-cross-origin-iframe-in-same-origin.
 fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
+[ Debug ] security/decode-buffer-size.html [ Skip ]
+[ Debug ] security/text-decode-long-strings.html [ Skip ]
 
 # Only iOS supports QuickLook
 quicklook [ Skip ]

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4351,6 +4351,9 @@ webkit.org/b/278719 imported/w3c/web-platform-tests/touch-events/touch-toucheven
 
 webkit.org/b/282966 imported/w3c/web-platform-tests/scroll-to-text-fragment/iframe-scroll.sub.html [ Failure ]
 
+# EWS indicates this test is too slow on bots.
+security/decode-buffer-size.html [ Skip ]
+
 webkit.org/b/153771 animations/resume-after-page-cache.html [ Failure Pass ]
 
 fast/canvas/webgl/context-lost-restored-p3.html [ Failure ]

--- a/LayoutTests/security/decode-buffer-size-expected.txt
+++ b/LayoutTests/security/decode-buffer-size-expected.txt
@@ -1,3 +1,5 @@
-ALERT: successfully caught exception RangeError: Bad value
-ALERT: successfully caught exception RangeError: Bad value
+ALERT: successfully caught exception TypeError: Type error
+ALERT: successfully caught exception TypeError: Type error
+ALERT: decoded string from array with length 0x80000000 populated with UTF-8 encoding of U+2118
+ALERT: successfully decoded many buffers
 

--- a/LayoutTests/security/decode-buffer-size.html
+++ b/LayoutTests/security/decode-buffer-size.html
@@ -6,6 +6,24 @@ const decoder = new TextDecoder('utf-8', { fatal: true });
 decoder.decode(new Uint8Array([0xf0]), {stream: true});
 try { decoder.decode(new Uint8Array(0xffffffff)) } catch (e) { alert('successfully caught exception ' + e); }
 try { decoder.decode(new Uint8Array(0x7fffffff)) } catch (e) { alert('successfully caught exception ' + e); }
+
+var array = new Uint8Array(0x80000000);
+const U2118 = new Uint8Array([0xe2, 0x84, 0x98]); // UTF-8 encoding of U+2118
+for (var i = 0; i < 0x80000000 - 3; i = i + 3) {
+    array.set(U2118, i)
+}
+try { decoder.decode(array) } catch (e) { alert('unexpected error ' + e) }
+alert('decoded string from array with length 0x80000000 populated with UTF-8 encoding of U+2118');
+
+try {
+    const d = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+    for (var i = 0; i < 3; i++) {
+        let s = d.decode(new Uint8Array(0x6fffffff));
+    }
+    alert('successfully decoded many buffers');
+} catch (e) {
+    alert('caught unexpected exception ' + e);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/security/text-decode-long-strings-expected.txt
+++ b/LayoutTests/security/text-decode-long-strings-expected.txt
@@ -1,3 +1,3 @@
-CONSOLE MESSAGE: error RangeError: Bad value
-CONSOLE MESSAGE: error RangeError: Bad value
+CONSOLE MESSAGE: stream decoded string from empty array with length 0x7fffffff
+CONSOLE MESSAGE: stream decoded string from empty array with length 0x80000000
 

--- a/LayoutTests/security/text-decode-long-strings.html
+++ b/LayoutTests/security/text-decode-long-strings.html
@@ -4,7 +4,9 @@
  var decoder = new TextDecoder('utf-8');
  decoder.decode(new Uint8Array(0x7fffffff), { stream: true });
  try { decoder.decode(new Uint8Array(1), { stream: true }) } catch (e) { console.log('error ' + e) }
+ console.log('stream decoded string from empty array with length 0x7fffffff');
 
- var decoder = new TextDecoder('utf-8');
  try { decoder.decode(new Uint8Array(0x80000000)) } catch (e) { console.log('error ' + e) }
+ console.log('stream decoded string from empty array with length 0x80000000');
+
  </script>

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -385,6 +385,10 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
         m_partialSequenceSize = 0;
     if (flush || buffer.length())
         m_shouldStripByteOrderMark = false;
+    if (buffer.length() > String::MaxLength) {
+        sawError = true;
+        return { };
+    }
     return String::adopt(WTFMove(buffer));
 
 upConvertTo16Bit:
@@ -466,6 +470,10 @@ upConvertTo16Bit:
         m_partialSequenceSize = 0;
     if (flush || buffer16.length())
         m_shouldStripByteOrderMark = false;
+    if (buffer16.length() > String::MaxLength) {
+        sawError = true;
+        return { };
+    }
     return String::adopt(WTFMove(buffer16));
 }
 

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -66,10 +66,6 @@ ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType>
             m_codec->stripByteOrderMark();
     }
 
-    m_decodedBytes += data.size();
-    if (m_decodedBytes > String::MaxLength)
-        return Exception { ExceptionCode::RangeError };
-
     bool sawError = false;
     String result = m_codec->decode(data, !options.stream, m_options.fatal, sawError);
 

--- a/Source/WebCore/dom/TextDecoder.h
+++ b/Source/WebCore/dom/TextDecoder.h
@@ -60,7 +60,6 @@ private:
     const PAL::TextEncoding m_textEncoding;
     const Options m_options;
     std::unique_ptr<PAL::TextCodec> m_codec;
-    size_t m_decodedBytes { 0 };
 };
 
 }


### PR DESCRIPTION
#### 8c5a1e5c6db5b95887631548137124af5e8aff98
<pre>
TextDecoder raises &quot;RangeError: Bad value&quot; exception after 2GB of text
<a href="https://bugs.webkit.org/show_bug.cgi?id=280593">https://bugs.webkit.org/show_bug.cgi?id=280593</a>
<a href="https://rdar.apple.com/137394167">rdar://137394167</a>

Reviewed by Darin Adler.

In <a href="https://rdar.apple.com/130960796">rdar://130960796</a> I restricted the total input of TextDecoder when I should&apos;ve
restricted the incremental output of TextDecoder.  I did so by limiting the String
output size of TextCodecUTF8 to String::MaxLength like we do other places we make
a String.  I verified that other TextCodec implementations all use StringBuilder,
which safely crashes on overflow, which we can&apos;t really test directly right now.

* LayoutTests/security/decode-buffer-size-expected.txt:
* LayoutTests/security/decode-buffer-size.html:
* LayoutTests/security/text-decode-long-strings-expected.txt:
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::decode):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::decode):
* Source/WebCore/dom/TextDecoder.h:

Canonical link: <a href="https://commits.webkit.org/293416@main">https://commits.webkit.org/293416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699392e5bd5395a1f93e3e4b5ebecd2410907ac3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14261 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89276 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48811 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84213 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19653 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16068 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31078 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->