### PR TITLE
[webkitcorepy] Improve Version's repr, and other improvements

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
 import unittest
 
 from webkitcorepy import Version
@@ -27,13 +28,19 @@ from webkitcorepy import Version
 
 class VersionTestCase(unittest.TestCase):
 
-    def test_string_constructor(self):
+    def test_from_string(self):
         v = Version.from_string('1.2.3.4.5')
         self.assertEqual(v.major, 1)
         self.assertEqual(v.minor, 2)
         self.assertEqual(v.tiny, 3)
         self.assertEqual(v.micro, 4)
         self.assertEqual(v.nano, 5)
+
+        with self.assertRaises(ValueError):
+            _ = Version.from_string('1.2.3.4.5.6.7')
+
+        with self.assertRaises(ValueError):
+            _ = Version.from_string('x')
 
     def test_from_list(self):
         v = Version.from_iterable([1, 2, 3, 4, 5])
@@ -43,11 +50,26 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(v.micro, 4)
         self.assertEqual(v.nano, 5)
 
+        with self.assertRaises(ValueError):
+            _ = Version.from_iterable([1, 2, 3, 4, 5, 6, 7])
+
     def test_from_tuple(self):
-        v = v = Version.from_iterable((1, 2, 3))
+        v = Version.from_iterable((1, 2, 3))
         self.assertEqual(v.major, 1)
         self.assertEqual(v.minor, 2)
         self.assertEqual(v.tiny, 3)
+
+        with self.assertRaises(ValueError):
+            _ = Version.from_iterable((1, 2, 3, 4, 5, 6, 7))
+
+    def test_from_iterator(self):
+        v = Version.from_iterable(iter([1, 2, 3]))
+        self.assertEqual(v.major, 1)
+        self.assertEqual(v.minor, 2)
+        self.assertEqual(v.tiny, 3)
+
+        with self.assertRaises(ValueError):
+            _ = Version.from_iterable(iter([1, 2, 3, 4, 5, 6, 7]))
 
     def test_int_constructor(self):
         v = Version(1)
@@ -56,6 +78,23 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(v.tiny, 0)
         self.assertEqual(v.micro, 0)
         self.assertEqual(v.nano, 0)
+
+    def test_string_constructor(self):
+        v = Version("1")
+        self.assertEqual(v.major, 1)
+        self.assertEqual(v.minor, 0)
+        self.assertEqual(v.tiny, 0)
+        self.assertEqual(v.micro, 0)
+        self.assertEqual(v.nano, 0)
+
+        with self.assertRaises(ValueError):
+            _ = Version("1.2")
+
+        with self.assertRaises(ValueError):
+            _ = Version("1.2.3.4.5")
+
+        with self.assertRaises(ValueError):
+            _ = Version("1.2.3.4.5.6.7")
 
     def test_len(self):
         self.assertEqual(len(Version(1, 2, 3, 4, 5)), 5)
@@ -95,6 +134,16 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(v[3], v.micro)
         self.assertEqual(v[4], v.nano)
 
+        v = Version(1)
+        self.assertEqual(v[0], v.major)
+        self.assertEqual(v[1], v.minor)
+        self.assertEqual(v[2], v.tiny)
+        self.assertEqual(v[3], v.micro)
+        self.assertEqual(v[4], v.nano)
+
+        with self.assertRaises(IndexError):
+            _ = v[5]
+
     def test_get_by_string(self):
         v = Version(1, 2, 3, 4, 5)
         self.assertEqual(v['major'], v.major)
@@ -103,11 +152,43 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(v['micro'], v.micro)
         self.assertEqual(v['nano'], v.nano)
 
+        with self.assertRaises(KeyError):
+            _ = v['foo']
+
+        with self.assertRaises(KeyError):
+            _ = v['matches']
+
+    def test_iterable(self):
+        self.assertEqual(list(iter(Version(1, 2, 3, 4, 5))), [1, 2, 3, 4, 5])
+        self.assertEqual(list(iter(Version(1))), [1, 0, 0, 0, 0])
+
     def test_string(self):
         self.assertEqual(str(Version(1, 2, 3)), '1.2.3')
         self.assertEqual(str(Version(1, 2, 0)), '1.2')
         self.assertEqual(str(Version(1, 2)), '1.2')
+        self.assertEqual(str(Version(1)), '1')
         self.assertEqual(str(Version(0, 0, 3)), '0.0.3')
+        self.assertEqual(str(Version(0, 3)), '0.3')
+        self.assertEqual(str(Version(0)), '0')
+
+    def test_representation(self):
+        self.assertEqual(repr(Version(1, 2, 3)), 'Version(1, 2, 3)')
+        self.assertEqual(repr(Version(1, 2, 0)), 'Version(1, 2)')
+        self.assertEqual(repr(Version(1, 2)), 'Version(1, 2)')
+        self.assertEqual(repr(Version(1)), 'Version(1)')
+        self.assertEqual(repr(Version(0, 0, 3)), 'Version(0, 0, 3)')
+        self.assertEqual(repr(Version(0, 3)), 'Version(0, 3)')
+        self.assertEqual(repr(Version(0)), 'Version(0)')
+
+    def test_hash(self):
+        self.assertEqual(Version(1).__hash__(), Version(1, 0, 0).__hash__())
+
+        # From the Python 3.13 docs:
+        # Note: hash() truncates the value returned from an object's
+        # custom __hash__() method to the size of a Py_ssize_t.
+        max_hash = 2 ** (sys.hash_info.width - 1) - 1
+        self.assertLessEqual(Version(1).__hash__(), max_hash)
+        self.assertLessEqual(Version(2025, 4, 7).__hash__(), max_hash)
 
     def test_contained_in(self):
         self.assertTrue(Version(11, 1) in Version(11))
@@ -131,6 +212,10 @@ class VersionTestCase(unittest.TestCase):
         self.assertGreater(Version(1, 3, 2), Version(1, 2, 3))
         self.assertGreater(Version(2, 1, 1), Version(1, 2, 3))
         self.assertNotEqual(Version(1, 2, 3), None)
+        self.assertGreater(Version(1, 2, 3), None)
+        self.assertGreaterEqual(Version(1, 2, 3), None)
+        self.assertLess(None, Version(1, 2, 3))
+        self.assertLessEqual(None, Version(1, 2, 3))
 
     def test_matches(self):
         version = Version(1, 2, 3)


### PR DESCRIPTION
#### 3af6e0deadb6ab8486a8fef95c9d76abd4517bad
<pre>
[webkitcorepy] Improve Version&apos;s repr, and other improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=291244">https://bugs.webkit.org/show_bug.cgi?id=291244</a>

Reviewed by Brianna Fan.

Some highlights:

 * Adds a bunch more tests, especially for error cases,
 * Makes iter(Version()) provide an iterator, and
 * Provides a useful repr(Version()).

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py:
(VersionTestCase.test_from_string):
(VersionTestCase.test_from_list):
(VersionTestCase.test_from_tuple):
(VersionTestCase.test_from_iterator):
(VersionTestCase.test_string_constructor):
(VersionTestCase.test_get_by_int):
(VersionTestCase.test_get_by_string):
(VersionTestCase.test_iterable):
(VersionTestCase.test_string):
(VersionTestCase.test_representation):
(VersionTestCase.test_hash):
(VersionTestCase.test_compare_versions):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py:
(Version.from_string): Tidy up exceptions.
(Version.from_iterable):
Call the constructor, rather than mutating the object.
(Version.__getitem__):
Raise IndexError when passed an int, and KeyError when passed a str,
instead of ValueError.  Tighten allowed str values up so you can&apos;t do
v[&apos;__getitem__&apos;].
(Version.__setitem__):
Raise IndexError when passed an int, and KeyError when passed a str,
instead of ValueError.
(Version._strip_zeros): A helper, to remove trailing zeros.
(Version.__contains__): Rewrite in terms of _strip_zeros.
(Version.__str__): Provide the obvious str value.
(Version.__repr__): Provide an actual Python expression.
(Version.__hash__):
Don&apos;t reimplement custom hashing logic, let Python do its thing for a
tuple of ints. This avoids us creating hash values so large they get
truncated.
(Version.__eq__):
(Version.__lt__):
(Version.__le__):
(Version.__gt__):
(Version.__ge__):
(Version.__cmp__): Deleted. This is very Python 2.
(Version.__ne__): Deleted. Python 3 defaults to &quot;not (a == b)&quot;.

Canonical link: <a href="https://commits.webkit.org/293683@main">https://commits.webkit.org/293683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c6cc853b195051e001046ebc97d05d435773e95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75227 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55586 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98301 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18889 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84190 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/98386 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83688 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28336 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19625 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16213 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25867 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->