### PR TITLE
[GTK] Move gtk3 code to get the dpi from PlatformScreen to SystemSettingsManagerProxy

### DIFF
--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -38,7 +38,6 @@
 #include "ScreenProperties.h"
 #include "SystemSettings.h"
 #include "Widget.h"
-#include <gtk/gtk.h>
 
 namespace WebCore {
 
@@ -87,16 +86,6 @@ bool screenHasInvertedColors()
 
 double fontDPI()
 {
-#if !USE(GTK4)
-    // The code in this conditionally-compiled block is needed in order to
-    // respect the GDK_DPI_SCALE setting that was present in GTK3 as an
-    // additional font scaling factor.
-    if (auto* display = gdk_display_get_default()) {
-        if (auto* screen = gdk_display_get_default_screen(display))
-            return gdk_screen_get_resolution(screen);
-    }
-#endif
-
     auto xftDPI = SystemSettings::singleton().xftDPI();
     if (xftDPI)
         return xftDPI.value() / 1024.0;

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -110,6 +110,15 @@ String SystemSettingsManagerProxy::xftRGBA() const
 
 int SystemSettingsManagerProxy::xftDPI() const
 {
+#if !USE(GTK4)
+    // The code in this conditionally-compiled block is needed in order to
+    // respect the GDK_DPI_SCALE setting that was present in GTK3 as an
+    // additional font scaling factor.
+    if (auto* display = gdk_display_get_default()) {
+        if (auto* screen = gdk_display_get_default_screen(display))
+            return gdk_screen_get_resolution(screen);
+    }
+#endif
     int dpiSetting;
     g_object_get(m_settings, "gtk-xft-dpi", &dpiSetting, nullptr);
     return dpiSetting;


### PR DESCRIPTION
#### a738c9c7797da06bedee4b16fa7cca2b9dbd4467
<pre>
[GTK] Move gtk3 code to get the dpi from PlatformScreen to SystemSettingsManagerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=291259">https://bugs.webkit.org/show_bug.cgi?id=291259</a>

Reviewed by Patrick Griffis.

We are now handling that in the UI process.

* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::fontDPI):
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::xftDPI const):

Canonical link: <a href="https://commits.webkit.org/293449@main">https://commits.webkit.org/293449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/802fcc0b8943583948d781d6acc1de02ebbe705e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32387 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7245 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84219 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83717 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6038 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19660 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16093 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31085 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->