### PR TITLE
address more safer cpp failures in WebKit/UIProcess/Cocoa

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -47,9 +47,7 @@ UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
-UIProcess/Cocoa/UIDelegate.mm
 UIProcess/Cocoa/WKContactPicker.mm
-UIProcess/Cocoa/WKShareSheet.mm
 UIProcess/Cocoa/WKStorageAccessAlert.mm
 UIProcess/Cocoa/WebPageProxyCocoa.mm
 UIProcess/Cocoa/WebPreferencesCocoa.mm

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -347,8 +347,8 @@ static bool previewHasCameraSupport(ASVInlinePreview *preview)
 
 void ModelElementController::getCameraForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<WebCore::HTMLModelElementCamera, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasCameraSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasCameraSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -375,8 +375,8 @@ void ModelElementController::getCameraForModelElement(ModelIdentifier modelIdent
 
 void ModelElementController::setCameraForModelElement(ModelIdentifier modelIdentifier, WebCore::HTMLModelElementCamera camera, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasCameraSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasCameraSupport(preview.get())) {
         completionHandler(false);
         return;
     }
@@ -400,8 +400,8 @@ static bool previewHasAnimationSupport(ASVInlinePreview *preview)
 
 void ModelElementController::isPlayingAnimationForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<bool, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -415,8 +415,8 @@ void ModelElementController::isPlayingAnimationForModelElement(ModelIdentifier m
 
 void ModelElementController::setAnimationIsPlayingForModelElement(ModelIdentifier modelIdentifier, bool isPlaying, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(false);
         return;
     }
@@ -435,8 +435,8 @@ void ModelElementController::setAnimationIsPlayingForModelElement(ModelIdentifie
 
 void ModelElementController::isLoopingAnimationForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<bool, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -450,14 +450,14 @@ void ModelElementController::isLoopingAnimationForModelElement(ModelIdentifier m
 
 void ModelElementController::setIsLoopingAnimationForModelElement(ModelIdentifier modelIdentifier, bool isLooping, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(false);
         return;
     }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_ANIMATIONS_CONTROL)
-    preview.isLooping = isLooping;
+    preview.get().isLooping = isLooping;
     completionHandler(true);
 #else
     ASSERT_NOT_REACHED();
@@ -466,8 +466,8 @@ void ModelElementController::setIsLoopingAnimationForModelElement(ModelIdentifie
 
 void ModelElementController::animationDurationForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<Seconds, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -481,8 +481,8 @@ void ModelElementController::animationDurationForModelElement(ModelIdentifier mo
 
 void ModelElementController::animationCurrentTimeForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<Seconds, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -496,14 +496,14 @@ void ModelElementController::animationCurrentTimeForModelElement(ModelIdentifier
 
 void ModelElementController::setAnimationCurrentTimeForModelElement(ModelIdentifier modelIdentifier, Seconds currentTime, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAnimationSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAnimationSupport(preview.get())) {
         completionHandler(false);
         return;
     }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_ANIMATIONS_CONTROL)
-    preview.currentTime = currentTime.seconds();
+    preview.get().currentTime = currentTime.seconds();
     completionHandler(true);
 #else
     ASSERT_NOT_REACHED();
@@ -521,8 +521,8 @@ static bool previewHasAudioSupport(ASVInlinePreview *preview)
 
 void ModelElementController::hasAudioForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<bool, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAudioSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAudioSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -536,8 +536,8 @@ void ModelElementController::hasAudioForModelElement(ModelIdentifier modelIdenti
 
 void ModelElementController::isMutedForModelElement(ModelIdentifier modelIdentifier, CompletionHandler<void(Expected<bool, WebCore::ResourceError>)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAudioSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAudioSupport(preview.get())) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::ResourceError::Type::General }));
         return;
     }
@@ -551,14 +551,14 @@ void ModelElementController::isMutedForModelElement(ModelIdentifier modelIdentif
 
 void ModelElementController::setIsMutedForModelElement(ModelIdentifier modelIdentifier, bool isMuted, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* preview = previewForModelIdentifier(modelIdentifier);
-    if (!previewHasAudioSupport(preview)) {
+    RetainPtr preview = previewForModelIdentifier(modelIdentifier);
+    if (!previewHasAudioSupport(preview.get())) {
         completionHandler(false);
         return;
     }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_AUDIO_CONTROL)
-    preview.isMuted = isMuted;
+    preview.get().isMuted = isMuted;
     completionHandler(true);
 #else
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -38,6 +38,7 @@
 @class _WKActivatedElementInfo;
 @class WKWebView;
 @protocol WKUIDelegate;
+@protocol WKUIDelegatePrivate;
 
 namespace API {
 class FrameInfo;
@@ -205,6 +206,8 @@ private:
         void recentlyAccessedGamepadsForTesting(WebPageProxy&) final;
         void stoppedAccessingGamepadsForTesting(WebPageProxy&) final;
 #endif
+
+        id<WKUIDelegatePrivate> uiDelegatePrivate();
 
         WeakPtr<UIDelegate> m_uiDelegate;
     };


### PR DESCRIPTION
#### 87d8c1ec3c3acbd65aa444f628629c120e6caeea
<pre>
address more safer cpp failures in WebKit/UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=291249">https://bugs.webkit.org/show_bug.cgi?id=291249</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::getCameraForModelElement):
(WebKit::ModelElementController::setCameraForModelElement):
(WebKit::ModelElementController::isPlayingAnimationForModelElement):
(WebKit::ModelElementController::setAnimationIsPlayingForModelElement):
(WebKit::ModelElementController::isLoopingAnimationForModelElement):
(WebKit::ModelElementController::setIsLoopingAnimationForModelElement):
(WebKit::ModelElementController::animationDurationForModelElement):
(WebKit::ModelElementController::animationCurrentTimeForModelElement):
(WebKit::ModelElementController::setAnimationCurrentTimeForModelElement):
(WebKit::ModelElementController::hasAudioForModelElement):
(WebKit::ModelElementController::isMutedForModelElement):
(WebKit::ModelElementController::setIsMutedForModelElement):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::requestStorageAccessConfirm):
(WebKit::UIDelegate::UIClient::focusFromServiceWorker):
(WebKit::UIDelegate::UIClient::didChangeFontAttributes):
(WebKit::UIDelegate::UIClient::callDisplayCapturePermissionDelegate):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
(WebKit::UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting):
(WebKit::UIDelegate::UIClient::queryPermission):
(WebKit::UIDelegate::UIClient::didEnableInspectorBrowserDomain):
(WebKit::UIDelegate::UIClient::didDisableInspectorBrowserDomain):
(WebKit::UIDelegate::UIClient::updateAppBadge):
(WebKit::UIDelegate::UIClient::didAdjustVisibilityWithSelectors):
(WebKit::UIDelegate::UIClient::recentlyAccessedGamepadsForTesting):
(WebKit::UIDelegate::UIClient::stoppedAccessingGamepadsForTesting):
(WebKit::UIDelegate::UIClient::requestPermissionOnXRSessionFeatures):
(WebKit::UIDelegate::UIClient::supportedXRSessionFeatures):
(WebKit::UIDelegate::UIClient::startXRSession):
(WebKit::UIDelegate::UIClient::endXRSession):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker _contactInfoFromCNContact:]):
(-[WKContactPicker _contactsFromJSContacts:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(typeIdentifierForFileURL):
(nameForFileURLWithTypeIdentifier):
(placeholderMetadataWithFileURL):
(appendFilesAsShareableURLs):
(-[WKShareSheet presentWithShareDataArray:inRect:]):
(+[WKShareSheet setQuarantineInformationForFilePath:]):
(+[WKShareSheet createTemporarySharingDirectory]):
(+[WKShareSheet createRandomSharingDirectoryForFile:]):
(+[WKShareSheet writeFileToShareableURL:data:temporaryDirectory:]):

Canonical link: <a href="https://commits.webkit.org/293461@main">https://commits.webkit.org/293461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ac90ac37e173bfc7cdc8c50f3f30b9570ce5d7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49577 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32481 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14172 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7369 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106480 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83819 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19809 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16098 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31221 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->