### PR TITLE
[Page color sampling] instagram.com: avoid excessive hit-testing in Instagram reels

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller-expected.txt
@@ -1,0 +1,10 @@
+PASS colors.top is "rgb(255, 99, 71)"
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world
+
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            overflow: hidden;
+        }
+
+        .scroller {
+            width: 100%;
+            height: 100%;
+            overflow-y: scroll;
+        }
+
+        .fixed {
+            position: fixed;
+            width: 100%;
+            height: 40px;
+            background: tomato;
+        }
+
+        .tall {
+            width: 10px;
+            height: 3000px;
+        }
+
+        h1 {
+            margin-top: 40px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+        colors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colors.top", "rgb(255, 99, 71)");
+        shouldBeNull("colors.left");
+        shouldBeNull("colors.right");
+        shouldBeNull("colors.bottom");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="fixed"></div>
+        <h1>Hello world</h1>
+        <div class="tall"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt
@@ -1,0 +1,8 @@
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(225, 225, 225)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            font-family: system-ui;
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+
+        .content {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            top: 0;
+            overflow-y: scroll;
+            padding: 0 1em;
+        }
+
+        .box {
+            width: 100%;
+            height: 100px;
+            margin-bottom: 50px;
+            box-sizing: border-box;
+            border-radius: 1em;
+        }
+
+        footer {
+            position: fixed;
+            bottom: 0;
+            width: 100%;
+            height: 50px;
+            background: rgb(225, 225, 225);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+        colors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("colors.top");
+        shouldBeNull("colors.left");
+        shouldBeNull("colors.right");
+        shouldBeEqualToString("colors.bottom", "rgb(225, 225, 225)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <pre id="console"></pre>
+    <pre id="description"></pre>
+    <div class="content">
+        <div class="box" style="background: rgb(0, 122, 255);"></div>
+        <div class="box" style="background: rgb(52, 199, 89);"></div>
+        <div class="box" style="background: rgb(88, 86, 214);"></div>
+        <div class="box" style="background: rgb(255, 149, 0);"></div>
+        <div class="box" style="background: rgb(255, 45, 85);"></div>
+        <div class="box" style="background: rgb(175, 82, 222);"></div>
+        <div class="box" style="background: rgb(255, 59, 48);"></div>
+        <div class="box" style="background: rgb(90, 200, 250);"></div>
+        <div class="box" style="background: rgb(255, 204, 0);"></div>
+        <div class="box" style="background: rgb(200, 200, 200);"></div>
+        <div class="box" style="background: rgb(160, 82, 45);"></div>
+        <div class="box" style="background: rgb(64, 224, 208);"></div>
+    </div>
+    <footer></footer>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1994,7 +1994,7 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
             ReadOnly,
             DisallowUserAgentShadowContent,
             IgnoreClipping,
-            ViewportConstrainedLayersOnly,
+            ForFixedContainerSampling,
         };
 
         HitTestResult result { hitTestLocationForSide(side) };

--- a/Source/WebCore/rendering/HitTestRequest.h
+++ b/Source/WebCore/rendering/HitTestRequest.h
@@ -51,7 +51,7 @@ public:
         // When using list-based testing, continue hit testing even after a hit has been found.
         IncludeAllElementsUnderPoint = 1 << 16,
         PenEvent = 1 << 17,
-        ViewportConstrainedLayersOnly = 1 << 18,
+        ForFixedContainerSampling = 1 << 18,
     };
 
     static constexpr OptionSet defaultTypes = { Type::ReadOnly, Type::Active, Type::DisallowUserAgentShadowContent };
@@ -101,7 +101,7 @@ public:
     bool resultIsElementList() const { return m_type.contains(Type::CollectMultipleElements); }
     bool includesAllElementsUnderPoint() const { return m_type.contains(Type::IncludeAllElementsUnderPoint); }
     bool userTriggered() const { return m_source == HitTestSource::User; }
-    bool viewportConstrainedLayersOnly() const { return m_type.contains(Type::ViewportConstrainedLayersOnly); }
+    bool isForFixedContainerSampling() const { return m_type.contains(Type::ForFixedContainerSampling); }
 
     // Convenience functions
     bool touchMove() const { return move() && touchEvent(); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4645,7 +4645,20 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
             return { };
     }
 
-    if (request.viewportConstrainedLayersOnly() && !m_hasViewportConstrainedDescendant && !isViewportConstrained() && !hasFixedAncestor())
+    bool skipLayerForFixedContainerSampling = [&] {
+        if (!request.isForFixedContainerSampling())
+            return false;
+
+        if (!m_hasViewportConstrainedDescendant && !isViewportConstrained() && !hasFixedAncestor())
+            return true;
+
+        if (hasCompositedScrollableOverflow() && !renderer().hasBackground())
+            return true;
+
+        return false;
+    }();
+
+    if (skipLayerForFixedContainerSampling)
         return { };
 
     // The natural thing would be to keep HitTestingTransformState on the stack, but it's big, so we heap-allocate.


### PR DESCRIPTION
#### d4529857cdb245efa263d39ceac1fcdabcb92786
<pre>
[Page color sampling] instagram.com: avoid excessive hit-testing in Instagram reels
<a href="https://bugs.webkit.org/show_bug.cgi?id=291246">https://bugs.webkit.org/show_bug.cgi?id=291246</a>
<a href="https://rdar.apple.com/148785149">rdar://148785149</a>

Reviewed by Abrar Rahman Protyasha.

To further reduce overhead from fixed container edge detection and sampling, bail from hit-testing
subscrollable containers that don&apos;t have backgrounds. This dramatically reduces the overhead
introduced by page color sampling when scrolling through Instagram Reels, due to the fact that all
of the videos and content (except for the bottom fixed nav bar) is inside of a scrollable, fixed-
position container. As such, the existing optimization to avoid sampling non-viewport-constrained
content does not help us avoid any hit-testing.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html: Added.

Add a test to verify that a fixed-positioned container in the DOM subtree of a subscrollable
container is still detected and sampled.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html: Added.

Add a test to verify that viewport-constrained subscrollable containers without opaque backgrounds
are not sampled.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/rendering/HitTestRequest.h:

Rename `ViewportConstrainedLayersOnly` to `ForFixedContainerSampling`, now that this flag does more
than just skip non-viewport-constrained content during hit-testing.

(WebCore::HitTestRequest::isForFixedContainerSampling const):
(WebCore::HitTestRequest::viewportConstrainedLayersOnly const): Deleted.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):

Canonical link: <a href="https://commits.webkit.org/293390@main">https://commits.webkit.org/293390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc360696ad0afc5ed7b22e0745191259b324ba3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75219 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48773 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25901 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84187 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83685 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28327 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19612 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->