### PR TITLE
Fix a fallout on webkitpy.llvm_profile_utils.

### DIFF
--- a/Tools/Scripts/webkitpy/llvm_profile_utils.py
+++ b/Tools/Scripts/webkitpy/llvm_profile_utils.py
@@ -53,9 +53,10 @@ class ExecutablesFromEnvAndXcode:
     @cache
     def detect_binaries(cls):
         llvm_profdata_binaries = []
-        process = shutil.which(cls.EXECUTABLE_NAME)
-        if not process.returncode:
-            llvm_profdata_binaries.append(process.stdout.strip())
+
+        llvm_profdata_from_search_path = shutil.which(cls.EXECUTABLE_NAME)
+        if llvm_profdata_from_search_path:
+            llvm_profdata_binaries.append(llvm_profdata_from_search_path)
 
         for sdk_name in ('macosx.internal', 'iphoneos.internal', 'macosx', 'iphoneos'):
             binary_path = locate_binary_xcrun(sdk_name, cls.EXECUTABLE_NAME)


### PR DESCRIPTION
#### 030dff1f622c44178513048ac0c91ad5c214d0bf
<pre>
Fix a fallout on webkitpy.llvm_profile_utils.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291242">https://bugs.webkit.org/show_bug.cgi?id=291242</a>
<a href="https://rdar.apple.com/148177797">rdar://148177797</a>

Reviewed by Sam Sneddon, Stephanie Lewis, and Yusuke Suzuki.

Fix a bug that is introduced while switching to use `shutil.which` in webkitpy.llvm_profile_util.

* Tools/Scripts/webkitpy/llvm_profile_utils.py:
(ExecutablesFromEnvAndXcode.detect_binaries):

Canonical link: <a href="https://commits.webkit.org/293394@main">https://commits.webkit.org/293394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/101fca2e28aac17ee494c7b9655edd13e37a5f73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32346 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55570 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98283 "Passed tests") | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14017 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48768 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84177 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83673 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21139 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19607 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16057 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25846 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->