### PR TITLE
[WebGPU] Debug metal device detection is failing on LegacySV iOS devices

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -155,7 +155,8 @@ bool isShaderValidationEnabled(id<MTLDevice> device)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // Workaround for rdar://141660277
-        if ((result = [NSStringFromClass([device class]) containsString:@"Debug"]))
+        NSString* deviceName = NSStringFromClass([device class]);
+        if ((result = [deviceName containsString:@"Debug"] || [deviceName containsString:@"LegacySV"]))
             WTFLogAlways("WebGPU: Using DEBUG Metal device: retaining references"); // NOLINT
     });
     return result;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -353,7 +353,6 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
     if (!icbCommand)
         return true;
 
-#if CPU(X86_64)
     RefPtr renderPassEncoder = m_renderPassEncoder.get();
     if (renderPassEncoder && passWasSplit) {
         id<MTLRenderCommandEncoder> commandEncoder = renderPassEncoder->renderCommandEncoder();
@@ -381,9 +380,6 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
             }
         }
     }
-#else
-    UNUSED_PARAM(passWasSplit);
-#endif
 
     for (auto& [groupIndex, group] : m_bindGroups) {
         RefPtr protectedGroup = group;


### PR DESCRIPTION
#### 7b791573affbab202268645adf291fc44f98b30c
<pre>
[WebGPU] Debug metal device detection is failing on LegacySV iOS devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=291218">https://bugs.webkit.org/show_bug.cgi?id=291218</a>
<a href="https://rdar.apple.com/148445495">rdar://148445495</a>

Reviewed by Cameron McCormack.

The shader validation workaround added in <a href="https://bugs.webkit.org/show_bug.cgi?id=290739">https://bugs.webkit.org/show_bug.cgi?id=290739</a>
was never applied on some devices since their MTLDevice name was MTLLegacySVDevice which
does not contain the string &apos;Debug&apos;.

No test as LegacySV is only applicable to older iOS devices which are not run as part of EWS.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::isShaderValidationEnabled):
Check for both strings.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
This is needed on SV iOS devices too, in production we would never encounter this logic.

Canonical link: <a href="https://commits.webkit.org/293389@main">https://commits.webkit.org/293389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/684bb2135ccc79b8ac9cddbd01f70ae7272326fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55532 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/13974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48717 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106243 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84144 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83633 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30977 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->