### PR TITLE
Increase $Apache2::SizeLimit::MAX_UNSHARED_SIZE to reduce number of httpd processes from being terminated

### DIFF
--- a/Websites/bugs.webkit.org/mod_perl.pl
+++ b/Websites/bugs.webkit.org/mod_perl.pl
@@ -58,7 +58,7 @@ use Apache2::SizeLimit;
 # not counting RAM it is sharing with the other httpd processes.
 #if WEBKIT_CHANGES
 # bugs.webkit.org children are normally about 400MB.
-$Apache2::SizeLimit::MAX_UNSHARED_SIZE = 800000;
+$Apache2::SizeLimit::MAX_UNSHARED_SIZE = 1500000;
 #endif // WEBKIT_CHANGES
 
 my $cgi_path = Bugzilla::Constants::bz_locations()->{'cgi_path'};


### PR DESCRIPTION
#### c72c4f4793cdc6ea34aff15f68ee247ce1ee474a
<pre>
Increase $Apache2::SizeLimit::MAX_UNSHARED_SIZE to reduce number of httpd processes from being terminated
<a href="https://bugs.webkit.org/show_bug.cgi?id=291287">https://bugs.webkit.org/show_bug.cgi?id=291287</a>
<a href="https://rdar.apple.com/148858973">rdar://148858973</a>

Reviewed by Alexey Proskuryakov.

HTTPD error logs show a large number of processes getting terminated before they complete. Large number of these are scans from search engine robots. However, I am also trying to eliminate a possible cause for the Webkitbot bug creation errors that we have seen appearing intermittenly lately.

* Websites/bugs.webkit.org/mod_perl.pl:

Canonical link: <a href="https://commits.webkit.org/295568@main">https://commits.webkit.org/295568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/106e9d86e2bf4f617bda80ea2c2c7bce363db6ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49524 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75312 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32444 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89340 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55673 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14122 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85537 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83776 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19752 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25983 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->