### PR TITLE
[visionOS] External playback can get stuck in AcceleratedVideoMode::StagedVideoRenderer

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1063,17 +1063,17 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
         return;
 
     VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), contextId, WTFMove(playerIdentifier), endpoint, endpointIdentifier);
-    xpc_connection_send_message(xpcConnection.get(), endpointMessage.encode().get());
+    xpc_connection_send_message_with_reply(xpcConnection.get(), endpointMessage.encode().get(), dispatch_get_main_queue(), ^(xpc_object_t reply) {
+        RefPtr videoPresentationManager = page->videoPresentationManager();
+        if (!videoPresentationManager)
+            return;
 
-    RefPtr videoPresentationManager = page->videoPresentationManager();
-    if (!videoPresentationManager)
-        return;
+        RefPtr controlsManagerInterface = videoPresentationManager->controlsManagerInterface();
+        if (!controlsManagerInterface)
+            return;
 
-    RefPtr controlsManagerInterface = videoPresentationManager->controlsManagerInterface();
-    if (!controlsManagerInterface)
-        return;
-
-    controlsManagerInterface->didSetVideoReceiverEndpoint();
+        controlsManagerInterface->didSetVideoReceiverEndpoint();
+    });
 #else
     UNUSED_PARAM(contextId);
     UNUSED_PARAM(endpoint);


### PR DESCRIPTION
#### 78ee70b1b6b889eee83750260dd49c3c34e0eae4
<pre>
[visionOS] External playback can get stuck in AcceleratedVideoMode::StagedVideoRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=291231">https://bugs.webkit.org/show_bug.cgi?id=291231</a>
<a href="https://rdar.apple.com/148627593">rdar://148627593</a>

Reviewed by Andy Estes.

With commit 293272@main, we wait to set the isInFullscreenOrPiP state until we
send the setVideoReceiverEndpoint message, counting that the videoTarget would
be set before the isInFullscreenOrPiP message is received. However, because
they use different paths to go from the UI to WebGPU process, the timing is
inconsistent, so sometimes the order is received backwards. This results in the
possibility for accelerated video mode to be stuck in StagedVideoRenderer.

To fix, move the second message that needs to be received after the first to
the handler of the XPC reply from the first message (setVideoReceiverEndpoint).

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):

Canonical link: <a href="https://commits.webkit.org/293539@main">https://commits.webkit.org/293539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30dcd1012f70e45079459134d7efd806f44362c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75189 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13981 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48739 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106265 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84157 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83649 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5981 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19578 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31006 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->