### PR TITLE
[WKTRApp] Wrong .appex extensions sometimes used.

### DIFF
--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = 00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0F18E6E51D6B9B9E0027E547 /* UIScriptContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DD1D6B9AAF0027E547 /* UIScriptContext.cpp */; };
 		0F18E6E61D6B9BA20027E547 /* UIScriptControllerShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DF1D6B9AAF0027E547 /* UIScriptControllerShared.cpp */; };
 		0F18E7181D6BC4560027E547 /* JSWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E7151D6BC4560027E547 /* JSWrapper.cpp */; };
@@ -275,6 +276,7 @@
 			files = (
 				E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */,
 				E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */,
+				00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */,
 				E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */,
 			);
 			name = "Embed Extensions";
@@ -283,6 +285,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = WebContentCaptivePortalExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F18E6DD1D6B9AAF0027E547 /* UIScriptContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UIScriptContext.cpp; path = ../TestRunnerShared/UIScriptContext/UIScriptContext.cpp; sourceTree = "<group>"; };
 		0F18E6DE1D6B9AAF0027E547 /* UIScriptContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIScriptContext.h; path = ../TestRunnerShared/UIScriptContext/UIScriptContext.h; sourceTree = "<group>"; };
 		0F18E6DF1D6B9AAF0027E547 /* UIScriptControllerShared.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UIScriptControllerShared.cpp; path = ../TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp; sourceTree = "<group>"; };
@@ -566,6 +569,7 @@
 		08FB7794FE84155DC02AAC07 /* WebKitTestRunner */ = {
 			isa = PBXGroup;
 			children = (
+				00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */,
 				E3E17D412CC4445D0077C3AE /* WebKitEligibilityUtil */,
 				E372BC392C08F323006DFE67 /* WebContentExtension.appex */,
 				E372BC372C08EB01006DFE67 /* GPUExtension.appex */,


### PR DESCRIPTION
#### a206897f97e2995f108708bf04ed6a2a83203a26
<pre>
[WKTRApp] Wrong .appex extensions sometimes used.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291243">https://bugs.webkit.org/show_bug.cgi?id=291243</a>
<a href="https://rdar.apple.com/148784145">rdar://148784145</a>

Reviewed by Per Arne Vollan.

When performing layout testing using WebKitTestRunnerApp, the wrong .appex
records will sometimes be loaded. This manifests itself as either the
CaptivePortal variant being loaded instead of the standard WebContent,
system extensions being loaded instead of bundled ones, or both.

So, we do two main things to mitigate this.

The first thing we do is package WebContentCaptivePortalExtension with WKTRApp
builds. This ensures all extensions assets are within the bundle in an attempt
to prevent the app from calling system extensions.

* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj: Add WebContentCaptivePortalExtension to build products for WKTRApp.

The second (and most important) thing we do is explicitly define the bundle IDs
of the extensions that we&apos;re trying to load. This eliminates any lingering
ambiguity at runtime and allows the system to choose the correct extension.

* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
    -&gt; (WebKit::serviceNameAndIdentifier):
        - Add the extensions in app bundle check from launchWithExtensionKit into serviceNameAndIdentifier.
        - Determine correct bundle IDs to request based on if extensions are in an app bundle or CaptivePortal vs. WebContent.
    -&gt; (WebKit::launchWithExtensionKit):
        - Remove now redundant extensions in app bundle check.
        - Check for if extensions are bundled before calling process initializers with explicit bundle IDs.

Canonical link: <a href="https://commits.webkit.org/293550@main">https://commits.webkit.org/293550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af61cc5182f05d8b508e00d2e8a283d84d06dfd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75530 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32628 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84490 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84008 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28661 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20069 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26284 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->