### PR TITLE
RemoteInspectorMessageParser is missing WTF_ALLOW_UNSAFE_BUFFER_USAGE

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
@@ -46,6 +46,7 @@ MessageParser::MessageParser(Function<void(Vector<uint8_t>&&)>&& listener)
 {
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Vector<uint8_t> MessageParser::createMessage(std::span<const uint8_t> data)
 {
     if (data.empty() || data.size() > std::numeric_limits<uint32_t>::max())
@@ -57,6 +58,7 @@ Vector<uint8_t> MessageParser::createMessage(std::span<const uint8_t> data)
     memcpy(&messageBuffer[sizeof(uint32_t)], data.data(), data.size());
     return messageBuffer;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void MessageParser::pushReceivedData(std::span<const uint8_t> data)
 {
@@ -74,6 +76,7 @@ void MessageParser::clearReceivedData()
     m_buffer.clear();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 bool MessageParser::parse()
 {
     while (m_buffer.size() >= sizeof(uint32_t)) {
@@ -102,6 +105,7 @@ bool MessageParser::parse()
 
     return true;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace Inspector
 


### PR DESCRIPTION
#### 3628c5914bc703560b935ee975ad6100d3afed62
<pre>
RemoteInspectorMessageParser is missing WTF_ALLOW_UNSAFE_BUFFER_USAGE
<a href="https://bugs.webkit.org/show_bug.cgi?id=291252">https://bugs.webkit.org/show_bug.cgi?id=291252</a>

Reviewed by Don Olmstead.

RemoteInspectorMessageParser has memcpy calls, which hit -Wunsafe-buffer-usage-in-libc-call.
These should be guarded with WTF_ALLOW_UNSAFE_BUFFER_USAGE.

* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp:

Canonical link: <a href="https://commits.webkit.org/293397@main">https://commits.webkit.org/293397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e00742b034cc0e847e5e28358e3df609c181b8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49424 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75244 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48804 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91525 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/83988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97465 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25932 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85458 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/83705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28357 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19645 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16059 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25885 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121081 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25705 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33863 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->