### PR TITLE
[UnifiedPDF] Main frame tiles are empty, wasted memory behind the PDF

### DIFF
--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -149,7 +149,8 @@ public:
         CoverageForVisibleArea = 0,
         CoverageForVerticalScrolling = 1 << 0,
         CoverageForHorizontalScrolling = 1 << 1,
-        CoverageForScrolling = CoverageForVerticalScrolling | CoverageForHorizontalScrolling
+        CoverageForScrolling = CoverageForVerticalScrolling | CoverageForHorizontalScrolling,
+        NoCoverage = 1 << 2, // Not to be used in combination with other bits.
     };
     typedef unsigned TileCoverage;
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -351,6 +351,11 @@ void TileGrid::removeTilesInCohort(TileCohort cohort)
 
 void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
 {
+    if (m_controller->tileCoverage() == TiledBacking::NoCoverage) {
+        removeAllTiles();
+        return;
+    }
+
     FloatRect coverageRect = m_controller->coverageRect();
     IntRect bounds = m_controller->bounds();
 
@@ -574,8 +579,11 @@ void TileGrid::cohortRemovalTimerFired()
 
 IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& tilesNeedingDisplay, CoverageType newTileType)
 {
+    if (m_controller->tileCoverage() == TiledBacking::NoCoverage)
+        return { };
+
     if (!m_controller->isInWindow())
-        return IntRect();
+        return { };
 
     FloatRect scaledRect(rect);
     scaledRect.scale(m_scale);
@@ -584,7 +592,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& 
     TileIndex topLeft;
     TileIndex bottomRight;
     if (!getTileIndexRangeForRect(rectInTileCoords, topLeft, bottomRight))
-        return IntRect();
+        return { };
 
     TileCohort currCohort = nextTileCohort();
     unsigned tilesInCohort = 0;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -50,6 +50,7 @@
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/_WKFeature.h>
 #import <wtf/RetainPtr.h>
@@ -257,6 +258,56 @@ UNIFIED_PDF_TEST(SnapshotsPaintPageContent)
     }];
 
     Util::run(&done);
+}
+
+static bool traverseLayerTree(CALayer *layer, bool(^block)(CALayer *))
+{
+    if (block(layer))
+        return true;
+    for (CALayer *child in layer.sublayers) {
+        if (traverseLayerTree(child, block))
+            return true;
+    }
+
+    return false;
+}
+
+static CALayer *renderViewTileGridLayer(WKWebView *webView)
+{
+    __block CALayer *renderViewLayer = nil;
+    __block CALayer *tileGridLayer = nil;
+
+    traverseLayerTree([webView layer], ^(CALayer *layer) {
+        if ([layer.name containsString:@"RenderView"]) {
+            renderViewLayer = layer;
+            return true;
+        }
+        return false;
+    });
+
+    traverseLayerTree(renderViewLayer, ^(CALayer *layer) {
+        if ([layer.name containsString:@"TileGrid container"]) {
+            tileGridLayer = layer;
+            return true;
+        }
+        return false;
+    });
+
+    return tileGridLayer;
+}
+
+UNIFIED_PDF_TEST(MainFrameTileGridHasNoCoverage)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
+
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
+    [webView loadRequest:request.get()];
+    [webView _test_waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    CALayer *tileGridLayer = renderViewTileGridLayer(webView.get());
+    EXPECT_NOT_NULL(tileGridLayer);
+    EXPECT_EQ(tileGridLayer.sublayers.count, 0UL);
 }
 
 #if PLATFORM(IOS) || PLATFORM(VISION)


### PR DESCRIPTION
#### ea5f2ab1ddadfad019681e9dc024599720288fd0
<pre>
[UnifiedPDF] Main frame tiles are empty, wasted memory behind the PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=291282">https://bugs.webkit.org/show_bug.cgi?id=291282</a>
<a href="https://rdar.apple.com/148853328">rdar://148853328</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/platform/graphics/TiledBacking.h:
Add a bit (this enum is a mixture of two dimensions, but we can fix that separately)
tracking that we want no coverage for a given TiledBacking.

* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::revalidateTiles):
(WebCore::TileGrid::ensureTilesForRect):
Avoid creating tiles and remove existing tiles if we want no tile coverage.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::computePageTiledBackingCoverage):
(WebCore::RenderLayerBacking::adjustTiledBackingCoverage):
Opt into no-tiles mode for the main frame tiled backing for PluginDocuments
(all of which are PDFPlugin-backed, and use child compositing layers for their contents).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::traverseLayerTree):
(TestWebKitAPI::renderViewTileGridLayer):
(TestWebKitAPI::UNIFIED_PDF_TEST):
Add a test that asserts that there are no tiles under the RenderView&apos;s TileGrid.

Canonical link: <a href="https://commits.webkit.org/293454@main">https://commits.webkit.org/293454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/024f463e99950bc5c1dff5bab0c5c1d2fd36dd90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98958 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75331 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32459 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89367 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55692 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26055 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18991 "Found 1 new test failure: pdf/annotations/radio-buttons-select-second.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83795 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->