### PR TITLE
Reduce use of (NSString *) casting in the codebase

### DIFF
--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -274,7 +274,7 @@ bool setExcludedFromBackup(const String& path, bool excluded)
         return false;
 
     NSError *error;
-    if (![[NSURL fileURLWithPath:(NSString *)path isDirectory:YES] setResourceValue:[NSNumber numberWithBool:excluded] forKey:NSURLIsExcludedFromBackupKey error:&error]) {
+    if (![[NSURL fileURLWithPath:path.createNSString().get() isDirectory:YES] setResourceValue:[NSNumber numberWithBool:excluded] forKey:NSURLIsExcludedFromBackupKey error:&error]) {
         LOG_ERROR("Cannot exclude path '%s' from backup with error '%@'", path.utf8().data(), error.localizedDescription);
         return false;
     }

--- a/Source/WTF/wtf/cocoa/NSURLExtras.h
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.h
@@ -35,8 +35,8 @@ namespace WTF {
 WTF_EXPORT_PRIVATE NSString *userVisibleString(NSURL *);
 WTF_EXPORT_PRIVATE NSURL *URLWithUserTypedString(NSString *, NSURL *ignored = nil); // Return value of nil means error.
 WTF_EXPORT_PRIVATE NSURL *URLByRemovingUserInfo(NSURL *);
-WTF_EXPORT_PRIVATE NSString *decodeHostName(NSString *); // Return value of nil means error.
-WTF_EXPORT_PRIVATE NSString *encodeHostName(NSString *); // Return value of nil means error.
+WTF_EXPORT_PRIVATE RetainPtr<NSString> decodeHostName(NSString *); // Return value of nil means error.
+WTF_EXPORT_PRIVATE RetainPtr<NSString> encodeHostName(NSString *); // Return value of nil means error.
 WTF_EXPORT_PRIVATE NSURL *URLByTruncatingOneCharacterBeforeComponent(NSURL *, CFURLComponentType);
 WTF_EXPORT_PRIVATE NSURL *URLWithData(NSData *, NSURL *baseURL);
 WTF_EXPORT_PRIVATE NSData *originalURLData(NSURL *);

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -100,20 +100,24 @@ static String decodePercentEscapes(const String& string)
     return substring.get();
 }
 
-NSString *decodeHostName(NSString *string)
+RetainPtr<NSString> decodeHostName(NSString *string)
 {
     std::optional<String> host = URLHelpers::mapHostName(string, nullptr);
     if (!host)
         return nil;
-    return !*host ? string : (NSString *)*host;
+    if (!*host)
+        return string;
+    return host->createNSString();
 }
 
-NSString *encodeHostName(NSString *string)
+RetainPtr<NSString> encodeHostName(NSString *string)
 {
     std::optional<String> host = URLHelpers::mapHostName(string, decodePercentEscapes);
     if (!host)
         return nil;
-    return !*host ? string : (NSString *)*host;
+    if (!*host)
+        return string;
+    return host->createNSString();
 }
 
 static RetainPtr<NSString> stringByTrimmingWhitespace(NSString *string)

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm
@@ -29,6 +29,8 @@
 #if ENABLE(APPLE_PAY)
 
 #import "ApplePaySessionError.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
 #import <pal/cocoa/PassKitSoftLink.h>
 
 namespace WebCore {
@@ -44,9 +46,8 @@ static std::optional<ApplePaySessionError> additionalError(NSError *error)
     if (error.code != pkPaymentAuthorizationFeatureApplicationError)
         return std::nullopt;
 
-    id bindTokenValue = error.userInfo[bindTokenKey];
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!bindTokenValue || [bindTokenValue isKindOfClass:NSString.class]);
-    return ApplePaySessionError { "featureApplicationError"_s, { { "bindToken"_s, (NSString *)bindTokenValue } } };
+    RetainPtr bindTokenValue = checked_objc_cast<NSString>(error.userInfo[bindTokenKey]);
+    return ApplePaySessionError { "featureApplicationError"_s, { { "bindToken"_s, bindTokenValue.get() } } };
 #else
     UNUSED_PARAM(error);
     return std::nullopt;

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
@@ -77,11 +77,11 @@ NSDictionary *NotificationOptionsPayload::dictionaryRepresentation() const
 {
     return @{
         WebDirKey : @((uint8_t)dir),
-        WebLangKey : (NSString *)lang,
-        WebBodyKey : (NSString *)body,
-        WebTagKey : (NSString *)tag,
-        WebIconKey : (NSString *)icon,
-        WebDataJSONKey : (NSString *)dataJSONString,
+        WebLangKey : lang.createNSString().get(),
+        WebBodyKey : body.createNSString().get(),
+        WebTagKey : tag.createNSString().get(),
+        WebIconKey : icon.createNSString().get(),
+        WebDataJSONKey : dataJSONString.createNSString().get(),
         WebSilentKey : silent.has_value() ? @(*silent) : [NSNull null],
     };
 }

--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -81,7 +81,7 @@ NSDictionary *NotificationPayload::dictionaryRepresentation() const
 
     return @{
         WebNotificationDefaultActionKey : defaultActionURL.createNSURL().get(),
-        WebNotificationTitleKey : (NSString *)title,
+        WebNotificationTitleKey : title.createNSString().get(),
         WebNotificationAppBadgeKey : nsAppBadge,
         WebNotificationOptionsKey : nsOptions,
         WebNotificationMutableKey : @(isMutable),

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -7,7 +7,6 @@ Modules/applepay/cocoa/PaymentCocoa.mm
 Modules/applepay/cocoa/PaymentContactCocoa.mm
 Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
 Modules/applepay/cocoa/PaymentMethodCocoa.mm
-Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm
 Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
 Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
 Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -75,7 +74,6 @@ platform/cocoa/ParentalControlsContentFilter.mm
 platform/cocoa/PasteboardCocoa.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
-platform/cocoa/PublicSuffixStoreCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -539,7 +539,7 @@ static void addFirstTextMarker(NSMutableDictionary *change, AXObjectCache& cache
 
 static NSDictionary *textReplacementChangeDictionary(AXObjectCache& cache, AccessibilityObject& object, AXTextEditType type, const String& string, const VisiblePosition& visiblePosition = { })
 {
-    NSString *text = (NSString *)string;
+    RetainPtr text = string.createNSString();
     NSUInteger length = [text length];
     if (!length)
         return nil;
@@ -550,7 +550,7 @@ static NSDictionary *textReplacementChangeDictionary(AXObjectCache& cache, Acces
         [change setObject:@(length) forKey:NSAccessibilityTextChangeValueLength];
         text = [text substringToIndex:AXValueChangeTruncationLength];
     }
-    [change setObject:text forKey:NSAccessibilityTextChangeValue];
+    [change setObject:text.get() forKey:NSAccessibilityTextChangeValue];
 
     if (!visiblePosition.isNull())
         addTextMarkerForVisiblePosition(change.get(), cache, visiblePosition);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -393,7 +393,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (NSArray<NSString *> *)baseAccessibilitySpeechHint
 {
-    return [(NSString *)self.axBackingObject->speechHint() componentsSeparatedByString:@" "];
+    return [self.axBackingObject->speechHint().createNSString() componentsSeparatedByString:@" "];
 }
 
 #if HAVE(ACCESSIBILITY_FRAMEWORK)
@@ -717,13 +717,13 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
     auto editingStyles = axObject->resolvedEditingStyles();
     for (String& key : editingStyles.keys()) {
         auto value = editingStyles.get(key);
-        id result = WTF::switchOn(value,
-            [] (String& typedValue) -> id { return (NSString *)typedValue; },
-            [] (bool& typedValue) -> id { return @(typedValue); },
-            [] (int& typedValue) -> id { return @(typedValue); },
+        RetainPtr result = WTF::switchOn(value,
+            [] (String& typedValue) -> RetainPtr<id> { return typedValue.createNSString(); },
+            [] (bool& typedValue) -> RetainPtr<id> { return @(typedValue); },
+            [] (int& typedValue) -> RetainPtr<id> { return @(typedValue); },
             [] (auto&) { return nil; }
         );
-        results[(NSString *)key] = result;
+        results[key.createNSString().get()] = result.get();
     }
     return results;
 }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1330,7 +1330,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             [] (bool& typedValue) -> id { return @(typedValue); },
             [] (unsigned& typedValue) -> id { return @(typedValue); },
             [] (float& typedValue) -> id { return @(typedValue); },
-            [] (String& typedValue) -> id { return (NSString *)typedValue; },
+            [] (String& typedValue) -> id { return typedValue.createNSString().autorelease(); },
             [&backingObject] (WallTime& typedValue) -> id {
                 NSInteger offset = gmtToLocalTimeOffset(backingObject->dateTimeComponentsType());
                 auto time = typedValue.secondsSinceEpoch().value();
@@ -1346,7 +1346,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityDateTimeComponentsAttribute])
         return @(convertToAXFDateTimeComponents(backingObject->dateTimeComponentsType()));
 
-    if ([attributeName isEqualToString:(NSString *)kAXMenuItemMarkCharAttribute]) {
+    if ([attributeName isEqualToString:bridge_cast(kAXMenuItemMarkCharAttribute)]) {
         const unichar ch = 0x2713; // ✓ used on Mac for selected menu items.
         return (backingObject->isChecked()) ? [NSString stringWithCharacters:&ch length:1] : nil;
     }
@@ -3441,22 +3441,22 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if (backingObject->isTextControl()) {
-        if ([attribute isEqualToString: (NSString *)kAXLineForIndexParameterizedAttribute]) {
+        if ([attribute isEqualToString: bridge_cast(kAXLineForIndexParameterizedAttribute)]) {
             int lineNumber = backingObject->doAXLineForIndex([number intValue]);
             if (lineNumber < 0)
                 return nil;
             return @(lineNumber);
         }
 
-        if ([attribute isEqualToString:(NSString *)kAXRangeForLineParameterizedAttribute]) {
+        if ([attribute isEqualToString:bridge_cast(kAXRangeForLineParameterizedAttribute)]) {
             auto textRange = backingObject->doAXRangeForLine([number intValue]);
             return [NSValue valueWithRange:textRange];
         }
 
-        if ([attribute isEqualToString:(NSString *)kAXStringForRangeParameterizedAttribute])
+        if ([attribute isEqualToString:bridge_cast(kAXStringForRangeParameterizedAttribute)])
             return rangeSet ? (id)backingObject->doAXStringForRange(range) : nil;
 
-        if ([attribute isEqualToString:(NSString *)kAXRangeForPositionParameterizedAttribute]) {
+        if ([attribute isEqualToString:bridge_cast(kAXRangeForPositionParameterizedAttribute)]) {
             if (!pointSet)
                 return nil;
 
@@ -3465,12 +3465,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return [NSValue valueWithRange:textRange];
         }
 
-        if ([attribute isEqualToString:(NSString *)kAXRangeForIndexParameterizedAttribute]) {
+        if ([attribute isEqualToString:bridge_cast(kAXRangeForIndexParameterizedAttribute)]) {
             auto textRange = backingObject->doAXRangeForIndex([number intValue]);
             return [NSValue valueWithRange:textRange];
         }
 
-        if ([attribute isEqualToString:(NSString *)kAXBoundsForRangeParameterizedAttribute]) {
+        if ([attribute isEqualToString:bridge_cast(kAXBoundsForRangeParameterizedAttribute)]) {
             if (!rangeSet)
                 return nil;
 
@@ -3479,13 +3479,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return [NSValue valueWithRect:rect];
         }
 
-        if ([attribute isEqualToString:(NSString *)kAXRTFForRangeParameterizedAttribute])
+        if ([attribute isEqualToString:bridge_cast(kAXRTFForRangeParameterizedAttribute)])
             return rangeSet ? rtfForNSRange(*backingObject, range) : nil;
 
-        if ([attribute isEqualToString:(NSString *)kAXAttributedStringForRangeParameterizedAttribute])
+        if ([attribute isEqualToString:bridge_cast(kAXAttributedStringForRangeParameterizedAttribute)])
             return rangeSet ? attributedStringForNSRange(*backingObject, range) : nil;
 
-        if ([attribute isEqualToString:(NSString *)kAXStyleRangeForIndexParameterizedAttribute]) {
+        if ([attribute isEqualToString:bridge_cast(kAXStyleRangeForIndexParameterizedAttribute)]) {
             auto textRange = backingObject->doAXStyleRangeForIndex([number intValue]);
             return [NSValue valueWithRange:textRange];
         }

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -35,6 +35,7 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/VectorCF.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
@@ -93,7 +94,7 @@ static std::optional<Vector<uint8_t>> createAndStoreMasterKey()
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSString *applicationName = [mainBundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     if (!applicationName)
-        applicationName = [mainBundle objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
+        applicationName = [mainBundle objectForInfoDictionaryKey:bridge_cast(kCFBundleNameKey)];
     if (!applicationName)
         applicationName = [mainBundle bundleIdentifier];
     NSString *localizedItemName = webCryptoMasterKeyKeychainLabel(applicationName);

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -59,6 +59,7 @@
 #import "VisibleUnits.h"
 #import <wtf/WorkQueue.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/ParsingUtilities.h>
 #import <wtf/text/StringBuilder.h>
@@ -177,7 +178,7 @@ std::optional<DetectedItem> DataDetection::detectItemAroundHitTestResult(const H
 
 bool DataDetection::canBePresentedByDataDetectors(const URL& url)
 {
-    return [PAL::softLink_DataDetectorsCore_DDURLTapAndHoldSchemes() containsObject:(NSString *)url.protocol().convertToASCIILowercase()];
+    return [PAL::softLink_DataDetectorsCore_DDURLTapAndHoldSchemes() containsObject:url.protocol().convertToASCIILowercase().createNSString().get()];
 }
 
 bool DataDetection::isDataDetectorLink(Element& element)
@@ -235,12 +236,12 @@ static BOOL resultIsURL(DDResultRef result)
         return NO;
     
     static NeverDestroyed<RetainPtr<NSSet>> urlTypes = [NSSet setWithObjects:
-        (NSString *)PAL::get_DataDetectorsCore_DDBinderHttpURLKey(),
-        (NSString *)PAL::get_DataDetectorsCore_DDBinderWebURLKey(),
-        (NSString *)PAL::get_DataDetectorsCore_DDBinderMailURLKey(),
-        (NSString *)PAL::get_DataDetectorsCore_DDBinderGenericURLKey(),
-        (NSString *)PAL::get_DataDetectorsCore_DDBinderEmailKey(), nil];
-    return [urlTypes.get() containsObject:(NSString *)PAL::softLink_DataDetectorsCore_DDResultGetType(result)];
+        bridge_cast(PAL::get_DataDetectorsCore_DDBinderHttpURLKey()),
+        bridge_cast(PAL::get_DataDetectorsCore_DDBinderWebURLKey()),
+        bridge_cast(PAL::get_DataDetectorsCore_DDBinderMailURLKey()),
+        bridge_cast(PAL::get_DataDetectorsCore_DDBinderGenericURLKey()),
+        bridge_cast(PAL::get_DataDetectorsCore_DDBinderEmailKey()), nil];
+    return [urlTypes.get() containsObject:bridge_cast(PAL::softLink_DataDetectorsCore_DDResultGetType(result))];
 }
 
 static NSString *constructURLStringForResult(DDResultRef currentResult, NSString *resultIdentifier, NSDate *referenceDate, NSTimeZone *referenceTimeZone, OptionSet<DataDetectorType> detectionTypes)

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1840,9 +1840,9 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
     } else if (element.hasTagName(brTag)) {
         Element* blockElement = _blockLevelElementForNode(element.parentInComposedTree());
         NSString *breakClass = element.getAttribute(classAttr);
-        NSString *blockTag = blockElement ? (NSString *)blockElement->tagName() : nil;
+        RetainPtr blockTag = blockElement ? blockElement->tagName().createNSString() : nil;
         BOOL isExtraBreak = [AppleInterchangeNewline.createNSString() isEqualToString:breakClass];
-        BOOL blockElementIsParagraph = ([@"P" isEqualToString:blockTag] || [@"LI" isEqualToString:blockTag] || ([blockTag hasPrefix:@"H"] && 2 == [blockTag length]));
+        BOOL blockElementIsParagraph = ([@"P" isEqualToString:blockTag.get()] || [@"LI" isEqualToString:blockTag.get()] || ([blockTag hasPrefix:@"H"] && 2 == [blockTag length]));
         if (isExtraBreak)
             _flags.hasTrailingNewline = YES;
         else {
@@ -1874,14 +1874,14 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
     } else if (element.hasTagName(inputTag)) {
         if (RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element)) {
             if (inputElement->type() == textAtom()) {
-                RetainPtr value = (NSString *)inputElement->value();
+                RetainPtr value = inputElement->value().createNSString();
                 if (value && [value length] > 0)
                     _addValue(value.get(), element);
             }
         }
     } else if (element.hasTagName(textareaTag)) {
         if (RefPtr textAreaElement = dynamicDowncast<HTMLTextAreaElement>(element)) {
-            RetainPtr value = (NSString *)textAreaElement->value();
+            RetainPtr value = textAreaElement->value().createNSString();
             if (value && [value length] > 0)
                 _addValue(value.get(), element);
         }
@@ -2401,7 +2401,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForElement(const HTMLAttachmentElemen
 {
     auto identifier = element.uniqueIdentifier();
 
-    RetainPtr data = [(NSString *)identifier dataUsingEncoding:NSUTF8StringEncoding];
+    RetainPtr data = [identifier.createNSString() dataUsingEncoding:NSUTF8StringEncoding];
     if (!data)
         return nil;
 

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -233,7 +233,7 @@ String Editor::plainTextFromPasteboard(const PasteboardPlainText& text)
         string = WTF::userVisibleString([NSURL URLWithString:string]);
 
     // FIXME: WTF should offer a non-Mac-specific way to convert string to precomposed form so we can do it for all platforms.
-    return [(NSString *)string precomposedStringWithCanonicalMapping];
+    return [string.createNSString() precomposedStringWithCanonicalMapping];
 }
 
 void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElement, const URL& url, const String& title)

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -418,7 +418,7 @@ void AudioSessionIOS::updateSpatialExperience()
         [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{
             @"AVAudioSessionSpatialExperienceOptionSoundStageSize" : @(size),
             @"AVAudioSessionSpatialExperienceOptionAnchoringStrategy" : @(AVAudioSessionAnchoringStrategyScene),
-            @"AVAudioSessionSpatialExperienceOptionSceneIdentifier" : (NSString *)m_sceneIdentifier
+            @"AVAudioSessionSpatialExperienceOptionSceneIdentifier" : m_sceneIdentifier.createNSString().get()
         } error:&error];
     } else {
         [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -251,7 +251,7 @@ String DragData::asPlainText() const
         return WTF::userVisibleString([NSURL URLWithString:string]);
 
     // FIXME: WTF should offer a non-Mac-specific way to convert string to precomposed form so we can do it for all platforms.
-    return [(NSString *)string precomposedStringWithCanonicalMapping];
+    return [string.createNSString() precomposedStringWithCanonicalMapping];
 }
 
 Color DragData::asColor() const

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -181,7 +181,7 @@ String MIMETypeRegistry::preferredExtensionForMIMEType(const String& type)
     if (isUSDMIMEType(type))
         return "usdz"_s;
 
-    NSString *preferredExtension = [[NSURLFileTypeMappings sharedMappings] preferredExtensionForMIMEType:(NSString *)type];
+    NSString *preferredExtension = [[NSURLFileTypeMappings sharedMappings] preferredExtensionForMIMEType:type.createNSString().get()];
     if (preferredExtension.length)
         return preferredExtension;
 

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -28,13 +28,14 @@
 
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 
 static bool isPublicSuffixCF(const String& domain)
 {
-    NSString *host = WTF::decodeHostName(domain);
-    return host && _CFHostIsDomainTopLevel((__bridge CFStringRef)host);
+    RetainPtr host = WTF::decodeHostName(domain);
+    return host && _CFHostIsDomainTopLevel(bridge_cast(host.get()));
 }
 
 bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -71,8 +71,8 @@ SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *i
             m_data->otherAttributes.add(keyString, value);
     }
 
-    if ([item.key isKindOfClass:NSString.class])
-        m_data->key = (NSString *)item.key;
+    if (auto *keyString = dynamic_objc_cast<NSString>(item.key))
+        m_data->key = keyString;
 
     if (item.locale)
         m_data->locale = item.locale;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -49,6 +49,7 @@
 #import <wtf/JSONValues.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/StringHash.h>
@@ -1029,11 +1030,11 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession(LicenseType license
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
-            NSString *playbackSessionIdValue = (NSString *)[expiredSession objectForKey:PlaybackSessionIdKey];
-            if (![playbackSessionIdValue isKindOfClass:[NSString class]])
+            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            if (!playbackSessionIdValue)
                 continue;
 
-            if (sessionId == String(playbackSessionIdValue)) {
+            if (sessionId == String(playbackSessionIdValue.get())) {
                 // FIXME(rdar://problem/35934922): use key values stored in expired session report once available
                 changedKeys.append((KeyStatusVector::ValueType){ SharedBuffer::create(), KeyStatus::Released });
                 m_expiredSessions.append(expiredSessionData);
@@ -1095,11 +1096,11 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
-            NSString *playbackSessionIdValue = (NSString *)[expiredSession objectForKey:PlaybackSessionIdKey];
-            if (![playbackSessionIdValue isKindOfClass:[NSString class]])
+            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            if (!playbackSessionIdValue)
                 continue;
 
-            if (sessionId == String(playbackSessionIdValue)) {
+            if (sessionId == String(playbackSessionIdValue.get())) {
                 // FIXME(rdar://problem/35934922): use key values stored in expired session report once available
                 changedKeys.append((KeyStatusVector::ValueType){ SharedBuffer::create(), KeyStatus::Released });
                 m_expiredSessions.append(expiredSessionData);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -50,6 +50,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -213,11 +214,11 @@ void CDMSessionAVContentKeySession::releaseKeys()
         for (NSData* expiredSessionData in expiredSessions) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
-            NSString *playbackSessionIdValue = (NSString *)[expiredSession objectForKey:PlaybackSessionIdKey];
-            if (![playbackSessionIdValue isKindOfClass:[NSString class]])
+            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            if (!playbackSessionIdValue)
                 continue;
 
-            if (m_sessionId == String(playbackSessionIdValue)) {
+            if (m_sessionId == String(playbackSessionIdValue.get())) {
                 ALWAYS_LOG(LOGIDENTIFIER, "found session, sending expiration message");
                 m_expiredSession = expiredSessionData;
                 m_client->sendMessage(Uint8Array::create(span(m_expiredSession.get())).ptr(), emptyString());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -908,10 +908,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     if (PAL::canLoad_AVFoundation_AVURLAssetOutOfBandMIMETypeKey() && !type.isEmpty() && !player->contentMIMETypeWasInferredFromExtension()) {
         auto codecs = player->contentTypeCodecs();
         if (!codecs.isEmpty()) {
-            NSString *typeString = [NSString stringWithFormat:@"%@; codecs=\"%@\"", (NSString *)type, (NSString *)codecs];
-            [options setObject:typeString forKey:AVURLAssetOutOfBandMIMETypeKey];
+            RetainPtr typeString = adoptNS([[NSString alloc] initWithFormat:@"%@; codecs=\"%@\"", type.createNSString().get(), codecs.createNSString().get()]);
+            [options setObject:typeString.get() forKey:AVURLAssetOutOfBandMIMETypeKey];
         } else
-            [options setObject:(NSString *)type forKey:AVURLAssetOutOfBandMIMETypeKey];
+            [options setObject:type.createNSString().get() forKey:AVURLAssetOutOfBandMIMETypeKey];
     }
 
     auto outOfBandTrackSources = player->outOfBandTrackSources();
@@ -950,7 +950,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     if (allowedMediaContainerTypes && PAL::canLoad_AVFoundation_AVURLAssetAllowableTypeCategoriesKey()) {
         auto nsTypes = adoptNS([[NSMutableArray alloc] init]);
         for (auto type : *allowedMediaContainerTypes)
-            [nsTypes addObject:(NSString *)UTIFromMIMEType(type)];
+            [nsTypes addObject:UTIFromMIMEType(type).createNSString().get()];
         [options setObject:nsTypes.get() forKey:AVURLAssetAllowableTypeCategoriesKey];
     }
 

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -503,7 +503,7 @@ static RetainPtr<NSString> cocoaTypeFromHTMLClipboardType(const String& type)
         return utiType;
 
     // No mapping, just pass the whole string though.
-    return (NSString *)type;
+    return type.createNSString();
 }
 
 void Pasteboard::clear(const String& type)

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -448,7 +448,7 @@ static void addRepresentationsForPlainText(WebItemProviderRegistrationInfoList *
         [itemsToRegister addRepresentingObject:platformURL];
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [itemsToRegister addData:[(NSString *)plainText dataUsingEncoding:NSUTF8StringEncoding] forType:(NSString *)kUTTypeUTF8PlainText];
+    [itemsToRegister addData:[plainText.createNSString() dataUsingEncoding:NSUTF8StringEncoding] forType:bridge_cast(kUTTypeUTF8PlainText)];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -491,14 +491,14 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (content.dataInRTFDFormat)
-        [representationsToRegister addData:content.dataInRTFDFormat->createNSData().get() forType:(NSString *)kUTTypeFlatRTFD];
+        [representationsToRegister addData:content.dataInRTFDFormat->createNSData().get() forType:bridge_cast(kUTTypeFlatRTFD)];
 
     if (content.dataInRTFFormat)
-        [representationsToRegister addData:content.dataInRTFFormat->createNSData().get() forType:(NSString *)kUTTypeRTF];
+        [representationsToRegister addData:content.dataInRTFFormat->createNSData().get() forType:bridge_cast(kUTTypeRTF)];
 
     if (!content.dataInHTMLFormat.isEmpty()) {
-        NSData *htmlAsData = [(NSString *)content.dataInHTMLFormat dataUsingEncoding:NSUTF8StringEncoding];
-        [representationsToRegister addData:htmlAsData forType:(NSString *)kUTTypeHTML];
+        NSData *htmlAsData = [content.dataInHTMLFormat.createNSString() dataUsingEncoding:NSUTF8StringEncoding];
+        [representationsToRegister addData:htmlAsData forType:bridge_cast(kUTTypeHTML)];
     }
 ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -525,7 +525,7 @@ void PlatformPasteboard::write(const PasteboardImage& pasteboardImage)
             utiOrMIMEType = UTIFromMIMEType(utiOrMIMEType);
 
         auto imageData = pasteboardImage.resourceData->makeContiguous()->createNSData();
-        [representationsToRegister addData:imageData.get() forType:(NSString *)utiOrMIMEType];
+        [representationsToRegister addData:imageData.get() forType:utiOrMIMEType.createNSString().get()];
         [representationsToRegister setPreferredPresentationSize:pasteboardImage.imageSize];
         [representationsToRegister setSuggestedName:pasteboardImage.suggestedName];
     }
@@ -536,7 +536,7 @@ void PlatformPasteboard::write(const PasteboardImage& pasteboardImage)
     auto& pasteboardURL = pasteboardImage.url;
     if (RetainPtr nsURL = pasteboardURL.url.createNSURL()) {
 #if HAVE(NSURL_TITLE)
-        [nsURL _web_setTitle:pasteboardURL.title.isEmpty() ? WTF::userVisibleString(pasteboardURL.url.createNSURL().get()) : (NSString *)pasteboardURL.title];
+        [nsURL _web_setTitle:pasteboardURL.title.isEmpty() ? WTF::userVisibleString(pasteboardURL.url.createNSURL().get()) : pasteboardURL.title.createNSString().get()];
 #endif
         [representationsToRegister addRepresentingObject:nsURL.get()];
     }
@@ -574,7 +574,7 @@ void PlatformPasteboard::write(const PasteboardURL& url)
             [nsURL _web_setTitle:url.title];
 #endif
         [representationsToRegister addRepresentingObject:nsURL.get()];
-        [representationsToRegister addRepresentingObject:(NSString *)url.url.string()];
+        [representationsToRegister addRepresentingObject:url.url.string().createNSString().get()];
     }
 
     registerItemToPasteboard(representationsToRegister.get(), m_pasteboard.get());
@@ -596,10 +596,10 @@ Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String& o
         if (![teamDataObject isKindOfClass:NSDictionary.class])
             continue;
 
-        id originInTeamData = [teamDataObject objectForKey:@(originKeyForTeamData)];
-        if (![originInTeamData isKindOfClass:NSString.class])
+        RetainPtr originInTeamData = dynamic_objc_cast<NSString>([teamDataObject objectForKey:@(originKeyForTeamData)]);
+        if (!originInTeamData)
             continue;
-        if (String((NSString *)originInTeamData) != origin)
+        if (String(originInTeamData.get()) != origin)
             continue;
 
         id customTypes = [teamDataObject objectForKey:@(customTypesKeyForTeamData)];
@@ -670,13 +670,13 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             else if (UTTypeConformsTo(cfType.get(), kUTTypePlainText))
                 [representationsToRegister addRepresentingObject:nsStringValue];
             else
-                [representationsToRegister addData:[nsStringValue dataUsingEncoding:NSUTF8StringEncoding] forType:(NSString *)cocoaType];
+                [representationsToRegister addData:[nsStringValue dataUsingEncoding:NSUTF8StringEncoding] forType:cocoaType.createNSString().get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
             return;
         }
 
         auto buffer = std::get<Ref<SharedBuffer>>(value);
-        [representationsToRegister addData:buffer->createNSData().get() forType:(NSString *)cocoaType];
+        [representationsToRegister addData:buffer->createNSData().get() forType:cocoaType.createNSString().get()];
     });
 
     return representationsToRegister;

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -35,6 +35,8 @@
 #import "ResourceRequest.h"
 #import "ResourceResponse.h"
 #import "SharedBuffer.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
 #import <pal/ios/QuickLookSoftLink.h>
 
 @interface WebPreviewConverterDelegate : NSObject
@@ -145,7 +147,7 @@ static NSDictionary *optionsWithPassword(const String& password)
     if (password.isNull())
         return nil;
     
-    return @{ (NSString *)PAL::get_QuickLook_kQLPreviewOptionPasswordKey() : password };
+    return @{ bridge_cast(PAL::get_QuickLook_kQLPreviewOptionPasswordKey()) : password.createNSString().get() };
 }
 
 void PreviewConverter::platformUnlockWithPassword(const String& password)

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -37,12 +37,14 @@
 #import <UIKit/UIColor.h>
 #import <UIKit/UIImage.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-#import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+#import <pal/ios/UIKitSoftLink.h>
 
 typedef void(^ItemProviderDataLoadCompletionHandler)(NSData *, NSError *);
 typedef void(^ItemProviderFileLoadCompletionHandler)(NSURL *, BOOL, NSError *);
@@ -156,15 +158,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 @end
 
 @interface WebItemProviderWritableObjectRegistrar : NSObject <WebItemProviderRegistrar>
-- (instancetype)initWithObject:(id <NSItemProviderWriting>)representingObject;
-@property (nonatomic, readonly) id <NSItemProviderWriting> representingObject;
+- (instancetype)initWithObject:(id<NSItemProviderWriting>)representingObject;
+@property (nonatomic, readonly) id<NSItemProviderWriting> representingObject;
 @end
 
 @implementation WebItemProviderWritableObjectRegistrar {
-    RetainPtr<id <NSItemProviderWriting>> _representingObject;
+    RetainPtr<id<NSItemProviderWriting>> _representingObject;
 }
 
-- (instancetype)initWithObject:(id <NSItemProviderWriting>)representingObject
+- (instancetype)initWithObject:(id<NSItemProviderWriting>)representingObject
 {
     if (!(self = [super init]))
         return nil;
@@ -173,12 +175,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return self;
 }
 
-- (id <NSItemProviderWriting>)representingObject
+- (id<NSItemProviderWriting>)representingObject
 {
     return _representingObject.get();
 }
 
-- (id <NSItemProviderWriting>)representingObjectForClient
+- (id<NSItemProviderWriting>)representingObjectForClient
 {
     return self.representingObject;
 }
@@ -269,7 +271,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_representations addObject:representation.get()];
 }
 
-- (void)addRepresentingObject:(id <NSItemProviderWriting>)object
+- (void)addRepresentingObject:(id<NSItemProviderWriting>)object
 {
     ASSERT([object conformsToProtocol:@protocol(NSItemProviderWriting)]);
     auto representation = adoptNS([[WebItemProviderWritableObjectRegistrar alloc] initWithObject:object]);
@@ -287,7 +289,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return [_representations count];
 }
 
-- (id <WebItemProviderRegistrar>)itemAtIndex:(NSUInteger)index
+- (id<WebItemProviderRegistrar>)itemAtIndex:(NSUInteger)index
 {
     if (index >= self.numberOfItems)
         return nil;
@@ -295,7 +297,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return [_representations objectAtIndex:index];
 }
 
-- (void)enumerateItems:(void (^)(id <WebItemProviderRegistrar>, NSUInteger))block
+- (void)enumerateItems:(void (^)(id<WebItemProviderRegistrar>, NSUInteger))block
 {
     for (NSUInteger index = 0; index < self.numberOfItems; ++index)
         block([self itemAtIndex:index], index);
@@ -324,7 +326,7 @@ static UIPreferredPresentationStyle uiPreferredPresentationStyle(WebPreferredPre
         return nil;
 
     auto itemProvider = adoptNS([NSItemProvider new]);
-    for (id <WebItemProviderRegistrar> representation in _representations.get())
+    for (id<WebItemProviderRegistrar> representation in _representations.get())
         [representation registerItemProvider:itemProvider.get()];
     [itemProvider setSuggestedName:self.suggestedName];
 #if !PLATFORM(MACCATALYST)
@@ -339,7 +341,7 @@ static UIPreferredPresentationStyle uiPreferredPresentationStyle(WebPreferredPre
 {
     __block NSMutableString *description = [NSMutableString string];
     [description appendFormat:@"<%@: %p", [self class], self];
-    [self enumerateItems:^(id <WebItemProviderRegistrar> item, NSUInteger index) {
+    [self enumerateItems:^(id<WebItemProviderRegistrar> item, NSUInteger index) {
         if (index)
             [description appendString:@", "];
         [description appendString:[item description]];
@@ -606,16 +608,16 @@ static Class classForTypeIdentifier(NSString *typeIdentifier, NSString *&outType
 
     // First, try to load a platform NSItemProviderReading-conformant object as-is.
     for (Class<NSItemProviderReading> loadableClass in allLoadableClasses()) {
-        if ([[loadableClass readableTypeIdentifiersForItemProvider] containsObject:(NSString *)typeIdentifier])
+        if ([[loadableClass readableTypeIdentifiersForItemProvider] containsObject:typeIdentifier])
             return loadableClass;
     }
 
     // If we were unable to load any object, check if the given type identifier is still something
     // WebKit knows how to handle.
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([typeIdentifier isEqualToString:(NSString *)kUTTypeHTML]) {
+    if ([typeIdentifier isEqualToString:bridge_cast(kUTTypeHTML)]) {
         // Load kUTTypeHTML as a plain text HTML string.
-        outTypeIdentifierToLoad = (NSString *)kUTTypePlainText;
+        outTypeIdentifierToLoad = bridge_cast(kUTTypePlainText);
         return [NSString class];
     }
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -644,7 +646,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!preloadedData)
             return;
 
-        if (id <NSItemProviderReading> readObject = [readableClass objectWithItemProviderData:preloadedData typeIdentifier:(NSString *)typeIdentifierToLoad error:nil])
+        if (id<NSItemProviderReading> readObject = [readableClass objectWithItemProviderData:preloadedData typeIdentifier:typeIdentifierToLoad error:nil])
             [values addObject:readObject];
     }];
 

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -82,7 +82,7 @@ static Vector<String> writableTypesForImage()
 
 NSArray *Pasteboard::supportedFileUploadPasteboardTypes()
 {
-    return @[ (NSString *)legacyFilesPromisePasteboardType(), (NSString *)legacyFilenamesPasteboardType() ];
+    return @[ legacyFilesPromisePasteboardType(), legacyFilenamesPasteboardType() ];
 }
 
 Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context)
@@ -211,7 +211,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     
     RetainPtr nsURL = pasteboardURL.url.createNSURL();
     NSString *userVisibleString = pasteboardURL.userVisibleForm;
-    NSString *title = (NSString *)pasteboardURL.title;
+    RetainPtr title = pasteboardURL.title.createNSString();
     if (![title length]) {
         title = [[nsURL path] lastPathComponent];
         if (![title length])
@@ -219,7 +219,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     }
 
     if (types.contains(WebURLsWithTitlesPboardType)) {
-        PasteboardURL url = { pasteboardURL.url, String(title).trim(deprecatedIsSpaceOrNewline), emptyString() };
+        PasteboardURL url = { pasteboardURL.url, String(title.get()).trim(deprecatedIsSpaceOrNewline), emptyString() };
         newChangeCount = platformStrategies()->pasteboardStrategy()->setURL(url, pasteboardName, context);
     }
     if (types.contains(String(legacyURLPasteboardType())))
@@ -227,7 +227,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     if (types.contains(WebURLPboardType))
         newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString, WebURLPboardType, pasteboardName, context);
     if (types.contains(WebURLNamePboardType))
-        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(title, WebURLNamePboardType, pasteboardName, context);
+        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(title.get(), WebURLNamePboardType, pasteboardName, context);
     if (types.contains(String(legacyStringPasteboardType())))
         newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString, legacyStringPasteboardType(), pasteboardName, context);
 

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -73,10 +73,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto& urlData = data.urlData()) {
         RetainPtr nsURL = urlData->url.createNSURL();
         NSString *userVisibleString = urlData->userVisibleForm;
-        NSString *title = (NSString *)urlData->title;
-        if (!title.length) {
+        RetainPtr title = urlData->title.createNSString();
+        if (!title.get().length) {
             title = nsURL.get().path.lastPathComponent;
-            if (!title.length)
+            if (!title.get().length)
                 title = userVisibleString;
         }
 
@@ -100,7 +100,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 
         // WebURLNamePboardType.
-        [pasteboardItem setString:title forType:@"public.url-name"];
+        [pasteboardItem setString:title.get() forType:@"public.url-name"];
 
         // NSPasteboardTypeString.
         [pasteboardItem setString:userVisibleString forType:NSPasteboardTypeString];

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -330,11 +330,11 @@ RetainPtr<NSArray> NetworkStorageSession::httpCookiesForURL(CFHTTPCookieStorageR
     // NetworkStorageSession could instead keep a NSHTTPCookieStorage object for us.
     RetainPtr<NSHTTPCookieStorage> nsCookieStorage = adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:cookieStorage]);
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
-    NSString* partitionKey = isOptInCookiePartitioningEnabled() ? (NSString *)cookiePartitionIdentifier(firstParty) : nil;
+    RetainPtr partitionKey = isOptInCookiePartitioningEnabled() ? cookiePartitionIdentifier(firstParty).createNSString() : nil;
 #else
-    NSString* partitionKey = nil;
+    RetainPtr<NSString> partitionKey;
 #endif
-    return cookiesForURLFromStorage(nsCookieStorage.get(), url, firstParty, sameSiteInfo, thirdPartyCookieBlockingDecision, partitionKey);
+    return cookiesForURLFromStorage(nsCookieStorage.get(), url, firstParty, sameSiteInfo, thirdPartyCookieBlockingDecision, partitionKey.get());
 }
 
 RetainPtr<NSHTTPCookie> NetworkStorageSession::capExpiryOfPersistentCookie(NSHTTPCookie *cookie, Seconds cap)
@@ -366,7 +366,7 @@ NSHTTPCookie *NetworkStorageSession::setCookiePartition(NSHTTPCookie *cookie, NS
     }
 
     auto properties = adoptNS([[cookie properties] mutableCopy]);
-    [properties setObject:(NSString *)partitionKey forKey:@"StoragePartition"];
+    [properties setObject:partitionKey forKey:@"StoragePartition"];
     return [NSHTTPCookie cookieWithProperties:properties.get()];
 }
 #endif
@@ -733,7 +733,7 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
     auto host = firstParty.host().toString();
 
     // _getCookiesForDomain only returned unpartitioned (i.e., nil partition) cookies
-    RetainPtr<NSArray> unpartitionedCookies = [nsCookieStorage() _getCookiesForDomain:(NSString *)host];
+    RetainPtr<NSArray> unpartitionedCookies = [nsCookieStorage() _getCookiesForDomain:host.createNSString().get()];
     RetainPtr nsCookies = adoptNS([[NSMutableArray alloc] initWithArray:unpartitionedCookies.get()]);
 
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
@@ -745,7 +745,7 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
         // completionHandler synchronously. We crash if this invariant is not
         // met.
         bool wasCompletionHandlerCalled { false };
-        String partitionKey = cookiePartitionIdentifier(firstParty);
+        RetainPtr partitionKey = cookiePartitionIdentifier(firstParty).createNSString();
         auto completionHandler = [&wasCompletionHandlerCalled, &nsCookies, &host, &partitionKey, &firstParty] (NSArray *cookies) {
             wasCompletionHandlerCalled = true;
 
@@ -756,15 +756,15 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)
                 if (![host hasSuffix:nsCookie.domain])
                     continue;
 
-                ASSERT([nsCookie._storagePartition isEqualToString:partitionKey]);
-                if (![nsCookie._storagePartition isEqualToString:partitionKey])
+                ASSERT([nsCookie._storagePartition isEqualToString:partitionKey.get()]);
+                if (![nsCookie._storagePartition isEqualToString:partitionKey.get()])
                     continue;
 
                 [nsCookies addObject:nsCookie];
             }
         };
 
-        [nsCookieStorage() _getCookiesForPartition:(NSString *)partitionKey completionHandler:completionHandler];
+        [nsCookieStorage() _getCookiesForPartition:partitionKey.get() completionHandler:completionHandler];
         RELEASE_ASSERT(wasCompletionHandlerCalled);
     }
 #endif
@@ -847,10 +847,10 @@ bool NetworkStorageSession::startListeningForCookieChangeNotifications(CookieCha
 
     if (!m_subscribedDomainsForCookieChanges)
         m_subscribedDomainsForCookieChanges = adoptNS([[NSMutableSet alloc] init]);
-    else if ([m_subscribedDomainsForCookieChanges containsObject:(NSString *)host])
+    else if ([m_subscribedDomainsForCookieChanges containsObject:host.createNSString().get()])
         return true;
 
-    [m_subscribedDomainsForCookieChanges addObject:(NSString *)host];
+    [m_subscribedDomainsForCookieChanges addObject:host.createNSString().get()];
     [nsCookieStorage() _setSubscribedDomainsForCookieChanges:m_subscribedDomainsForCookieChanges.get()];
     return true;
 }
@@ -869,8 +869,8 @@ void NetworkStorageSession::stopListeningForCookieChangeNotifications(CookieChan
         observers.remove(observer);
         if (observers.isEmptyIgnoringNullReferences()) {
             m_cookieChangeObservers.remove(it);
-            ASSERT([m_subscribedDomainsForCookieChanges containsObject:(NSString *)host]);
-            [m_subscribedDomainsForCookieChanges removeObject:(NSString *)host];
+            ASSERT([m_subscribedDomainsForCookieChanges containsObject:host.createNSString().get()]);
+            [m_subscribedDomainsForCookieChanges removeObject:host.createNSString().get()];
             subscribedURLsChanged = true;
         }
     }

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -38,6 +38,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/CString.h>
 
@@ -206,7 +207,7 @@ void ResourceRequest::doUpdateResourceRequest()
     }
 
     if (m_nsRequest) {
-        RetainPtr<NSString> cachePartition = [NSURLProtocol propertyForKey:(NSString *)_kCFURLCachePartitionKey inRequest:m_nsRequest.get()];
+        RetainPtr<NSString> cachePartition = [NSURLProtocol propertyForKey:bridge_cast(_kCFURLCachePartitionKey) inRequest:m_nsRequest.get()];
         if (cachePartition)
             m_cachePartition = cachePartition.get();
     }
@@ -325,7 +326,7 @@ void ResourceRequest::doUpdatePlatformRequest()
     String partition = cachePartition();
     if (!partition.isNull() && !partition.isEmpty()) {
         RetainPtr partitionValue = adoptNS([[NSString alloc] initWithUTF8String:partition.utf8().data()]);
-        [NSURLProtocol setProperty:partitionValue.get() forKey:(NSString *)_kCFURLCachePartitionKey inRequest:nsRequest.get()];
+        [NSURLProtocol setProperty:partitionValue.get() forKey:bridge_cast(_kCFURLCachePartitionKey) inRequest:nsRequest.get()];
     }
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -66,12 +66,12 @@ void ResourceResponse::initNSURLResponse() const
     // FIXME: We lose the status text and the HTTP version here.
     RetainPtr headerDictionary = adoptNS([[NSMutableDictionary alloc] init]);
     for (auto& header : m_httpHeaderFields)
-        [headerDictionary setObject:(NSString *)header.value forKey:(NSString *)header.key];
+        [headerDictionary setObject:header.value.createNSString().get() forKey:header.key.createNSString().get()];
 
     m_nsResponse = adoptNS([[NSHTTPURLResponse alloc] initWithURL:m_url.createNSURL().get() statusCode:m_httpStatusCode HTTPVersion:(NSString*)kCFHTTPVersion1_1 headerFields:headerDictionary.get()]);
 
     // Mime type sniffing doesn't work with a synthesized response.
-    [m_nsResponse _setMIMEType:(NSString *)m_mimeType];
+    [m_nsResponse _setMIMEType:m_mimeType.createNSString().get()];
 }
 
 void ResourceResponse::disableLazyInitialization()

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -103,7 +103,7 @@ static RetainPtr<NSError> createNSErrorFromResourceErrorBase(const ResourceError
         [userInfo setValue:resourceError.localizedDescription() forKey:NSLocalizedDescriptionKey];
 
     if (!resourceError.failingURL().isEmpty()) {
-        [userInfo setValue:(NSString *)resourceError.failingURL().string() forKey:@"NSErrorFailingURLStringKey"];
+        [userInfo setValue:resourceError.failingURL().string().createNSString().get() forKey:@"NSErrorFailingURLStringKey"];
         if (RetainPtr cocoaURL = (NSURL *)resourceError.failingURL().createNSURL())
             [userInfo setValue:cocoaURL.get() forKey:@"NSErrorFailingURLKey"];
     }

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -43,6 +43,7 @@
 #import <pal/spi/cocoa/NSURLConnectionSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebCore;
 
@@ -340,7 +341,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
                 metrics->responseEnd = WallTime::fromRawSeconds(adoptNS([[NSDate alloc] initWithTimeIntervalSinceReferenceDate:responseEndTime]).get().timeIntervalSince1970).approximateMonotonicTime();
             else
                 metrics->responseEnd = metrics->responseStart;
-            metrics->protocol = (NSString *)[timingData objectForKey:@"_kCFNTimingDataNetworkProtocolName"];
+            metrics->protocol = checked_objc_cast<NSString>([timingData objectForKey:@"_kCFNTimingDataNetworkProtocolName"]);
             metrics->responseBodyBytesReceived = [[timingData objectForKey:@"_kCFNTimingDataResponseBodyBytesReceived"] unsignedLongLongValue];
             metrics->responseBodyDecodedSize = [[timingData objectForKey:@"_kCFNTimingDataResponseBodyBytesDecoded"] unsignedLongLongValue];
             metrics->markComplete();

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -74,7 +74,7 @@ template<typename T> static Vector<std::pair<String, RetainPtr<T>>> vectorFromDi
     __block Vector<std::pair<String, RetainPtr<T>>> result;
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL*){
         if ([key isKindOfClass:NSString.class] && [value isKindOfClass:IPC::getClass<T>()])
-            result.append((NSString *)key, (T)value);
+            result.append(checked_objc_cast<NSString>(key), (T)value);
     }];
     return result;
 }

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -573,7 +573,7 @@ RetainPtr<NSObject<NSSecureCoding>> Object::toNSObject()
     case Object::Type::Data:
         return API::wrapper(downcast<API::Data>(*this));
     case Object::Type::String:
-        return (NSString *)downcast<API::String>(*this).string();
+        return downcast<API::String>(*this).string().createNSString();
     default:
         // Other API::Object::Types are intentionally not supported.
         break;

--- a/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
@@ -56,7 +56,7 @@ void SandboxInitializationParameters::addConfDirectoryParameter(ASCIILiteral nam
 
 void SandboxInitializationParameters::addPathParameter(ASCIILiteral name, NSString *path)
 {
-    appendPathInternal(name, [path length] ? [(NSString *)path fileSystemRepresentation] : "");
+    appendPathInternal(name, [path length] ? [path fileSystemRepresentation] : "");
 }
 
 void SandboxInitializationParameters::addPathParameter(ASCIILiteral name, const char* path)

--- a/Source/WebKit/Shared/Cocoa/WKNSString.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSString.mm
@@ -28,6 +28,7 @@
 
 #import "APIString.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebKit;
 
@@ -36,7 +37,7 @@ using namespace WebKit;
 - (NSObject *)_web_createTarget
 {
     String string = RefPtr { downcast<API::String>(&self._apiObject) }->string();
-    return (NSString *)string.createCFString().leakRef();
+    return bridge_cast(string.createCFString().leakRef());
 }
 
 - (Class)superclass

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -40,6 +40,7 @@
 #import <WebCore/ExceptionDetails.h>
 #import <WebCore/SerializedScriptValue.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 
@@ -62,7 +63,7 @@ RetainPtr<id> JavaScriptEvaluationResult::toID(Variant&& root)
     }, [] (CoreIPCNumber&& value) -> RetainPtr<id> {
         return value.toID();
     }, [] (String&& value) -> RetainPtr<id> {
-        return (NSString *)value;
+        return value.createNSString();
     }, [] (Seconds value) -> RetainPtr<id> {
         return [NSDate dateWithTimeIntervalSince1970:value.seconds()];
     }, [&] (Vector<JSObjectID>&& vector) -> RetainPtr<id> {
@@ -168,8 +169,8 @@ auto JavaScriptEvaluationResult::toVariant(id object) -> Variant
         return CoreIPCNumber((NSNumber *)object);
     }
 
-    if ([object isKindOfClass:NSString.class])
-        return String((NSString *)object);
+    if (auto* nsString = dynamic_objc_cast<NSString>(object))
+        return String(nsString);
 
     if ([object isKindOfClass:NSDate.class])
         return Seconds([(NSDate *)object timeIntervalSince1970]);

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -30,6 +30,7 @@
 #import "WebPageProxy.h"
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/SharedBuffer.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -109,12 +110,12 @@ void Attachment::setFileWrapperAndUpdateContentType(NSFileWrapper *fileWrapper, 
     if (!contentType.length) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (fileWrapper.directory)
-            contentType = (NSString *)kUTTypeDirectory;
+            contentType = bridge_cast(kUTTypeDirectory);
         else if (fileWrapper.regularFile) {
             if (NSString *pathExtension = (fileWrapper.filename.length ? fileWrapper.filename : fileWrapper.preferredFilename).pathExtension)
                 contentType = WebCore::MIMETypeRegistry::mimeTypeForExtension(WTF::String(pathExtension));
             if (!contentType.length)
-                contentType = (NSString *)kUTTypeData;
+                contentType = bridge_cast(kUTTypeData);
         }
 ALLOW_DEPRECATED_DECLARATIONS_END
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -88,7 +88,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (NSString *)_downloadAttribute
 {
     const String& attribute = _navigationResponse->downloadAttribute();
-    return attribute.isNull() ? nil : (NSString *)attribute;
+    return attribute.isNull() ? nil : attribute.createNSString().autorelease();
 }
 
 - (BOOL)_wasPrivateRelayed

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -72,7 +72,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 - (NSString *)debugDescription
 {
     return [NSString stringWithFormat:@"<%@: %p; identifier = %@; shortcut = %@>", NSStringFromClass(self.class), self,
-        self.identifier, self.activationKey.length ? (NSString *)self._protectedWebExtensionCommand->shortcutString() : @"(none)"];
+        self.identifier, self.activationKey.length ? self._protectedWebExtensionCommand->shortcutString().createNSString().get() : @"(none)"];
 }
 
 - (WKWebExtensionContext *)webExtensionContext

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1699,7 +1699,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 
 - (NSString *)mediaType
 {
-    return _page->overriddenMediaType().isNull() ? nil : (NSString *)_page->overriddenMediaType();
+    return _page->overriddenMediaType().isNull() ? nil : _page->overriddenMediaType().createNSString().autorelease();
 }
 
 - (id)interactionState

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -219,7 +219,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return contents;
 
 #if PLATFORM(IOS_FAMILY)
-    return [_contentView _contentsOfUserInterfaceItem:(NSString *)userInterfaceItem];
+    return [_contentView _contentsOfUserInterfaceItem:userInterfaceItem];
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -356,7 +356,7 @@ private:
         if (!m_hasDidExceedMemoryFootprintThresholdSelector)
             return;
 
-        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() domain:(NSString *)domain didExceedMemoryFootprintThreshold:footprint withPageCount:pageCount processLifetime:processLifetime.seconds() inForeground:inForeground wasPrivateRelayed:wasPrivateRelayed == WebCore::WasPrivateRelayed::Yes canSuspend:canSuspend == CanSuspend::Yes];
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() domain:domain.createNSString().get() didExceedMemoryFootprintThreshold:footprint withPageCount:pageCount processLifetime:processLifetime.seconds() inForeground:inForeground wasPrivateRelayed:wasPrivateRelayed == WebCore::WasPrivateRelayed::Yes canSuspend:canSuspend == CanSuspend::Yes];
     }
 
     WeakObjCPtr<WKWebsiteDataStore> m_dataStore;
@@ -665,7 +665,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         if (errorString.isEmpty())
             return completionHandlerCopy(nil);
 
-        completionHandlerCopy([NSError errorWithDomain:@"WKWebSiteDataStore" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:(NSString *)errorString }]);
+        completionHandlerCopy([NSError errorWithDomain:@"WKWebSiteDataStore" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:errorString.createNSString().get() }]);
     });
 }
 
@@ -1250,7 +1250,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     _websiteDataStore->protectedNetworkProcess()->getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (auto identifiers) {
         auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
         for (auto identifier : identifiers)
-            [result addObject:(NSString *)identifier];
+            [result addObject:identifier];
         completionHandler(result.autorelease());
     });
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -359,14 +359,14 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     return *_applicationManifest;
 }
 
-static NSString *nullableNSString(const WTF::String& string)
+static RetainPtr<NSString> nullableNSString(const WTF::String& string)
 {
-    return string.isNull() ? nil : (NSString *)string;
+    return !string.isNull() ? string.createNSString() : nil;
 }
 
 - (NSString *)rawJSON
 {
-    return nullableNSString(_applicationManifest->applicationManifest().rawJSON);
+    return nullableNSString(_applicationManifest->applicationManifest().rawJSON).autorelease();
 }
 
 - (_WKApplicationManifestDirection)direction
@@ -387,17 +387,17 @@ static NSString *nullableNSString(const WTF::String& string)
 
 - (NSString *)name
 {
-    return nullableNSString(_applicationManifest->applicationManifest().name);
+    return nullableNSString(_applicationManifest->applicationManifest().name).autorelease();
 }
 
 - (NSString *)shortName
 {
-    return nullableNSString(_applicationManifest->applicationManifest().shortName);
+    return nullableNSString(_applicationManifest->applicationManifest().shortName).autorelease();
 }
 
 - (NSString *)applicationDescription
 {
-    return nullableNSString(_applicationManifest->applicationManifest().description);
+    return nullableNSString(_applicationManifest->applicationManifest().description).autorelease();
 }
 
 - (NSURL *)scope

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -88,7 +88,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)title
 {
-    return (NSString *)_coreData.title;
+    return _coreData.title.createNSString().autorelease();
 }
 
 - (void)setDir:(_WKNotificationDirection)dir
@@ -125,7 +125,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)lang
 {
-    return (NSString *)_coreData.language;
+    return _coreData.language.createNSString().autorelease();
 }
 
 - (void)setBody:(NSString *)body
@@ -135,7 +135,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)body
 {
-    return (NSString *)_coreData.body;
+    return _coreData.body.createNSString().autorelease();
 }
 
 - (void)setTag:(NSString *)tag
@@ -145,7 +145,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)tag
 {
-    return (NSString *)_coreData.tag;
+    return _coreData.tag.createNSString().autorelease();
 }
 
 - (void)setAlert:(_WKNotificationAlert)alert
@@ -182,7 +182,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)origin
 {
-    return (NSString *)_coreData.originString;
+    return _coreData.originString.createNSString().autorelease();
 }
 
 - (void)setSecurityOrigin:(NSURL *)securityOrigin
@@ -207,7 +207,7 @@ static NSString *dataKey = @"data";
 
 - (NSString *)identifier
 {
-    return (NSString *)_coreData.notificationID.toString();
+    return _coreData.notificationID.toString().createNSString().autorelease();
 }
 
 - (void)setUuid:(NSUUID *)uuid

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -217,7 +217,7 @@
 
     auto bounds = _info->boundsInRootView();
     return [NSString stringWithFormat:@"<%@ %p \"%@\" at {{%.0f,%.0f},{%.0f,%.0f}}>"
-        , self.class, self, (NSString *)firstSelector
+        , self.class, self, firstSelector.createNSString().get()
         , bounds.x(), bounds.y(), bounds.width(), bounds.height()];
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -298,7 +298,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     auto shareDataArray = adoptNS([[NSMutableArray alloc] init]);
     
     if (!data.shareData.text.isEmpty())
-        [shareDataArray addObject:(NSString *)data.shareData.text];
+        [shareDataArray addObject:data.shareData.text.createNSString().get()];
     
     if (data.url) {
         RetainPtr url = data.url.value().createNSURL();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
@@ -51,11 +51,11 @@ void WebExtensionController::testResult(bool result, String message, String sour
         message = "(no message)"_s;
 
     if (result) {
-        RELEASE_LOG_INFO(Extensions, "Test assertion passed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+        RELEASE_LOG_INFO(Extensions, "Test assertion passed: %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
         return;
     }
 
-    RELEASE_LOG_ERROR(Extensions, "Test assertion failed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_ERROR(Extensions, "Test assertion failed: %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testEqual(bool result, String expectedValue, String actualValue, String message, String sourceURL, unsigned lineNumber)
@@ -70,11 +70,11 @@ void WebExtensionController::testEqual(bool result, String expectedValue, String
         message = "Expected equality of these values"_s;
 
     if (result) {
-        RELEASE_LOG_INFO(Extensions, "Test equality passed: %{public}@: %{public}@ === %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
+        RELEASE_LOG_INFO(Extensions, "Test equality passed: %{public}@: %{public}@ === %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), expectedValue.createNSString().get(), actualValue.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
         return;
     }
 
-    RELEASE_LOG_ERROR(Extensions, "Test equality failed: %{public}@: %{public}@ !== %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_ERROR(Extensions, "Test equality failed: %{public}@: %{public}@ !== %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), expectedValue.createNSString().get(), actualValue.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testLogMessage(String message, String sourceURL, unsigned lineNumber)
@@ -88,7 +88,7 @@ void WebExtensionController::testLogMessage(String message, String sourceURL, un
     if (message.isEmpty())
         message = "(no message)"_s;
 
-    RELEASE_LOG_INFO(Extensions, "Test log: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test log: %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testSentMessage(String message, String argument, String sourceURL, unsigned lineNumber)
@@ -99,7 +99,7 @@ void WebExtensionController::testSentMessage(String message, String argument, St
         return;
     }
 
-    RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)argument, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", message.createNSString().get(), (NSString *)argument, sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testAdded(String testName, String sourceURL, unsigned lineNumber)
@@ -110,7 +110,7 @@ void WebExtensionController::testAdded(String testName, String sourceURL, unsign
         return;
     }
 
-    RELEASE_LOG_INFO(Extensions, "Test added: %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test added: %{public}@ (%{public}@:%{public}u)", testName.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testStarted(String testName, String sourceURL, unsigned lineNumber)
@@ -121,7 +121,7 @@ void WebExtensionController::testStarted(String testName, String sourceURL, unsi
         return;
     }
 
-    RELEASE_LOG_INFO(Extensions, "Test started: %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test started: %{public}@ (%{public}@:%{public}u)", testName.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 void WebExtensionController::testFinished(String testName, bool result, String message, String sourceURL, unsigned lineNumber)
@@ -139,11 +139,11 @@ void WebExtensionController::testFinished(String testName, bool result, String m
         message = "(no message)"_s;
 
     if (result) {
-        RELEASE_LOG_INFO(Extensions, "Test passed: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)message, (NSString *)sourceURL, lineNumber);
+        RELEASE_LOG_INFO(Extensions, "Test passed: %{public}@ %{public}@ (%{public}@:%{public}u)", testName.createNSString().get(), message.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
         return;
     }
 
-    RELEASE_LOG_ERROR(Extensions, "Test failed: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_ERROR(Extensions, "Test failed: %{public}@ %{public}@ (%{public}@:%{public}u)", testName.createNSString().get(), message.createNSString().get(), sourceURL.createNSString().get(), lineNumber);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -129,7 +129,7 @@ bool WebExtensionCommand::setActivationKey(String activationKey)
         notAllowedCharacterSet = allowedCharacterSet.invertedSet;
     });
 
-    if ([(NSString *)activationKey rangeOfCharacterFromSet:notAllowedCharacterSet].location != NSNotFound)
+    if ([activationKey.createNSString() rangeOfCharacterFromSet:notAllowedCharacterSet].location != NSNotFound)
         return false;
 
     dispatchChangedEventSoonIfNeeded();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4336,7 +4336,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 {
     if (!_page->editorState().postLayoutData)
         return nil;
-    return (NSString *)_page->editorState().postLayoutData->wordAtSelection;
+    return _page->editorState().postLayoutData->wordAtSelection.createNSString().autorelease();
 }
 
 - (NSArray *)alternativesForSelectedText

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -52,6 +52,7 @@
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(APPLETV)
 #import "PDFKitSoftLink.h"
@@ -698,8 +699,8 @@ static NSStringCompareOptions stringCompareOptions(_WKFindOptions findOptions)
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     NSDictionary *representations = @{
-        (NSString *)kUTTypeUTF8PlainText : (NSString *)_positionInformation.url.string(),
-        (NSString *)kUTTypeURL : _positionInformation.url.createNSURL().get(),
+        bridge_cast(kUTTypeUTF8PlainText) : _positionInformation.url.string().createNSString().get(),
+        bridge_cast(kUTTypeURL) : _positionInformation.url.createNSURL().get(),
     };
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -725,7 +725,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _location = location;
 
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
-    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]).get()];
+    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), self.location]).get()];
     [_bannerLabel sizeToFit];
 #endif
 }
@@ -833,7 +833,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_bannerLabel setNumberOfLines:0];
     [_bannerLabel setLineBreakMode:NSLineBreakByWordWrapping];
     [_bannerLabel setTextAlignment:NSTextAlignmentCenter];
-    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]).get()];
+    [_bannerLabel setText:adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), self.location]).get()];
 
     auto banner = adoptNS([[WKFullscreenStackView alloc] init]);
     [banner addArrangedSubview:_bannerLabel.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
@@ -1127,7 +1127,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     RetainPtr alertTitle = WEB_UI_STRING("It looks like you are typing while in full screen", "Full Screen Deceptive Website Warning Sheet Title").createNSString();
-    RetainPtr alertMessage = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Typing is not allowed in full screen websites. “%@” may be showing a fake keyboard to trick you into disclosing personal or financial information.", "Full Screen Deceptive Website Warning Sheet Content Text"), (NSString *)self.location]);
+    RetainPtr alertMessage = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Typing is not allowed in full screen websites. “%@” may be showing a fake keyboard to trick you into disclosing personal or financial information.", "Full Screen Deceptive Website Warning Sheet Content Text"), self.location]);
     RetainPtr alert = WebKit::createUIAlertController(alertTitle.get(), alertMessage.get());
 
     if (page) {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2766,7 +2766,7 @@ void WebViewImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, UndoOr
     RetainPtr undoManager = [m_view undoManager];
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:((undoOrRedo == UndoOrRedo::Undo) ? @selector(undoEditing:) : @selector(redoEditing:)) object:commandObjC.get()];
     if (!actionName.isEmpty())
-        [undoManager setActionName:(NSString *)actionName];
+        [undoManager setActionName:actionName.createNSString().get()];
 }
 
 void WebViewImpl::clearAllEditCommands()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -107,19 +107,20 @@ void WebExtensionContextProxy::dispatchCommandsCommandEvent(const String& identi
 
     auto *tab = tabParameters ? toWebAPI(tabParameters.value()) : nil;
 
+    RetainPtr nsIdentifier = identifier.createNSString();
     enumerateFramesAndNamespaceObjects([&](auto& frame, auto& namespaceObject) {
         RefPtr coreFrame = frame.protectedCoreLocalFrame();
         WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, coreFrame ? coreFrame->document() : nullptr);
-        namespaceObject.commands().onCommand().invokeListenersWithArgument((NSString *)identifier, tab);
+        namespaceObject.commands().onCommand().invokeListenersWithArgument(nsIdentifier.get(), tab);
     });
 }
 
 void WebExtensionContextProxy::dispatchCommandsChangedEvent(const String& identifier, const String& oldShortcut, const String& newShortcut)
 {
     auto *changeInfo = @{
-        nameKey: (NSString *)identifier,
-        oldShortcutKey: (NSString *)oldShortcut,
-        newShortcutKey: (NSString *)newShortcut
+        nameKey: identifier.createNSString().get(),
+        oldShortcutKey: oldShortcut.createNSString().get(),
+        newShortcutKey: newShortcut.createNSString().get()
     };
 
     enumerateNamespaceObjects([&](auto& namespaceObject) {

--- a/Source/WebKit/webpushd/WebClipCache.mm
+++ b/Source/WebKit/webpushd/WebClipCache.mm
@@ -198,7 +198,7 @@ void WebClipCache::persist()
             NSString *securityOriginString = [url absoluteString];
             if (!securityOriginString)
                 continue;
-            [entries addObject:@[bundleIdentifier.get(), securityOriginString, (NSString *)webClipIdentifier]];
+            [entries addObject:@[bundleIdentifier.get(), securityOriginString, webClipIdentifier.createNSString().get()]];
         }
 
         NSError *error = nil;

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm
@@ -51,6 +51,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/StdLibExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebCore;
 
@@ -295,7 +296,7 @@ static RetainPtr<CGColorRef> createCGColorWithDeviceWhite(CGFloat white, CGFloat
         title = adoptCF(CGPDFStringCopyTextString(value));
 
     if (title && CFStringGetLength(title.get())) {
-        _title = (NSString *)title.get();
+        _title = bridge_cast(title.get());
         core([self _frame])->loader().client().dispatchDidReceiveTitle({ _title.get(), TextDirection::LTR });
     }
 }

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -50,6 +50,7 @@
 #import <wtf/MonotonicTime.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebCore;
 
@@ -334,8 +335,8 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         title = adoptCF(CGPDFStringCopyTextString(value));
 
     if (title && CFStringGetLength(title.get())) {
-        [self setTitle:(NSString *)title.get()];
-        [[self _frame] _dispatchDidReceiveTitle:(NSString *)title.get()];
+        [self setTitle:bridge_cast(title.get())];
+        [[self _frame] _dispatchDidReceiveTitle:bridge_cast(title.get())];
     }
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -198,24 +198,26 @@
 
 - (NSString *)_web_decodeHostName
 {
-    NSString *name = WTF::decodeHostName(self);
-    return !name ? self : name;
+    if (RetainPtr name = WTF::decodeHostName(self))
+        return name.autorelease();
+    return self;
 }
 
 - (NSString *)_web_encodeHostName
 {
-    NSString *name = WTF::encodeHostName(self);
-    return !name ? self : name;
+    if (RetainPtr name = WTF::encodeHostName(self))
+        return name.autorelease();
+    return self;
 }
 
 - (NSString *)_webkit_decodeHostName
 {
-    return WTF::decodeHostName(self);
+    return WTF::decodeHostName(self).autorelease();
 }
 
 - (NSString *)_webkit_encodeHostName
 {
-    return WTF::encodeHostName(self);
+    return WTF::encodeHostName(self).autorelease();
 }
 
 -(NSRange)_webkit_rangeOfURLScheme

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -297,8 +297,8 @@ TEST(URLExtras, URLExtras_ParsingError)
     NSURL *url = WTF::URLWithUserTypedString(@"http://.com", nil);
     EXPECT_TRUE(url == nil);
 
-    NSString *encodedHostName = WTF::encodeHostName(@"http://.com");
-    EXPECT_TRUE(encodedHostName == nil);
+    RetainPtr encodedHostName = WTF::encodeHostName(@"http://.com");
+    EXPECT_TRUE(encodedHostName.get() == nil);
 
     WTF::URL url2 { utf16String(u"http://\u2267\u222E\uFE63\u0661\u06F1") };
     EXPECT_NULL([url2.createNSURL() absoluteString]);


### PR DESCRIPTION
#### 4142580276a38fa413fb95c6edf45796ba81a622
<pre>
Reduce use of (NSString *) casting in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=291221">https://bugs.webkit.org/show_bug.cgi?id=291221</a>

Reviewed by Timothy Hatcher.

Use modern casting functions instead for proper casting. For converting from
a WTF::String to a NSString, use `String::createNSString()` instead, which
has the benefit of making it clear it allocates a new NSString and doesn&apos;t
return an autoreleased object.

* Source/JavaScriptCore/API/JSValue.mm:
(performPropertyOperation):
(objectToValueWithoutCopy):
(objectToValue):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::setExcludedFromBackup):
* Source/WTF/wtf/cocoa/NSURLExtras.h:
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::decodeHostName):
(WTF::encodeHostName):
* Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm:
(WebCore::additionalError):
* Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm:
(WebCore::NotificationOptionsPayload::dictionaryRepresentation const):
* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm:
(WebCore::NotificationPayload::dictionaryRepresentation const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase baseAccessibilitySpeechHint]):
(-[WebAccessibilityObjectWrapperBase baseAccessibilityResolvedEditingStyles]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::createAndStoreMasterKey):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
(WebCore::toNSDictionary):
(WebCore::AttributedString::nsAttributedString const):
(WebCore::extractArray):
(WebCore::extractDictionary):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::canBePresentedByDataDetectors):
(WebCore::resultIsURL):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processElement):
(fileWrapperForElement):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::plainTextFromPasteboard):
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::updateSpatialExperience):
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::asPlainText const):
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::MIMETypeRegistry::preferredExtensionForMIMEType):
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::isPublicSuffixCF):
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::SerializedPlatformDataCueValue):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::cocoaTypeFromHTMLClipboardType):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::addRepresentationsForPlainText):
(WebCore::PlatformPasteboard::write):
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
(WebCore::createItemProviderRegistrationList):
* Source/WebCore/platform/ios/PreviewConverterIOS.mm:
(WebCore::optionsWithPassword):
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
(classForTypeIdentifier):
(-[WebItemProviderPasteboard valuesForPasteboardType:inItemSet:]):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::supportedFileUploadPasteboardTypes):
(WebCore::writeURLForTypes):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::isFilePasteboardType):
(WebCore::PlatformPasteboard::getPathnamesForType const):
(WebCore::pasteboardMayContainFilePaths):
(WebCore::PlatformPasteboard::setStringForType):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::httpCookiesForURL const):
(WebCore::NetworkStorageSession::setCookiePartition):
(WebCore::NetworkStorageSession::domCookiesForHost):
(WebCore::NetworkStorageSession::startListeningForCookieChangeNotifications):
(WebCore::NetworkStorageSession::stopListeningForCookieChangeNotifications):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::initNSURLResponse const):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::createNSErrorFromResourceErrorBase):
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connectionDidFinishLoading:]):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::vectorFromDictionary):
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::toNSObject):
* Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm:
(WebKit::SandboxInitializationParameters::addPathParameter):
* Source/WebKit/Shared/Cocoa/WKNSString.mm:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toID):
(WebKit::JavaScriptEvaluationResult::toVariant):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::setFileWrapperAndUpdateContentType):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _downloadAttribute]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand debugDescription]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView mediaType]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _contentsOfUserInterfaceItem:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _removeDataStoreWithIdentifier:completionHandler:]):
(-[WKWebsiteDataStore _getAllBackgroundFetchIdentifiers:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(nullableNSString):
(-[_WKApplicationManifest rawJSON]):
(-[_WKApplicationManifest name]):
(-[_WKApplicationManifest shortName]):
(-[_WKApplicationManifest applicationDescription]):
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm:
(-[_WKNotificationData title]):
(-[_WKNotificationData lang]):
(-[_WKNotificationData body]):
(-[_WKNotificationData tag]):
(-[_WKNotificationData origin]):
(-[_WKNotificationData identifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo debugDescription]):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithParameters:inRect:completionHandler:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm:
(WebKit::WebExtensionController::testResult):
(WebKit::WebExtensionController::testEqual):
(WebKit::WebExtensionController::testLogMessage):
(WebKit::WebExtensionController::testSentMessage):
(WebKit::WebExtensionController::testAdded):
(WebKit::WebExtensionController::testStarted):
(WebKit::WebExtensionController::testFinished):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::setActivationKey):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView selectedText]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView actionSheetAssistant:performAction:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController setLocation:]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _showPhishingAlert]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::registerEditCommand):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchCommandsCommandEvent):
(WebKit::WebExtensionContextProxy::dispatchCommandsChangedEvent):
* Source/WebKit/webpushd/WebClipCache.mm:
(WebPushD::WebClipCache::persist):
* Source/WebKitLegacy/ios/WebView/WebPDFViewIOS.mm:
(-[WebPDFView _checkPDFTitle]):
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
(-[WebPDFViewPlaceholder _updateTitleForDocumentIfAvailable]):
* Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm:
(-[NSString _web_decodeHostName]):
(-[NSString _web_encodeHostName]):
(-[NSString _webkit_decodeHostName]):
(-[NSString _webkit_encodeHostName]):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(WTF_URLExtras, URLExtras_ParsingError)):

Canonical link: <a href="https://commits.webkit.org/293429@main">https://commits.webkit.org/293429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f936a8572e219b78fc2c9e7ab1cfd5087435ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98880 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32406 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101884 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14296 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55637 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98364 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7268 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48849 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106375 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97510 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25977 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83738 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31116 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121126 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25750 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33874 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->