### PR TITLE
Adopt the C++ spaceship operator in more places

### DIFF
--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -831,24 +831,9 @@ public:
     }
 
     // Other comparisons
-    template <typename V> bool operator<(Checked<T, V> rhs) const
+    template <typename V> std::strong_ordering operator<=>(Checked<T, V> rhs) const
     {
-        return value() < rhs.value();
-    }
-
-    template <typename V> bool operator<=(Checked<T, V> rhs) const
-    {
-        return value() <= rhs.value();
-    }
-
-    template <typename V> bool operator>(Checked<T, V> rhs) const
-    {
-        return value() > rhs.value();
-    }
-
-    template <typename V> bool operator>=(Checked<T, V> rhs) const
-    {
-        return value() >= rhs.value();
+        return value() <=> rhs.value();
     }
 
 private:

--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -226,27 +226,9 @@ public:
     }
 
     template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator<(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    std::strong_ordering operator<=>(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
     {
-        return m_storage < rhs.m_storage;
-    }
-
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator<=(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
-    {
-        return m_storage <= rhs.m_storage;
-    }
-
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator>(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
-    {
-        return m_storage > rhs.m_storage;
-    }
-
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator>=(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
-    {
-        return m_storage >= rhs.m_storage;
+        return m_storage <=> rhs.m_storage;
     }
 
 private:

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -340,98 +340,87 @@ MediaTime::operator bool() const
         && !isInvalid();
 }
 
-MediaTime::ComparisonFlags MediaTime::compare(const MediaTime& rhs) const
+std::weak_ordering operator<=>(const MediaTime& a, const MediaTime& b)
 {
-    auto andFlags = m_timeFlags & rhs.m_timeFlags;
-    if (andFlags & (PositiveInfinite | NegativeInfinite | Indefinite))
-        return EqualTo;
+    auto andFlags = a.m_timeFlags & b.m_timeFlags;
+    if (andFlags & (MediaTime::PositiveInfinite | MediaTime::NegativeInfinite | MediaTime::Indefinite))
+        return std::weak_ordering::equivalent;
 
-    auto orFlags = m_timeFlags | rhs.m_timeFlags;
-    if (!(orFlags & Valid))
-        return EqualTo;
+    auto orFlags = a.m_timeFlags | b.m_timeFlags;
+    if (!(orFlags & MediaTime::Valid))
+        return std::weak_ordering::equivalent;
 
-    if (!(andFlags & Valid))
-        return isInvalid() ? GreaterThan : LessThan;
+    if (!(andFlags & MediaTime::Valid))
+        return a.isInvalid() ? std::weak_ordering::greater : std::weak_ordering::less;
 
-    if (orFlags & NegativeInfinite)
-        return isNegativeInfinite() ? LessThan : GreaterThan;
+    if (orFlags & MediaTime::NegativeInfinite)
+        return a.isNegativeInfinite() ? std::weak_ordering::less : std::weak_ordering::greater;
 
-    if (orFlags & PositiveInfinite)
-        return isPositiveInfinite() ? GreaterThan : LessThan;
+    if (orFlags & MediaTime::PositiveInfinite)
+        return a.isPositiveInfinite() ? std::weak_ordering::greater : std::weak_ordering::less;
 
-    if (orFlags & Indefinite)
-        return isIndefinite() ? GreaterThan : LessThan;
+    if (orFlags & MediaTime::Indefinite)
+        return a.isIndefinite() ? std::weak_ordering::greater : std::weak_ordering::less;
 
-    if (andFlags & DoubleValue) {
-        if (m_timeValueAsDouble == rhs.m_timeValueAsDouble)
-            return EqualTo;
+    if (andFlags & MediaTime::DoubleValue) {
+        if (a.m_timeValueAsDouble == b.m_timeValueAsDouble)
+            return std::weak_ordering::equivalent;
 
-        return m_timeValueAsDouble < rhs.m_timeValueAsDouble ? LessThan : GreaterThan;
+        return a.m_timeValueAsDouble < b.m_timeValueAsDouble ? std::weak_ordering::less : std::weak_ordering::greater;
     }
 
-    if (orFlags & DoubleValue) {
-        double a = toDouble();
-        double b = rhs.toDouble();
-        if (a > b)
-            return GreaterThan;
-        if (a < b)
-            return LessThan;
-        return EqualTo;
+    if (orFlags & MediaTime::DoubleValue) {
+        double aAsDouble = a.toDouble();
+        double bAsDouble = b.toDouble();
+        if (aAsDouble > bAsDouble)
+            return std::weak_ordering::greater;
+        if (aAsDouble < bAsDouble)
+            return std::weak_ordering::less;
+        return std::weak_ordering::equivalent;
     }
 
-    if ((m_timeValue < 0) != (rhs.m_timeValue < 0))
-        return m_timeValue < 0 ? LessThan : GreaterThan;
+    if ((a.m_timeValue < 0) != (b.m_timeValue < 0))
+        return a.m_timeValue < 0 ? std::weak_ordering::less : std::weak_ordering::greater;
 
-    if (!m_timeValue && !rhs.m_timeValue)
-        return EqualTo;
+    if (!a.m_timeValue && !b.m_timeValue)
+        return std::weak_ordering::equivalent;
 
-    if (m_timeScale == rhs.m_timeScale) {
-        if (m_timeValue == rhs.m_timeValue)
-            return EqualTo;
-        return m_timeValue < rhs.m_timeValue ? LessThan : GreaterThan;
-    }
+    if (a.m_timeScale == b.m_timeScale)
+        return a.m_timeValue <=> b.m_timeValue;
 
-    if (m_timeValue == rhs.m_timeValue)
-        return m_timeScale < rhs.m_timeScale ? GreaterThan : LessThan;
+    if (a.m_timeValue == b.m_timeValue)
+        return b.m_timeScale <=> a.m_timeScale;
 
-    if (m_timeValue >= 0) {
-        if (m_timeValue < rhs.m_timeValue && m_timeScale > rhs.m_timeScale)
-            return LessThan;
+    if (a.m_timeValue >= 0) {
+        if (a.m_timeValue < b.m_timeValue && a.m_timeScale > b.m_timeScale)
+            return std::weak_ordering::less;
 
-        if (m_timeValue > rhs.m_timeValue && m_timeScale < rhs.m_timeScale)
-            return GreaterThan;
+        if (a.m_timeValue > b.m_timeValue && a.m_timeScale < b.m_timeScale)
+            return std::weak_ordering::greater;
     } else {
-        if (m_timeValue < rhs.m_timeValue && m_timeScale < rhs.m_timeScale)
-            return LessThan;
+        if (a.m_timeValue < b.m_timeValue && a.m_timeScale < b.m_timeScale)
+            return std::weak_ordering::less;
 
-        if (m_timeValue > rhs.m_timeValue && m_timeScale > rhs.m_timeScale)
-            return GreaterThan;
+        if (a.m_timeValue > b.m_timeValue && a.m_timeScale > b.m_timeScale)
+            return std::weak_ordering::greater;
     }
 
-    int64_t lhsFactor;
-    int64_t rhsFactor;
-    if (safeMultiply(m_timeValue, static_cast<int64_t>(rhs.m_timeScale), lhsFactor)
-        && safeMultiply(rhs.m_timeValue, static_cast<int64_t>(m_timeScale), rhsFactor)) {
-        if (lhsFactor == rhsFactor)
-            return EqualTo;
-        return lhsFactor < rhsFactor ? LessThan : GreaterThan;
-    }
+    int64_t aFactor;
+    int64_t bFactor;
+    if (safeMultiply(a.m_timeValue, static_cast<int64_t>(b.m_timeScale), aFactor) && safeMultiply(b.m_timeValue, static_cast<int64_t>(a.m_timeScale), bFactor))
+        return aFactor <=> bFactor;
 
-    int64_t rhsWhole = rhs.m_timeValue / rhs.m_timeScale;
-    int64_t lhsWhole = m_timeValue / m_timeScale;
-    if (lhsWhole > rhsWhole)
-        return GreaterThan;
-    if (lhsWhole < rhsWhole)
-        return LessThan;
+    int64_t bWhole = b.m_timeValue / b.m_timeScale;
+    int64_t aWhole = a.m_timeValue / a.m_timeScale;
+    if (auto result = aWhole <=> bWhole; is_neq(result))
+        return result;
 
-    int64_t rhsRemain = rhs.m_timeValue % rhs.m_timeScale;
-    int64_t lhsRemain = m_timeValue % m_timeScale;
-    lhsFactor = lhsRemain * rhs.m_timeScale;
-    rhsFactor = rhsRemain * m_timeScale;
+    int64_t bRemain = b.m_timeValue % b.m_timeScale;
+    int64_t aRemain = a.m_timeValue % a.m_timeScale;
+    aFactor = aRemain * b.m_timeScale;
+    bFactor = bRemain * a.m_timeScale;
 
-    if (lhsFactor == rhsFactor)
-        return EqualTo;
-    return lhsFactor > rhsFactor ? GreaterThan : LessThan;
+    return aFactor <=> bFactor;
 }
 
 bool MediaTime::isBetween(const MediaTime& a, const MediaTime& b) const

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -75,21 +75,11 @@ public:
     MediaTime operator-(const MediaTime& rhs) const;
     MediaTime operator-() const;
     MediaTime operator*(int32_t) const;
-    bool operator<(const MediaTime& rhs) const { return compare(rhs) == LessThan; }
-    bool operator>(const MediaTime& rhs) const { return compare(rhs) == GreaterThan; }
-    bool operator==(const MediaTime& rhs) const { return compare(rhs) == EqualTo; }
-    bool operator>=(const MediaTime& rhs) const { return compare(rhs) >= EqualTo; }
-    bool operator<=(const MediaTime& rhs) const { return compare(rhs) <= EqualTo; }
     bool operator!() const;
     explicit operator bool() const;
 
-    typedef enum {
-        LessThan = -1,
-        EqualTo = 0,
-        GreaterThan = 1,
-    } ComparisonFlags;
-
-    ComparisonFlags compare(const MediaTime& rhs) const;
+    WTF_EXPORT_PRIVATE friend std::weak_ordering operator<=>(const MediaTime&, const MediaTime&);
+    friend bool operator==(const MediaTime& a, const MediaTime& b) { return is_eq(a <=> b); }
     bool isBetween(const MediaTime&, const MediaTime&) const;
 
     bool isValid() const { return m_timeFlags & Valid; }

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -277,40 +277,16 @@ public:
         : StringTypeAdapter<UUID>(identifier.toRawValue()) { }
 };
 
-template<typename T, typename ThreadSafety>
-bool operator==(const ObjectIdentifierGeneric<T, ThreadSafety, UUID>& a, const ObjectIdentifierGeneric<T, ThreadSafety, UUID>& b)
+template<typename T, typename ThreadSafety, typename RawValue>
+bool operator==(const ObjectIdentifierGeneric<T, ThreadSafety, RawValue>& a, const ObjectIdentifierGeneric<T, ThreadSafety, RawValue>& b)
 {
     return a.toRawValue() == b.toRawValue();
 }
 
 template<typename T, typename ThreadSafety>
-bool operator==(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
+std::strong_ordering operator<=>(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
 {
-    return a.toRawValue() == b.toRawValue();
-}
-
-template<typename T, typename ThreadSafety>
-bool operator>(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
-{
-    return a.toRawValue() > b.toRawValue();
-}
-
-template<typename T, typename ThreadSafety>
-bool operator>=(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
-{
-    return a.toRawValue() >= b.toRawValue();
-}
-
-template<typename T, typename ThreadSafety>
-bool operator<(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
-{
-    return a.toRawValue() < b.toRawValue();
-}
-
-template<typename T, typename ThreadSafety>
-bool operator<=(const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& a, const ObjectIdentifierGeneric<T, ThreadSafety, uint64_t>& b)
-{
-    return a.toRawValue() <= b.toRawValue();
+    return a.toRawValue() <=> b.toRawValue();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1560,6 +1560,12 @@ ALWAYS_INLINE std::optional<double> stringToDouble(std::span<const char> buffer,
     return result;
 }
 
+template<typename FloatingPointType>
+ALWAYS_INLINE std::weak_ordering compareFloatingPointWithWeakOrdering(FloatingPointType a, FloatingPointType b) requires (std::is_floating_point_v<FloatingPointType>)
+{
+    return (a < b) ? std::weak_ordering::less : ((a > b) ? std::weak_ordering::greater : std::weak_ordering::equivalent);
+}
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1587,6 +1593,7 @@ using WTF::callStatelessLambda;
 using WTF::checkAndSet;
 using WTF::clampedMoveCursorWithinSpan;
 using WTF::compareSpans;
+using WTF::compareFloatingPointWithWeakOrdering;
 using WTF::constructFixedSizeArrayWithArguments;
 using WTF::consume;
 using WTF::consumeAndReinterpretCastTo;

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -128,28 +128,10 @@ Seconds TimeWithDynamicClockType::operator-(const TimeWithDynamicClockType& othe
     return Seconds(m_value - other.m_value);
 }
 
-bool TimeWithDynamicClockType::operator<(const TimeWithDynamicClockType& other) const
+std::partial_ordering operator<=>(const TimeWithDynamicClockType& a, const TimeWithDynamicClockType& b)
 {
-    RELEASE_ASSERT(m_type == other.m_type);
-    return m_value < other.m_value;
-}
-
-bool TimeWithDynamicClockType::operator>(const TimeWithDynamicClockType& other) const
-{
-    RELEASE_ASSERT(m_type == other.m_type);
-    return m_value > other.m_value;
-}
-
-bool TimeWithDynamicClockType::operator<=(const TimeWithDynamicClockType& other) const
-{
-    RELEASE_ASSERT(m_type == other.m_type);
-    return m_value <= other.m_value;
-}
-
-bool TimeWithDynamicClockType::operator>=(const TimeWithDynamicClockType& other) const
-{
-    RELEASE_ASSERT(m_type == other.m_type);
-    return m_value >= other.m_value;
+    RELEASE_ASSERT(a.m_type == b.m_type);
+    return a.m_value <=> b.m_value;
 }
 
 void TimeWithDynamicClockType::dump(PrintStream& out) const

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -139,10 +139,7 @@ public:
     friend bool operator==(const TimeWithDynamicClockType&, const TimeWithDynamicClockType&) = default;
     
     // To do relative comparisons, you must be using times with the same clock type.
-    WTF_EXPORT_PRIVATE bool operator<(const TimeWithDynamicClockType&) const;
-    WTF_EXPORT_PRIVATE bool operator>(const TimeWithDynamicClockType&) const;
-    WTF_EXPORT_PRIVATE bool operator<=(const TimeWithDynamicClockType&) const;
-    WTF_EXPORT_PRIVATE bool operator>=(const TimeWithDynamicClockType&) const;
+    WTF_EXPORT_PRIVATE friend std::partial_ordering operator<=>(const TimeWithDynamicClockType&, const TimeWithDynamicClockType&);
     
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
     

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -262,10 +262,10 @@ ExceptionOr<void> IDBCursor::continueFunction(const IDBKeyData& key)
         return Exception { ExceptionCode::DataError, "Failed to execute 'continue' on 'IDBCursor': The parameter is not a valid key."_s };
 
     if (m_info.isDirectionForward()) {
-        if (!key.isNull() && key.compare(m_keyData) <= 0)
+        if (!key.isNull() && key <= m_keyData)
             return Exception { ExceptionCode::DataError, "Failed to execute 'continue' on 'IDBCursor': The parameter is less than or equal to this cursor's position."_s };
     } else {
-        if (!key.isNull() && key.compare(m_keyData) >= 0)
+        if (!key.isNull() && key >= m_keyData)
             return Exception { ExceptionCode::DataError, "Failed to execute 'continue' on 'IDBCursor': The parameter is greater than or equal to this cursor's position."_s };
     }
 

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
@@ -130,7 +130,10 @@ ExceptionOr<short> IDBFactory::cmp(JSGlobalObject& execState, JSValue firstValue
     if (!second->isValid())
         return Exception { ExceptionCode::DataError, "Failed to execute 'cmp' on 'IDBFactory': The parameter is not a valid key."_s };
 
-    return first->compare(second.get());
+    auto comparison = first->compare(second.get());
+    if (is_eq(comparison))
+        return 0;
+    return is_lt(comparison) ? -1 : 1;
 }
 
 void IDBFactory::databases(ScriptExecutionContext& context, IDBDatabasesResponsePromise&& promise)

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -107,54 +107,52 @@ bool IDBKey::isValid() const
     return true;
 }
 
-int IDBKey::compare(const IDBKey& other) const
+std::weak_ordering IDBKey::compare(const IDBKey& other) const
 {
     if (m_type != other.m_type)
-        return m_type > other.m_type ? -1 : 1;
+        return other.m_type <=> m_type;
 
     switch (m_type) {
     case IndexedDB::KeyType::Array: {
         auto& array = std::get<IDBKeyVector>(m_value);
         auto& otherArray = std::get<IDBKeyVector>(other.m_value);
         for (size_t i = 0; i < array.size() && i < otherArray.size(); ++i) {
-            if (int result = array[i]->compare(*otherArray[i]))
+            if (auto result = array[i]->compare(*otherArray[i]); is_neq(result))
                 return result;
         }
-        if (array.size() < otherArray.size())
-            return -1;
-        if (array.size() > otherArray.size())
-            return 1;
-        return 0;
+        return array.size() <=> otherArray.size();
     }
     case IndexedDB::KeyType::Binary:
         return compareBinaryKeyData(std::get<ThreadSafeDataBuffer>(m_value), std::get<ThreadSafeDataBuffer>(other.m_value));
-    case IndexedDB::KeyType::String:
-        return -codePointCompare(std::get<String>(other.m_value), std::get<String>(m_value));
-    case IndexedDB::KeyType::Date:
-    case IndexedDB::KeyType::Number: {
-        auto number = std::get<double>(m_value);
-        auto otherNumber = std::get<double>(other.m_value);
-        return (number < otherNumber) ? -1 : ((number > otherNumber) ? 1 : 0);
+    case IndexedDB::KeyType::String: {
+        // FIXME: codePointCompare() should return a std::strong_ordering.
+        int comparison = codePointCompare(std::get<String>(m_value), std::get<String>(other.m_value));
+        if (!comparison)
+            return std::weak_ordering::equivalent;
+        return comparison < 0 ? std::weak_ordering::less : std::weak_ordering::greater;
     }
+    case IndexedDB::KeyType::Date:
+    case IndexedDB::KeyType::Number:
+        return compareFloatingPointWithWeakOrdering(std::get<double>(m_value), std::get<double>(other.m_value));
     case IndexedDB::KeyType::Invalid:
     case IndexedDB::KeyType::Min:
     case IndexedDB::KeyType::Max:
         ASSERT_NOT_REACHED();
-        return 0;
+        return std::weak_ordering::equivalent;
     }
 
     ASSERT_NOT_REACHED();
-    return 0;
+    return std::weak_ordering::equivalent;
 }
 
 bool IDBKey::isLessThan(const IDBKey& other) const
 {
-    return compare(other) == -1;
+    return is_lt(compare(other));
 }
 
 bool IDBKey::isEqual(const IDBKey& other) const
 {
-    return !compare(other);
+    return is_eq(compare(other));
 }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/Modules/indexeddb/IDBKey.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.h
@@ -138,7 +138,7 @@ public:
         return std::get<ThreadSafeDataBuffer>(m_value);
     }
 
-    int compare(const IDBKey& other) const;
+    std::weak_ordering compare(const IDBKey& other) const;
     bool isLessThan(const IDBKey& other) const;
     bool isEqual(const IDBKey& other) const;
 
@@ -172,39 +172,31 @@ private:
     enum { OverheadSize = 16 };
 };
 
-inline int compareBinaryKeyData(const Vector<uint8_t>& a, const Vector<uint8_t>& b)
+inline std::strong_ordering compareBinaryKeyData(const Vector<uint8_t>& a, const Vector<uint8_t>& b)
 {
     size_t length = std::min(a.size(), b.size());
 
     for (size_t i = 0; i < length; ++i) {
-        if (a[i] > b[i])
-            return 1;
-        if (a[i] < b[i])
-            return -1;
+        if (auto result = a[i] <=> b[i]; is_neq(result))
+            return result;
     }
 
-    if (a.size() == b.size())
-        return 0;
-
-    if (a.size() > b.size())
-        return 1;
-
-    return -1;
+    return a.size() <=> b.size();
 }
 
-inline int compareBinaryKeyData(const ThreadSafeDataBuffer& a, const ThreadSafeDataBuffer& b)
+inline std::strong_ordering compareBinaryKeyData(const ThreadSafeDataBuffer& a, const ThreadSafeDataBuffer& b)
 {
     auto* aData = a.data();
     auto* bData = b.data();
 
     // Covers the cases where both pointers are null as well as both pointing to the same buffer.
     if (aData == bData)
-        return 0;
+        return std::strong_ordering::equal;
 
-    if (aData && !bData)
-        return 1;
-    if (!aData && bData)
-        return -1;
+    if (!bData)
+        return std::strong_ordering::greater;
+    if (!aData)
+        return std::strong_ordering::less;
 
     return compareBinaryKeyData(*aData, *bData);
 }

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -249,69 +249,58 @@ bool IDBKeyData::decode(KeyedDecoder& decoder, IDBKeyData& result)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-int IDBKeyData::compare(const IDBKeyData& other) const
+std::weak_ordering operator<=>(const IDBKeyData& a, const IDBKeyData& b)
 {
-    auto type = this->type();
-    auto otherType = other.type();
+    auto aType = a.type();
+    auto bType = b.type();
 
-    if (type == IndexedDB::KeyType::Invalid) {
-        if (otherType != IndexedDB::KeyType::Invalid)
-            return -1;
-        if (otherType == IndexedDB::KeyType::Invalid)
-            return 0;
-    } else if (otherType == IndexedDB::KeyType::Invalid)
-        return 1;
+    if (aType == IndexedDB::KeyType::Invalid) {
+        if (bType != IndexedDB::KeyType::Invalid)
+            return std::weak_ordering::less;
+        if (bType == IndexedDB::KeyType::Invalid)
+            return std::weak_ordering::equivalent;
+    } else if (bType == IndexedDB::KeyType::Invalid)
+        return std::weak_ordering::greater;
 
     // The IDBKey::type() enum is in reverse sort order.
-    if (type != otherType)
-        return type < otherType ? 1 : -1;
+    if (aType != bType)
+        return bType <=> aType;
 
     // The types are the same, so handle actual value comparison.
-    switch (type) {
+    switch (aType) {
     case IndexedDB::KeyType::Invalid:
         // Invalid type should have been fully handled above
         ASSERT_NOT_REACHED();
-        return 0;
+        return std::weak_ordering::equivalent;
     case IndexedDB::KeyType::Array: {
-        auto& array = std::get<Vector<IDBKeyData>>(m_value);
-        auto& otherArray = std::get<Vector<IDBKeyData>>(other.m_value);
-        for (size_t i = 0; i < array.size() && i < otherArray.size(); ++i) {
-            if (int result = array[i].compare(otherArray[i]))
+        auto& aArray = std::get<Vector<IDBKeyData>>(a.m_value);
+        auto& bArray = std::get<Vector<IDBKeyData>>(b.m_value);
+        for (size_t i = 0; i < aArray.size() && i < bArray.size(); ++i) {
+            if (auto result = aArray[i] <=> bArray[i]; is_neq(result))
                 return result;
         }
-        if (array.size() < otherArray.size())
-            return -1;
-        if (array.size() > otherArray.size())
-            return 1;
-        return 0;
+        return aArray.size() <=> bArray.size();
     }
     case IndexedDB::KeyType::Binary:
-        return compareBinaryKeyData(std::get<ThreadSafeDataBuffer>(m_value), std::get<ThreadSafeDataBuffer>(other.m_value));
-    case IndexedDB::KeyType::String:
-        return codePointCompare(std::get<String>(m_value), std::get<String>(other.m_value));
-    case IndexedDB::KeyType::Date: {
-        auto number = std::get<Date>(m_value).value;
-        auto otherNumber = std::get<Date>(other.m_value).value;
-
-        if (number == otherNumber)
-            return 0;
-        return number > otherNumber ? 1 : -1;
+        return compareBinaryKeyData(std::get<ThreadSafeDataBuffer>(a.m_value), std::get<ThreadSafeDataBuffer>(b.m_value));
+    case IndexedDB::KeyType::String: {
+        // FIXME: codePointCompare() should return a std::strong_ordering.
+        int comparison = codePointCompare(std::get<String>(a.m_value), std::get<String>(b.m_value));
+        if (!comparison)
+            return std::weak_ordering::equivalent;
+        return comparison < 0 ? std::weak_ordering::less : std::weak_ordering::greater;
     }
-    case IndexedDB::KeyType::Number: {
-        auto number = std::get<double>(m_value);
-        auto otherNumber = std::get<double>(other.m_value);
-
-        if (number == otherNumber)
-            return 0;
-        return number > otherNumber ? 1 : -1;
-    }
+    case IndexedDB::KeyType::Date:
+        return compareFloatingPointWithWeakOrdering(std::get<IDBKeyData::Date>(a.m_value).value, std::get<IDBKeyData::Date>(b.m_value).value);
+    case IndexedDB::KeyType::Number:
+        return compareFloatingPointWithWeakOrdering(std::get<double>(a.m_value), std::get<double>(b.m_value));
     case IndexedDB::KeyType::Max:
     case IndexedDB::KeyType::Min:
-        return 0;
+        return std::weak_ordering::equivalent;
     }
 
     ASSERT_NOT_REACHED();
-    return 0;
+    return std::weak_ordering::equivalent;
 }
 
 String IDBKeyData::loggingString() const
@@ -425,11 +414,6 @@ bool IDBKeyData::isValidValue(const ValueVariant& variant)
     }, [&](const auto&) {
         return true;
     });
-}
-
-bool IDBKeyData::operator<(const IDBKeyData& rhs) const
-{
-    return compare(rhs) < 0;
 }
 
 bool IDBKeyData::operator==(const IDBKeyData& other) const

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -89,12 +89,6 @@ public:
     WEBCORE_EXPORT void encode(KeyedEncoder&) const;
     WEBCORE_EXPORT static WARN_UNUSED_RETURN bool decode(KeyedDecoder&, IDBKeyData&);
 
-    // compare() has the same semantics as strcmp().
-    //   - Returns negative if this IDBKeyData is less than other.
-    //   - Returns positive if this IDBKeyData is greater than other.
-    //   - Returns zero if this IDBKeyData is equal to other.
-    WEBCORE_EXPORT int compare(const IDBKeyData& other) const;
-
     void setArrayValue(const Vector<IDBKeyData>&);
     void setBinaryValue(const ThreadSafeDataBuffer&);
     void setStringValue(const String&);
@@ -108,21 +102,7 @@ public:
     WEBCORE_EXPORT static bool isValidValue(const ValueVariant&);
     IndexedDB::KeyType type() const;
 
-    bool operator<(const IDBKeyData&) const;
-    bool operator>(const IDBKeyData& other) const
-    {
-        return !(*this < other) && !(*this == other);
-    }
-
-    bool operator<=(const IDBKeyData& other) const
-    {
-        return !(*this > other);
-    }
-
-    bool operator>=(const IDBKeyData& other) const
-    {
-        return !(*this < other);
-    }
+    WEBCORE_EXPORT friend std::weak_ordering operator<=>(const IDBKeyData&, const IDBKeyData&);
 
     bool operator==(const IDBKeyData& other) const;
 

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
@@ -140,20 +140,20 @@ ExceptionOr<bool> IDBKeyRange::includes(JSC::JSGlobalObject& state, JSC::JSValue
         return Exception { ExceptionCode::DataError, "Failed to execute 'includes' on 'IDBKeyRange': The passed-in value is not a valid IndexedDB key."_s };
 
     if (m_lower) {
-        int compare = m_lower->compare(key.get());
+        auto compare = m_lower->compare(key.get());
 
-        if (compare > 0)
+        if (is_gt(compare))
             return false;
-        if (m_isLowerOpen && !compare)
+        if (m_isLowerOpen && is_eq(compare))
             return false;
     }
 
     if (m_upper) {
-        int compare = m_upper->compare(key.get());
+        auto compare = m_upper->compare(key.get());
 
-        if (compare < 0)
+        if (is_lt(compare))
             return false;
-        if (m_isUpperOpen && !compare)
+        if (m_isUpperOpen && is_eq(compare))
             return false;
     }
 

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp
@@ -60,23 +60,23 @@ bool IDBKeyRangeData::isExactlyOneKey() const
     if (isNull() || lowerOpen || upperOpen || !upperKey.isValid() || !lowerKey.isValid())
         return false;
 
-    return !lowerKey.compare(upperKey);
+    return lowerKey == upperKey;
 }
 
 bool IDBKeyRangeData::containsKey(const IDBKeyData& key) const
 {
     if (lowerKey.isValid()) {
-        auto compare = lowerKey.compare(key);
-        if (compare > 0)
+        auto compare = lowerKey <=> key;
+        if (is_gt(compare))
             return false;
-        if (lowerOpen && !compare)
+        if (lowerOpen && is_eq(compare))
             return false;
     }
     if (upperKey.isValid()) {
-        auto compare = upperKey.compare(key);
-        if (compare < 0)
+        auto compare = upperKey <=> key;
+        if (is_lt(compare))
             return false;
-        if (upperOpen && !compare)
+        if (upperOpen && is_eq(compare))
             return false;
     }
 

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -198,7 +198,7 @@ IDBKeyDataSet::iterator IndexValueStore::lowestIteratorInRange(const IDBKeyRange
     }
 
     if (!range.upperKey.isNull()) {
-        if (lowestInRange->compare(range.upperKey) > 0)
+        if (*lowestInRange > range.upperKey)
             return m_orderedKeys.end();
         if (range.upperOpen && *lowestInRange == range.upperKey)
             return m_orderedKeys.end();
@@ -222,7 +222,7 @@ IDBKeyDataSet::reverse_iterator IndexValueStore::highestReverseIteratorInRange(c
     }
 
     if (!range.lowerKey.isNull()) {
-        if (highestInRange->compare(range.lowerKey) < 0)
+        if (*highestInRange < range.lowerKey)
             return m_orderedKeys.rend();
         if (range.lowerOpen && *highestInRange == range.lowerKey)
             return m_orderedKeys.rend();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -504,7 +504,7 @@ IDBKeyData MemoryObjectStore::lowestKeyWithRecordInRange(const IDBKeyRangeData& 
         return { };
 
     if (!keyRangeData.upperKey.isNull()) {
-        if (lowestInRange->compare(keyRangeData.upperKey) > 0)
+        if (*lowestInRange > keyRangeData.upperKey)
             return { };
         if (keyRangeData.upperOpen && *lowestInRange == keyRangeData.upperKey)
             return { };

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
@@ -126,7 +126,7 @@ void MemoryObjectStoreCursor::setForwardIteratorFromRemainingRange(IDBKeyDataSet
     }
 
     if (!m_remainingRange.upperKey.isNull()) {
-        if (lowest->compare(m_remainingRange.upperKey) > 0)
+        if (*lowest > m_remainingRange.upperKey)
             return;
 
         if (m_remainingRange.upperOpen && *lowest == m_remainingRange.upperKey)
@@ -177,7 +177,7 @@ void MemoryObjectStoreCursor::setReverseIteratorFromRemainingRange(IDBKeyDataSet
     }
 
     if (!m_remainingRange.lowerKey.isNull()) {
-        if (highest->compare(m_remainingRange.lowerKey) < 0)
+        if (*highest < m_remainingRange.lowerKey)
             return;
 
         if (m_remainingRange.lowerOpen && *highest == m_remainingRange.lowerKey)
@@ -233,7 +233,7 @@ void MemoryObjectStoreCursor::incrementForwardIterator(IDBKeyDataSet& set, const
         if (!info().range().containsKey(key))
             return;
 
-        if ((*m_iterator)->compare(key) < 0) {
+        if (**m_iterator < key) {
             m_remainingRange.lowerKey = key;
             m_remainingRange.lowerOpen = false;
             setFirstInRemainingRange(set);
@@ -247,7 +247,7 @@ void MemoryObjectStoreCursor::incrementForwardIterator(IDBKeyDataSet& set, const
 
     // If the forwardIterator was reset because it's previous record had been deleted,
     // we might have already advanced past the current position, eating one one of the iteration counts.
-    if (didResetIterator && (*m_iterator)->compare(m_currentPositionKey) > 0)
+    if (didResetIterator && **m_iterator > m_currentPositionKey)
         --count;
 
     while (count) {
@@ -287,7 +287,7 @@ void MemoryObjectStoreCursor::incrementReverseIterator(IDBKeyDataSet& set, const
         if (!info().range().containsKey(key))
             return;
 
-        if ((*m_iterator)->compare(key) > 0) {
+        if (**m_iterator > key) {
             m_remainingRange.upperKey = key;
             m_remainingRange.upperOpen = false;
 
@@ -302,7 +302,7 @@ void MemoryObjectStoreCursor::incrementReverseIterator(IDBKeyDataSet& set, const
 
     // If the reverseIterator was reset because it's previous record had been deleted,
     // we might have already advanced past the current position, eating one one of the iteration counts.
-    if (didResetIterator && (*m_iterator)->compare(m_currentPositionKey) < 0)
+    if (didResetIterator && **m_iterator < m_currentPositionKey)
         --count;
 
     while (count) {

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -96,7 +96,10 @@ static int idbKeyCollate(std::span<const uint8_t> aBuffer, std::span<const uint8
         return 1;
     }
 
-    return a.compare(b);
+    auto comparison = a <=> b;
+    if (is_eq(comparison))
+        return 0;
+    return is_lt(comparison) ? -1 : 1;
 }
 
 static const String v1RecordsTableSchema(ASCIILiteral tableName)

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -442,7 +442,7 @@ bool SQLiteIDBCursor::fetch()
     while (fetchNextRecord(m_fetchedRecords.last())) {
         m_fetchedRecordsSize += m_fetchedRecords.last().record.size();
 
-        if (m_currentKeyForUniqueness.compare(m_fetchedRecords.last().record.key))
+        if (m_currentKeyForUniqueness != m_fetchedRecords.last().record.key)
             return true;
 
         if (m_fetchedRecords.last().completed)
@@ -598,24 +598,24 @@ bool SQLiteIDBCursor::iterate(const IDBKeyData& targetKey, const IDBKeyData& tar
 
         // Search for the next key >= the target if the cursor is a Next cursor, or the next key <= if the cursor is a Previous cursor.
         if (m_cursorDirection == IndexedDB::CursorDirection::Next || m_cursorDirection == IndexedDB::CursorDirection::Nextunique) {
-            if (m_fetchedRecords.first().record.key.compare(targetKey) >= 0)
+            if (m_fetchedRecords.first().record.key >= targetKey)
                 break;
-        } else if (m_fetchedRecords.first().record.key.compare(targetKey) <= 0)
+        } else if (m_fetchedRecords.first().record.key <= targetKey)
             break;
 
         result = advance(1);
     }
 
     if (targetPrimaryKey.isValid()) {
-        while (!m_fetchedRecords.first().isTerminalRecord() && !m_fetchedRecords.first().record.key.compare(targetKey)) {
+        while (!m_fetchedRecords.first().isTerminalRecord() && m_fetchedRecords.first().record.key == targetKey) {
             if (!result)
                 return false;
 
             // Search for the next primary key >= the primary target if the cursor is a Next cursor, or the next key <= if the cursor is a Previous cursor.
             if (m_cursorDirection == IndexedDB::CursorDirection::Next || m_cursorDirection == IndexedDB::CursorDirection::Nextunique) {
-                if (m_fetchedRecords.first().record.primaryKey.compare(targetPrimaryKey) >= 0)
+                if (m_fetchedRecords.first().record.primaryKey >= targetPrimaryKey)
                     break;
-            } else if (m_fetchedRecords.first().record.primaryKey.compare(targetPrimaryKey) <= 0)
+            } else if (m_fetchedRecords.first().record.primaryKey <= targetPrimaryKey)
                 break;
 
             result = advance(1);

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -347,7 +347,7 @@ bool injectIDBKeyIntoScriptValue(JSGlobalObject& lexicalGlobalObject, const IDBK
 
     // Do not set if object already has the correct property value.
     JSValue existingKey;
-    if (get(lexicalGlobalObject, parent, keyPathElements.last(), existingKey) && !key->compare(createIDBKeyFromValue(lexicalGlobalObject, existingKey)))
+    if (get(lexicalGlobalObject, parent, keyPathElements.last(), existingKey) && key->isEqual(createIDBKeyFromValue(lexicalGlobalObject, existingKey)))
         return true;
     if (!set(lexicalGlobalObject.vm(), parent, keyPathElements.last(), toJS(lexicalGlobalObject, lexicalGlobalObject, key.get())))
         return false;


### PR DESCRIPTION
#### 49059735c89606ea4750dae483a6cfc28b1b3ef2
<pre>
Adopt the C++ spaceship operator in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=291247">https://bugs.webkit.org/show_bug.cgi?id=291247</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::Checked::operator&lt;=&gt; const):
(WTF::Checked::operator&lt; const): Deleted.
(WTF::Checked::operator&lt;= const): Deleted.
(WTF::Checked::operator&gt; const): Deleted.
(WTF::Checked::operator&gt;= const): Deleted.
* Source/WTF/wtf/EnumeratedArray.h:
(WTF::EnumeratedArray::operator&lt;=&gt; const):
(WTF::EnumeratedArray::operator&lt; const): Deleted.
(WTF::EnumeratedArray::operator&lt;= const): Deleted.
(WTF::EnumeratedArray::operator&gt; const): Deleted.
(WTF::EnumeratedArray::operator&gt;= const): Deleted.
* Source/WTF/wtf/MediaTime.cpp:
(WTF::operator&lt;=&gt;):
(WTF::MediaTime::compare const): Deleted.
* Source/WTF/wtf/MediaTime.h:
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::operator==):
(WTF::operator&lt;=&gt;):
(WTF::operator&gt;): Deleted.
(WTF::operator&gt;=): Deleted.
(WTF::operator&lt;): Deleted.
(WTF::operator&lt;=): Deleted.
* Source/WTF/wtf/TimeWithDynamicClockType.cpp:
(WTF::operator&lt;=&gt;):
(WTF::TimeWithDynamicClockType::operator&lt; const): Deleted.
(WTF::TimeWithDynamicClockType::operator&gt; const): Deleted.
(WTF::TimeWithDynamicClockType::operator&lt;= const): Deleted.
(WTF::TimeWithDynamicClockType::operator&gt;= const): Deleted.
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
(WebCore::IDBCursor::continueFunction):
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
(WebCore::IDBFactory::cmp):
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::IDBKey::compare const): Deleted.
(WebCore::IDBKey::isLessThan const): Deleted.
(WebCore::IDBKey::isEqual const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKey.h:
(WebCore::IDBKey::createMultiEntryArray):
(WebCore::IDBKey::operator==):
(WebCore::compareBinaryKeyData):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::IDBKeyData::compare const): Deleted.
(WebCore::IDBKeyData::operator&lt; const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
(WebCore::IDBKeyData::operator&gt; const): Deleted.
(WebCore::IDBKeyData::operator&lt;= const): Deleted.
(WebCore::IDBKeyData::operator&gt;= const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp:
(WebCore::IDBKeyRange::bound):
(WebCore::IDBKeyRange::isOnlyKey const):
(WebCore::IDBKeyRange::includes):
* Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp:
(WebCore::IDBKeyRangeData::isExactlyOneKey const):
(WebCore::IDBKeyRangeData::containsKey const):
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::lowestIteratorInRange const):
(WebCore::IDBServer::IndexValueStore::highestReverseIteratorInRange const):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::lowestKeyWithRecordInRange const):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp:
(WebCore::IDBServer::MemoryObjectStoreCursor::setForwardIteratorFromRemainingRange):
(WebCore::IDBServer::MemoryObjectStoreCursor::setReverseIteratorFromRemainingRange):
(WebCore::IDBServer::MemoryObjectStoreCursor::incrementForwardIterator):
(WebCore::IDBServer::MemoryObjectStoreCursor::incrementReverseIterator):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::idbKeyCollate):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::fetch):
(WebCore::IDBServer::SQLiteIDBCursor::iterate):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::injectIDBKeyIntoScriptValue):

Canonical link: <a href="https://commits.webkit.org/293455@main">https://commits.webkit.org/293455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeafde9260eefc1136fc10995b285dc99b428bf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98978 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32477 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48947 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91668 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106473 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97608 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84315 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28473 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6139 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 10 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19802 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31214 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121224 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25848 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33893 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->