### PR TITLE
Crash under WebExtensionStorageSQLiteStore::getStorageSizeForKeys().

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -70,18 +70,20 @@ int WebExtensionSQLiteDatabase::close()
     return result;
 }
 
-void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, const String& query, RefPtr<API::Error> outError)
+void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, const String& query, RefPtr<API::Error>& outError)
 {
     assertQueue();
     ASSERT(errorCode != SQLITE_OK);
 
-    if (outError)
-        outError = API::Error::create({ WebExtensionSQLiteErrorDomain, errorCode, m_url, emptyString() });
+    if (!query.isEmpty())
+        RELEASE_LOG_ERROR(Extensions, "SQLite error (%d) occurred with query: %{private}s", errorCode, query.utf8().data());
     else
-        RELEASE_LOG_ERROR(Extensions, "Unhandled SQLite error: %d", errorCode);
+        RELEASE_LOG_ERROR(Extensions, "SQLite error (%d) occurred", errorCode);
+
+    outError = errorWithSQLiteErrorCode(errorCode);
 }
 
-void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, sqlite3_stmt* statement, RefPtr<API::Error> outError)
+void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, sqlite3_stmt* statement, RefPtr<API::Error>& outError)
 {
     assertQueue();
     ASSERT(errorCode != SQLITE_OK);
@@ -90,10 +92,11 @@ void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, sqlite3_stmt
         if (char* sql = sqlite3_expanded_sql(statement)) {
             reportErrorWithCode(errorCode, String::fromUTF8(sql), outError);
             sqlite3_free(sql);
+            return;
         }
     }
 
-    reportErrorWithCode(errorCode, emptyString(), outError);
+    reportErrorWithCode(errorCode, { }, outError);
 }
 
 RefPtr<API::Error> WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode(int errorCode)
@@ -101,8 +104,8 @@ RefPtr<API::Error> WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode(int erro
     if (errorCode == SQLITE_OK)
         return nullptr;
 
-    String errorMessage = String::fromUTF8(sqlite3_errstr(errorCode));
-    return API::Error::create({ WebExtensionSQLiteErrorDomain, errorCode, { }, emptyString() });
+    auto errorMessage = String::fromUTF8(sqlite3_errstr(errorCode));
+    return API::Error::create({ WebExtensionSQLiteErrorDomain, errorCode, m_url, errorMessage });
 }
 
 bool WebExtensionSQLiteDatabase::enableWAL(RefPtr<API::Error>& error)
@@ -115,7 +118,7 @@ bool WebExtensionSQLiteDatabase::enableWAL(RefPtr<API::Error>& error)
     return SQLiteDatabaseEnumerate(*this, error, "PRAGMA journal_mode = WAL"_s, std::tie(std::ignore));
 }
 
-bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, ProtectionType protectionType, const String& vfs, RefPtr<API::Error> outError)
+bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, RefPtr<API::Error>& outError, ProtectionType protectionType, const String& vfs)
 {
     int flags = SQLITE_OPEN_NOMUTEX;
 
@@ -161,11 +164,8 @@ bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, Prote
 
         auto directory = m_url.truncatedForUseAsBase().fileSystemPath();
         if (!FileSystem::makeAllDirectories(directory) || FileSystem::fileType(directory) != FileSystem::FileType::Directory) {
-            if (outError) {
-                RELEASE_LOG_ERROR(Extensions, "Unable to create parent folder for database at path: %s", m_url.fileSystemPath().utf8().data());
-                outError = errorWithSQLiteErrorCode(SQLITE_CANTOPEN);
-            }
-
+            RELEASE_LOG_ERROR(Extensions, "Unable to create parent folder for database at path: %s", m_url.fileSystemPath().utf8().data());
+            outError = errorWithSQLiteErrorCode(SQLITE_CANTOPEN);
             return false;
         }
     }
@@ -182,8 +182,7 @@ bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, Prote
     if (result == SQLITE_CANTOPEN && !(flags & SQLITE_OPEN_CREATE))
         return false;
 
-    if (outError)
-        outError = errorWithSQLiteErrorCode(result);
+    outError = errorWithSQLiteErrorCode(result);
 
     return false;
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -78,11 +78,11 @@ public:
         Complete
     };
 
-    bool openWithAccessType(AccessType, ProtectionType = { }, const String& vfs = { }, RefPtr<API::Error> = nullptr);
+    bool openWithAccessType(AccessType, RefPtr<API::Error>&, ProtectionType = { }, const String& vfs = { });
     bool enableWAL(RefPtr<API::Error>&);
 
-    void reportErrorWithCode(int, const String& query, RefPtr<API::Error> = nullptr);
-    void reportErrorWithCode(int, sqlite3_stmt* statement, RefPtr<API::Error> = nullptr);
+    void reportErrorWithCode(int, const String& query, RefPtr<API::Error>&);
+    void reportErrorWithCode(int, sqlite3_stmt* statement, RefPtr<API::Error>&);
 
     int close();
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
@@ -110,23 +110,16 @@ WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator(Ref<WebExtensio
 RefPtr<WebExtensionSQLiteRow> WebExtensionSQLiteRowEnumerator::next()
 {
     m_statement->database()->assertQueue();
-    int lastResultCode = sqlite3_step(m_statement->handle());
 
-    switch (lastResultCode) {
+    switch (sqlite3_step(m_statement->handle())) {
     case SQLITE_ROW:
         if (!m_row)
             m_row = WebExtensionSQLiteRow::create(m_statement);
         return m_row;
-    case SQLITE_OK:
-    case SQLITE_DONE:
-        break;
 
     default:
-        m_statement->database()->reportErrorWithCode(lastResultCode, m_statement->handle(), nullptr);
-        break;
+        return nullptr;
     }
-
-    return nullptr;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
@@ -39,7 +39,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteStatement);
 
-WebExtensionSQLiteStatement::WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase> database, const String& query, RefPtr<API::Error> outError)
+WebExtensionSQLiteStatement::WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase> database, const String& query, RefPtr<API::Error>& outError)
     : m_db(database)
 {
     Ref db = m_db;

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
@@ -51,7 +51,7 @@ public:
         return adoptRef(*new WebExtensionSQLiteStatement(std::forward<Args>(args)...));
     }
 
-    explicit WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase>, const String& query, RefPtr<API::Error> outError = nullptr);
+    explicit WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase>, const String& query, RefPtr<API::Error>&);
 
     ~WebExtensionSQLiteStatement();
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
@@ -121,7 +121,7 @@ String WebExtensionSQLiteStore::openDatabase(const URL& databaseURL, WebExtensio
 
     // FIXME: rdar://87898825 (unlimitedStorage: Allow the SQLite database to be opened as SQLiteDatabaseAccessTypeReadOnly if the request is to calculate storage size).
     RefPtr<API::Error> error;
-    if (RefPtr db = m_database; !db->openWithAccessType(accessType, { }, { }, error)) {
+    if (RefPtr db = m_database; !db->openWithAccessType(accessType, error)) {
         if (!error && accessType != WebExtensionSQLiteDatabase::AccessType::ReadWriteCreate) {
             // The file didn't exist and we were not asked to create it.
             m_database = nullptr;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
@@ -132,10 +132,10 @@ void WebExtensionStorageSQLiteStore::getStorageSizeForKeys(Vector<String> keys, 
 
         int64_t result = 0;
         RefPtr<API::Error> error;
-        bool success = SQLiteDatabaseEnumerate(*(protectedThis->database()), error, "SELECT SUM(LENGTH(key) + LENGTH(value)) FROM extension_storage"_s, std::tie(result));
+        SQLiteDatabaseEnumerate(*(protectedThis->database()), error, "SELECT SUM(LENGTH(key) + LENGTH(value)) FROM extension_storage"_s, std::tie(result));
 
-        WorkQueue::protectedMain()->dispatch([success, result, error, completionHandler = WTFMove(completionHandler)]() mutable {
-            if (success)
+        WorkQueue::protectedMain()->dispatch([result, error, completionHandler = WTFMove(completionHandler)]() mutable {
+            if (!error)
                 completionHandler(result, { });
             else {
                 RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for keys: %s", error->localizedDescription().utf8().data());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -380,6 +380,24 @@ TEST(WKWebExtensionAPIStorage, GetBytesInUse)
     Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
 }
 
+TEST(WKWebExtensionAPIStorage, GetBytesInUseWhenEmpty)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"var result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 0)",
+
+        @"result = await browser?.storage?.local?.getBytesInUse('nonexistent')",
+        @"browser.test.assertEq(result, 0)",
+
+        @"result = await browser?.storage?.local?.getBytesInUse([ 'a', 'b', 'c' ])",
+        @"browser.test.assertEq(result, 0)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
 TEST(WKWebExtensionAPIStorage, Remove)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 931ec1560a9532616482cc4aeb14e00ea2fdf7fe
<pre>
Crash under WebExtensionStorageSQLiteStore::getStorageSizeForKeys().
<a href="https://webkit.org/b/291224">https://webkit.org/b/291224</a>
<a href="https://rdar.apple.com/146574493">rdar://146574493</a>

Reviewed by Brian Weinstein.

Fix error handling for WebExtensionSQLiteDatabase by properly passing
outError as a reference. As-is the error at the call sites were always
null, which would cause a null dereference when calling getBytesInUse().
This was the only place where the error value actually mattered.

* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp:
(WebExtensionSQLiteDatabase::reportErrorWithCode):
(WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode):
(WebExtensionSQLiteDatabase::openWithAccessType):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteHelpers.h:
(WebKit::SQLiteDatabaseFetch):
(WebKit::SQLiteStatementFetchColumnsInTuple):
(WebKit::SQLiteDatabaseEnumerate):
(WebKit::SQLiteDatabaseEnumerateRows):
(WebKit::WBSStatementFetchColumnsInTuple): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp:
(WebKit::WebExtensionSQLiteRowEnumerator::next):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp:
(WebKit::WebExtensionSQLiteStatement::WebExtensionSQLiteStatement):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp:
(WebKit::WebExtensionSQLiteStore::openDatabase):
* Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp:
(WebKit::WebExtensionStorageSQLiteStore::getStorageSizeForKeys):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, GetBytesInUseWhenEmpty)): Added.

Canonical link: <a href="https://commits.webkit.org/293409@main">https://commits.webkit.org/293409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce5e484beb82c79eb43464a595ec9767a544b1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75210 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101784 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14218 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84168 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83661 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19589 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->