### PR TITLE
[libpas] Add padding between partial-views within a segregated page

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
@@ -51,6 +51,7 @@ PAS_API void bmalloc_heap_config_activate(void);
     .check_deallocation = false, \
     .small_segregated_min_align_shift = BMALLOC_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = BMALLOC_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -67,6 +68,7 @@ PAS_API void bmalloc_heap_config_activate(void);
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_no_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
@@ -52,6 +52,7 @@ PAS_API void hotbit_heap_config_activate(void);
     .check_deallocation = false, \
     .small_segregated_min_align_shift = HOTBIT_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -68,6 +69,7 @@ PAS_API void hotbit_heap_config_activate(void);
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
@@ -50,6 +50,7 @@ PAS_BEGIN_EXTERN_C;
     .check_deallocation = true, \
     .small_segregated_min_align_shift = ISO_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -66,6 +67,7 @@ PAS_BEGIN_EXTERN_C;
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_no_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h
@@ -50,6 +50,7 @@ PAS_BEGIN_EXTERN_C;
     .check_deallocation = true, \
     .small_segregated_min_align_shift = ISO_TEST_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -66,6 +67,7 @@ PAS_BEGIN_EXTERN_C;
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_no_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
@@ -182,6 +182,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
             .kind = pas_segregated_page_config_kind_jit_small_segregated, \
             .wasteage_handicap = 1., \
             .sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+            .partial_view_padding = 0, \
             .num_alloc_bits = PAS_BASIC_SEGREGATED_NUM_ALLOC_BITS(JIT_SMALL_SEGREGATED_MIN_ALIGN_SHIFT, \
                                                                   JIT_SMALL_PAGE_SIZE), \
             .shared_payload_offset = 0, \

--- a/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h
@@ -54,6 +54,7 @@ PAS_API void minalign32_heap_config_activate(void);
     .check_deallocation = false, \
     .small_segregated_min_align_shift = MINALIGN32_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = MINALIGN32_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -70,6 +71,7 @@ PAS_API void minalign32_heap_config_activate(void);
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h
@@ -55,6 +55,7 @@ PAS_API void pagesize64k_heap_config_activate(void);
     .check_deallocation = false, \
     .small_segregated_min_align_shift = PAGESIZE64K_MINALIGN_SHIFT, \
     .small_segregated_sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAGESIZE64K_SMALL_PAGE_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_oblivious_logging_mode, \
@@ -71,6 +72,7 @@ PAS_API void pagesize64k_heap_config_activate(void);
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_size_aware_logging_mode, \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -70,6 +70,7 @@ typedef struct {
     bool check_deallocation;
     uint8_t small_segregated_min_align_shift;
     uint8_t small_segregated_sharing_shift;
+    uint8_t small_segregated_partial_view_padding;
     size_t small_segregated_page_size;
     double small_segregated_wasteage_handicap;
     pas_segregated_deallocation_logging_mode small_exclusive_segregated_logging_mode;
@@ -86,6 +87,7 @@ typedef struct {
     bool use_medium_segregated;
     uint8_t medium_segregated_min_align_shift;
     uint8_t medium_segregated_sharing_shift;
+    uint8_t medium_segregated_partial_view_padding;
     double medium_segregated_wasteage_handicap;
     pas_segregated_deallocation_logging_mode medium_exclusive_segregated_logging_mode;
     pas_segregated_deallocation_logging_mode medium_shared_segregated_logging_mode;
@@ -127,6 +129,8 @@ typedef struct {
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_wasteage_handicap, \
         .sharing_shift = \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_sharing_shift, \
+        .partial_view_padding = \
+            ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_partial_view_padding, \
         .num_alloc_bits = PAS_BASIC_SEGREGATED_NUM_ALLOC_BITS( \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_min_align_shift, \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).small_segregated_page_size), \
@@ -193,6 +197,8 @@ typedef struct {
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_segregated_wasteage_handicap, \
         .sharing_shift = \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_segregated_sharing_shift, \
+        .partial_view_padding = \
+            ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_segregated_partial_view_padding, \
         .num_alloc_bits = PAS_BASIC_SEGREGATED_NUM_ALLOC_BITS( \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_segregated_min_align_shift, \
             ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_page_size), \

--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -66,6 +66,12 @@
 /* Use VA-based memory zeroing when the allocation size exceeds this threshold. */
 #define PAS_VA_BASED_ZERO_MEMORY_SHIFT   24
 
+/* Default amount of padding between backing allocations of different partial views within a
+ * single segregated shared page. Most useful for heaps which allocate user-facing objects. */
+#define PAS_SMALL_PARTIAL_VIEW_PADDING   16
+#define PAS_MEDIUM_PARTIAL_VIEW_PADDING  0
+#define PAS_PARTIAL_VIEW_PADDING_ALIGN   16
+
 /* This is the same as PAS_BITVECTOR_WORD_SHIFT, which is a nice performance optimization but
    isn't necessary. It's a performance optimization because there are specialized fast code
    paths for sharing_shift == PAS_BITVECTOR_WORD_SHIFT. */

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -618,6 +618,7 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
     unsigned size;
+    unsigned effective_minimum_size;
     unsigned alignment;
 
     PAS_ASSERT(page_config.base.is_enabled);
@@ -627,6 +628,8 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
 
     size = allocator->object_size;
     alignment = (unsigned)pas_local_allocator_alignment(allocator);
+    effective_minimum_size = pas_segregated_shared_view_compute_minimum_size_for_bump(
+        size, page_config);
     
     for (;;) {
         pas_segregated_shared_view* shared_view;
@@ -641,7 +644,7 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
         shared_page_directory = page_config.shared_page_directory_selector(heap, size_directory);
         
         shared_view = pas_segregated_shared_page_directory_find_first_eligible(
-            shared_page_directory, size, alignment, pas_lock_is_not_held);
+            shared_page_directory, effective_minimum_size, alignment, pas_lock_is_not_held);
 
         PAS_ASSERT(shared_view);
         

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
@@ -137,6 +137,10 @@ struct pas_segregated_page_config {
     /* Sharing granule size expressed as a shift. The sweet spot is PAS_BITVECTOR_WORD_SHIFT if
        you want perf. */
     uint8_t sharing_shift;
+
+    /* Padding to insert between partial views in the page, in bytes.
+     * Aligned to PAS_PARTIAL_VIEW_PADDING_ALIGN bytes. */
+    uint8_t partial_view_padding;
     
     /* Number of bits needed for alloc bits. This ends up impacting the size of the page header,
        so this value needs to be set in a way that is compatible with page_size, payload_size,

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
@@ -127,6 +127,16 @@ pas_segregated_shared_view_can_bump(
     return result.new_bump <= bump_limit;
 }
 
+static PAS_ALWAYS_INLINE unsigned
+pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding(
+    unsigned allocation_size,
+    unsigned trailing_padding_size,
+    unsigned trailing_padding_alignment)
+{
+    return pas_round_up_to_power_of_2(allocation_size, trailing_padding_alignment)
+        + trailing_padding_size;
+}
+
 static PAS_ALWAYS_INLINE pas_shared_view_computed_bump_result
 pas_segregated_shared_view_compute_new_bump(
     pas_segregated_shared_view* view,
@@ -137,12 +147,29 @@ pas_segregated_shared_view_compute_new_bump(
     pas_shared_view_computed_bump_result result;
     unsigned total_shift;
     unsigned bump_limit;
+    unsigned trailing_padding_size;
+    unsigned trailing_padding_alignment;
+    unsigned size_plus_padding;
+    unsigned padding_delta;
+
+    /* NOTE: we assume both (allocation_)alignment and trailing_padding_alignment
+     * are powers-of-2. We could assert here to ensure that is the case, but
+     * pas_segregated_shared_view_compute_initial_new_bump already decided not
+     * to so we adopt that decision here as well. */
+
+    trailing_padding_size = page_config.partial_view_padding;
+    trailing_padding_alignment = page_config.partial_view_padding ? PAS_PARTIAL_VIEW_PADDING_ALIGN : 1;
+    size_plus_padding = pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding(
+        size, trailing_padding_size, trailing_padding_alignment);
+    padding_delta = size_plus_padding - size;
 
     total_shift = page_config.base.min_align_shift + page_config.sharing_shift;
     bump_limit = (unsigned)
         pas_segregated_page_config_payload_end_offset_for_role(page_config, pas_segregated_page_shared_role);
-    result = pas_segregated_shared_view_compute_initial_new_bump(view, size, alignment, page_config);
 
+    result = pas_segregated_shared_view_compute_initial_new_bump(
+        view, size_plus_padding, PAS_MAX(alignment, trailing_padding_alignment), page_config);
+    result.end_bump -= padding_delta;
     if (result.new_bump > bump_limit)
         return pas_shared_view_computed_bump_result_create_empty();
     
@@ -154,11 +181,23 @@ pas_segregated_shared_view_compute_new_bump(
             break;
         }
 
-        result.end_bump = result.new_bump;
+        result.end_bump = result.new_bump - padding_delta;
         result.num_objects++;
     }
 
     return result;
+}
+
+static PAS_ALWAYS_INLINE unsigned
+pas_segregated_shared_view_compute_minimum_size_for_bump(
+    unsigned size,
+    pas_segregated_page_config page_config)
+{
+    unsigned trailing_padding_alignment;
+
+    trailing_padding_alignment = page_config.partial_view_padding ? PAS_PARTIAL_VIEW_PADDING_ALIGN : 1;
+    return pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding(
+        size, page_config.partial_view_padding, trailing_padding_alignment);
 }
 
 static PAS_ALWAYS_INLINE pas_shared_view_computed_bump_result

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
@@ -111,6 +111,7 @@ PAS_API void pas_utility_heap_config_dump_shared_page_directory_arg(
             .kind = pas_segregated_page_config_kind_pas_utility_small, \
             .wasteage_handicap = 1., \
             .sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+            .partial_view_padding = 0, \
             .num_alloc_bits = PAS_UTILITY_NUM_ALLOC_BITS, \
             .shared_payload_offset = 0, \
             .exclusive_payload_offset = PAS_UTILITY_HEAP_PAYLOAD_OFFSET, \

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap_config.h
@@ -51,6 +51,7 @@ PAS_BEGIN_EXTERN_C;
     .check_deallocation = true, \
     .small_segregated_min_align_shift = THINGY_MIN_ALIGN_SHIFT, \
     .small_segregated_sharing_shift = PAS_SMALL_SHARING_SHIFT, \
+    .small_segregated_partial_view_padding = PAS_SMALL_PARTIAL_VIEW_PADDING, \
     .small_segregated_page_size = PAS_SMALL_PAGE_DEFAULT_SIZE, \
     .small_segregated_wasteage_handicap = PAS_SMALL_PAGE_HANDICAP, \
     .small_exclusive_segregated_logging_mode = \
@@ -68,6 +69,7 @@ PAS_BEGIN_EXTERN_C;
     .use_medium_segregated = true, \
     .medium_segregated_min_align_shift = PAS_MIN_MEDIUM_ALIGN_SHIFT, \
     .medium_segregated_sharing_shift = PAS_MEDIUM_SHARING_SHIFT, \
+    .medium_segregated_partial_view_padding = PAS_MEDIUM_PARTIAL_VIEW_PADDING, \
     .medium_segregated_wasteage_handicap = PAS_MEDIUM_PAGE_HANDICAP, \
     .medium_exclusive_segregated_logging_mode = pas_segregated_deallocation_checked_size_aware_logging_mode, \
     .medium_shared_segregated_logging_mode = pas_segregated_deallocation_no_logging_mode, \


### PR DESCRIPTION
#### 35a47bb89d44e6447fd451cbd7d4fd0956a646a9
<pre>
[libpas] Add padding between partial-views within a segregated page
<a href="https://bugs.webkit.org/show_bug.cgi?id=291240">https://bugs.webkit.org/show_bug.cgi?id=291240</a>
<a href="https://rdar.apple.com/148783142">rdar://148783142</a>

Reviewed by David Degazio.

Segregated pages allocate partial views out of shared views. This is the
only thing we ever bump shared views for -- which, beyond the fact that
that&apos;s the only reason we *currently* bump shared views for, is
evidenced by how sharing_shift (which expands the allocation to include
more than just one object-slot) is *always* used inside
pas_segregated_shared_view_compute_new_bump.

Hardcoding this padding as a global constant would have reduced the
runtime performance overhead at least slightly, but at the cost of
additional space usage because it would no longer be possible to
differentiate between different heap types (e.g. utility vs. bmalloc)
or small and medium pages within a heap -- at least without manually
checking, which would just reintroduce this overhead.

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h:
* Source/bmalloc/libpas/src/libpas/jit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_internal_config.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_start_allocating_in_primordial_partial_view):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h:
(pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding):
(pas_segregated_shared_view_compute_new_bump):
(pas_segregated_shared_view_compute_minimum_size_for_bump):
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h:
* Source/bmalloc/libpas/src/libpas/thingy_heap_config.h:

Canonical link: <a href="https://commits.webkit.org/293476@main">https://commits.webkit.org/293476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d60523dada7ef1ef635c2e4a0822daf0de90ba5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98807 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26893 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75225 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32356 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7207 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48776 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91497 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106302 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97437 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84185 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25857 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121053 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25677 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33858 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->