### PR TITLE
Stack exhaustion in WebCore::classifyBlock

### DIFF
--- a/LayoutTests/fast/css/css-parser-classifyblock-endblock-crash-expected.txt
+++ b/LayoutTests/fast/css/css-parser-classifyblock-endblock-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if webkit does not crash.
+
+PASS

--- a/LayoutTests/fast/css/css-parser-classifyblock-endblock-crash.html
+++ b/LayoutTests/fast/css/css-parser-classifyblock-endblock-crash.html
@@ -1,0 +1,15 @@
+<head>
+  <script>
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    function test() {
+      document.documentElement.style = 'content: ' + '('.repeat(35000) + '";';
+      result.textContent = 'PASS';
+      window.testRunner?.notifyDone();
+    }
+  </script>
+</head>
+<body onload="test()">
+  <p>This test passes if webkit does not crash.</p>
+  <div id="result"></div>
+</body>


### PR DESCRIPTION
#### 538dddc9dd22c4cacfb8882df6c5a34d6e3cc0ad
<pre>
Stack exhaustion in WebCore::classifyBlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=289252">https://bugs.webkit.org/show_bug.cgi?id=289252</a>
<a href="https://rdar.apple.com/146395737">rdar://146395737</a>

Reviewed by Matthieu Dubet.

CSS parser block classification overflows the stack with a recursive call
if there&apos;s too many SSParserToken::BlockStart on range. This fixes the
bug by eliminating the recursion using an std::stack.

* LayoutTests/fast/css/css-parser-classifyblock-endblock-crash-expected.txt: Added.
* LayoutTests/fast/css/css-parser-classifyblock-endblock-crash.html: Added.
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::classifyBlock):

Canonical link: <a href="https://commits.webkit.org/293494@main">https://commits.webkit.org/293494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f76233587dc5c6cfe55cba9b280beef512c3ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75397 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106536 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6200 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19875 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31284 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->