### PR TITLE
AX: WebKit fails to construct text marker ranges that include replaced elements, and never includes AXAttachment in attributed strings, causing various VoiceOver usage issues

### DIFF
--- a/LayoutTests/accessibility/mac/attributed-string-with-image-expected.txt
+++ b/LayoutTests/accessibility/mac/attributed-string-with-image-expected.txt
@@ -1,0 +1,17 @@
+This test ensures we include the AXAttachment attribute in attributed strings created from ranges that include images.
+
+Attributes in range {0, 1}:
+AXAttachment: {present}
+Attributes in range {1, 3}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+[ATTACHMENT]xyz
+PASS successfullyParsed is true
+
+TEST COMPLETE
+xyz

--- a/LayoutTests/accessibility/mac/attributed-string-with-image.html
+++ b/LayoutTests/accessibility/mac/attributed-string-with-image.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="wrapper" role="group" aria-label="wrapper text">
+    <img src="/Users/twilco/projects/OpenSource/LayoutTests/accessibility/resources/cake.png"/>xyz
+</div>
+
+<script>
+var output = "This test ensures we include the AXAttachment attribute in attributed strings created from ranges that include images.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+
+    setTimeout(async function() {
+        output += webarea.attributedStringForTextMarkerRange(await selectElementTextById("wrapper", webarea)).replace(String.fromCharCode(65532), "[ATTACHMENT]");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+
+
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/mac/replaced-element-text-selection-expected.txt
+++ b/LayoutTests/accessibility/mac/replaced-element-text-selection-expected.txt
@@ -1,0 +1,23 @@
+This test ensures we can create valid text marker ranges from positions adjacent to replaced elements.
+
+PASS: webarea.stringForTextMarkerRange(range) === '￼'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '￼'
+PASS: webarea.stringForTextMarkerRange(range) === 'x'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'x'
+PASS: webarea.stringForTextMarkerRange(range) === 'y'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'y'
+PASS: webarea.stringForTextMarkerRange(range) === 'z'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'z'
+PASS: webarea.stringForTextMarkerRange(range) === 'z'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'z'
+PASS: webarea.stringForTextMarkerRange(range) === 'y'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'y'
+PASS: webarea.stringForTextMarkerRange(range) === 'x'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'x'
+PASS: webarea.stringForTextMarkerRange(range) === '￼'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '￼'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+xyz

--- a/LayoutTests/accessibility/mac/replaced-element-text-selection.html
+++ b/LayoutTests/accessibility/mac/replaced-element-text-selection.html
@@ -1,0 +1,84 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="editable" contenteditable="true"><img src="../resources/cake.png" />xyz</div>
+
+<script>
+var output = "This test ensures we can create valid text marker ranges from positions adjacent to replaced elements.\n\n";
+// The bug that inspired this fix was that for text selection changes adjacent to replaced elements (like images), we
+// would post an AXSelectedTextChanged notification but fail to include a valid text marker range. This happened thanks
+// to a bug in how we text marker ranges when |shouldCreateAXThreadCompatibleMarkers()| is true. This meant VoiceOver
+// wasn't announcing characters as you moved between them.
+
+var range;
+var webarea;
+var editable = document.getElementById("editable");
+async function select(domNode, startIndex, endIndex, expectedCharacter, searchBackwards) {
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+
+    await waitFor(() => {
+        const selectedRange = webarea.selectedTextMarkerRange();
+        return !webarea.isTextMarkerRangeValid(selectedRange);
+    });
+
+    const domRange = document.createRange();
+    domRange.setStart(domNode, startIndex);
+    domRange.setEnd(domNode, endIndex);
+    selection.addRange(domRange);
+
+    let selectedRange;
+    await waitFor(() => {
+        selectedRange = webarea.selectedTextMarkerRange();
+        return webarea.isTextMarkerRangeValid(selectedRange);
+    });
+
+    let start, end;
+    if (searchBackwards) {
+        end = webarea.endTextMarkerForTextMarkerRange(selectedRange);
+        start = webarea.previousTextMarker(end);
+    } else {
+        start = webarea.startTextMarkerForTextMarkerRange(selectedRange);
+        end = webarea.nextTextMarker(start);
+    }
+
+    range = webarea.textMarkerRangeForMarkers(start, end);
+    output += expect("webarea.stringForTextMarkerRange(range)", `'${expectedCharacter}'`)
+    output += expect("webarea.attributedStringForTextMarkerRange(range).slice(-1)", `'${expectedCharacter}'`)
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    webarea = accessibilityController.rootElement.childAtIndex(0);
+    setTimeout(async function() {
+        // |<img>xyz
+        await select(editable, 0, 0, String.fromCharCode(65532));
+        // <img>|xyz
+        await select(editable, 1, 1, "x");
+        // <img>x|yz
+        await select(editable.childNodes[1], 1, 1, "y");
+        // <img>xy|z
+        await select(editable.childNodes[1], 2, 2, "z");
+        // <img>xyz|
+        await select(editable.childNodes[1], 3, 3, "z", /* searchBackwards */ true);
+        // <img>xy|z
+        await select(editable.childNodes[1], 2, 2, "y", /* searchBackwards */ true);
+        // <img>x|yz
+        await select(editable.childNodes[1], 1, 1, "x", /* searchBackwards */ true);
+        // <img>|xyz
+        await select(editable.childNodes[1], 0, 0, String.fromCharCode(65532), /* searchBackwards */ true);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1236,7 +1236,9 @@ accessibility/mac/text-operation/text-operation-smart-replace.html [ Skip ]
 accessibility/mac/text-operation/text-operation-uppercase.html [ Skip ]
 
 # Skipping because AXTextMarkerRangeIsValid is not supported on WK1.
+accessibility/mac/attributed-string-with-image.html [ Skip ]
 accessibility/mac/dynamic-selection.html [ Skip ]
+accessibility/mac/replaced-element-text-selection.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End features not supported in WebKit1

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -947,6 +947,7 @@ bool AXCoreObject::isTableCellInSameColGroup(AXCoreObject* tableCell)
 
 bool AXCoreObject::isReplacedElement() const
 {
+    // FIXME: Should this include <legend> and form control elements like TextIterator::isRendererReplacedElement does?
     switch (roleValue()) {
     case AccessibilityRole::Audio:
     case AccessibilityRole::Image:

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3665,6 +3665,30 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
         // We need to convert the DOM offset (which is offset into pre-whitespace-collapse text) into an offset into
         // the rendered, post-whitespace-collapse text.
         unsigned domOffset = position.deprecatedEditingOffset();
+
+        auto createFromRendererAndOffset = [&origin] (RenderObject& renderer, unsigned offset) -> std::optional<TextMarkerData> {
+            CheckedPtr cache = renderer.document().axObjectCache();
+            RefPtr object = cache ? cache->getOrCreate(renderer) : nullptr;
+            if (!object)
+                return std::nullopt;
+
+            return std::optional(TextMarkerData {
+                cache->treeID(),
+                object->objectID(),
+                offset,
+                Position::PositionIsOffsetInAnchor,
+                Affinity::Downstream,
+                0,
+                offset,
+                object->isIgnored(),
+                origin
+            });
+
+        };
+
+        if (isRendererReplacedElement(node->renderer()))
+            return createFromRendererAndOffset(*node->renderer(), domOffset);
+
         CheckedPtr<const RenderText> renderText = dynamicDowncast<RenderText>(node ? node->renderer() : nullptr);
 
         if (!renderText) {
@@ -3692,26 +3716,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
         }
         RELEASE_ASSERT(domOffset >= differenceBetweenDomAndRenderedOffsets);
         unsigned renderedOffset = domOffset - differenceBetweenDomAndRenderedOffsets;
-
-        CheckedPtr cache = renderText->document().axObjectCache();
-        if (!cache)
-            return std::nullopt;
-
-        RefPtr object = cache->getOrCreate(const_cast<RenderText&>(*renderText));
-        if (!object)
-            return std::nullopt;
-
-        return std::optional(TextMarkerData {
-            cache->treeID(),
-            object->objectID(),
-            renderedOffset,
-            Position::PositionIsOffsetInAnchor,
-            Affinity::Downstream,
-            0,
-            renderedOffset,
-            object->isIgnored(),
-            origin
-        });
+        return createFromRendererAndOffset(const_cast<RenderText&>(*renderText), renderedOffset);
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1416,8 +1416,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         return { renderLineBreak->containingBlock(), { AXTextRun(box ? box->lineIndex() : 0, makeString('\n').isolatedCopy(), { lengthOneDomOffsets }, { 0 }, 0) } };
     }
 
-    RefPtr node = this->node();
-    if (is<HTMLMediaElement>(node) || is<HTMLAttachmentElement>(node) || isImage()) {
+    if (isReplacedElement()) {
         auto* containingBlock = renderer ? renderer->containingBlock() : nullptr;
         FloatRect rect = frameRect();
         uint16_t width = static_cast<uint16_t>(rect.width());

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -208,6 +208,18 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
 
     auto string = adoptNS([[NSMutableAttributedString alloc] initWithString:text.createNSStringWithoutCopying().get()]);
     NSRange range = NSMakeRange(0, [string length]);
+
+    if (isReplacedElement()) {
+        if (id wrapper = this->wrapper()) {
+#if PLATFORM(MAC)
+            [string.get() addAttribute:NSAccessibilityAttachmentTextAttribute value:(__bridge id)adoptCF(NSAccessibilityCreateAXUIElementRef(wrapper)).get() range:range];
+#else
+            [string.get() addAttribute:AccessibilityTokenAttachment value:wrapper range:range];
+#endif // PLATFORM(MAC)
+        }
+        return string;
+    }
+
     attributedStringSetStyle(string.get(), stylesForAttributedString(), range);
 
     unsigned blockquoteLevel = 0;
@@ -269,7 +281,6 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
         } else
             attributedStringSetNeedsSpellCheck(string.get(), *this);
     }
-
     return string;
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2545,6 +2545,10 @@ static JSRetainPtr<JSStringRef> createJSStringRef(id string)
             [mutableString appendFormat:@"%@: YES\n", NSAccessibilityStrikethroughTextAttribute];
             appendColorDescription(mutableString, NSAccessibilityStrikethroughColorTextAttribute, attributes);
         }
+
+        id attachment = [attributes objectForKey:NSAccessibilityAttachmentTextAttribute];
+        if (attachment)
+            [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityAttachmentTextAttribute];
     };
     [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
     [mutableString appendString:[string string]];


### PR DESCRIPTION
#### 631a9678ee656600d2e8353511cbbac17786b37b
<pre>
AX: WebKit fails to construct text marker ranges that include replaced elements, and never includes AXAttachment in attributed strings, causing various VoiceOver usage issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=291267">https://bugs.webkit.org/show_bug.cgi?id=291267</a>
<a href="https://rdar.apple.com/148834405">rdar://148834405</a>

Reviewed by Joshua Hoffman.

This commit fixes several bugs introduced by ENABLE(AX_THREAD_TEXT_APIS):

  - We never included the AXAttachment attribute in attributed strings that include attachments, like images. This is
    expected to be an AXUIElement. With this commit, we include this attribute.

  - When posting AXSelectedTextChanged notifications, we must include a valid text marker range, or else VoiceOver won&apos;t
    speak anything. We were failing to create a valid text marker range from VisiblePositions associated with replaced
    elements because AXObjectCache::textMarkerDataForVisiblePosition exited early for anything that wasn&apos;t a RenderText,
    which is a problem for things like images and another replaced elements. Fix this by special-casing replaced elements
    in AXObjectCache::textMarkerDataForVisiblePosition.

  - In AXTextMarkerRange::toAttributedString, we would create our result attributed string based on the text produced
    by the |start| marker. But if the start marker object produced no text, like in the case of a marker with offset 1
    in a replaced element, a nil attributed string would be created. Then subsequent attempts to append more attributed
    strings would fail because they were trying to append to a nil attributed string. Fix this by making an append method
    that detects this scenario.

The two new tests cover all three bugs.

* LayoutTests/accessibility/mac/attributed-string-with-image-expected.txt: Added.
* LayoutTests/accessibility/mac/attributed-string-with-image.html: Added.
* LayoutTests/accessibility/mac/replaced-element-text-selection-expected.txt: Added.
* LayoutTests/accessibility/mac/replaced-element-text-selection.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isReplacedElement const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::createJSStringRef):

Canonical link: <a href="https://commits.webkit.org/293443@main">https://commits.webkit.org/293443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35838e1afe20b35f397ec399c1a2df81d99d05fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75310 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106411 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83762 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6091 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19735 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->