### PR TITLE
Remove unneeded forward declarations.

### DIFF
--- a/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
@@ -31,7 +31,10 @@ DECLARE_SYSTEM_HEADER
 
 #import <BackBoardServices/BKSAnimationFence.h>
 #import <BackBoardServices/BKSAnimationFence_Private.h>
+#import <BackBoardServices/BKSHIDEventAttributes.h>
+#import <BackBoardServices/BKSHIDEventKeyCommand.h>
 #import <BackBoardServices/BKSMousePointerService.h>
+
 
 #else
 
@@ -54,13 +57,6 @@ DECLARE_SYSTEM_HEADER
 - (id<BSInvalidatable>)addPointerDeviceObserver:(id<BKSMousePointerDeviceObserver>)observer;
 @end
 
-#endif // USE(APPLE_INTERNAL_SDK)
-
-// Unfortunately, the following declarations need to be forward declared even when using the internal SDK,
-// since the headers that define these symbols (BKSHIDEventKeyCommand.h and BKSHIDEventAttributes.h) include
-// additional private headers that attempt to define macros, which conflict with other macros within WebKit
-// (in particular, `kB` being defined in BrightnessSystemKeys.h, and Sizes.h in bmalloc).
-
 typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
     BKSKeyModifierShift = 1 << 17,
     BKSKeyModifierControl = 1 << 18,
@@ -74,3 +70,7 @@ typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
 @interface BKSHIDEventDigitizerAttributes : BKSHIDEventBaseAttributes
 @property (nonatomic) BKSKeyModifierFlags activeModifiers;
 @end
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+


### PR DESCRIPTION
#### d15ea51130119a010e33c2d3c26fcfa4d0be5f73
<pre>
Remove unneeded forward declarations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291225">https://bugs.webkit.org/show_bug.cgi?id=291225</a>
<a href="https://rdar.apple.com/148771459">rdar://148771459</a>

Reviewed by Tim Horton.

After <a href="https://rdar.apple.com/107586783">rdar://107586783</a> was fixed, we not longer have the
clashing kB definition, so we can move this to only be pre-declared
for non-internal situations, and have the correct includes for internal builds.

* Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h:

Canonical link: <a href="https://commits.webkit.org/293413@main">https://commits.webkit.org/293413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b86f3bccdeb2d48901d6a19c18a513061f153bfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75183 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32331 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13977 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106253 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18857 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84151 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->