### PR TITLE
load-and-stall.cgi: Can't call method "size" on an undefined value at http/tests/resources/load-and-stall.cgi line 13

### DIFF
--- a/LayoutTests/http/tests/navigation/page-cache-pending-ping-load-cross-origin.html
+++ b/LayoutTests/http/tests/navigation/page-cache-pending-ping-load-cross-origin.html
@@ -35,9 +35,9 @@ window.addEventListener('load', function() {
 }, false);
 
 </script>
-<a id="testPing1" href="javascript:void(0);" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&bar" style="display: none;"></a>
-<a id="testPing2" href="javascript:void(0);" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&baz" style="display: none;"></a>
-<a id="testLink" href="http://localhost:8000/navigation/resources/page-cache-helper.html" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&foo">Click me</a>
+<a id="testPing1" href="javascript:void(0);" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&bar" style="display: none;"></a>
+<a id="testPing2" href="javascript:void(0);" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&baz" style="display: none;"></a>
+<a id="testLink" href="http://localhost:8000/navigation/resources/page-cache-helper.html" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&foo">Click me</a>
 <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/page-cache-pending-ping-load-same-origin.html
+++ b/LayoutTests/http/tests/navigation/page-cache-pending-ping-load-same-origin.html
@@ -36,9 +36,9 @@ window.addEventListener('load', function() {
 }, false);
 
 </script>
-<a id="testPing1" href="javascript:void(0);" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&bar" style="display: none;"></a>
-<a id="testPing2" href="javascript:void(0);" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&baz" style="display: none;"></a>
-<a id="testLink" href="resources/page-cache-helper.html" ping="/resources/load-and-stall.cgi?name=load-and-stall.cgi&stallFor=3&stallAt=0&mimeType=text/plain&foo">Click me</a>
+<a id="testPing1" href="javascript:void(0);" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&bar" style="display: none;"></a>
+<a id="testPing2" href="javascript:void(0);" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&baz" style="display: none;"></a>
+<a id="testLink" href="resources/page-cache-helper.html" ping="/resources/load-and-stall.py?name=load-and-stall.py&stallFor=3&stallAt=0&mimeType=text/plain&foo">Click me</a>
 <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### ec0e2c01f8318617fc40ac0d347e3626b110263e
<pre>
load-and-stall.cgi: Can&apos;t call method &quot;size&quot; on an undefined value at http/tests/resources/load-and-stall.cgi line 13
<a href="https://bugs.webkit.org/show_bug.cgi?id=291301">https://bugs.webkit.org/show_bug.cgi?id=291301</a>

Reviewed by Chris Dumez.

load-and-stall.cgi doesn&apos;t work as expected for ping requests because
they are POST requests. load-and-stall.py works fine for them.
Replaced load-and-stall.cgi with load-and-stall.py.

* LayoutTests/http/tests/navigation/page-cache-pending-ping-load-cross-origin.html:
* LayoutTests/http/tests/navigation/page-cache-pending-ping-load-same-origin.html:

Canonical link: <a href="https://commits.webkit.org/293489@main">https://commits.webkit.org/293489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f313e6d54112902d019c6876ec7ce5b141f84135

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75333 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32466 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106458 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83803 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19784 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16110 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26013 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->