### PR TITLE
Reduce use of memcpy in `NetworkCacheDataGLib.cpp`

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <wtf/StdLibExtras.h>
 
 #if !PLATFORM(WIN)
 #include <gio/gfiledescriptorbased.h>
@@ -47,7 +48,7 @@ namespace NetworkCache {
 Data::Data(std::span<const uint8_t> data)
 {
     uint8_t* copiedData = static_cast<uint8_t*>(fastMalloc(data.size()));
-    memcpy(copiedData, data.data(), data.size());
+    memcpySpan(std::span(copiedData, data.size()), data);
     m_buffer = adoptGRef(g_bytes_new_with_free_func(copiedData, data.size(), fastFree, copiedData));
 }
 
@@ -109,10 +110,10 @@ Data concatenate(const Data& a, const Data& b)
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     gsize aLength;
     const auto* aData = g_bytes_get_data(a.bytes(), &aLength);
-    memcpy(data, aData, aLength);
+    memcpySpan(std::span(data, aLength), std::span(static_cast<const uint8_t*>(aData), aLength));
     gsize bLength;
     const auto* bData = g_bytes_get_data(b.bytes(), &bLength);
-    memcpy(data + aLength, bData, bLength);
+    memcpySpan(std::span(data + aLength, bLength), std::span(static_cast<const uint8_t*>(bData), bLength));
 
     return { adoptGRef(g_bytes_new_with_free_func(data, size, fastFree, data)) };
 }


### PR DESCRIPTION
#### 2de42146bc4d11e4029331e2638d59af3ba5a903
<pre>
Reduce use of memcpy in `NetworkCacheDataGLib.cpp`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291238">https://bugs.webkit.org/show_bug.cgi?id=291238</a>

Reviewed by NOBODY (OOPS!).

Reduce use of memcpy.

* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::Data):
(WebKit::NetworkCache::concatenate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2de42146bc4d11e4029331e2638d59af3ba5a903

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32337 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101786 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14215 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14007 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84167 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83660 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5991 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19591 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->