### PR TITLE
js heap growth using timing data

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -778,6 +778,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/Subspace.h
     heap/SubspaceInlines.h
     heap/Synchronousness.h
+    heap/Timing.h
     heap/TinyBloomFilter.h
     heap/VerifierSlotVisitor.h
     heap/VisitRaceKey.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1242,6 +1242,7 @@
 		5C3A77B922F2480B003827FF /* testb3_3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C3A77B122F247CB003827FF /* testb3_3.cpp */; };
 		5C3A77BA22F2480F003827FF /* testb3_2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C3A77B222F247CB003827FF /* testb3_2.cpp */; };
 		5C4E8E961DBEBE620036F1FC /* JSONParseTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C4E8E941DBEBDA20036F1FC /* JSONParseTest.cpp */; };
+		5C979E782DD5557100DCE436 /* Timing.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C979E762DD5557100DCE436 /* Timing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D5D8AD10E0D0EBE00F9C692 /* libedit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */; };
 		5DBB1525131D0BD70056AD36 /* minidom.js in Copy Support Script */ = {isa = PBXBuildFile; fileRef = 1412110D0A48788700480255 /* minidom.js */; };
 		5DE6E5B30E1728EC00180407 /* create_hash_table in Headers */ = {isa = PBXBuildFile; fileRef = F692A8540255597D01FF60F7 /* create_hash_table */; settings = {ATTRIBUTES = (); }; };
@@ -4430,6 +4431,8 @@
 		5C3A77BB22F24890003827FF /* testb3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = testb3.h; path = b3/testb3.h; sourceTree = "<group>"; };
 		5C4E8E941DBEBDA20036F1FC /* JSONParseTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JSONParseTest.cpp; path = API/tests/JSONParseTest.cpp; sourceTree = "<group>"; };
 		5C4E8E951DBEBDA20036F1FC /* JSONParseTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSONParseTest.h; path = API/tests/JSONParseTest.h; sourceTree = "<group>"; };
+		5C979E762DD5557100DCE436 /* Timing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Timing.h; sourceTree = "<group>"; };
+		5C979E772DD5557100DCE436 /* Timing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Timing.cpp; sourceTree = "<group>"; };
 		5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libedit.dylib; path = /usr/lib/libedit.dylib; sourceTree = "<absolute>"; };
 		5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = JSC.xcconfig; sourceTree = "<group>"; };
 		5DE3D0F40DD8DDFB00468714 /* WebKitAvailability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitAvailability.h; sourceTree = "<group>"; };
@@ -7296,6 +7299,8 @@
 				0FD79A2C1EBBBDB200DA88D3 /* Synchronousness.h */,
 				0F1FB38A1E173A6200A9BE50 /* SynchronousStopTheWorldMutatorScheduler.cpp */,
 				0F1FB38B1E173A6200A9BE50 /* SynchronousStopTheWorldMutatorScheduler.h */,
+				5C979E772DD5557100DCE436 /* Timing.cpp */,
+				5C979E762DD5557100DCE436 /* Timing.h */,
 				141448CC13A1783700F5BA1A /* TinyBloomFilter.h */,
 				FE2BD66E25C0DC8200999D3B /* VerifierSlotVisitor.cpp */,
 				FE287D01252FB2E800D723F9 /* VerifierSlotVisitor.h */,
@@ -11982,6 +11987,7 @@
 				FE3422121D6B81C30032BE88 /* ThrowScope.h in Headers */,
 				0F572D4F16879FDD00E57FBD /* ThunkGenerator.h in Headers */,
 				A7386556118697B400540279 /* ThunkGenerators.h in Headers */,
+				5C979E782DD5557100DCE436 /* Timing.h in Headers */,
 				141448CD13A1783700F5BA1A /* TinyBloomFilter.h in Headers */,
 				0F55989817C86C5800A1E543 /* ToNativeFromValue.h in Headers */,
 				0F2D4DE919832DAC007D4B19 /* ToThisStatus.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -586,6 +586,7 @@ heap/StructureAlignedMemoryAllocator.cpp
 heap/Subspace.cpp
 heap/SynchronousStopTheWorldMutatorScheduler.cpp
 heap/Synchronousness.cpp
+heap/Timing.cpp
 heap/VerifierSlotVisitor.cpp
 heap/VisitRaceKey.cpp
 heap/WeakBlock.cpp

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -46,6 +46,7 @@
 #include "PreciseSubspace.h"
 #include "StructureID.h"
 #include "Synchronousness.h"
+#include "Timing.h"
 #include "WeakHandleOwner.h"
 #include <wtf/AutomaticThread.h>
 #include <wtf/ConcurrentPtrHashSet.h>
@@ -753,6 +754,8 @@ private:
 
     void deleteUnmarkedCompiledCode();
     JS_EXPORT_PRIVATE void addToRememberedSet(const JSCell*);
+    void updateMaxEdenSize(size_t);
+    void updateMaxOldSize(size_t);
     void updateAllocationLimits();
     void didFinishCollection();
     void resumeCompilerThreads();
@@ -825,6 +828,7 @@ private:
     size_t m_bytesAbandonedSinceLastFullCollect { 0 };
     size_t m_maxEdenSize;
     size_t m_maxEdenSizeWhenCritical;
+    size_t m_maxOldSize;
     size_t m_maxHeapSize;
     size_t m_totalBytesVisitedAfterLastFullCollect { 0 };
     size_t m_totalBytesVisited { 0 };
@@ -970,6 +974,7 @@ private:
 
     RefPtr<Thread> m_collectContinuouslyThread { nullptr };
     
+    ParallelCPUTimer m_timer;
     MonotonicTime m_lastGCStartTime;
     MonotonicTime m_lastGCEndTime;
     MonotonicTime m_currentGCStartTime;

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -27,6 +27,7 @@
 
 #include "AbstractSlotVisitor.h"
 #include "HandleTypes.h"
+#include "Timing.h"
 #include <wtf/Forward.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/MonotonicTime.h>
@@ -137,7 +138,7 @@ public:
     
     enum SharedDrainMode { HelperDrain, MainDrain };
     enum class SharedDrainResult { Done, TimedOut };
-    SharedDrainResult drainFromShared(SharedDrainMode, MonotonicTime timeout = MonotonicTime::infinity());
+    SharedDrainResult drainFromShared(SharedDrainMode, MonotonicTime timeout = MonotonicTime::infinity(), ParallelCPUTimer* = nullptr);
 
     SharedDrainResult drainInParallel(MonotonicTime timeout = MonotonicTime::infinity());
     SharedDrainResult drainInParallelPassively(MonotonicTime timeout = MonotonicTime::infinity());

--- a/Source/JavaScriptCore/heap/Timing.cpp
+++ b/Source/JavaScriptCore/heap/Timing.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Timing.h"
+
+#include <wtf/CPUTime.h>
+
+namespace JSC {
+
+CPUTimingScope::CPUTimingScope(const std::function<void(Seconds)>& notifier)
+    : m_notifier(notifier)
+{
+    m_before = CPUTime::forCurrentThreadSlow();
+}
+CPUTimingScope::CPUTimingScope(CPUTimingScope&& other)
+    : m_before(other.m_before)
+    , m_notifier(other.m_notifier)
+    , m_cancelled(other.m_cancelled)
+{
+    other.m_cancelled = true;
+}
+CPUTimingScope& CPUTimingScope::operator=(CPUTimingScope&& other) noexcept {
+    if (this != &other) {
+        m_before = other.m_before;
+        m_notifier = other.m_notifier;
+        m_cancelled = other.m_cancelled;
+
+        other.m_cancelled = true;
+    }
+    return *this;
+}
+CPUTimingScope::~CPUTimingScope()
+{
+    if (m_cancelled)
+        return;
+    Seconds after = CPUTime::forCurrentThreadSlow();
+    Seconds duration = after - m_before;
+    m_notifier(duration);
+}
+
+CPUTimingScope ParallelCPUTimer::synchronousScope()
+{
+    ASSERT(!m_inParrallelMainThreadScope);
+    ASSERT(!m_inSychronousThreadScope);
+    m_inSychronousThreadScope = true;
+    return CPUTimingScope([&] (Seconds duration) {
+        m_duration += duration;
+        m_inSychronousThreadScope = false;
+    });
+}
+CPUTimingScope ParallelCPUTimer::parallelMainScope()
+{
+    ASSERT(!m_inParrallelMainThreadScope);
+    m_inParrallelMainThreadScope = true;
+    Seconds durationBefore = m_parallelDuration.load();
+    return CPUTimingScope([&] (Seconds duration) {
+        if (m_inSychronousThreadScope)
+            m_duration -= duration; // don't double count this time since we're inside a synchronousScope
+        parallelDurationFetchMax(durationBefore + duration);
+        m_inParrallelMainThreadScope = false;
+    });
+}
+CPUTimingScope ParallelCPUTimer::parallelHelperScope()
+{
+    Seconds durationBefore = m_parallelDuration.load();
+    return CPUTimingScope([&] (Seconds duration) {
+        parallelDurationFetchMax(durationBefore + duration);
+    });
+}
+Seconds ParallelCPUTimer::read()
+{
+    accumulateParallelThreads();
+    return m_duration;
+}
+void ParallelCPUTimer::clear()
+{
+    m_parallelDuration.store(0_s);
+    m_duration = 0_s;
+}
+void ParallelCPUTimer::accumulateParallelThreads()
+{
+    m_duration += m_parallelDuration.exchange(0_s);
+}
+void ParallelCPUTimer::parallelDurationFetchMax(Seconds duration)
+{
+    while (true) {
+        auto current = m_parallelDuration.load();
+        if (current >= duration)
+            return;
+        if (m_parallelDuration.compareExchangeWeakRelaxed(current, duration))
+            return;
+    }
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -611,7 +611,6 @@ static void overrideDefaults()
 #if USE(BMALLOC_MEMORY_FOOTPRINT_API)
     // On iOS and conditionally Linux, we control heap growth using process memory footprint. Therefore these values can be agressive.
     Options::smallHeapRAMFraction() = 0.8;
-    Options::mediumHeapRAMFraction() = 0.9;
 #endif
 
 #if !ENABLE(SIGNAL_BASED_VM_TRAPS)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -209,14 +209,11 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, mediumHeapSize, 4 * 1024 * 1024, Normal, nullptr) \
     v(Unsigned, smallHeapSize, 1 * 1024 * 1024, Normal, nullptr) \
     v(Double, smallHeapRAMFraction, 0.25, Normal, nullptr) \
-    v(Double, smallHeapGrowthFactor, 2, Normal, nullptr) \
-    v(Double, mediumHeapRAMFraction, 0.5, Normal, nullptr) \
-    v(Double, mediumHeapGrowthFactor, 1.5, Normal, nullptr) \
     v(Double, largeHeapGrowthFactor, 1.24, Normal, nullptr) \
     v(Double, miniVMHeapGrowthFactor, 1.20, Normal, nullptr) \
-    v(Double, heapGrowthSteepnessFactor, 2.00, Normal, nullptr) \
-    v(Double, heapGrowthMaxIncrease, 3.00, Normal, nullptr) \
-    v(Unsigned, heapGrowthFunctionThresholdInMB, 16 * 1024, Normal, nullptr) \
+    v(Double, oldHeapGrowthMaxIncrease, 2.00, Normal, "maximum growth factor for old heap size"_s) \
+    v(Unsigned, maxEdenSizeLimitMultiplier, 8, Normal, "how many times larger than minHeapSize maxEdenSize can be"_s) \
+    v(Double, idealProportionOfTimeSpentDoingGC, 0.01, Normal, "the fraction of wall time since end of last gc that was spent doing gc on the cpu (gc cpu time / wall time since last gc) that the gc will aim for"_s) \
     v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold"_s) \
     v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)"_s) \
     v(Double, minimumMutatorUtilization, 0, Normal, nullptr) \

--- a/Source/WTF/wtf/win/CPUTimeWin.cpp
+++ b/Source/WTF/wtf/win/CPUTimeWin.cpp
@@ -70,4 +70,9 @@ Seconds CPUTime::forCurrentThread()
     return fileTimeToSeconds(userTime) + fileTimeToSeconds(kernelTime);
 }
 
+Seconds CPUTime::forCurrentThreadSlow()
+{
+    return CPUTime::forCurrentThread();
+}
+
 }


### PR DESCRIPTION
#### d0eb6967e02e1f700b3671badc8a3965ef7bb70c
<pre>
js heap growth using timing data
<a href="https://bugs.webkit.org/show_bug.cgi?id=291274">https://bugs.webkit.org/show_bug.cgi?id=291274</a>
<a href="https://rdar.apple.com/148838666">rdar://148838666</a>

Reviewed by NOBODY (OOPS!).

Previously, we choose m_maxEdenSize (the number of bytes at which we&apos;ll trigger gc in a
slow allocation) as a multiple of currentHeapSize (with a lower limit) after Full GC.
We want to adapt to the workload to some degree, allowing ourselves to temporarily use
more memory when we&apos;re busy and being careful not to use more memory than necessary
when we&apos;re mostly idle.

Adjust m_maxEdenSize on every GC to aim for a desired idealProportionOfTimeSpentDoingGC,
the amount of CPU time spent doing GC divided by the wall time since the last GC.
To ensure that m_maxEdenSize is reasonable, use minHeapSize as the minimum value and
maxEdenSizeLimitMultiplier * minHeapSize as the maximum value.

Since m_maxEdenSize affects how we currently decide to set m_shouldDoFullCollection,
introduce m_maxOldSize to make the decision instead and use a linear function of RAM
usage to choose how much larger than currentHeapSize we should set m_maxOldSize to be
after each Full GC.
(This is similar to how m_maxEdenSize was calculated, but this is a bit simpler.
The idea is to grow more slowly when approaching criticalGCMemoryThreshold.)

To measure the CPU time of each GC cycle, add synchronous timing scopes to the Begin and
End phases as well as the part of Fixpoint that the world is stopped for.
Also accumulate CPU time in the parallel helper threads using the new ParallelCPUTimer,
which takes the sum over the chunks of work done in SlotVisitor::drainFromShared, only
including the maximum set of chunks that don&apos;t overlap in time.
ParallelCPUTimer creates RAII objects (CPUTimingScope) to record CPU time across scopes.

Also introduce CPUTime::forCurrentThreadSlow (which uses `thread_info`) as a temporary
workaround for CPUTime::forCurrentThread failing on MacOS due to WCP sandbox.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
(JSC::Heap::updateMaxEdenSize):
(JSC::Heap::updateMaxOldSize):
(JSC::Heap::updateAllocationLimits):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0eb6967e02e1f700b3671badc8a3965ef7bb70c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79244 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54391 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111946 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102974 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87941 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10608 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25988 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36773 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/127177 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31242 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34967 "jscore-tests (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->