### PR TITLE
Add call to revert model animation after drag ends

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -537,6 +537,11 @@ void HTMLModelElement::tryAnimateModelToFitPortal(bool handledDrag, CompletionHa
 
     completionHandler(handledDrag);
 }
+void HTMLModelElement::resetModelTransformAfterDrag()
+{
+    if (hasPortal() && m_modelPlayer)
+        m_modelPlayer->resetModelTransformAfterDrag();
+}
 #endif // ENABLE(MODEL_PROCESS)
 
 // MARK: - Fullscreen support.

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -163,6 +163,7 @@ public:
     WEBCORE_EXPORT void updateStageModeTransform(const TransformationMatrix&);
     WEBCORE_EXPORT void endStageModeInteraction();
     WEBCORE_EXPORT void tryAnimateModelToFitPortal(bool handledDrag, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void resetModelTransformAfterDrag();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -167,6 +167,11 @@ void ModelPlayer::animateModelToFitPortal(CompletionHandler<void(bool)>&& comple
 {
     completionHandler(false);
 }
+
+void ModelPlayer::resetModelTransformAfterDrag()
+{
+}
+
 #endif // ENABLE(MODEL_PROCESS)
 
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -112,6 +112,7 @@ public:
     virtual void endStageModeInteraction();
     virtual void renderingAbruptlyStopped();
     virtual void animateModelToFitPortal(CompletionHandler<void(bool)>&&);
+    virtual void resetModelTransformAfterDrag();
 #endif
 };
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1430,7 +1430,6 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
         if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(state.source); modelElement && m_dragSourceAction.contains(DragSourceAction::Model))
             item.modelLayerID = modelElement->layerID();
 #endif
-
         elementID = element->identifier();
     }
     client().startDrag(WTFMove(item), *state.dataTransfer, mainFrame.get(), elementID);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -133,6 +133,7 @@ public:
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
+    void resetModelTransformAfterDrag() final;
     void stageModeInteractionDidUpdateModel();
     void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -43,6 +43,7 @@ messages -> ModelProcessModelPlayerProxy {
     UpdateStageModeTransform(WebCore::TransformationMatrix transform)
     EndStageModeInteraction()
     AnimateModelToFitPortal() -> (bool success)
+    ResetModelTransformAfterDrag()
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -745,6 +745,11 @@ void ModelProcessModelPlayerProxy::endStageModeInteraction()
     [m_stageModeInteractionDriver interactionDidEnd];
 }
 
+void ModelProcessModelPlayerProxy::resetModelTransformAfterDrag()
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291289
+}
+
 void ModelProcessModelPlayerProxy::stageModeInteractionDidUpdateModel()
 {
     if (stageModeInteractionInProgress() && m_modelRKEntity)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3829,6 +3829,12 @@ void WebPageProxy::setDragCaretRect(const IntRect& dragCaretRect)
     pageClient->didChangeDragCaretRect(previousRect, dragCaretRect);
 }
 
+#if ENABLE(MODEL_PROCESS)
+void WebPageProxy::modelDragEnded(const WebCore::ElementIdentifier elementIdentifier)
+{
+    send(Messages::WebPage::ModelDragEnded(elementIdentifier));
+}
+#endif
 #endif
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1625,6 +1625,9 @@ public:
 #if PLATFORM(GTK)
     void startDrag(WebCore::SelectionData&&, OptionSet<WebCore::DragOperation>, std::optional<WebCore::ShareableBitmapHandle>&& dragImage, WebCore::IntPoint&& dragImageHotspot);
 #endif
+#if ENABLE(MODEL_PROCESS)
+    void modelDragEnded(const WebCore::ElementIdentifier);
+#endif
 #endif
 
     void processDidBecomeUnresponsive();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10648,7 +10648,8 @@ static std::optional<WebCore::DragOperation> coreDragOperationForUIDropOperation
         if (RefPtr modelPresentationManager = _page->modelPresentationManagerProxy())
             modelPresentationManager->doneWithCurrentDragSession();
 
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=291293
+        if (_dragDropInteractionState.elementIdentifier())
+            _page->modelDragEnded(_dragDropInteractionState.elementIdentifier().value());
     }
 #endif
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -397,6 +397,11 @@ void ModelProcessModelPlayer::animateModelToFitPortal(CompletionHandler<void(boo
     sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::AnimateModelToFitPortal(), WTFMove(completionHandler));
 }
 
+void ModelProcessModelPlayer::resetModelTransformAfterDrag()
+{
+    send(Messages::ModelProcessModelPlayerProxy::ResetModelTransformAfterDrag());
+}
+
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -118,6 +118,7 @@ private:
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
     void animateModelToFitPortal(CompletionHandler<void(bool)>&&) final;
+    void resetModelTransformAfterDrag() final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5577,6 +5577,21 @@ void WebPage::dragCancelled()
         localMainFrame->eventHandler().dragCancelled();
 }
 
+#if ENABLE(MODEL_PROCESS)
+void WebPage::modelDragEnded(ElementIdentifier elementIdentifier)
+{
+    RefPtr element = Element::fromIdentifier(elementIdentifier);
+    if (!element)
+        return;
+
+    RefPtr modelElement = dynamicDowncast<HTMLModelElement>(element);
+    if (!modelElement)
+        return;
+
+    modelElement->resetModelTransformAfterDrag();
+}
+#endif
+
 #endif // ENABLE(DRAG_SUPPORT)
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1292,6 +1292,9 @@ public:
     void didStartDrag();
     void dragCancelled();
     OptionSet<WebCore::DragSourceAction> allowedDragSourceActions() const { return m_allowedDragSourceActions; }
+#if ENABLE(MODEL_PROCESS)
+    void modelDragEnded(WebCore::ElementIdentifier);
+#endif
 #endif
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -368,6 +368,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
     StageModeSessionDidEnd(std::optional<WebCore::ElementIdentifier> elementID)
 #endif
 
+#if ENABLE(MODEL_PROCESS) && ENABLE(DRAG_SUPPORT)
+    ModelDragEnded(WebCore::ElementIdentifier elementID)
+#endif
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
     RequestDragStart(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask) -> (bool started)
     RequestAdditionalItemsForDragSession(WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask) -> (bool started)


### PR DESCRIPTION
#### 60015985f0b4f0be2b9a7ea8183df29eeff30c55
<pre>
Add call to revert model animation after drag ends
<a href="https://bugs.webkit.org/show_bug.cgi?id=291293">https://bugs.webkit.org/show_bug.cgi?id=291293</a>
<a href="https://rdar.apple.com/148843848">rdar://148843848</a>

Reviewed by Ada Chan.

This PR adds IPC calls from the web to model process when the drag session is ending to
reset the model transform after it is dragged.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::resetModelTransformAfterDrag):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::resetModelTransformAfterDrag):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dragSourceEndedAt):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::resetModelTransformAfterDrag):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpDragSourceSessionState]):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::resetModelTransformAfterDrag):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/294678@main">https://commits.webkit.org/294678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaebc82e4de21e1fb727f931e528e559eaceadaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110044 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86963 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86558 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31388 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23890 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34884 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->