### PR TITLE
[SaferCpp] Address issues in WKPreferences.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -32,7 +32,6 @@ UIProcess/API/C/WKOpenPanelParametersRef.cpp
 UIProcess/API/C/WKOpenPanelResultListener.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/WKPageConfigurationRef.cpp
-UIProcess/API/C/WKPreferences.cpp
 UIProcess/API/C/WKProtectionSpace.cpp
 UIProcess/API/C/WKQueryPermissionResultCallback.cpp
 UIProcess/API/C/WKSpeechRecognitionPermissionCallback.cpp

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -52,17 +52,17 @@ WKPreferencesRef WKPreferencesCreateWithIdentifier(WKStringRef identifierRef)
 
 WKPreferencesRef WKPreferencesCreateCopy(WKPreferencesRef preferencesRef)
 {
-    return toAPILeakingRef(toImpl(preferencesRef)->copy());
+    return toAPILeakingRef(toProtectedImpl(preferencesRef)->copy());
 }
 
 void WKPreferencesStartBatchingUpdates(WKPreferencesRef preferencesRef)
 {
-    toImpl(preferencesRef)->startBatchingUpdates();
+    toProtectedImpl(preferencesRef)->startBatchingUpdates();
 }
 
 void WKPreferencesEndBatchingUpdates(WKPreferencesRef preferencesRef)
 {
-    toImpl(preferencesRef)->endBatchingUpdates();
+    toProtectedImpl(preferencesRef)->endBatchingUpdates();
 }
 
 WKArrayRef WKPreferencesCopyExperimentalFeatures(WKPreferencesRef preferencesRef)
@@ -73,12 +73,12 @@ WKArrayRef WKPreferencesCopyExperimentalFeatures(WKPreferencesRef preferencesRef
 
 void WKPreferencesEnableAllExperimentalFeatures(WKPreferencesRef preferencesRef)
 {
-    toImpl(preferencesRef)->enableAllExperimentalFeatures();
+    toProtectedImpl(preferencesRef)->enableAllExperimentalFeatures();
 }
 
 void WKPreferencesSetExperimentalFeatureForKey(WKPreferencesRef preferencesRef, bool value, WKStringRef experimentalFeatureKey)
 {
-    toImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(experimentalFeatureKey), value);
+    toProtectedImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(experimentalFeatureKey), value);
 }
 
 WKArrayRef WKPreferencesCopyInternalDebugFeatures(WKPreferencesRef preferencesRef)
@@ -89,1625 +89,1625 @@ WKArrayRef WKPreferencesCopyInternalDebugFeatures(WKPreferencesRef preferencesRe
 
 void WKPreferencesResetAllInternalDebugFeatures(WKPreferencesRef preferencesRef)
 {
-    toImpl(preferencesRef)->resetAllInternalDebugFeatures();
+    toProtectedImpl(preferencesRef)->resetAllInternalDebugFeatures();
 }
 
 void WKPreferencesSetInternalDebugFeatureForKey(WKPreferencesRef preferencesRef, bool value, WKStringRef internalDebugFeatureKey)
 {
-    toImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(internalDebugFeatureKey), value);
+    toProtectedImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(internalDebugFeatureKey), value);
 }
 
 void WKPreferencesSetBoolValueForKeyForTesting(WKPreferencesRef preferencesRef, bool value, WKStringRef key)
 {
-    toImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
+    toProtectedImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetDoubleValueForKeyForTesting(WKPreferencesRef preferencesRef, double value, WKStringRef key)
 {
-    toImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
+    toProtectedImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetUInt32ValueForKeyForTesting(WKPreferencesRef preferencesRef, uint32_t value, WKStringRef key)
 {
-    toImpl(preferencesRef)->setUInt32ValueForKey(toWTFString(key), value, true);
+    toProtectedImpl(preferencesRef)->setUInt32ValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetStringValueForKeyForTesting(WKPreferencesRef preferencesRef, WKStringRef value, WKStringRef key)
 {
-    toImpl(preferencesRef)->setStringValueForKey(toWTFString(key), toWTFString(value), true);
+    toProtectedImpl(preferencesRef)->setStringValueForKey(toWTFString(key), toWTFString(value), true);
 }
 
 void WKPreferencesResetTestRunnerOverrides(WKPreferencesRef preferencesRef)
 {
     // Currently we reset the overrides on the web process when preferencesDidChange() is called. Since WTR preferences
     // are usually always the same (in the UI process), they are not sent to web process, not triggering the reset.
-    toImpl(preferencesRef)->forceUpdate();
+    toProtectedImpl(preferencesRef)->forceUpdate();
 }
 
 void WKPreferencesSetJavaScriptEnabled(WKPreferencesRef preferencesRef, bool javaScriptEnabled)
 {
-    toImpl(preferencesRef)->setJavaScriptEnabled(javaScriptEnabled);
+    toProtectedImpl(preferencesRef)->setJavaScriptEnabled(javaScriptEnabled);
 }
 
 bool WKPreferencesGetJavaScriptEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->javaScriptEnabled();
+    return toProtectedImpl(preferencesRef)->javaScriptEnabled();
 }
 
 void WKPreferencesSetJavaScriptMarkupEnabled(WKPreferencesRef preferencesRef, bool javaScriptMarkupEnabled)
 {
-    toImpl(preferencesRef)->setJavaScriptMarkupEnabled(javaScriptMarkupEnabled);
+    toProtectedImpl(preferencesRef)->setJavaScriptMarkupEnabled(javaScriptMarkupEnabled);
 }
 
 bool WKPreferencesGetJavaScriptMarkupEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->javaScriptMarkupEnabled();
+    return toProtectedImpl(preferencesRef)->javaScriptMarkupEnabled();
 }
 
 void WKPreferencesSetLoadsImagesAutomatically(WKPreferencesRef preferencesRef, bool loadsImagesAutomatically)
 {
-    toImpl(preferencesRef)->setLoadsImagesAutomatically(loadsImagesAutomatically);
+    toProtectedImpl(preferencesRef)->setLoadsImagesAutomatically(loadsImagesAutomatically);
 }
 
 bool WKPreferencesGetLoadsImagesAutomatically(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->loadsImagesAutomatically();
+    return toProtectedImpl(preferencesRef)->loadsImagesAutomatically();
 }
 
 void WKPreferencesSetLocalStorageEnabled(WKPreferencesRef preferencesRef, bool localStorageEnabled)
 {
-    toImpl(preferencesRef)->setLocalStorageEnabled(localStorageEnabled);
+    toProtectedImpl(preferencesRef)->setLocalStorageEnabled(localStorageEnabled);
 }
 
 bool WKPreferencesGetLocalStorageEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->localStorageEnabled();
+    return toProtectedImpl(preferencesRef)->localStorageEnabled();
 }
 
 void WKPreferencesSetDatabasesEnabled(WKPreferencesRef preferencesRef, bool databasesEnabled)
 {
-    toImpl(preferencesRef)->setDatabasesEnabled(databasesEnabled);
+    toProtectedImpl(preferencesRef)->setDatabasesEnabled(databasesEnabled);
 }
 
 bool WKPreferencesGetDatabasesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->databasesEnabled();
+    return toProtectedImpl(preferencesRef)->databasesEnabled();
 }
 
 void WKPreferencesSetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferencesRef, bool javaScriptCanOpenWindowsAutomatically)
 {
-    toImpl(preferencesRef)->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
+    toProtectedImpl(preferencesRef)->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
 }
 
 bool WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->javaScriptCanOpenWindowsAutomatically();
+    return toProtectedImpl(preferencesRef)->javaScriptCanOpenWindowsAutomatically();
 }
 
 void WKPreferencesSetHyperlinkAuditingEnabled(WKPreferencesRef preferencesRef, bool hyperlinkAuditingEnabled)
 {
-    toImpl(preferencesRef)->setHyperlinkAuditingEnabled(hyperlinkAuditingEnabled);
+    toProtectedImpl(preferencesRef)->setHyperlinkAuditingEnabled(hyperlinkAuditingEnabled);
 }
 
 bool WKPreferencesGetHyperlinkAuditingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->hyperlinkAuditingEnabled();
+    return toProtectedImpl(preferencesRef)->hyperlinkAuditingEnabled();
 }
 
 void WKPreferencesSetStandardFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setStandardFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setStandardFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyStandardFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->standardFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->standardFontFamily());
 }
 
 void WKPreferencesSetFixedFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setFixedFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setFixedFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyFixedFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->fixedFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->fixedFontFamily());
 }
 
 void WKPreferencesSetSerifFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setSerifFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setSerifFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopySerifFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->serifFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->serifFontFamily());
 }
 
 void WKPreferencesSetSansSerifFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setSansSerifFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setSansSerifFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopySansSerifFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->sansSerifFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->sansSerifFontFamily());
 }
 
 void WKPreferencesSetCursiveFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setCursiveFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setCursiveFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyCursiveFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->cursiveFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->cursiveFontFamily());
 }
 
 void WKPreferencesSetFantasyFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setFantasyFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setFantasyFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyFantasyFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->fantasyFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->fantasyFontFamily());
 }
 
 void WKPreferencesSetPictographFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toImpl(preferencesRef)->setPictographFontFamily(toWTFString(family));
+    toProtectedImpl(preferencesRef)->setPictographFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyPictographFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->pictographFontFamily());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->pictographFontFamily());
 }
 
 void WKPreferencesSetDefaultFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toImpl(preferencesRef)->setDefaultFontSize(size);
+    toProtectedImpl(preferencesRef)->setDefaultFontSize(size);
 }
 
 uint32_t WKPreferencesGetDefaultFontSize(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->defaultFontSize();
+    return toProtectedImpl(preferencesRef)->defaultFontSize();
 }
 
 void WKPreferencesSetDefaultFixedFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toImpl(preferencesRef)->setDefaultFixedFontSize(size);
+    toProtectedImpl(preferencesRef)->setDefaultFixedFontSize(size);
 }
 
 uint32_t WKPreferencesGetDefaultFixedFontSize(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->defaultFixedFontSize();
+    return toProtectedImpl(preferencesRef)->defaultFixedFontSize();
 }
 
 void WKPreferencesSetMinimumFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toImpl(preferencesRef)->setMinimumFontSize(size);
+    toProtectedImpl(preferencesRef)->setMinimumFontSize(size);
 }
 
 uint32_t WKPreferencesGetMinimumFontSize(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->minimumFontSize();
+    return toProtectedImpl(preferencesRef)->minimumFontSize();
 }
 
 
 void WKPreferencesSetCookieEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setCookieEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setCookieEnabled(enabled);
 }
 
 bool WKPreferencesGetCookieEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->cookieEnabled();
+    return toProtectedImpl(preferencesRef)->cookieEnabled();
 }
 
 void WKPreferencesSetEditableLinkBehavior(WKPreferencesRef preferencesRef, WKEditableLinkBehavior wkBehavior)
 {
-    toImpl(preferencesRef)->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(wkBehavior)));
+    toProtectedImpl(preferencesRef)->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(wkBehavior)));
 }
 
 WKEditableLinkBehavior WKPreferencesGetEditableLinkBehavior(WKPreferencesRef preferencesRef)
 {
-    return toAPI(static_cast<WebCore::EditableLinkBehavior>(toImpl(preferencesRef)->editableLinkBehavior()));
+    return toAPI(static_cast<WebCore::EditableLinkBehavior>(toProtectedImpl(preferencesRef)->editableLinkBehavior()));
 }
 
 void WKPreferencesSetDefaultTextEncodingName(WKPreferencesRef preferencesRef, WKStringRef name)
 {
-    toImpl(preferencesRef)->setDefaultTextEncodingName(toWTFString(name));
+    toProtectedImpl(preferencesRef)->setDefaultTextEncodingName(toWTFString(name));
 }
 
 WKStringRef WKPreferencesCopyDefaultTextEncodingName(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->defaultTextEncodingName());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->defaultTextEncodingName());
 }
 
 void WKPreferencesSetDeveloperExtrasEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setDeveloperExtrasEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setDeveloperExtrasEnabled(enabled);
 }
 
 bool WKPreferencesGetDeveloperExtrasEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->developerExtrasEnabled();
+    return toProtectedImpl(preferencesRef)->developerExtrasEnabled();
 }
 
 void WKPreferencesSetJavaScriptRuntimeFlags(WKPreferencesRef preferencesRef, WKJavaScriptRuntimeFlagSet javaScriptRuntimeFlagSet)
 {
-    toImpl(preferencesRef)->setJavaScriptRuntimeFlags(javaScriptRuntimeFlagSet);
+    toProtectedImpl(preferencesRef)->setJavaScriptRuntimeFlags(javaScriptRuntimeFlagSet);
 }
 
 WKJavaScriptRuntimeFlagSet WKPreferencesGetJavaScriptRuntimeFlags(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->javaScriptRuntimeFlags();
+    return toProtectedImpl(preferencesRef)->javaScriptRuntimeFlags();
 }
 
 void WKPreferencesSetTextAreasAreResizable(WKPreferencesRef preferencesRef, bool resizable)
 {
-    toImpl(preferencesRef)->setTextAreasAreResizable(resizable);
+    toProtectedImpl(preferencesRef)->setTextAreasAreResizable(resizable);
 }
 
 bool WKPreferencesGetTextAreasAreResizable(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->textAreasAreResizable();
+    return toProtectedImpl(preferencesRef)->textAreasAreResizable();
 }
 
 void WKPreferencesSetAcceleratedDrawingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setAcceleratedDrawingEnabled(flag);
+    toProtectedImpl(preferencesRef)->setAcceleratedDrawingEnabled(flag);
 }
 
 bool WKPreferencesGetAcceleratedDrawingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->acceleratedDrawingEnabled();
+    return toProtectedImpl(preferencesRef)->acceleratedDrawingEnabled();
 }
 
 void WKPreferencesSetCanvasUsesAcceleratedDrawing(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCanvasUsesAcceleratedDrawing(flag);
+    toProtectedImpl(preferencesRef)->setCanvasUsesAcceleratedDrawing(flag);
 }
 
 bool WKPreferencesGetCanvasUsesAcceleratedDrawing(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->canvasUsesAcceleratedDrawing();
+    return toProtectedImpl(preferencesRef)->canvasUsesAcceleratedDrawing();
 }
 
 void WKPreferencesSetAcceleratedCompositingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setAcceleratedCompositingEnabled(flag);
+    toProtectedImpl(preferencesRef)->setAcceleratedCompositingEnabled(flag);
 }
 
 bool WKPreferencesGetAcceleratedCompositingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->acceleratedCompositingEnabled();
+    return toProtectedImpl(preferencesRef)->acceleratedCompositingEnabled();
 }
 
 void WKPreferencesSetCompositingBordersVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCompositingBordersVisible(flag);
+    toProtectedImpl(preferencesRef)->setCompositingBordersVisible(flag);
 }
 
 bool WKPreferencesGetCompositingBordersVisible(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->compositingBordersVisible();
+    return toProtectedImpl(preferencesRef)->compositingBordersVisible();
 }
 
 void WKPreferencesSetCompositingRepaintCountersVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCompositingRepaintCountersVisible(flag);
+    toProtectedImpl(preferencesRef)->setCompositingRepaintCountersVisible(flag);
 }
 
 bool WKPreferencesGetCompositingRepaintCountersVisible(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->compositingRepaintCountersVisible();
+    return toProtectedImpl(preferencesRef)->compositingRepaintCountersVisible();
 }
 
 void WKPreferencesSetTiledScrollingIndicatorVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setTiledScrollingIndicatorVisible(flag);
+    toProtectedImpl(preferencesRef)->setTiledScrollingIndicatorVisible(flag);
 }
 
 bool WKPreferencesGetTiledScrollingIndicatorVisible(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->tiledScrollingIndicatorVisible();
+    return toProtectedImpl(preferencesRef)->tiledScrollingIndicatorVisible();
 }
 
 void WKPreferencesSetWebGLEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setWebGLEnabled(flag);
+    toProtectedImpl(preferencesRef)->setWebGLEnabled(flag);
 }
 
 bool WKPreferencesGetWebGLEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webGLEnabled();
+    return toProtectedImpl(preferencesRef)->webGLEnabled();
 }
 
 void WKPreferencesSetNeedsSiteSpecificQuirks(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setNeedsSiteSpecificQuirks(flag);
+    toProtectedImpl(preferencesRef)->setNeedsSiteSpecificQuirks(flag);
 }
 
 bool WKPreferencesGetNeedsSiteSpecificQuirks(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->needsSiteSpecificQuirks();
+    return toProtectedImpl(preferencesRef)->needsSiteSpecificQuirks();
 }
 
 void WKPreferencesSetForceFTPDirectoryListings(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setForceFTPDirectoryListings(flag);
+    toProtectedImpl(preferencesRef)->setForceFTPDirectoryListings(flag);
 }
 
 bool WKPreferencesGetForceFTPDirectoryListings(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->forceFTPDirectoryListings();
+    return toProtectedImpl(preferencesRef)->forceFTPDirectoryListings();
 }
 
 void WKPreferencesSetFTPDirectoryTemplatePath(WKPreferencesRef preferencesRef, WKStringRef pathRef)
 {
-    toImpl(preferencesRef)->setFTPDirectoryTemplatePath(toWTFString(pathRef));
+    toProtectedImpl(preferencesRef)->setFTPDirectoryTemplatePath(toWTFString(pathRef));
 }
 
 WKStringRef WKPreferencesCopyFTPDirectoryTemplatePath(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->ftpDirectoryTemplatePath());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->ftpDirectoryTemplatePath());
 }
 
 void WKPreferencesSetTabsToLinks(WKPreferencesRef preferencesRef, bool tabsToLinks)
 {
-    toImpl(preferencesRef)->setTabsToLinks(tabsToLinks);
+    toProtectedImpl(preferencesRef)->setTabsToLinks(tabsToLinks);
 }
 
 bool WKPreferencesGetTabsToLinks(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->tabsToLinks();
+    return toProtectedImpl(preferencesRef)->tabsToLinks();
 }
 
 void WKPreferencesSetAuthorAndUserStylesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAuthorAndUserStylesEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setAuthorAndUserStylesEnabled(enabled);
 }
 
 bool WKPreferencesGetAuthorAndUserStylesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->authorAndUserStylesEnabled();
+    return toProtectedImpl(preferencesRef)->authorAndUserStylesEnabled();
 }
 
 void WKPreferencesSetShouldPrintBackgrounds(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setShouldPrintBackgrounds(flag);
+    toProtectedImpl(preferencesRef)->setShouldPrintBackgrounds(flag);
 }
 
 bool WKPreferencesGetShouldPrintBackgrounds(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldPrintBackgrounds();
+    return toProtectedImpl(preferencesRef)->shouldPrintBackgrounds();
 }
 
 void WKPreferencesSetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setDOMTimersThrottlingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setDOMTimersThrottlingEnabled(enabled);
 }
 
 bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->domTimersThrottlingEnabled();
+    return toProtectedImpl(preferencesRef)->domTimersThrottlingEnabled();
 }
 
 void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
 }
 
 bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webArchiveDebugModeEnabled();
+    return toProtectedImpl(preferencesRef)->webArchiveDebugModeEnabled();
 }
 
 void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setLocalFileContentSniffingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setLocalFileContentSniffingEnabled(enabled);
 }
 
 bool WKPreferencesGetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->localFileContentSniffingEnabled();
+    return toProtectedImpl(preferencesRef)->localFileContentSniffingEnabled();
 }
 
 void WKPreferencesSetPageCacheEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setUsesBackForwardCache(enabled);
+    toProtectedImpl(preferencesRef)->setUsesBackForwardCache(enabled);
 }
 
 bool WKPreferencesGetPageCacheEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->usesBackForwardCache();
+    return toProtectedImpl(preferencesRef)->usesBackForwardCache();
 }
 
 void WKPreferencesSetDOMPasteAllowed(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setDOMPasteAllowed(enabled);
+    toProtectedImpl(preferencesRef)->setDOMPasteAllowed(enabled);
 }
 
 bool WKPreferencesGetDOMPasteAllowed(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->domPasteAllowed();
+    return toProtectedImpl(preferencesRef)->domPasteAllowed();
 }
 
 void WKPreferencesSetJavaScriptCanAccessClipboard(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setJavaScriptCanAccessClipboard(enabled);
+    toProtectedImpl(preferencesRef)->setJavaScriptCanAccessClipboard(enabled);
 }
 
 bool WKPreferencesGetJavaScriptCanAccessClipboard(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->javaScriptCanAccessClipboard();
+    return toProtectedImpl(preferencesRef)->javaScriptCanAccessClipboard();
 }
 
 void WKPreferencesSetFullScreenEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setFullScreenEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setFullScreenEnabled(enabled);
 }
 
 bool WKPreferencesGetFullScreenEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->fullScreenEnabled();
+    return toProtectedImpl(preferencesRef)->fullScreenEnabled();
 }
 
 void WKPreferencesSetAsynchronousSpellCheckingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAsynchronousSpellCheckingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setAsynchronousSpellCheckingEnabled(enabled);
 }
 
 bool WKPreferencesGetAsynchronousSpellCheckingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->asynchronousSpellCheckingEnabled();
+    return toProtectedImpl(preferencesRef)->asynchronousSpellCheckingEnabled();
 }
 
 void WKPreferencesSetAVFoundationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAVFoundationEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setAVFoundationEnabled(enabled);
 }
 
 bool WKPreferencesGetAVFoundationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->isAVFoundationEnabled();
+    return toProtectedImpl(preferencesRef)->isAVFoundationEnabled();
 }
 
 void WKPreferencesSetWebSecurityEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebSecurityEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setWebSecurityEnabled(enabled);
 }
 
 bool WKPreferencesGetWebSecurityEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webSecurityEnabled();
+    return toProtectedImpl(preferencesRef)->webSecurityEnabled();
 }
 
 void WKPreferencesSetUniversalAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toImpl(preferencesRef)->setAllowUniversalAccessFromFileURLs(allowed);
+    toProtectedImpl(preferencesRef)->setAllowUniversalAccessFromFileURLs(allowed);
 }
 
 bool WKPreferencesGetUniversalAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowUniversalAccessFromFileURLs();
+    return toProtectedImpl(preferencesRef)->allowUniversalAccessFromFileURLs();
 }
 
 void WKPreferencesSetFileAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toImpl(preferencesRef)->setAllowFileAccessFromFileURLs(allowed);
+    toProtectedImpl(preferencesRef)->setAllowFileAccessFromFileURLs(allowed);
 }
 
 bool WKPreferencesGetFileAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowFileAccessFromFileURLs();
+    return toProtectedImpl(preferencesRef)->allowFileAccessFromFileURLs();
 }
 
 void WKPreferencesSetTopNavigationToDataURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toImpl(preferencesRef)->setAllowTopNavigationToDataURLs(allowed);
+    toProtectedImpl(preferencesRef)->setAllowTopNavigationToDataURLs(allowed);
 }
 
 bool WKPreferencesGetTopNavigationToDataURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowTopNavigationToDataURLs();
+    return toProtectedImpl(preferencesRef)->allowTopNavigationToDataURLs();
 }
 
 void WKPreferencesSetNeedsStorageAccessFromFileURLsQuirk(WKPreferencesRef preferencesRef, bool needsQuirk)
 {
-    toImpl(preferencesRef)->setNeedsStorageAccessFromFileURLsQuirk(needsQuirk);
+    toProtectedImpl(preferencesRef)->setNeedsStorageAccessFromFileURLsQuirk(needsQuirk);
 }
 
 bool WKPreferencesGetNeedsStorageAccessFromFileURLsQuirk(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->needsStorageAccessFromFileURLsQuirk();
+    return toProtectedImpl(preferencesRef)->needsStorageAccessFromFileURLsQuirk();
 }
 
 void WKPreferencesSetMediaPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setRequiresUserGestureForMediaPlayback(flag);
+    toProtectedImpl(preferencesRef)->setRequiresUserGestureForMediaPlayback(flag);
 }
 
 bool WKPreferencesGetMediaPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->requiresUserGestureForMediaPlayback();
+    return toProtectedImpl(preferencesRef)->requiresUserGestureForMediaPlayback();
 }
 
 void WKPreferencesSetVideoPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setRequiresUserGestureForVideoPlayback(flag);
+    toProtectedImpl(preferencesRef)->setRequiresUserGestureForVideoPlayback(flag);
 }
 
 bool WKPreferencesGetVideoPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->requiresUserGestureForVideoPlayback();
+    return toProtectedImpl(preferencesRef)->requiresUserGestureForVideoPlayback();
 }
 
 void WKPreferencesSetAudioPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setRequiresUserGestureForAudioPlayback(flag);
+    toProtectedImpl(preferencesRef)->setRequiresUserGestureForAudioPlayback(flag);
 }
 
 bool WKPreferencesGetAudioPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->requiresUserGestureForAudioPlayback();
+    return toProtectedImpl(preferencesRef)->requiresUserGestureForAudioPlayback();
 }
 
 void WKPreferencesSetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setMainContentUserGestureOverrideEnabled(flag);
+    toProtectedImpl(preferencesRef)->setMainContentUserGestureOverrideEnabled(flag);
 }
 
 bool WKPreferencesGetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mainContentUserGestureOverrideEnabled();
+    return toProtectedImpl(preferencesRef)->mainContentUserGestureOverrideEnabled();
 }
 
 bool WKPreferencesGetVerifyUserGestureInUIProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->verifyWindowOpenUserGestureFromUIProcess();
+    return toProtectedImpl(preferencesRef)->verifyWindowOpenUserGestureFromUIProcess();
 }
 
 void WKPreferencesSetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef, double threshold)
 {
-    toImpl(preferencesRef)->setManagedMediaSourceLowThreshold(threshold);
+    toProtectedImpl(preferencesRef)->setManagedMediaSourceLowThreshold(threshold);
 }
 
 double WKPreferencesGetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->managedMediaSourceLowThreshold();
+    return toProtectedImpl(preferencesRef)->managedMediaSourceLowThreshold();
 }
 
 void WKPreferencesSetManagedMediaSourceHighThreshold(WKPreferencesRef preferencesRef, double threshold)
 {
-    toImpl(preferencesRef)->setManagedMediaSourceHighThreshold(threshold);
+    toProtectedImpl(preferencesRef)->setManagedMediaSourceHighThreshold(threshold);
 }
 
 double WKPreferencesGetManagedMediaSourceHighThreshold(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->managedMediaSourceHighThreshold();
+    return toProtectedImpl(preferencesRef)->managedMediaSourceHighThreshold();
 }
 
 void WKPreferencesSetMediaPlaybackAllowsInline(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setAllowsInlineMediaPlayback(flag);
+    toProtectedImpl(preferencesRef)->setAllowsInlineMediaPlayback(flag);
 }
 
 bool WKPreferencesGetMediaPlaybackAllowsInline(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowsInlineMediaPlayback();
+    return toProtectedImpl(preferencesRef)->allowsInlineMediaPlayback();
 }
 
 void WKPreferencesSetInlineMediaPlaybackRequiresPlaysInlineAttribute(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setInlineMediaPlaybackRequiresPlaysInlineAttribute(flag);
+    toProtectedImpl(preferencesRef)->setInlineMediaPlaybackRequiresPlaysInlineAttribute(flag);
 }
 
 bool WKPreferencesGetInlineMediaPlaybackRequiresPlaysInlineAttribute(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->inlineMediaPlaybackRequiresPlaysInlineAttribute();
+    return toProtectedImpl(preferencesRef)->inlineMediaPlaybackRequiresPlaysInlineAttribute();
 }
 
 void WKPreferencesSetBeaconAPIEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setBeaconAPIEnabled(flag);
+    toProtectedImpl(preferencesRef)->setBeaconAPIEnabled(flag);
 }
 
 bool WKPreferencesGetBeaconAPIEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->beaconAPIEnabled();
+    return toProtectedImpl(preferencesRef)->beaconAPIEnabled();
 }
 
 void WKPreferencesSetDirectoryUploadEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setDirectoryUploadEnabled(flag);
+    toProtectedImpl(preferencesRef)->setDirectoryUploadEnabled(flag);
 }
 
 bool WKPreferencesGetDirectoryUploadEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->directoryUploadEnabled();
+    return toProtectedImpl(preferencesRef)->directoryUploadEnabled();
 }
 
 void WKPreferencesSetMediaControlsScaleWithPageZoom(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setMediaControlsScaleWithPageZoom(flag);
+    toProtectedImpl(preferencesRef)->setMediaControlsScaleWithPageZoom(flag);
 }
 
 bool WKPreferencesGetMediaControlsScaleWithPageZoom(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaControlsScaleWithPageZoom();
+    return toProtectedImpl(preferencesRef)->mediaControlsScaleWithPageZoom();
 }
 
 void WKPreferencesSetWebAuthenticationEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setWebAuthenticationEnabled(flag);
+    toProtectedImpl(preferencesRef)->setWebAuthenticationEnabled(flag);
 }
 
 bool WKPreferencesGetWebAuthenticationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webAuthenticationEnabled();
+    return toProtectedImpl(preferencesRef)->webAuthenticationEnabled();
 }
 
 void WKPreferencesSetDigitalCredentialsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setDigitalCredentialsEnabled(flag);
+    toProtectedImpl(preferencesRef)->setDigitalCredentialsEnabled(flag);
 }
 
 bool WKPreferencesGetDigitalCredentialsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->digitalCredentialsEnabled();
+    return toProtectedImpl(preferencesRef)->digitalCredentialsEnabled();
 }
 
 void WKPreferencesSetInvisibleMediaAutoplayPermitted(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setInvisibleAutoplayNotPermitted(!flag);
+    toProtectedImpl(preferencesRef)->setInvisibleAutoplayNotPermitted(!flag);
 }
 
 bool WKPreferencesGetInvisibleMediaAutoplayPermitted(WKPreferencesRef preferencesRef)
 {
-    return !toImpl(preferencesRef)->invisibleAutoplayNotPermitted();
+    return !toProtectedImpl(preferencesRef)->invisibleAutoplayNotPermitted();
 }
 
 void WKPreferencesSetShowsToolTipOverTruncatedText(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setShowsToolTipOverTruncatedText(flag);
+    toProtectedImpl(preferencesRef)->setShowsToolTipOverTruncatedText(flag);
 }
 
 bool WKPreferencesGetShowsToolTipOverTruncatedText(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->showsToolTipOverTruncatedText();
+    return toProtectedImpl(preferencesRef)->showsToolTipOverTruncatedText();
 }
 
 void WKPreferencesSetMockScrollbarsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setMockScrollbarsEnabled(flag);
+    toProtectedImpl(preferencesRef)->setMockScrollbarsEnabled(flag);
 }
 
 bool WKPreferencesGetMockScrollbarsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mockScrollbarsEnabled();
+    return toProtectedImpl(preferencesRef)->mockScrollbarsEnabled();
 }
 
 void WKPreferencesSetAttachmentElementEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setAttachmentElementEnabled(flag);
+    toProtectedImpl(preferencesRef)->setAttachmentElementEnabled(flag);
 }
 
 bool WKPreferencesGetAttachmentElementEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->attachmentElementEnabled();
+    return toProtectedImpl(preferencesRef)->attachmentElementEnabled();
 }
 
 void WKPreferencesSetWebAudioEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebAudioEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setWebAudioEnabled(enabled);
 }
 
 bool WKPreferencesGetWebAudioEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webAudioEnabled();
+    return toProtectedImpl(preferencesRef)->webAudioEnabled();
 }
 
 void WKPreferencesSetSuppressesIncrementalRendering(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setSuppressesIncrementalRendering(enabled);
+    toProtectedImpl(preferencesRef)->setSuppressesIncrementalRendering(enabled);
 }
 
 bool WKPreferencesGetSuppressesIncrementalRendering(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->suppressesIncrementalRendering();
+    return toProtectedImpl(preferencesRef)->suppressesIncrementalRendering();
 }
 
 void WKPreferencesSetBackspaceKeyNavigationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setBackspaceKeyNavigationEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setBackspaceKeyNavigationEnabled(enabled);
 }
 
 bool WKPreferencesGetBackspaceKeyNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->backspaceKeyNavigationEnabled();
+    return toProtectedImpl(preferencesRef)->backspaceKeyNavigationEnabled();
 }
 
 void WKPreferencesSetCaretBrowsingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setCaretBrowsingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setCaretBrowsingEnabled(enabled);
 }
 
 bool WKPreferencesGetCaretBrowsingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->caretBrowsingEnabled();
+    return toProtectedImpl(preferencesRef)->caretBrowsingEnabled();
 }
 
 void WKPreferencesSetShouldDisplaySubtitles(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setShouldDisplaySubtitles(enabled);
+    toProtectedImpl(preferencesRef)->setShouldDisplaySubtitles(enabled);
 }
 
 bool WKPreferencesGetShouldDisplaySubtitles(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldDisplaySubtitles();
+    return toProtectedImpl(preferencesRef)->shouldDisplaySubtitles();
 }
 
 void WKPreferencesSetShouldDisplayCaptions(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setShouldDisplayCaptions(enabled);
+    toProtectedImpl(preferencesRef)->setShouldDisplayCaptions(enabled);
 }
 
 bool WKPreferencesGetShouldDisplayCaptions(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldDisplayCaptions();
+    return toProtectedImpl(preferencesRef)->shouldDisplayCaptions();
 }
 
 void WKPreferencesSetShouldDisplayTextDescriptions(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setShouldDisplayTextDescriptions(enabled);
+    toProtectedImpl(preferencesRef)->setShouldDisplayTextDescriptions(enabled);
 }
 
 bool WKPreferencesGetShouldDisplayTextDescriptions(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldDisplayTextDescriptions();
+    return toProtectedImpl(preferencesRef)->shouldDisplayTextDescriptions();
 }
 
 void WKPreferencesSetNotificationsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setNotificationsEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setNotificationsEnabled(enabled);
 }
 
 bool WKPreferencesGetNotificationsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->notificationsEnabled();
+    return toProtectedImpl(preferencesRef)->notificationsEnabled();
 }
 
 void WKPreferencesSetShouldRespectImageOrientation(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setShouldRespectImageOrientation(enabled);
+    toProtectedImpl(preferencesRef)->setShouldRespectImageOrientation(enabled);
 }
 
 bool WKPreferencesGetShouldRespectImageOrientation(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldRespectImageOrientation();
+    return toProtectedImpl(preferencesRef)->shouldRespectImageOrientation();
 }
 
 void WKPreferencesSetStorageBlockingPolicy(WKPreferencesRef preferencesRef, WKStorageBlockingPolicy policy)
 {
-    toImpl(preferencesRef)->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
+    toProtectedImpl(preferencesRef)->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
 }
 
 WKStorageBlockingPolicy WKPreferencesGetStorageBlockingPolicy(WKPreferencesRef preferencesRef)
 {
-    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(toImpl(preferencesRef)->storageBlockingPolicy()));
+    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(toProtectedImpl(preferencesRef)->storageBlockingPolicy()));
 }
 
 void WKPreferencesSetDiagnosticLoggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setDiagnosticLoggingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setDiagnosticLoggingEnabled(enabled);
 }
 
 bool WKPreferencesGetDiagnosticLoggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->diagnosticLoggingEnabled();
+    return toProtectedImpl(preferencesRef)->diagnosticLoggingEnabled();
 }
 
 void WKPreferencesSetInteractiveFormValidationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setInteractiveFormValidationEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setInteractiveFormValidationEnabled(enabled);
 }
 
 bool WKPreferencesGetInteractiveFormValidationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->interactiveFormValidationEnabled();
+    return toProtectedImpl(preferencesRef)->interactiveFormValidationEnabled();
 }
 
 void WKPreferencesSetScrollingPerformanceLoggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setScrollingPerformanceTestingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setScrollingPerformanceTestingEnabled(enabled);
 }
 
 bool WKPreferencesGetScrollingPerformanceLoggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->scrollingPerformanceTestingEnabled();
+    return toProtectedImpl(preferencesRef)->scrollingPerformanceTestingEnabled();
 }
 
 void WKPreferencesSetPDFPluginEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setPDFPluginEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setPDFPluginEnabled(enabled);
 }
 
 bool WKPreferencesGetPDFPluginEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->pdfPluginEnabled();
+    return toProtectedImpl(preferencesRef)->pdfPluginEnabled();
 }
 
 void WKPreferencesSetEncodingDetectorEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setUsesEncodingDetector(enabled);
+    toProtectedImpl(preferencesRef)->setUsesEncodingDetector(enabled);
 }
 
 bool WKPreferencesGetEncodingDetectorEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->usesEncodingDetector();
+    return toProtectedImpl(preferencesRef)->usesEncodingDetector();
 }
 
 void WKPreferencesSetTextAutosizingEnabled(WKPreferencesRef preferencesRef, bool textAutosizingEnabled)
 {
-    toImpl(preferencesRef)->setTextAutosizingEnabled(textAutosizingEnabled);
+    toProtectedImpl(preferencesRef)->setTextAutosizingEnabled(textAutosizingEnabled);
 }
 
 bool WKPreferencesGetTextAutosizingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->textAutosizingEnabled();
+    return toProtectedImpl(preferencesRef)->textAutosizingEnabled();
 }
 
 void WKPreferencesSetTextAutosizingUsesIdempotentMode(WKPreferencesRef preferencesRef, bool textAutosizingUsesIdempotentModeEnabled)
 {
-    toImpl(preferencesRef)->setTextAutosizingUsesIdempotentMode(textAutosizingUsesIdempotentModeEnabled);
+    toProtectedImpl(preferencesRef)->setTextAutosizingUsesIdempotentMode(textAutosizingUsesIdempotentModeEnabled);
 }
 
 bool WKPreferencesGetTextAutosizingUsesIdempotentMode(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->textAutosizingUsesIdempotentMode();
+    return toProtectedImpl(preferencesRef)->textAutosizingUsesIdempotentMode();
 }
 
 void WKPreferencesSetAggressiveTileRetentionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAggressiveTileRetentionEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setAggressiveTileRetentionEnabled(enabled);
 }
 
 bool WKPreferencesGetAggressiveTileRetentionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->aggressiveTileRetentionEnabled();
+    return toProtectedImpl(preferencesRef)->aggressiveTileRetentionEnabled();
 }
 
 void WKPreferencesSetLogsPageMessagesToSystemConsoleEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setLogsPageMessagesToSystemConsoleEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setLogsPageMessagesToSystemConsoleEnabled(enabled);
 }
 
 bool WKPreferencesGetLogsPageMessagesToSystemConsoleEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->logsPageMessagesToSystemConsoleEnabled();
+    return toProtectedImpl(preferencesRef)->logsPageMessagesToSystemConsoleEnabled();
 }
 
 void WKPreferencesSetPageVisibilityBasedProcessSuppressionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
 }
 
 bool WKPreferencesGetPageVisibilityBasedProcessSuppressionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->pageVisibilityBasedProcessSuppressionEnabled();
+    return toProtectedImpl(preferencesRef)->pageVisibilityBasedProcessSuppressionEnabled();
 }
 
 void WKPreferencesSetSmartInsertDeleteEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setSmartInsertDeleteEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setSmartInsertDeleteEnabled(enabled);
 }
 
 bool WKPreferencesGetSmartInsertDeleteEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->smartInsertDeleteEnabled();
+    return toProtectedImpl(preferencesRef)->smartInsertDeleteEnabled();
 }
 
 void WKPreferencesSetSelectTrailingWhitespaceEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setSelectTrailingWhitespaceEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setSelectTrailingWhitespaceEnabled(enabled);
 }
 
 bool WKPreferencesGetSelectTrailingWhitespaceEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->selectTrailingWhitespaceEnabled();
+    return toProtectedImpl(preferencesRef)->selectTrailingWhitespaceEnabled();
 }
 
 void WKPreferencesSetShowsURLsInToolTipsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setShowsURLsInToolTipsEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setShowsURLsInToolTipsEnabled(enabled);
 }
 
 bool WKPreferencesGetShowsURLsInToolTipsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->showsURLsInToolTipsEnabled();
+    return toProtectedImpl(preferencesRef)->showsURLsInToolTipsEnabled();
 }
 
 void WKPreferencesSetHiddenPageDOMTimerThrottlingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingEnabled(enabled);
 }
 
 void WKPreferencesSetHiddenPageDOMTimerThrottlingAutoIncreases(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingAutoIncreases(enabled);
+    toProtectedImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingAutoIncreases(enabled);
 }
 
 bool WKPreferencesGetHiddenPageDOMTimerThrottlingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->hiddenPageDOMTimerThrottlingEnabled();
+    return toProtectedImpl(preferencesRef)->hiddenPageDOMTimerThrottlingEnabled();
 }
 
 bool WKPreferencesGetHiddenPageDOMTimerThrottlingAutoIncreases(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->hiddenPageDOMTimerThrottlingAutoIncreases();
+    return toProtectedImpl(preferencesRef)->hiddenPageDOMTimerThrottlingAutoIncreases();
 }
 
 void WKPreferencesSetHiddenPageCSSAnimationSuspensionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setHiddenPageCSSAnimationSuspensionEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setHiddenPageCSSAnimationSuspensionEnabled(enabled);
 }
 
 bool WKPreferencesGetHiddenPageCSSAnimationSuspensionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->hiddenPageCSSAnimationSuspensionEnabled();
+    return toProtectedImpl(preferencesRef)->hiddenPageCSSAnimationSuspensionEnabled();
 }
 
 void WKPreferencesSetIncrementalRenderingSuppressionTimeout(WKPreferencesRef preferencesRef, double timeout)
 {
-    toImpl(preferencesRef)->setIncrementalRenderingSuppressionTimeout(timeout);
+    toProtectedImpl(preferencesRef)->setIncrementalRenderingSuppressionTimeout(timeout);
 }
 
 double WKPreferencesGetIncrementalRenderingSuppressionTimeout(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->incrementalRenderingSuppressionTimeout();
+    return toProtectedImpl(preferencesRef)->incrementalRenderingSuppressionTimeout();
 }
 
 void WKPreferencesSetThreadedScrollingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setThreadedScrollingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setThreadedScrollingEnabled(enabled);
 }
 
 bool WKPreferencesGetThreadedScrollingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->threadedScrollingEnabled();
+    return toProtectedImpl(preferencesRef)->threadedScrollingEnabled();
 }
 
 void WKPreferencesSetLegacyLineLayoutVisualCoverageEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setLegacyLineLayoutVisualCoverageEnabled(flag);
+    toProtectedImpl(preferencesRef)->setLegacyLineLayoutVisualCoverageEnabled(flag);
 }
 
 bool WKPreferencesGetLegacyLineLayoutVisualCoverageEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->legacyLineLayoutVisualCoverageEnabled();
+    return toProtectedImpl(preferencesRef)->legacyLineLayoutVisualCoverageEnabled();
 }
 
 void WKPreferencesSetContentChangeObserverEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setContentChangeObserverEnabled(flag);
+    toProtectedImpl(preferencesRef)->setContentChangeObserverEnabled(flag);
 }
 
 bool WKPreferencesGetContentChangeObserverEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->contentChangeObserverEnabled();
+    return toProtectedImpl(preferencesRef)->contentChangeObserverEnabled();
 }
 
 void WKPreferencesSetUseGiantTiles(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setUseGiantTiles(flag);
+    toProtectedImpl(preferencesRef)->setUseGiantTiles(flag);
 }
 
 bool WKPreferencesGetUseGiantTiles(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->useGiantTiles();
+    return toProtectedImpl(preferencesRef)->useGiantTiles();
 }
 
 void WKPreferencesSetMediaDevicesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setMediaDevicesEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setMediaDevicesEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaDevicesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaDevicesEnabled();
+    return toProtectedImpl(preferencesRef)->mediaDevicesEnabled();
 }
 
 void WKPreferencesSetPeerConnectionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setPeerConnectionEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setPeerConnectionEnabled(enabled);
 }
 
 bool WKPreferencesGetPeerConnectionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->peerConnectionEnabled();
+    return toProtectedImpl(preferencesRef)->peerConnectionEnabled();
 }
 
 void WKPreferencesSetSpatialNavigationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setSpatialNavigationEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setSpatialNavigationEnabled(enabled);
 }
 
 bool WKPreferencesGetSpatialNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->spatialNavigationEnabled();
+    return toProtectedImpl(preferencesRef)->spatialNavigationEnabled();
 }
 
 void WKPreferencesSetMediaSourceEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setMediaSourceEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setMediaSourceEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaSourceEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaSourceEnabled();
+    return toProtectedImpl(preferencesRef)->mediaSourceEnabled();
 }
 
 void WKPreferencesSetSourceBufferChangeTypeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setSourceBufferChangeTypeEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setSourceBufferChangeTypeEnabled(enabled);
 }
 
 bool WKPreferencesGetSourceBufferChangeTypeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->sourceBufferChangeTypeEnabled();
+    return toProtectedImpl(preferencesRef)->sourceBufferChangeTypeEnabled();
 }
 
 void WKPreferencesSetViewGestureDebuggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setViewGestureDebuggingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setViewGestureDebuggingEnabled(enabled);
 }
 
 bool WKPreferencesGetViewGestureDebuggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->viewGestureDebuggingEnabled();
+    return toProtectedImpl(preferencesRef)->viewGestureDebuggingEnabled();
 }
 
 void WKPreferencesSetShouldConvertPositionStyleOnCopy(WKPreferencesRef preferencesRef, bool convert)
 {
-    toImpl(preferencesRef)->setShouldConvertPositionStyleOnCopy(convert);
+    toProtectedImpl(preferencesRef)->setShouldConvertPositionStyleOnCopy(convert);
 }
 
 bool WKPreferencesGetShouldConvertPositionStyleOnCopy(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldConvertPositionStyleOnCopy();
+    return toProtectedImpl(preferencesRef)->shouldConvertPositionStyleOnCopy();
 }
 
 void WKPreferencesSetTelephoneNumberParsingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setTelephoneNumberParsingEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setTelephoneNumberParsingEnabled(enabled);
 }
 
 bool WKPreferencesGetTelephoneNumberParsingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->telephoneNumberParsingEnabled();
+    return toProtectedImpl(preferencesRef)->telephoneNumberParsingEnabled();
 }
 
 void WKPreferencesSetEnableInheritURIQueryComponent(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setEnableInheritURIQueryComponent(enabled);
+    toProtectedImpl(preferencesRef)->setEnableInheritURIQueryComponent(enabled);
 }
 
 bool WKPreferencesGetEnableInheritURIQueryComponent(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->enableInheritURIQueryComponent();
+    return toProtectedImpl(preferencesRef)->enableInheritURIQueryComponent();
 }
 
 void WKPreferencesSetServiceControlsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setServiceControlsEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setServiceControlsEnabled(enabled);
 }
 
 bool WKPreferencesGetServiceControlsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->serviceControlsEnabled();
+    return toProtectedImpl(preferencesRef)->serviceControlsEnabled();
 }
 
 void WKPreferencesSetImageControlsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setImageControlsEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setImageControlsEnabled(enabled);
 }
 
 bool WKPreferencesGetImageControlsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->imageControlsEnabled();
+    return toProtectedImpl(preferencesRef)->imageControlsEnabled();
 }
 
 void WKPreferencesSetGamepadsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setGamepadsEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setGamepadsEnabled(enabled);
 }
 
 bool WKPreferencesGetGamepadsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->gamepadsEnabled();
+    return toProtectedImpl(preferencesRef)->gamepadsEnabled();
 }
 
 void WKPreferencesSetMinimumZoomFontSize(WKPreferencesRef preferencesRef, double size)
 {
-    toImpl(preferencesRef)->setMinimumZoomFontSize(size);
+    toProtectedImpl(preferencesRef)->setMinimumZoomFontSize(size);
 }
 
 double WKPreferencesGetMinimumZoomFontSize(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->minimumZoomFontSize();
+    return toProtectedImpl(preferencesRef)->minimumZoomFontSize();
 }
 
 void WKPreferencesSetVisibleDebugOverlayRegions(WKPreferencesRef preferencesRef, WKDebugOverlayRegions visibleRegions)
 {
-    toImpl(preferencesRef)->setVisibleDebugOverlayRegions(visibleRegions);
+    toProtectedImpl(preferencesRef)->setVisibleDebugOverlayRegions(visibleRegions);
 }
 
 WKDebugOverlayRegions WKPreferencesGetVisibleDebugOverlayRegions(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->visibleDebugOverlayRegions();
+    return toProtectedImpl(preferencesRef)->visibleDebugOverlayRegions();
 }
 
 void WKPreferencesSetMetaRefreshEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
 }
 
 bool WKPreferencesGetMetaRefreshEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->httpEquivEnabled();
+    return toProtectedImpl(preferencesRef)->httpEquivEnabled();
 }
 
 void WKPreferencesSetHTTPEquivEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
 }
 
 bool WKPreferencesGetHTTPEquivEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->httpEquivEnabled();
+    return toProtectedImpl(preferencesRef)->httpEquivEnabled();
 }
 
 void WKPreferencesSetAllowsAirPlayForMediaPlayback(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAllowsAirPlayForMediaPlayback(enabled);
+    toProtectedImpl(preferencesRef)->setAllowsAirPlayForMediaPlayback(enabled);
 }
 
 bool WKPreferencesGetAllowsAirPlayForMediaPlayback(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowsAirPlayForMediaPlayback();
+    return toProtectedImpl(preferencesRef)->allowsAirPlayForMediaPlayback();
 }
 
 void WKPreferencesSetUserInterfaceDirectionPolicy(WKPreferencesRef preferencesRef, _WKUserInterfaceDirectionPolicy userInterfaceDirectionPolicy)
 {
-    toImpl(preferencesRef)->setUserInterfaceDirectionPolicy(userInterfaceDirectionPolicy);
+    toProtectedImpl(preferencesRef)->setUserInterfaceDirectionPolicy(userInterfaceDirectionPolicy);
 }
 
 _WKUserInterfaceDirectionPolicy WKPreferencesGetUserInterfaceDirectionPolicy(WKPreferencesRef preferencesRef)
 {
-    return static_cast<_WKUserInterfaceDirectionPolicy>(toImpl(preferencesRef)->userInterfaceDirectionPolicy());
+    return static_cast<_WKUserInterfaceDirectionPolicy>(toProtectedImpl(preferencesRef)->userInterfaceDirectionPolicy());
 }
 
 void WKPreferencesSetResourceUsageOverlayVisible(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setResourceUsageOverlayVisible(enabled);
+    toProtectedImpl(preferencesRef)->setResourceUsageOverlayVisible(enabled);
 }
 
 bool WKPreferencesGetResourceUsageOverlayVisible(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->resourceUsageOverlayVisible();
+    return toProtectedImpl(preferencesRef)->resourceUsageOverlayVisible();
 }
 
 void WKPreferencesSetMockCaptureDevicesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setMockCaptureDevicesEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setMockCaptureDevicesEnabled(enabled);
 }
 
 bool WKPreferencesGetMockCaptureDevicesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mockCaptureDevicesEnabled();
+    return toProtectedImpl(preferencesRef)->mockCaptureDevicesEnabled();
 }
 
 void WKPreferencesSetGetUserMediaRequiresFocus(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setGetUserMediaRequiresFocus(enabled);
+    toProtectedImpl(preferencesRef)->setGetUserMediaRequiresFocus(enabled);
 }
 
 bool WKPreferencesGetGetUserMediaRequiresFocus(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->getUserMediaRequiresFocus();
+    return toProtectedImpl(preferencesRef)->getUserMediaRequiresFocus();
 }
 
 void WKPreferencesSetICECandidateFilteringEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setICECandidateFilteringEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setICECandidateFilteringEnabled(enabled);
 }
 
 bool WKPreferencesGetICECandidateFilteringEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->iceCandidateFilteringEnabled();
+    return toProtectedImpl(preferencesRef)->iceCandidateFilteringEnabled();
 }
 
 void WKPreferencesSetEnumeratingAllNetworkInterfacesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setEnumeratingAllNetworkInterfacesEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setEnumeratingAllNetworkInterfacesEnabled(enabled);
 }
 
 bool WKPreferencesGetEnumeratingAllNetworkInterfacesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->enumeratingAllNetworkInterfacesEnabled();
+    return toProtectedImpl(preferencesRef)->enumeratingAllNetworkInterfacesEnabled();
 }
 
 void WKPreferencesSetMediaCaptureRequiresSecureConnection(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setMediaCaptureRequiresSecureConnection(enabled);
+    toProtectedImpl(preferencesRef)->setMediaCaptureRequiresSecureConnection(enabled);
 }
 
 bool WKPreferencesGetMediaCaptureRequiresSecureConnection(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaCaptureRequiresSecureConnection();
+    return toProtectedImpl(preferencesRef)->mediaCaptureRequiresSecureConnection();
 }
 
 void WKPreferencesSetInactiveMediaCaptureStreamRepromptIntervalInMinutes(WKPreferencesRef preferencesRef, double interval)
 {
-    toImpl(preferencesRef)->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
+    toProtectedImpl(preferencesRef)->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
 }
 
 double WKPreferencesGetInactiveMediaCaptureStreamRepromptIntervalInMinutes(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
+    return toProtectedImpl(preferencesRef)->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
 }
 
 void WKPreferencesSetDataTransferItemsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setDataTransferItemsEnabled(flag);
+    toProtectedImpl(preferencesRef)->setDataTransferItemsEnabled(flag);
 }
 
 bool WKPreferencesGetDataTransferItemsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->dataTransferItemsEnabled();
+    return toProtectedImpl(preferencesRef)->dataTransferItemsEnabled();
 }
 
 void WKPreferencesSetCustomPasteboardDataEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCustomPasteboardDataEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCustomPasteboardDataEnabled(flag);
 }
 
 bool WKPreferencesGetCustomPasteboardDataEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->customPasteboardDataEnabled();
+    return toProtectedImpl(preferencesRef)->customPasteboardDataEnabled();
 }
 
 void WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setWriteRichTextDataWhenCopyingOrDragging(flag);
+    toProtectedImpl(preferencesRef)->setWriteRichTextDataWhenCopyingOrDragging(flag);
 }
 
 bool WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->writeRichTextDataWhenCopyingOrDragging();
+    return toProtectedImpl(preferencesRef)->writeRichTextDataWhenCopyingOrDragging();
 }
 
 void WKPreferencesSetWebShareEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setWebShareEnabled(flag);
+    toProtectedImpl(preferencesRef)->setWebShareEnabled(flag);
 }
 
 bool WKPreferencesGetWebShareEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webShareEnabled();
+    return toProtectedImpl(preferencesRef)->webShareEnabled();
 }
 
 void WKPreferencesSetDownloadAttributeEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setDownloadAttributeEnabled(flag);
+    toProtectedImpl(preferencesRef)->setDownloadAttributeEnabled(flag);
 }
 
 bool WKPreferencesGetDownloadAttributeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->downloadAttributeEnabled();
+    return toProtectedImpl(preferencesRef)->downloadAttributeEnabled();
 }
 
 void WKPreferencesSetWebRTCPlatformCodecsInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setWebRTCPlatformCodecsInGPUProcessEnabled(flag);
+    toProtectedImpl(preferencesRef)->setWebRTCPlatformCodecsInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetWebRTCPlatformCodecsInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webRTCPlatformCodecsInGPUProcessEnabled();
+    return toProtectedImpl(preferencesRef)->webRTCPlatformCodecsInGPUProcessEnabled();
 }
 
 WK_EXPORT void WKPreferencesSetIsAccessibilityIsolatedTreeEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setIsAccessibilityIsolatedTreeEnabled(flag);
+    toProtectedImpl(preferencesRef)->setIsAccessibilityIsolatedTreeEnabled(flag);
 }
 
 WK_EXPORT bool WKPreferencesGetIsAccessibilityIsolatedTreeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->isAccessibilityIsolatedTreeEnabled();
+    return toProtectedImpl(preferencesRef)->isAccessibilityIsolatedTreeEnabled();
 }
 
 void WKPreferencesSetAllowsPictureInPictureMediaPlayback(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setAllowsPictureInPictureMediaPlayback(enabled);
+    toProtectedImpl(preferencesRef)->setAllowsPictureInPictureMediaPlayback(enabled);
 }
 
 bool WKPreferencesGetAllowsPictureInPictureMediaPlayback(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowsPictureInPictureMediaPlayback();
+    return toProtectedImpl(preferencesRef)->allowsPictureInPictureMediaPlayback();
 }
 
 WK_EXPORT bool WKPreferencesGetApplePayEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toImpl(preferencesRef)->applePayEnabled();
+    return WebKit::toProtectedImpl(preferencesRef)->applePayEnabled();
 }
 
 void WKPreferencesSetApplePayEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toImpl(preferencesRef)->setApplePayEnabled(enabled);
+    WebKit::toProtectedImpl(preferencesRef)->setApplePayEnabled(enabled);
 }
 
 bool WKPreferencesGetCSSTransformStyleSeparatedEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toImpl(preferencesRef)->cssTransformStyleSeparatedEnabled();
+    return WebKit::toProtectedImpl(preferencesRef)->cssTransformStyleSeparatedEnabled();
 }
 
 void WKPreferencesSetCSSTransformStyleSeparatedEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toImpl(preferencesRef)->setCSSTransformStyleSeparatedEnabled(enabled);
+    WebKit::toProtectedImpl(preferencesRef)->setCSSTransformStyleSeparatedEnabled(enabled);
 }
 
 bool WKPreferencesGetApplePayCapabilityDisclosureAllowed(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toImpl(preferencesRef)->applePayCapabilityDisclosureAllowed();
+    return WebKit::toProtectedImpl(preferencesRef)->applePayCapabilityDisclosureAllowed();
 }
 
 void WKPreferencesSetApplePayCapabilityDisclosureAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    WebKit::toImpl(preferencesRef)->setApplePayCapabilityDisclosureAllowed(allowed);
+    WebKit::toProtectedImpl(preferencesRef)->setApplePayCapabilityDisclosureAllowed(allowed);
 }
 
 void WKPreferencesSetLinkPreloadEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setLinkPreloadEnabled(flag);
+    toProtectedImpl(preferencesRef)->setLinkPreloadEnabled(flag);
 }
 
 bool WKPreferencesGetLinkPreloadEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->linkPreloadEnabled();
+    return toProtectedImpl(preferencesRef)->linkPreloadEnabled();
 }
 
 void WKPreferencesSetMediaPreloadingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setMediaPreloadingEnabled(flag);
+    toProtectedImpl(preferencesRef)->setMediaPreloadingEnabled(flag);
 }
 
 bool WKPreferencesGetMediaPreloadingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaPreloadingEnabled();
+    return toProtectedImpl(preferencesRef)->mediaPreloadingEnabled();
 }
 
 void WKPreferencesSetExposeSpeakersEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setExposeSpeakersEnabled(flag);
+    toProtectedImpl(preferencesRef)->setExposeSpeakersEnabled(flag);
 }
 
 bool WKPreferencesGetExposeSpeakersEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->exposeSpeakersEnabled();
+    return toProtectedImpl(preferencesRef)->exposeSpeakersEnabled();
 }
 
 void WKPreferencesSetLargeImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setLargeImageAsyncDecodingEnabled(flag);
+    toProtectedImpl(preferencesRef)->setLargeImageAsyncDecodingEnabled(flag);
 }
 
 bool WKPreferencesGetLargeImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->largeImageAsyncDecodingEnabled();
+    return toProtectedImpl(preferencesRef)->largeImageAsyncDecodingEnabled();
 }
 
 void WKPreferencesSetAnimatedImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setAnimatedImageAsyncDecodingEnabled(flag);
+    toProtectedImpl(preferencesRef)->setAnimatedImageAsyncDecodingEnabled(flag);
 }
 
 bool WKPreferencesGetAnimatedImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->animatedImageAsyncDecodingEnabled();
+    return toProtectedImpl(preferencesRef)->animatedImageAsyncDecodingEnabled();
 }
 
 void WKPreferencesSetShouldSuppressKeyboardInputDuringProvisionalNavigation(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(flag);
+    toProtectedImpl(preferencesRef)->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(flag);
 }
 
 bool WKPreferencesGetShouldSuppressKeyboardInputDuringProvisionalNavigation(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
+    return toProtectedImpl(preferencesRef)->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
 }
 
 void WKPreferencesSetMediaUserGestureInheritsFromDocument(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setMediaUserGestureInheritsFromDocument(flag);
+    toProtectedImpl(preferencesRef)->setMediaUserGestureInheritsFromDocument(flag);
 }
 
 bool WKPreferencesGetMediaUserGestureInheritsFromDocument(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaUserGestureInheritsFromDocument();
+    return toProtectedImpl(preferencesRef)->mediaUserGestureInheritsFromDocument();
 }
 
 void WKPreferencesSetMediaContentTypesRequiringHardwareSupport(WKPreferencesRef preferencesRef, WKStringRef codecs)
 {
-    toImpl(preferencesRef)->setMediaContentTypesRequiringHardwareSupport(toWTFString(codecs));
+    toProtectedImpl(preferencesRef)->setMediaContentTypesRequiringHardwareSupport(toWTFString(codecs));
 }
 
 WKStringRef WKPreferencesCopyMediaContentTypesRequiringHardwareSupport(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toImpl(preferencesRef)->mediaContentTypesRequiringHardwareSupport());
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->mediaContentTypesRequiringHardwareSupport());
 }
 
 bool WKPreferencesGetLegacyEncryptedMediaAPIEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->legacyEncryptedMediaAPIEnabled();
+    return toProtectedImpl(preferencesRef)->legacyEncryptedMediaAPIEnabled();
 }
 
 void WKPreferencesSetLegacyEncryptedMediaAPIEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    return toImpl(preferencesRef)->setLegacyEncryptedMediaAPIEnabled(enabled);
+    return toProtectedImpl(preferencesRef)->setLegacyEncryptedMediaAPIEnabled(enabled);
 }
 
 bool WKPreferencesGetAllowMediaContentTypesRequiringHardwareSupportAsFallback(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->allowMediaContentTypesRequiringHardwareSupportAsFallback();
+    return toProtectedImpl(preferencesRef)->allowMediaContentTypesRequiringHardwareSupportAsFallback();
 }
 
 void WKPreferencesSetAllowMediaContentTypesRequiringHardwareSupportAsFallback(WKPreferencesRef preferencesRef, bool allow)
 {
-    return toImpl(preferencesRef)->setAllowMediaContentTypesRequiringHardwareSupportAsFallback(allow);
+    return toProtectedImpl(preferencesRef)->setAllowMediaContentTypesRequiringHardwareSupportAsFallback(allow);
 }
 
 void WKPreferencesSetCSSOMViewScrollingAPIEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCSSOMViewScrollingAPIEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCSSOMViewScrollingAPIEnabled(flag);
 }
 
 bool WKPreferencesGetCSSOMViewScrollingAPIEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->cssOMViewScrollingAPIEnabled();
+    return toProtectedImpl(preferencesRef)->cssOMViewScrollingAPIEnabled();
 }
 
 void WKPreferencesSetShouldAllowUserInstalledFonts(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setShouldAllowUserInstalledFonts(flag);
+    toProtectedImpl(preferencesRef)->setShouldAllowUserInstalledFonts(flag);
 }
 
 bool WKPreferencesGetShouldAllowUserInstalledFonts(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->shouldAllowUserInstalledFonts();
+    return toProtectedImpl(preferencesRef)->shouldAllowUserInstalledFonts();
 }
 
 void WKPreferencesSetMediaCapabilitiesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setMediaCapabilitiesEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setMediaCapabilitiesEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaCapabilitiesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->mediaCapabilitiesEnabled();
+    return toProtectedImpl(preferencesRef)->mediaCapabilitiesEnabled();
 }
 
 void WKPreferencesSetColorFilterEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setColorFilterEnabled(flag);
+    toProtectedImpl(preferencesRef)->setColorFilterEnabled(flag);
 }
 
 bool WKPreferencesGetColorFilterEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->colorFilterEnabled();
+    return toProtectedImpl(preferencesRef)->colorFilterEnabled();
 }
 
 void WKPreferencesSetProcessSwapOnNavigationEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setProcessSwapOnCrossSiteNavigationEnabled(flag);
+    toProtectedImpl(preferencesRef)->setProcessSwapOnCrossSiteNavigationEnabled(flag);
 }
 
 bool WKPreferencesGetProcessSwapOnNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->processSwapOnCrossSiteNavigationEnabled();
+    return toProtectedImpl(preferencesRef)->processSwapOnCrossSiteNavigationEnabled();
 }
 
 void WKPreferencesSetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setPunchOutWhiteBackgroundsInDarkMode(flag);
+    toProtectedImpl(preferencesRef)->setPunchOutWhiteBackgroundsInDarkMode(flag);
 }
 
 bool WKPreferencesGetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->punchOutWhiteBackgroundsInDarkMode();
+    return toProtectedImpl(preferencesRef)->punchOutWhiteBackgroundsInDarkMode();
 }
 
 void WKPreferencesSetCaptureAudioInUIProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCaptureAudioInUIProcessEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCaptureAudioInUIProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureAudioInUIProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->captureAudioInUIProcessEnabled();
+    return toProtectedImpl(preferencesRef)->captureAudioInUIProcessEnabled();
 }
 
 void WKPreferencesSetCaptureAudioInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCaptureAudioInGPUProcessEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCaptureAudioInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureAudioInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->captureAudioInGPUProcessEnabled();
+    return toProtectedImpl(preferencesRef)->captureAudioInGPUProcessEnabled();
 }
 
 void WKPreferencesSetCaptureVideoInUIProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCaptureVideoInUIProcessEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCaptureVideoInUIProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureVideoInUIProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->captureVideoInUIProcessEnabled();
+    return toProtectedImpl(preferencesRef)->captureVideoInUIProcessEnabled();
 }
 
 void WKPreferencesSetCaptureVideoInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setCaptureVideoInGPUProcessEnabled(flag);
+    toProtectedImpl(preferencesRef)->setCaptureVideoInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureVideoInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->captureVideoInGPUProcessEnabled();
+    return toProtectedImpl(preferencesRef)->captureVideoInGPUProcessEnabled();
 }
 
 void WKPreferencesSetVP9DecoderEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setVP9DecoderEnabled(flag);
+    toProtectedImpl(preferencesRef)->setVP9DecoderEnabled(flag);
 }
 
 bool WKPreferencesGetVP9DecoderEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->vp9DecoderEnabled();
+    return toProtectedImpl(preferencesRef)->vp9DecoderEnabled();
 }
 
 bool WKPreferencesGetRemotePlaybackEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toImpl(preferencesRef)->remotePlaybackEnabled();
+    return WebKit::toProtectedImpl(preferencesRef)->remotePlaybackEnabled();
 }
 
 void WKPreferencesSetRemotePlaybackEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toImpl(preferencesRef)->setRemotePlaybackEnabled(enabled);
+    WebKit::toProtectedImpl(preferencesRef)->setRemotePlaybackEnabled(enabled);
 }
 
 bool WKPreferencesGetShouldUseServiceWorkerShortTimeout(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toImpl(preferencesRef)->shouldUseServiceWorkerShortTimeout();
+    return WebKit::toProtectedImpl(preferencesRef)->shouldUseServiceWorkerShortTimeout();
 }
 
 void WKPreferencesSetShouldUseServiceWorkerShortTimeout(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toImpl(preferencesRef)->setShouldUseServiceWorkerShortTimeout(enabled);
+    WebKit::toProtectedImpl(preferencesRef)->setShouldUseServiceWorkerShortTimeout(enabled);
 }
 
 void WKPreferencesSetRequestVideoFrameCallbackEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setRequestVideoFrameCallbackEnabled(enabled);
+    toProtectedImpl(preferencesRef)->setRequestVideoFrameCallbackEnabled(enabled);
 }
 
 bool WKPreferencesGetRequestVideoFrameCallbackEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->requestVideoFrameCallbackEnabled();
+    return toProtectedImpl(preferencesRef)->requestVideoFrameCallbackEnabled();
 }
 
 


### PR DESCRIPTION
#### 567d1df2e1d9d1496e659b5f984414644c66b175
<pre>
[SaferCpp] Address issues in WKPreferences.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=291298">https://bugs.webkit.org/show_bug.cgi?id=291298</a>
<a href="https://rdar.apple.com/148865767">rdar://148865767</a>

Reviewed by Chris Dumez.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesCreateCopy):
(WKPreferencesStartBatchingUpdates):
(WKPreferencesEndBatchingUpdates):
(WKPreferencesEnableAllExperimentalFeatures):
(WKPreferencesSetExperimentalFeatureForKey):
(WKPreferencesResetAllInternalDebugFeatures):
(WKPreferencesSetInternalDebugFeatureForKey):
(WKPreferencesSetBoolValueForKeyForTesting):
(WKPreferencesSetDoubleValueForKeyForTesting):
(WKPreferencesSetUInt32ValueForKeyForTesting):
(WKPreferencesSetStringValueForKeyForTesting):
(WKPreferencesResetTestRunnerOverrides):
(WKPreferencesSetJavaScriptEnabled):
(WKPreferencesGetJavaScriptEnabled):
(WKPreferencesSetJavaScriptMarkupEnabled):
(WKPreferencesGetJavaScriptMarkupEnabled):
(WKPreferencesSetLoadsImagesAutomatically):
(WKPreferencesGetLoadsImagesAutomatically):
(WKPreferencesSetLocalStorageEnabled):
(WKPreferencesGetLocalStorageEnabled):
(WKPreferencesSetDatabasesEnabled):
(WKPreferencesGetDatabasesEnabled):
(WKPreferencesSetJavaScriptCanOpenWindowsAutomatically):
(WKPreferencesGetJavaScriptCanOpenWindowsAutomatically):
(WKPreferencesSetHyperlinkAuditingEnabled):
(WKPreferencesGetHyperlinkAuditingEnabled):
(WKPreferencesSetStandardFontFamily):
(WKPreferencesCopyStandardFontFamily):
(WKPreferencesSetFixedFontFamily):
(WKPreferencesCopyFixedFontFamily):
(WKPreferencesSetSerifFontFamily):
(WKPreferencesCopySerifFontFamily):
(WKPreferencesSetSansSerifFontFamily):
(WKPreferencesCopySansSerifFontFamily):
(WKPreferencesSetCursiveFontFamily):
(WKPreferencesCopyCursiveFontFamily):
(WKPreferencesSetFantasyFontFamily):
(WKPreferencesCopyFantasyFontFamily):
(WKPreferencesSetPictographFontFamily):
(WKPreferencesCopyPictographFontFamily):
(WKPreferencesSetDefaultFontSize):
(WKPreferencesGetDefaultFontSize):
(WKPreferencesSetDefaultFixedFontSize):
(WKPreferencesGetDefaultFixedFontSize):
(WKPreferencesSetMinimumFontSize):
(WKPreferencesGetMinimumFontSize):
(WKPreferencesSetCookieEnabled):
(WKPreferencesGetCookieEnabled):
(WKPreferencesSetEditableLinkBehavior):
(WKPreferencesGetEditableLinkBehavior):
(WKPreferencesSetDefaultTextEncodingName):
(WKPreferencesCopyDefaultTextEncodingName):
(WKPreferencesSetDeveloperExtrasEnabled):
(WKPreferencesGetDeveloperExtrasEnabled):
(WKPreferencesSetJavaScriptRuntimeFlags):
(WKPreferencesGetJavaScriptRuntimeFlags):
(WKPreferencesSetTextAreasAreResizable):
(WKPreferencesGetTextAreasAreResizable):
(WKPreferencesSetAcceleratedDrawingEnabled):
(WKPreferencesGetAcceleratedDrawingEnabled):
(WKPreferencesSetCanvasUsesAcceleratedDrawing):
(WKPreferencesGetCanvasUsesAcceleratedDrawing):
(WKPreferencesSetAcceleratedCompositingEnabled):
(WKPreferencesGetAcceleratedCompositingEnabled):
(WKPreferencesSetCompositingBordersVisible):
(WKPreferencesGetCompositingBordersVisible):
(WKPreferencesSetCompositingRepaintCountersVisible):
(WKPreferencesGetCompositingRepaintCountersVisible):
(WKPreferencesSetTiledScrollingIndicatorVisible):
(WKPreferencesGetTiledScrollingIndicatorVisible):
(WKPreferencesSetWebGLEnabled):
(WKPreferencesGetWebGLEnabled):
(WKPreferencesSetNeedsSiteSpecificQuirks):
(WKPreferencesGetNeedsSiteSpecificQuirks):
(WKPreferencesSetForceFTPDirectoryListings):
(WKPreferencesGetForceFTPDirectoryListings):
(WKPreferencesSetFTPDirectoryTemplatePath):
(WKPreferencesCopyFTPDirectoryTemplatePath):
(WKPreferencesSetTabsToLinks):
(WKPreferencesGetTabsToLinks):
(WKPreferencesSetAuthorAndUserStylesEnabled):
(WKPreferencesGetAuthorAndUserStylesEnabled):
(WKPreferencesSetShouldPrintBackgrounds):
(WKPreferencesGetShouldPrintBackgrounds):
(WKPreferencesSetDOMTimersThrottlingEnabled):
(WKPreferencesGetDOMTimersThrottlingEnabled):
(WKPreferencesSetWebArchiveDebugModeEnabled):
(WKPreferencesGetWebArchiveDebugModeEnabled):
(WKPreferencesSetLocalFileContentSniffingEnabled):
(WKPreferencesGetLocalFileContentSniffingEnabled):
(WKPreferencesSetPageCacheEnabled):
(WKPreferencesGetPageCacheEnabled):
(WKPreferencesSetDOMPasteAllowed):
(WKPreferencesGetDOMPasteAllowed):
(WKPreferencesSetJavaScriptCanAccessClipboard):
(WKPreferencesGetJavaScriptCanAccessClipboard):
(WKPreferencesSetFullScreenEnabled):
(WKPreferencesGetFullScreenEnabled):
(WKPreferencesSetAsynchronousSpellCheckingEnabled):
(WKPreferencesGetAsynchronousSpellCheckingEnabled):
(WKPreferencesSetAVFoundationEnabled):
(WKPreferencesGetAVFoundationEnabled):
(WKPreferencesSetWebSecurityEnabled):
(WKPreferencesGetWebSecurityEnabled):
(WKPreferencesSetUniversalAccessFromFileURLsAllowed):
(WKPreferencesGetUniversalAccessFromFileURLsAllowed):
(WKPreferencesSetFileAccessFromFileURLsAllowed):
(WKPreferencesGetFileAccessFromFileURLsAllowed):
(WKPreferencesSetTopNavigationToDataURLsAllowed):
(WKPreferencesGetTopNavigationToDataURLsAllowed):
(WKPreferencesSetNeedsStorageAccessFromFileURLsQuirk):
(WKPreferencesGetNeedsStorageAccessFromFileURLsQuirk):
(WKPreferencesSetMediaPlaybackRequiresUserGesture):
(WKPreferencesGetMediaPlaybackRequiresUserGesture):
(WKPreferencesSetVideoPlaybackRequiresUserGesture):
(WKPreferencesGetVideoPlaybackRequiresUserGesture):
(WKPreferencesSetAudioPlaybackRequiresUserGesture):
(WKPreferencesGetAudioPlaybackRequiresUserGesture):
(WKPreferencesSetMainContentUserGestureOverrideEnabled):
(WKPreferencesGetMainContentUserGestureOverrideEnabled):
(WKPreferencesGetVerifyUserGestureInUIProcessEnabled):
(WKPreferencesSetManagedMediaSourceLowThreshold):
(WKPreferencesGetManagedMediaSourceLowThreshold):
(WKPreferencesSetManagedMediaSourceHighThreshold):
(WKPreferencesGetManagedMediaSourceHighThreshold):
(WKPreferencesSetMediaPlaybackAllowsInline):
(WKPreferencesGetMediaPlaybackAllowsInline):
(WKPreferencesSetInlineMediaPlaybackRequiresPlaysInlineAttribute):
(WKPreferencesGetInlineMediaPlaybackRequiresPlaysInlineAttribute):
(WKPreferencesSetBeaconAPIEnabled):
(WKPreferencesGetBeaconAPIEnabled):
(WKPreferencesSetDirectoryUploadEnabled):
(WKPreferencesGetDirectoryUploadEnabled):
(WKPreferencesSetMediaControlsScaleWithPageZoom):
(WKPreferencesGetMediaControlsScaleWithPageZoom):
(WKPreferencesSetWebAuthenticationEnabled):
(WKPreferencesGetWebAuthenticationEnabled):
(WKPreferencesSetDigitalCredentialsEnabled):
(WKPreferencesGetDigitalCredentialsEnabled):
(WKPreferencesSetInvisibleMediaAutoplayPermitted):
(WKPreferencesGetInvisibleMediaAutoplayPermitted):
(WKPreferencesSetShowsToolTipOverTruncatedText):
(WKPreferencesGetShowsToolTipOverTruncatedText):
(WKPreferencesSetMockScrollbarsEnabled):
(WKPreferencesGetMockScrollbarsEnabled):
(WKPreferencesSetAttachmentElementEnabled):
(WKPreferencesGetAttachmentElementEnabled):
(WKPreferencesSetWebAudioEnabled):
(WKPreferencesGetWebAudioEnabled):
(WKPreferencesSetSuppressesIncrementalRendering):
(WKPreferencesGetSuppressesIncrementalRendering):
(WKPreferencesSetBackspaceKeyNavigationEnabled):
(WKPreferencesGetBackspaceKeyNavigationEnabled):
(WKPreferencesSetCaretBrowsingEnabled):
(WKPreferencesGetCaretBrowsingEnabled):
(WKPreferencesSetShouldDisplaySubtitles):
(WKPreferencesGetShouldDisplaySubtitles):
(WKPreferencesSetShouldDisplayCaptions):
(WKPreferencesGetShouldDisplayCaptions):
(WKPreferencesSetShouldDisplayTextDescriptions):
(WKPreferencesGetShouldDisplayTextDescriptions):
(WKPreferencesSetNotificationsEnabled):
(WKPreferencesGetNotificationsEnabled):
(WKPreferencesSetShouldRespectImageOrientation):
(WKPreferencesGetShouldRespectImageOrientation):
(WKPreferencesSetStorageBlockingPolicy):
(WKPreferencesGetStorageBlockingPolicy):
(WKPreferencesSetDiagnosticLoggingEnabled):
(WKPreferencesGetDiagnosticLoggingEnabled):
(WKPreferencesSetInteractiveFormValidationEnabled):
(WKPreferencesGetInteractiveFormValidationEnabled):
(WKPreferencesSetScrollingPerformanceLoggingEnabled):
(WKPreferencesGetScrollingPerformanceLoggingEnabled):
(WKPreferencesSetPDFPluginEnabled):
(WKPreferencesGetPDFPluginEnabled):
(WKPreferencesSetEncodingDetectorEnabled):
(WKPreferencesGetEncodingDetectorEnabled):
(WKPreferencesSetTextAutosizingEnabled):
(WKPreferencesGetTextAutosizingEnabled):
(WKPreferencesSetTextAutosizingUsesIdempotentMode):
(WKPreferencesGetTextAutosizingUsesIdempotentMode):
(WKPreferencesSetAggressiveTileRetentionEnabled):
(WKPreferencesGetAggressiveTileRetentionEnabled):
(WKPreferencesSetLogsPageMessagesToSystemConsoleEnabled):
(WKPreferencesGetLogsPageMessagesToSystemConsoleEnabled):
(WKPreferencesSetPageVisibilityBasedProcessSuppressionEnabled):
(WKPreferencesGetPageVisibilityBasedProcessSuppressionEnabled):
(WKPreferencesSetSmartInsertDeleteEnabled):
(WKPreferencesGetSmartInsertDeleteEnabled):
(WKPreferencesSetSelectTrailingWhitespaceEnabled):
(WKPreferencesGetSelectTrailingWhitespaceEnabled):
(WKPreferencesSetShowsURLsInToolTipsEnabled):
(WKPreferencesGetShowsURLsInToolTipsEnabled):
(WKPreferencesSetHiddenPageDOMTimerThrottlingEnabled):
(WKPreferencesSetHiddenPageDOMTimerThrottlingAutoIncreases):
(WKPreferencesGetHiddenPageDOMTimerThrottlingEnabled):
(WKPreferencesGetHiddenPageDOMTimerThrottlingAutoIncreases):
(WKPreferencesSetHiddenPageCSSAnimationSuspensionEnabled):
(WKPreferencesGetHiddenPageCSSAnimationSuspensionEnabled):
(WKPreferencesSetIncrementalRenderingSuppressionTimeout):
(WKPreferencesGetIncrementalRenderingSuppressionTimeout):
(WKPreferencesSetThreadedScrollingEnabled):
(WKPreferencesGetThreadedScrollingEnabled):
(WKPreferencesSetLegacyLineLayoutVisualCoverageEnabled):
(WKPreferencesGetLegacyLineLayoutVisualCoverageEnabled):
(WKPreferencesSetContentChangeObserverEnabled):
(WKPreferencesGetContentChangeObserverEnabled):
(WKPreferencesSetUseGiantTiles):
(WKPreferencesGetUseGiantTiles):
(WKPreferencesSetMediaDevicesEnabled):
(WKPreferencesGetMediaDevicesEnabled):
(WKPreferencesSetPeerConnectionEnabled):
(WKPreferencesGetPeerConnectionEnabled):
(WKPreferencesSetSpatialNavigationEnabled):
(WKPreferencesGetSpatialNavigationEnabled):
(WKPreferencesSetMediaSourceEnabled):
(WKPreferencesGetMediaSourceEnabled):
(WKPreferencesSetSourceBufferChangeTypeEnabled):
(WKPreferencesGetSourceBufferChangeTypeEnabled):
(WKPreferencesSetViewGestureDebuggingEnabled):
(WKPreferencesGetViewGestureDebuggingEnabled):
(WKPreferencesSetShouldConvertPositionStyleOnCopy):
(WKPreferencesGetShouldConvertPositionStyleOnCopy):
(WKPreferencesSetTelephoneNumberParsingEnabled):
(WKPreferencesGetTelephoneNumberParsingEnabled):
(WKPreferencesSetEnableInheritURIQueryComponent):
(WKPreferencesGetEnableInheritURIQueryComponent):
(WKPreferencesSetServiceControlsEnabled):
(WKPreferencesGetServiceControlsEnabled):
(WKPreferencesSetImageControlsEnabled):
(WKPreferencesGetImageControlsEnabled):
(WKPreferencesSetGamepadsEnabled):
(WKPreferencesGetGamepadsEnabled):
(WKPreferencesSetMinimumZoomFontSize):
(WKPreferencesGetMinimumZoomFontSize):
(WKPreferencesSetVisibleDebugOverlayRegions):
(WKPreferencesGetVisibleDebugOverlayRegions):
(WKPreferencesSetMetaRefreshEnabled):
(WKPreferencesGetMetaRefreshEnabled):
(WKPreferencesSetHTTPEquivEnabled):
(WKPreferencesGetHTTPEquivEnabled):
(WKPreferencesSetAllowsAirPlayForMediaPlayback):
(WKPreferencesGetAllowsAirPlayForMediaPlayback):
(WKPreferencesSetUserInterfaceDirectionPolicy):
(WKPreferencesGetUserInterfaceDirectionPolicy):
(WKPreferencesSetResourceUsageOverlayVisible):
(WKPreferencesGetResourceUsageOverlayVisible):
(WKPreferencesSetMockCaptureDevicesEnabled):
(WKPreferencesGetMockCaptureDevicesEnabled):
(WKPreferencesSetGetUserMediaRequiresFocus):
(WKPreferencesGetGetUserMediaRequiresFocus):
(WKPreferencesSetICECandidateFilteringEnabled):
(WKPreferencesGetICECandidateFilteringEnabled):
(WKPreferencesSetEnumeratingAllNetworkInterfacesEnabled):
(WKPreferencesGetEnumeratingAllNetworkInterfacesEnabled):
(WKPreferencesSetMediaCaptureRequiresSecureConnection):
(WKPreferencesGetMediaCaptureRequiresSecureConnection):
(WKPreferencesSetInactiveMediaCaptureStreamRepromptIntervalInMinutes):
(WKPreferencesGetInactiveMediaCaptureStreamRepromptIntervalInMinutes):
(WKPreferencesSetDataTransferItemsEnabled):
(WKPreferencesGetDataTransferItemsEnabled):
(WKPreferencesSetCustomPasteboardDataEnabled):
(WKPreferencesGetCustomPasteboardDataEnabled):
(WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging):
(WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging):
(WKPreferencesSetWebShareEnabled):
(WKPreferencesGetWebShareEnabled):
(WKPreferencesSetDownloadAttributeEnabled):
(WKPreferencesGetDownloadAttributeEnabled):
(WKPreferencesSetWebRTCPlatformCodecsInGPUProcessEnabled):
(WKPreferencesGetWebRTCPlatformCodecsInGPUProcessEnabled):
(WKPreferencesSetIsAccessibilityIsolatedTreeEnabled):
(WKPreferencesGetIsAccessibilityIsolatedTreeEnabled):
(WKPreferencesSetAllowsPictureInPictureMediaPlayback):
(WKPreferencesGetAllowsPictureInPictureMediaPlayback):
(WKPreferencesGetApplePayEnabled):
(WKPreferencesSetApplePayEnabled):
(WKPreferencesGetCSSTransformStyleSeparatedEnabled):
(WKPreferencesSetCSSTransformStyleSeparatedEnabled):
(WKPreferencesGetApplePayCapabilityDisclosureAllowed):
(WKPreferencesSetApplePayCapabilityDisclosureAllowed):
(WKPreferencesSetLinkPreloadEnabled):
(WKPreferencesGetLinkPreloadEnabled):
(WKPreferencesSetMediaPreloadingEnabled):
(WKPreferencesGetMediaPreloadingEnabled):
(WKPreferencesSetExposeSpeakersEnabled):
(WKPreferencesGetExposeSpeakersEnabled):
(WKPreferencesSetLargeImageAsyncDecodingEnabled):
(WKPreferencesGetLargeImageAsyncDecodingEnabled):
(WKPreferencesSetAnimatedImageAsyncDecodingEnabled):
(WKPreferencesGetAnimatedImageAsyncDecodingEnabled):
(WKPreferencesSetShouldSuppressKeyboardInputDuringProvisionalNavigation):
(WKPreferencesGetShouldSuppressKeyboardInputDuringProvisionalNavigation):
(WKPreferencesSetMediaUserGestureInheritsFromDocument):
(WKPreferencesGetMediaUserGestureInheritsFromDocument):
(WKPreferencesSetMediaContentTypesRequiringHardwareSupport):
(WKPreferencesCopyMediaContentTypesRequiringHardwareSupport):
(WKPreferencesGetLegacyEncryptedMediaAPIEnabled):
(WKPreferencesSetLegacyEncryptedMediaAPIEnabled):
(WKPreferencesGetAllowMediaContentTypesRequiringHardwareSupportAsFallback):
(WKPreferencesSetAllowMediaContentTypesRequiringHardwareSupportAsFallback):
(WKPreferencesSetCSSOMViewScrollingAPIEnabled):
(WKPreferencesGetCSSOMViewScrollingAPIEnabled):
(WKPreferencesSetShouldAllowUserInstalledFonts):
(WKPreferencesGetShouldAllowUserInstalledFonts):
(WKPreferencesSetMediaCapabilitiesEnabled):
(WKPreferencesGetMediaCapabilitiesEnabled):
(WKPreferencesSetColorFilterEnabled):
(WKPreferencesGetColorFilterEnabled):
(WKPreferencesSetProcessSwapOnNavigationEnabled):
(WKPreferencesGetProcessSwapOnNavigationEnabled):
(WKPreferencesSetPunchOutWhiteBackgroundsInDarkMode):
(WKPreferencesGetPunchOutWhiteBackgroundsInDarkMode):
(WKPreferencesSetCaptureAudioInUIProcessEnabled):
(WKPreferencesGetCaptureAudioInUIProcessEnabled):
(WKPreferencesSetCaptureAudioInGPUProcessEnabled):
(WKPreferencesGetCaptureAudioInGPUProcessEnabled):
(WKPreferencesSetCaptureVideoInUIProcessEnabled):
(WKPreferencesGetCaptureVideoInUIProcessEnabled):
(WKPreferencesSetCaptureVideoInGPUProcessEnabled):
(WKPreferencesGetCaptureVideoInGPUProcessEnabled):
(WKPreferencesSetVP9DecoderEnabled):
(WKPreferencesGetVP9DecoderEnabled):
(WKPreferencesGetRemotePlaybackEnabled):
(WKPreferencesSetRemotePlaybackEnabled):
(WKPreferencesGetShouldUseServiceWorkerShortTimeout):
(WKPreferencesSetShouldUseServiceWorkerShortTimeout):
(WKPreferencesSetRequestVideoFrameCallbackEnabled):
(WKPreferencesGetRequestVideoFrameCallbackEnabled):

Canonical link: <a href="https://commits.webkit.org/293642@main">https://commits.webkit.org/293642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975a79aaf18a9a640637ecdad152e7f89afac88a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50077 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27558 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14577 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84504 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106964 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26589 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84191 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6562 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20361 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26529 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->