### PR TITLE
Add call to animate model to center of portal on drag

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -529,6 +529,14 @@ void HTMLModelElement::renderingAbruptlyStopped()
     if (!document().hidden())
         createModelPlayer();
 }
+
+bool HTMLModelElement::tryAnimateModelToFitPortal()
+{
+    if (hasPortal() && m_modelPlayer)
+        return m_modelPlayer->animateModelToFitPortal();
+
+    return false;
+}
 #endif // ENABLE(MODEL_PROCESS)
 
 // MARK: - Fullscreen support.

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -162,6 +162,7 @@ public:
     WEBCORE_EXPORT void beginStageModeTransform(const TransformationMatrix&);
     WEBCORE_EXPORT void updateStageModeTransform(const TransformationMatrix&);
     WEBCORE_EXPORT void endStageModeInteraction();
+    WEBCORE_EXPORT bool tryAnimateModelToFitPortal();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -163,6 +163,10 @@ void ModelPlayer::renderingAbruptlyStopped()
 {
 }
 
+bool ModelPlayer::animateModelToFitPortal()
+{
+    return false;
+}
 #endif // ENABLE(MODEL_PROCESS)
 
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -111,6 +111,7 @@ public:
     virtual void updateStageModeTransform(const TransformationMatrix&);
     virtual void endStageModeInteraction();
     virtual void renderingAbruptlyStopped();
+    virtual bool animateModelToFitPortal();
 #endif
 };
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -827,6 +827,14 @@ DragStartRequestResult EventHandler::tryToBeginDragAtPoint(const IntPoint& clien
     // when we would process the next tap after a drag interaction.
     m_mousePressed = false;
 
+#if ENABLE(MODEL_PROCESS)
+    RefPtr targetElement = hitTestedMouseEvent.hitTestResult().targetElement();
+    if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(targetElement)) {
+        if (modelElement->tryAnimateModelToFitPortal())
+            return DragStartRequestResult::Delayed;
+    }
+#endif
+
     return handledDrag ? DragStartRequestResult::Started : DragStartRequestResult::Ended;
 }
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -134,6 +134,7 @@ public:
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
     void stageModeInteractionDidUpdateModel();
+    bool animateModelToFitPortal() final;
 
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -42,6 +42,7 @@ messages -> ModelProcessModelPlayerProxy {
     BeginStageModeTransform(WebCore::TransformationMatrix transform)
     UpdateStageModeTransform(WebCore::TransformationMatrix transform)
     EndStageModeInteraction()
+    AnimateModelToFitPortal()
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -756,6 +756,15 @@ bool ModelProcessModelPlayerProxy::stageModeInteractionInProgress() const
     return [m_stageModeInteractionDriver stageModeInteractionInProgress];
 }
 
+bool ModelProcessModelPlayerProxy::animateModelToFitPortal()
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291289
+    send(Messages::ModelProcessModelPlayer::DidAnimateModelForDrag());
+
+    // Return value is unused
+    return true;
+}
+
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()
 {
     if (m_transientEnvironmentMapData) {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -138,6 +138,13 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
     m_client->didFinishEnvironmentMapLoading(succeeded);
 }
 
+void ModelProcessModelPlayer::didAnimateModelForDrag()
+{
+    RELEASE_ASSERT(modelProcessEnabled());
+
+    m_page->didAnimateModelForDrag();
+}
+
 // MARK: - WebCore::ModelPlayer
 
 std::optional<WebCore::ModelPlayerAnimationState> ModelProcessModelPlayer::currentAnimationState() const
@@ -390,6 +397,12 @@ void ModelProcessModelPlayer::renderingAbruptlyStopped()
 {
     if (m_client)
         m_client->renderingAbruptlyStopped();
+}
+
+bool ModelProcessModelPlayer::animateModelToFitPortal()
+{
+    send(Messages::ModelProcessModelPlayerProxy::AnimateModelToFitPortal());
+    return true;
 }
 
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -73,6 +73,7 @@ private:
     void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
     void didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);
     void didFinishEnvironmentMapLoading(bool succeeded);
+    void didAnimateModelForDrag();
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
@@ -117,6 +118,7 @@ private:
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
+    bool animateModelToFitPortal() final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -34,6 +34,7 @@ messages -> ModelProcessModelPlayer {
     DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
     DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
     DidFinishEnvironmentMapLoading(bool succeeded)
+    DidAnimateModelForDrag()
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5599,6 +5599,12 @@ void WebPage::stageModeSessionDidEnd(std::optional<ElementIdentifier> elementID)
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
         localMainFrame->eventHandler().stageModeSessionDidEnd(elementID);
 }
+
+void WebPage::didAnimateModelForDrag()
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291284
+    send(Messages::WebPageProxy::DidHandleDragStartRequest(true));
+}
 #endif
 
 WebUndoStep* WebPage::webUndoStep(WebUndoStepID stepID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1298,6 +1298,7 @@ public:
     void requestInteractiveModelElementAtPoint(WebCore::IntPoint clientPosition);
     void stageModeSessionDidUpdate(std::optional<WebCore::ElementIdentifier>, const WebCore::TransformationMatrix&);
     void stageModeSessionDidEnd(std::optional<WebCore::ElementIdentifier>);
+    void didAnimateModelForDrag();
 #endif
 
     void beginPrinting(WebCore::FrameIdentifier, const PrintInfo&);


### PR DESCRIPTION
#### ed9d5b3d67342786a842d7613a5088281fae3bfa
<pre>
Add call to animate model to center of portal on drag
<a href="https://bugs.webkit.org/show_bug.cgi?id=291288">https://bugs.webkit.org/show_bug.cgi?id=291288</a>
<a href="https://rdar.apple.com/148843842">rdar://148843842</a>

Reviewed by Wenson Hsieh and Ada Chan.

This PR adds an extra IPC call between the web process and the model process when we drag a model
element, to animate the model during the drag. This is meant to position and transform the model
such that the snapshot we retrieve is not in a bad state.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::animateModelToFitPortal):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::animateModelToFitPortal):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::tryToBeginDragAtPoint):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::animateModelToFitPortal):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didAnimateModelForDrag):
(WebKit::ModelProcessModelPlayer::animateModelToFitPortal):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didAnimateModelForDrag):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/294549@main">https://commits.webkit.org/294549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78bb61c9c264ff856b82a801f1ec21ad6cd3677a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107428 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/52904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30443 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/52904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21672 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23642 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34623 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->