### PR TITLE
Consistently enable SDK aligned behaviors when testing WTF, WGSL, and IPC

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/app/AppCommon.mm
+++ b/Tools/TestWebKitAPI/cocoa/app/AppCommon.mm
@@ -29,6 +29,7 @@
 #import "TestBundleLoader.h"
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKitPrivate.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 namespace TestWebKitAPI {
 
@@ -54,9 +55,7 @@ void initializeApp()
 
     [NSUserDefaults.standardUserDefaults setVolatileDomain:argumentDomain forName:NSArgumentDomain];
 
-#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
-    [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
-#endif
+    enableAllSDKAlignedBehaviors();
 
     registerTestClasses();
 }

--- a/Tools/TestWebKitAPI/ios/mainIOS.mm
+++ b/Tools/TestWebKitAPI/ios/mainIOS.mm
@@ -27,10 +27,7 @@
 #import "TestsController.h"
 #import "UIKitMacHelperSPI.h"
 #import <wtf/RetainPtr.h>
-
-#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
-#import <WebKit/WKProcessPoolPrivate.h>
-#endif
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 int main(int argc, char** argv)
 {
@@ -49,9 +46,7 @@ int main(int argc, char** argv)
 
         [[NSUserDefaults standardUserDefaults] setVolatileDomain:argumentDomain.get() forName:NSArgumentDomain];
 
-#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
-        [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
-#endif
+        enableAllSDKAlignedBehaviors();
 
         passed = TestWebKitAPI::TestsController::singleton().run(argc, argv);
     }

--- a/Tools/TestWebKitAPI/mac/mainMac.mm
+++ b/Tools/TestWebKitAPI/mac/mainMac.mm
@@ -26,10 +26,7 @@
 #import "config.h"
 #import "TestsController.h"
 #import <wtf/RetainPtr.h>
-
-#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
-#import <WebKit/WKProcessPoolPrivate.h>
-#endif
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 extern "C" void _BeginEventReceiptOnThread(void);
 
@@ -73,9 +70,7 @@ int main(int argc, char** argv)
         [argumentDomain addEntriesFromDictionary:argumentDefaults.get()];
         [[NSUserDefaults standardUserDefaults] setVolatileDomain:argumentDomain.get() forName:NSArgumentDomain];
 
-#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
-        [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
-#endif
+        enableAllSDKAlignedBehaviors();
 
         [NSApplication sharedApplication];
         _BeginEventReceiptOnThread(); // Makes window visibility notifications work (and possibly more).


### PR DESCRIPTION
#### a0fd5d4001d6218764302c111db468047bf80d1c
<pre>
Consistently enable SDK aligned behaviors when testing WTF, WGSL, and IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=291306">https://bugs.webkit.org/show_bug.cgi?id=291306</a>
<a href="https://rdar.apple.com/148547358">rdar://148547358</a>

Reviewed by Anne van Kesteren.

Otherwise we get inconsistent failures on some platforms, like
TestWTF.WTF_URLExtras.URLExtras_ParsingError and
TestWTF.WTF_URLExtras.URLExtras_Space on platforms that don&apos;t have
ConvertsInvalidURLsToNull.

I was using the SPI WKProcessPool._setLinkedOnOrAfterEverythingForTesting
which is only available for executables that link WebKit.  Now I use
enableAllSDKAlignedBehaviors directly, which does the exact same thing
but is available for all the test executables.

* Tools/TestWebKitAPI/cocoa/app/AppCommon.mm:
(TestWebKitAPI::initializeApp):
* Tools/TestWebKitAPI/mac/mainMac.mm:
(main):

Canonical link: <a href="https://commits.webkit.org/293464@main">https://commits.webkit.org/293464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba39fa27980e8c3756c14e968dfef673f3ec0c8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75350 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83808 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19801 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16099 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->