### PR TITLE
REGRESSION (288361@main): [UnifiedPDF] PDF with 1800 pages reliably jetsams/crashes the web content process

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -194,10 +194,10 @@ public:
 
     // Updates existing tiles. Can result in temporarily stale content.
     void setNeedsRenderForRect(WebCore::GraphicsLayer&, const WebCore::FloatRect& bounds);
-    void setNeedsPagePreviewRenderForPageCoverage(const PDFPageCoverage&);
 
     void generatePreviewImageForPage(PDFDocumentLayout::PageIndex, float scale);
     void removePreviewForPage(PDFDocumentLayout::PageIndex);
+    void invalidatePreviewsForPageCoverage(const PDFPageCoverage&);
 
     void setShowDebugBorders(bool);
 
@@ -253,6 +253,7 @@ private:
 
     void didCompletePagePreviewRender(RefPtr<WebCore::NativeImage>&&, const PDFPagePreviewRenderRequest&);
     void removePagePreviewsOutsideCoverageRect(const WebCore::FloatRect&, const std::optional<PDFLayoutRow>& = { });
+    void ensurePreviewsForCurrentPageCoverage();
 
     static WebCore::FloatRect convertTileRectToPaintingCoords(const WebCore::FloatRect&, float pageScaleFactor);
     static WebCore::AffineTransform tileToPaintingTransform(float tilingScaleFactor);
@@ -286,6 +287,8 @@ private:
     ListHashSet<PDFPagePreviewRenderKey> m_pendingPagePreviewOrder;
     HashMap<PDFPagePreviewRenderKey, PDFPagePreviewRenderRequest> m_pendingPagePreviews;
     HashMap<PDFPagePreviewRenderKey, RenderedPDFPagePreview> m_pagePreviews;
+
+    std::optional<PDFPageCoverage> m_currentPageCoverage;
 
     bool m_showDebugBorders { false };
 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -216,7 +216,7 @@ void PDFPresentationController::setNeedsRepaintForPageCoverage(RepaintRequiremen
         }
         if (layer && !bounds.isEmpty())
             asyncRenderer->setNeedsRenderForRect(*layer, bounds);
-        asyncRenderer->setNeedsPagePreviewRenderForPageCoverage(coverage);
+        asyncRenderer->invalidatePreviewsForPageCoverage(coverage);
     }
 }
 


### PR DESCRIPTION
#### 689dde6b1d01550737623461501ad501d52a05a1
<pre>
REGRESSION (288361@main): [UnifiedPDF] PDF with 1800 pages reliably jetsams/crashes the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=291239">https://bugs.webkit.org/show_bug.cgi?id=291239</a>
<a href="https://rdar.apple.com/147425807">rdar://147425807</a>

Reviewed by Abrar Rahman Protyasha.

As part of an attempt to share repaint code between multiple callers, 288361@main
caused us to kick off page preview renders for every page in the document,
burning CPU and quickly causing us to run out of memory.

To avoid this, rename and adjust `setNeedsPagePreviewRenderForPageCoverage` to
`invalidatePreviewsForPageCoverage`, which is what it really needs to do:
mark the existing previews as no longer viable.

Then, kick off preview rendering for *just* the pages that are currently inside
the tile coverage, regardless of which pages were invalidated.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::ensurePreviewsForCurrentPageCoverage):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::invalidatePreviewsForPageCoverage):
(WebKit::AsyncPDFRenderer::setNeedsPagePreviewRenderForPageCoverage): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::setNeedsRepaintForPageCoverage):

Canonical link: <a href="https://commits.webkit.org/293398@main">https://commits.webkit.org/293398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2927349ae3a77c360f9bcaae55081c03c6e65066

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14043 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48799 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106325 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25927 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83701 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21177 "Failed to checkout and rebase branch from PR 43776") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28350 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19638 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25880 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->