### PR TITLE
[Page color sampling] weather.com: sticky positioned top header fails to be detected and sampled

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt
@@ -1,0 +1,13 @@
+PASS colorsBeforeScrolling.top is "rgb(250, 60, 0)"
+PASS colorsBeforeScrolling.left is null
+PASS colorsBeforeScrolling.right is null
+PASS colorsBeforeScrolling.bottom is null
+PASS colorsAfterScrolling.top is null
+PASS colorsAfterScrolling.left is null
+PASS colorsAfterScrolling.right is null
+PASS colorsAfterScrolling.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+No sticky header after this point
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    body, html {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        font-family: system-ui;
+        box-sizing: border-box;
+        border: 0.5px solid lightgray;
+    }
+
+    footer {
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        height: 60px;
+        background: darkgray;
+        color: white;
+        text-align: center;
+    }
+
+    header {
+        position: sticky;
+        top: 0;
+        width: 100%;
+        height: 60px;
+        z-index: 100;
+    }
+
+    .header-content {
+        position: absolute;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background: rgb(250, 60, 0);
+        will-change: transform;
+    }
+
+    .tall {
+        width: 10px;
+        height: 5000px;
+    }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        colorsBeforeScrolling = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colorsBeforeScrolling.top", "rgb(250, 60, 0)");
+        shouldBeNull("colorsBeforeScrolling.left");
+        shouldBeNull("colorsBeforeScrolling.right");
+        shouldBeNull("colorsBeforeScrolling.bottom");
+
+        scrollBy(0, 5000);
+        await UIHelper.ensurePresentationUpdate();
+
+        colorsAfterScrolling = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("colorsAfterScrolling.top");
+        shouldBeNull("colorsAfterScrolling.left");
+        shouldBeNull("colorsAfterScrolling.right");
+        shouldBeNull("colorsAfterScrolling.bottom");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <header>
+        <div class="header-content"></div>
+    </header>
+    <footer>No sticky header after this point</footer>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1924,7 +1924,7 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
     TraceScope tracingScope { FixedContainerEdgeSamplingStart, FixedContainerEdgeSamplingEnd };
 
     static constexpr auto sampleRectThickness = 2;
-    static constexpr auto sampleRectMargin = 2;
+    static constexpr auto sampleRectMargin = 4;
     static constexpr auto thinBorderWidth = 10;
 
     struct FixedContainerResult {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1062,7 +1062,7 @@ private:
 
     void willUpdateLayerPositions();
 
-    enum UpdateLayerPositionsFlag {
+    enum UpdateLayerPositionsFlag : uint16_t {
         CheckForRepaint                     = 1 << 0,
         NeedsFullRepaintInBacking           = 1 << 1,
         ContainingClippingLayerChangedSize  = 1 << 2,
@@ -1074,6 +1074,7 @@ private:
         SeenCompositedScrollingLayer        = 1 << 8,
         SubtreeNeedsUpdate                  = 1 << 9,
         EnvironmentChanged                  = 1 << 10,
+        SeenStickyLayer                     = 1 << 11,
     };
     static OptionSet<UpdateLayerPositionsFlag> flagsForUpdateLayerPositions(RenderLayer& startingLayer);
 
@@ -1363,6 +1364,7 @@ private:
     bool m_hasTransformedAncestor : 1;
     bool m_has3DTransformedAncestor : 1;
 
+    bool m_hasStickyAncestor : 1 { false };
     bool m_hasFixedAncestor : 1 { false };
     bool m_hasPaginatedAncestor : 1 { false };
 


### PR DESCRIPTION
#### 8067cb20e1223d0e23c954e33337ddd655fe8037
<pre>
[Page color sampling] weather.com: sticky positioned top header fails to be detected and sampled
<a href="https://bugs.webkit.org/show_bug.cgi?id=291296">https://bugs.webkit.org/show_bug.cgi?id=291296</a>
<a href="https://rdar.apple.com/148863230">rdar://148863230</a>

Reviewed by Abrar Rahman Protyasha.

Teach the fixed container edge detection heuristic about stickily-positioned containers. Currently,
both hit-testing and color sampling will ignore anything that&apos;s not viewport-constrained, or a
descendant of a fixed container; this doesn&apos;t include stickily-positioned containers, which causes
us to fail detection whenever the sampled color of a stickily-positioned element requires painting
child layers underneath the element.

To address this, we keep track of a `m_hasStickyAncestor` flag that&apos;s updated similarly to
`m_hasFixedAncestor`, and consult that bit alongside checks for `hasFixedAncestor()` in fixed edge
hit-testing/color-sampling code.

* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html: Added.

Add a layout test to verify that a `position: sticky;` container docked to the top of the viewport
inside the body element is successfully detected as a fixed container top edge, but after scrolling
past the body, it&apos;s no longer detected.

Note that in order to exercise the bug, the sticky container contains an inner div with a background
color hosted in a separate layer, which would have otherwise not been found via hit-testing or
sampled for colors.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Drive-by adjustment: slightly increase the hit-testing margins to avoid false negatives on some
websites.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::flagsForUpdateLayerPositions):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):

Update `m_hasStickyAncestor` as we&apos;re recursively updating layer positions.

(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::hitTestLayer):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/293450@main">https://commits.webkit.org/293450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2aeb1b2f56e4af291d9ae9d21046aae48148eb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75323 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84285 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21245 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6114 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19764 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31181 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->