### PR TITLE
REGRESSION(293377@main): [macOS Debug]  Two pdf tests are constant failures (flaky in EWS)

### DIFF
--- a/LayoutTests/pdf/pdf-in-embed-expected.txt
+++ b/LayoutTests/pdf/pdf-in-embed-expected.txt
@@ -22,7 +22,7 @@
                   (children 1
                     (GraphicsLayer
                       (anchor 0.00 0.00)
-                      (children 3
+                      (children 2
                         (GraphicsLayer
                           (anchor 0.00 0.00)
                           (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
@@ -46,13 +46,6 @@
                         (GraphicsLayer
                           (anchor 0.00 0.00)
                           (bounds 285.00 294.00)
-                          (drawsContent 1)
-                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
-                        )
-                        (GraphicsLayer
-                          (anchor 0.00 0.00)
-                          (bounds 285.00 294.00)
-                          (blendMode multiply)
                           (drawsContent 1)
                           (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
                         )

--- a/LayoutTests/pdf/pdf-in-styled-embed-expected.txt
+++ b/LayoutTests/pdf/pdf-in-styled-embed-expected.txt
@@ -25,7 +25,7 @@
                   (children 1
                     (GraphicsLayer
                       (anchor 0.00 0.00)
-                      (children 3
+                      (children 2
                         (GraphicsLayer
                           (anchor 0.00 0.00)
                           (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
@@ -49,13 +49,6 @@
                         (GraphicsLayer
                           (anchor 0.00 0.00)
                           (bounds 285.00 294.00)
-                          (drawsContent 1)
-                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
-                        )
-                        (GraphicsLayer
-                          (anchor 0.00 0.00)
-                          (bounds 285.00 294.00)
-                          (blendMode multiply)
                           (drawsContent 1)
                           (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
                         )


### PR DESCRIPTION
#### 95f4ee9da8c8ef3555cff35daba81bd4ba04feab
<pre>
REGRESSION(293377@main): [macOS Debug]  Two pdf tests are constant failures (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291294">https://bugs.webkit.org/show_bug.cgi?id=291294</a>
<a href="https://rdar.apple.com/148862333">rdar://148862333</a>

Reviewed by Tim Horton.

These test expectation changes are expected fallout from 293377@main,
but we could not receive EWS feedback pre-landing. This patch just
rebaselines the test results.

* LayoutTests/pdf/pdf-in-embed-expected.txt:
* LayoutTests/pdf/pdf-in-styled-embed-expected.txt:

Canonical link: <a href="https://commits.webkit.org/293436@main">https://commits.webkit.org/293436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d43b7f6fe31497f67085e86ed0f0812e6669552

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101953 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/14350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/89365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/55686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/14141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/7340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48918 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26046 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/18986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26421 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/85562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/83789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28445 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16089 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/25999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25819 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/29139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->