### PR TITLE
REGRESSION (290899@main): Fix WTF::RetainPtrType when using `id` type

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ *  Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -75,7 +75,7 @@ namespace WTF {
 template<typename T> class RetainPtr;
 
 template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
-template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T>, std::remove_pointer_t<T>, T>;
+template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
 
 template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -181,4 +181,11 @@ TEST(RetainPtr, RetainPtrCF)
     EXPECT_EQ(1, CFGetRetainCount(object2.get()));
 }
 
+TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)
+{
+    static_assert(std::is_same_v<RetainPtr<CFTypeRef>, RetainPtr<WTF::RetainPtrType<CFTypeRef>>>);
+    static_assert(std::is_same_v<RetainPtr<CFStringRef>, RetainPtr<WTF::RetainPtrType<CFStringRef>>>);
+    static_assert(std::is_same_v<RetainPtr<CFMutableStringRef>, RetainPtr<WTF::RetainPtrType<CFMutableStringRef>>>);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -246,7 +246,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
     }
 
     @autoreleasepool {
-        RetainPtr<id> object = adoptNS<id>([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
+        auto object = adoptNS<id>([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
         uintptr_t objectPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectPtr = reinterpret_cast<uintptr_t>(object.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -405,6 +405,21 @@ TEST(RETAIN_PTR_TEST_NAME, HashMapCFTypeDeletedValue)
     map.remove(key);
 
     EXPECT_EQ(1, CFGetRetainCount(key.get()));
+}
+
+TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)
+{
+    // CF Types.
+    static_assert(std::is_same_v<RetainPtr<CFTypeRef>, RetainPtr<WTF::RetainPtrType<CFTypeRef>>>);
+    static_assert(std::is_same_v<RetainPtr<CFStringRef>, RetainPtr<WTF::RetainPtrType<CFStringRef>>>);
+    static_assert(std::is_same_v<RetainPtr<CFMutableStringRef>, RetainPtr<WTF::RetainPtrType<CFMutableStringRef>>>);
+
+    // Cocoa Types.
+    static_assert(std::is_same_v<RetainPtr<id>, RetainPtr<WTF::RetainPtrType<id>>>);
+    static_assert(std::is_same_v<RetainPtr<NSString>, RetainPtr<WTF::RetainPtrType<NSString>>>);
+    static_assert(std::is_same_v<RetainPtr<NSString>, RetainPtr<WTF::RetainPtrType<NSString *>>>);
+    static_assert(std::is_same_v<RetainPtr<NSMutableString>, RetainPtr<WTF::RetainPtrType<NSMutableString>>>);
+    static_assert(std::is_same_v<RetainPtr<NSMutableString>, RetainPtr<WTF::RetainPtrType<NSMutableString *>>>);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 43dfb26178e86e86570b7a53003e2514ca6fac70
<pre>
REGRESSION (290899@main): Fix WTF::RetainPtrType when using `id` type
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=291276">https://bugs.webkit.org/show_bug.cgi?id=291276</a>&gt;
&lt;<a href="https://rdar.apple.com/148273952">rdar://148273952</a>&gt;

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtrType):
- RetainPtr&lt;RetainPtrType&lt;id&gt;&gt; should be the same as RetainPtr&lt;id&gt;.
  This fixes the regression in 290899@main.

* Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)):
- Add tests for WTF::RetainPtrType.
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)):
- Restore use of `auto` when assigning the return value of adoptNS&lt;id&gt;().
  This partially backs out changes from 291650@main and 293007@main to
  restore the code to its previous state.
* Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, RetainPtrType)):
- Add tests for WTF::RetainPtrType.

Canonical link: <a href="https://commits.webkit.org/293440@main">https://commits.webkit.org/293440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0bdeaa5409be9f8d1de6f3326a94b69cfd2b3b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7292 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48869 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91590 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106395 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97530 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83751 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19719 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16091 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31136 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121146 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25770 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33880 "Found 9 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/es6/ES6MathAPIs.js.default, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.default-wasm, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-bbq, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-collect-continuously, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-eager, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-eager-jettison, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-no-cjit, wasm.yaml/wasm/stress/i32_trunc_sat_f32_s.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->