### PR TITLE
[Python CGI] datetime.datetime.utcnow and datetime.utcfromtimestamp are deprecated

### DIFF
--- a/LayoutTests/http/tests/blink/sendbeacon/resources/save-beacon.py
+++ b/LayoutTests/http/tests/blink/sendbeacon/resources/save-beacon.py
@@ -5,7 +5,7 @@ import re
 import sys
 import tempfile
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode, parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -72,7 +72,7 @@ beacon_file.close()
 os.rename(beacon_filename + '.tmp', beacon_filename)
 
 if 'dontclearcookies' not in query.keys():
-    expires = datetime.utcnow() - timedelta(seconds=60)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=60)
     for name in get_cookies().keys():
         sys.stdout.write('Set-Cookie: {}=deleted; expires={} GMT; Max-Age=0; path=/\r\n'.format(name, expires.strftime('%a, %d-%b-%Y %H:%M:%S')))
 

--- a/LayoutTests/http/tests/cache/post-redirect-get.py
+++ b/LayoutTests/http/tests/cache/post-redirect-get.py
@@ -4,7 +4,7 @@ import cgi
 import os
 import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 # This test loads an uncacheable main resource and a cacheable image subresource.
@@ -18,7 +18,7 @@ file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))
 
 request_method = os.environ.get('REQUEST_METHOD', '')
-expires = '{} +0000'.format((datetime.utcnow() - timedelta(seconds=1)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) - timedelta(seconds=1)).strftime('%a, %d %b %Y %H:%M:%S'))
 finish = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('finish', [''])[0]
 
 request = {}

--- a/LayoutTests/http/tests/cache/post-with-cached-subresources.py
+++ b/LayoutTests/http/tests/cache/post-with-cached-subresources.py
@@ -4,7 +4,7 @@ import cgi
 import os
 import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # This test loads an uncacheable main resource and a cacheable image subresource.
 # We request this page as a GET, then reload this page with a POST.
@@ -17,7 +17,7 @@ file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))
 
 request_method = os.environ.get('REQUEST_METHOD', '')
-exp_time = datetime.utcnow() - timedelta(seconds=1)
+exp_time = datetime.now(timezone.utc) - timedelta(seconds=1)
 
 sys.stdout.write(
     'Cache-Control: no-cache, no-store, must-revalidate, max-age=0\r\n'

--- a/LayoutTests/http/tests/cache/resources/cacheable-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/cacheable-iframe.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 max_age = 12 * 31 * 24 * 60 * 60
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     f'Cache-Control: public, max-age={max_age}\r\n'

--- a/LayoutTests/http/tests/cache/resources/iframe304.py
+++ b/LayoutTests/http/tests/cache/resources/iframe304.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')
 
@@ -13,8 +13,8 @@ if modified_since:
     sys.exit(0)
 
 one_year = 12 * 31 * 24 * 60 * 60
-last_modified = '{} +0000'.format((datetime.utcnow() - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+last_modified = '{} +0000'.format((datetime.now(timezone.utc) - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     f'Cache-Control: no-cache, max-age={one_year}\r\n'

--- a/LayoutTests/http/tests/cache/resources/post-image-to-verify.py
+++ b/LayoutTests/http/tests/cache/resources/post-image-to-verify.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -29,9 +29,9 @@ filemtime = stat.st_mtime
 filesize = stat.st_size
 
 etag = '"{}-{}"'.format(filesize, filemtime)
-last_modified = '{} +0000'.format(datetime.utcfromtimestamp(filemtime).strftime('%a, %d %b %Y %H:%M:%S'))
+last_modified = '{} +0000'.format(datetime.fromtimestamp(filemtime, timezone.utc).strftime('%a, %d %b %Y %H:%M:%S'))
 max_age = 12 * 31 * 24 * 60 * 60
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     'Cache-Control: public, max-age={}\r\n'

--- a/LayoutTests/http/tests/cache/resources/reload-main-resource-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/reload-main-resource-iframe.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))
@@ -26,8 +26,8 @@ file = open(tmpFile, 'w+')
 file.close()
 
 max_age = 12 * 31 * 24 * 60 * 60
-last_modified = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
+last_modified = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=max_age)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     f'Cache-Control: public, max-age={max_age}\r\n'

--- a/LayoutTests/http/tests/cache/resources/stylesheet304-bad-content-type.py
+++ b/LayoutTests/http/tests/cache/resources/stylesheet304-bad-content-type.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')
 if modified_since:
@@ -13,8 +13,8 @@ if modified_since:
     sys.exit(0)
 
 one_year = 12 * 31 * 24 * 60 * 60
-last_modified = '{} +0000'.format((datetime.utcnow() - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+last_modified = '{} +0000'.format((datetime.now(timezone.utc) - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     f'Cache-Control: public, max-age={one_year}\r\n'

--- a/LayoutTests/http/tests/cache/resources/x-frame-options.py
+++ b/LayoutTests/http/tests/cache/resources/x-frame-options.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')
 
@@ -13,8 +13,8 @@ if modified_since:
     sys.exit(0)
 
 one_year = 365 * 24 * 60 * 60
-last_modified = '{} +0000'.format((datetime.utcnow() - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
-expires = '{} +0000'.format((datetime.utcnow() + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+last_modified = '{} +0000'.format((datetime.now(timezone.utc) - timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
+expires = '{} +0000'.format((datetime.now(timezone.utc) + timedelta(seconds=one_year)).strftime('%a, %d %b %Y %H:%M:%S'))
 
 sys.stdout.write(
     'Cache-Control: no-cache, max-age={}\r\n'

--- a/LayoutTests/http/tests/contentextensions/resources/save_ping.py
+++ b/LayoutTests/http/tests/contentextensions/resources/save_ping.py
@@ -2,12 +2,12 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ping_file_path import ping_filepath
 
 def not_being_called():
     cookies = {}
-    expires = datetime.utcnow() - timedelta(seconds=60)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=60)
     if 'HTTP_COOKIE' in os.environ:
         header_cookies = os.environ['HTTP_COOKIE']
         header_cookies = header_cookies.split('; ')

--- a/LayoutTests/http/tests/cookies/multiple-redirect-and-set-cookie.py
+++ b/LayoutTests/http/tests/cookies/multiple-redirect-and-set-cookie.py
@@ -3,7 +3,7 @@
 import hashlib
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -12,7 +12,7 @@ sys.path.insert(0, http_root)
 
 from resources.portabilityLayer import get_cookies
 
-current_time = datetime.utcnow()
+current_time = datetime.now(timezone.utc)
 expires = current_time + timedelta(seconds=1)
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/cookies/resources/cookie-utility.py
+++ b/LayoutTests/http/tests/cookies/resources/cookie-utility.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -14,7 +14,7 @@ from resources.portabilityLayer import get_cookies
 cookies = get_cookies()
 
 def delete_cookie(name):
-    expires = datetime.utcnow() - timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=86400)
     sys.stdout.write('Set-Cookie: {}=deleted; expires={} GMT; Max-Age=0; SameSite=None; Secure; path=/\r\n'.format(name, expires.strftime('%a, %d-%b-%Y %H:%M:%S')))
 
 query_function = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('queryfunction', [''])[0]
@@ -33,7 +33,7 @@ elif query_function == 'deleteCookies':
     sys.exit(0)
     
 elif query_function == 'setFooCookie':
-    expires = datetime.utcnow() + timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
     sys.stdout.write(
         'Set-Cookie: foo=awesomevalue; expires={} GMT; Max-Age=86400; SameSite=None; Secure; path=/\r\n\r\n'
         'Set the foo cookie'.format(expires.strftime('%a, %d-%b-%Y %H:%M:%S'))
@@ -41,7 +41,7 @@ elif query_function == 'setFooCookie':
     sys.exit(0)
     
 elif query_function == 'setFooAndBarCookie':
-    expires = datetime.utcnow() + timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
     sys.stdout.write(
         'Set-Cookie: foo=awesomevalue; expires={expires} GMT; Max-Age=86400; SameSite=None; Secure; path=/\r\n'
         'Set-Cookie: bar=anotherawesomevalue; expires={expires} GMT; Max-Age=86400; SameSite=None; Secure; path=/\r\n\r\n'

--- a/LayoutTests/http/tests/cookies/resources/cookie_utilities.py
+++ b/LayoutTests/http/tests/cookies/resources/cookie_utilities.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))
@@ -16,7 +16,7 @@ def hostname_is_equal_to_string(hostname):
 
 
 def reset_cookies_for_current_origin():
-    expires = datetime.utcnow() - timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=86400)
     for cookie in get_cookies().keys():
         sys.stdout.write('Set-Cookie: {}=deleted; expires={} GMT; Max-Age=0; path=/\r\n'.format(cookie, expires.strftime('%a, %d-%b-%Y %H:%M:%S')))
 

--- a/LayoutTests/http/tests/cookies/resources/delete-cookie.py
+++ b/LayoutTests/http/tests/cookies/resources/delete-cookie.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -15,7 +15,7 @@ cookies = get_cookies()
 
 
 def delete_cookie(name):
-    expires = datetime.utcnow() - timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=86400)
     sys.stdout.write('Set-Cookie: {}=deleted; expires={} GMT; Max-Age=0; path=/\r\n'.format(name, expires.strftime('%a, %d-%b-%Y %H:%M:%S')))
 
 

--- a/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 redirect_back_to = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('redirectBackTo', [''])[0]
@@ -14,7 +14,7 @@ if parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('isP
 sys.stdout.write('Content-Type: text/html\r\n')
 
 if redirect_back_to:
-    expires = datetime.utcnow() + timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
     sys.stdout.write(
         'status: 302\r\n'
         'Set-Cookie: test_cookie=1; path=/; expires={} GMT; Max-Age=86400{}\r\n'

--- a/LayoutTests/http/tests/cookies/resources/set-cookie-on-redirect.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-on-redirect.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]
@@ -22,7 +22,7 @@ if step == 1:
     )
     
 elif step == 2:
-    expires = datetime.utcnow() + timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
     sys.stdout.write(
         'Set-Cookie: test_cookie=1; expires={} GMT; Max-Age=86400\r\n'
         'Location: http://localhost:8000/cookies/resources/set-cookie-on-redirect.py?step=3\r\n'
@@ -32,7 +32,7 @@ elif step == 2:
 elif step == 3:
     cookies = get_cookies()
     if cookies.get('test_cookie', None) is not None:
-        expires = datetime.utcnow() - timedelta(seconds=86400)
+        expires = datetime.now(timezone.utc) - timedelta(seconds=86400)
         sys.stdout.write(
             'Set-Cookie: test_cookie=deleted; expires={} GMT; Max-Age=0\r\n\r\n'
             'PASSED: Cookie successfully set\n'.format(expires.strftime('%a, %d-%b-%Y %H:%M:%S'))

--- a/LayoutTests/http/tests/cookies/resources/set-http-only-cookie.py
+++ b/LayoutTests/http/tests/cookies/resources/set-http-only-cookie.py
@@ -2,11 +2,11 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 cookie_name = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('cookieName', [''])[0]
-expires = datetime.utcnow() + timedelta(seconds=86400)
+expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
 
 sys.stdout.write('Content-Type: text/html\r\n')
 

--- a/LayoutTests/http/tests/inspector/page/resources/set-cookie.py
+++ b/LayoutTests/http/tests/inspector/page/resources/set-cookie.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
 name = query.get('name')[0]
 value = query.get('value')[0]
-exp_time = datetime.utcnow() + timedelta(hours=1)
+exp_time = datetime.now(timezone.utc) + timedelta(hours=1)
 
 sys.stdout.write(
     'Set-Cookie: {}={}; expires={} GMT; Max-Age=3600\r\n'

--- a/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
+++ b/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
@@ -5,7 +5,7 @@
 import os
 import sys
 from datetime import datetime
-from datetime import timedelta
+from datetime import timedelta, timezone
 from urllib.parse import parse_qs
 
 sys.stdout.write(
@@ -14,12 +14,12 @@ sys.stdout.write(
     'Last-Modified: {modified} GMT\r\n'
     'Pragma: no-cache\r\n'
     'Etag: "{size}-{mtime}"\r\n'
-    'Content-Type: application/x-mpegurl\r\n\r\n'.format(modified=datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S'), size=os.path.getsize(__file__), mtime=os.stat(__file__).st_mtime)
+    'Content-Type: application/x-mpegurl\r\n\r\n'.format(modified=datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S'), size=os.path.getsize(__file__), mtime=os.stat(__file__).st_mtime)
 )
 
 chunk_duration = 6.0272
 chunk_count = 5
-chunk_time = datetime.utcnow()
+chunk_time = datetime.now(timezone.utc)
 
 sys.stdout.write(
     '#EXTM3U\n'

--- a/LayoutTests/http/tests/media/resources/hls/generate-vod.py
+++ b/LayoutTests/http/tests/media/resources/hls/generate-vod.py
@@ -4,11 +4,11 @@
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
-last_modified = datetime.utcnow()
+last_modified = datetime.now(timezone.utc)
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/media/resources/hls/sub-playlist-with-cookie.py
+++ b/LayoutTests/http/tests/media/resources/hls/sub-playlist-with-cookie.py
@@ -4,7 +4,7 @@
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 sys.stdout.write(
     'status: 200\r\n'
@@ -24,10 +24,10 @@ sys.stdout.write(
     '#EXTM3U\n'
     '#EXT-X-TARGETDURATION:7\n'
     '#EXT-X-VERSION:4\n'
-    '#EXT-X-MEDIA-SEQUENCE:{}\n'.format(int(datetime.utcnow().timestamp() / chunk_duration) % 100)
+    '#EXT-X-MEDIA-SEQUENCE:{}\n'.format(int(datetime.now(timezone.utc).timestamp() / chunk_duration) % 100)
 )
 
-time = datetime.utcnow()
+time = datetime.now(timezone.utc)
 time = time.timestamp() - time.timestamp() % chunk_duration
 
 for _ in range(0, chunk_count):

--- a/LayoutTests/http/tests/media/resources/hls/test-live.py
+++ b/LayoutTests/http/tests/media/resources/hls/test-live.py
@@ -4,11 +4,11 @@
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
-last_modified = datetime.utcnow()
+last_modified = datetime.now(timezone.utc)
 
 sys.stdout.write(
     'status: 200\r\n'
@@ -35,10 +35,10 @@ sys.stdout.write(
     '#EXTM3U\n'
     '#EXT-X-TARGETDURATION:7\n'
     '#EXT-X-VERSION:4\n'
-    '#EXT-X-MEDIA-SEQUENCE:{}\n'.format(int(datetime.utcnow().timestamp() / chunk_duration) % 100)
+    '#EXT-X-MEDIA-SEQUENCE:{}\n'.format(int(datetime.now(timezone.utc).timestamp() / chunk_duration) % 100)
 )
 
-time = datetime.utcnow()
+time = datetime.now(timezone.utc)
 time = time.timestamp() - time.timestamp() % chunk_duration
 
 for _ in range(0, chunk_count):

--- a/LayoutTests/http/tests/media/resources/serve_video.py
+++ b/LayoutTests/http/tests/media/resources/serve_video.py
@@ -10,7 +10,7 @@ import math
 import os
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import parse_qs
 
 https = os.environ.get('HTTPS', None)
@@ -69,7 +69,7 @@ def answering():
         sys.stdout.flush()
         sys.exit(0)
 
-    last_modified = datetime.utcnow()
+    last_modified = datetime.now(timezone.utc)
     sys.stdout.write(
         'Last-Modified: {} GMT\r\n'
         'Cache-Control: no-cache\r\n'

--- a/LayoutTests/http/tests/misc/resources/prefetch-purpose.py
+++ b/LayoutTests/http/tests/misc/resources/prefetch-purpose.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))
@@ -19,7 +19,7 @@ cookies = get_cookies()
 purpose = cookies.get('Purpose', None)
 
 if purpose is not None:
-    expires= datetime.utcnow() - timedelta(seconds=3600)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=3600)
     sys.stdout.write(
         'Set-Cookie: Purpose=deleted, expires={} GMT; Max-Age=0\r\n\r\n'
         '<h1>The cookie was set!</h1>'

--- a/LayoutTests/http/tests/navigation/resources/save_ping.py
+++ b/LayoutTests/http/tests/navigation/resources/save_ping.py
@@ -2,13 +2,13 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ping_file_path import ping_filepath
 
 
 def not_being_called():
     cookies = {}
-    expires = datetime.utcnow() - timedelta(seconds=60)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=60)
     if 'HTTP_COOKIE' in os.environ:
         header_cookies = os.environ['HTTP_COOKIE']
         header_cookies = header_cookies.split('; ')

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-all-kinds-of-cookies.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-all-kinds-of-cookies.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-expires = datetime.utcnow() + timedelta(seconds=300)
+expires = datetime.now(timezone.utc) + timedelta(seconds=300)
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie-on-redirect.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie-on-redirect.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 step = int(parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('step', [0])[0])
@@ -15,7 +15,7 @@ if step == 1:
         'Location: http://localhost:8000/cookies/resources/set-cookie-on-redirect.py?step=2\r\n\r\n'
     )
 elif step == 2:
-    expires = datetime.utcnow() + timedelta(seconds=86400)
+    expires = datetime.now(timezone.utc) + timedelta(seconds=86400)
     sys.stdout.write(
         'status: 302\r\n'
         'Set-Cookie: test_cookie=1; expires={} GMT; Max-Age=86400\r\n'
@@ -33,7 +33,7 @@ elif step == 3:
 
     sys.stdout.write('status: 200\r\n')
     if cookies.get('test_cookie', None) is not None:
-        expires = datetime.utcnow() - timedelta(seconds=86400)
+        expires = datetime.now(timezone.utc) - timedelta(seconds=86400)
         sys.stdout.write(
             'Set-Cookie: text_cookie=deleted; expires={} GMT; Max-Age=0\r\n\r\n'
             'PASSED: Cookie successfully set\n'.format(expires.strftime('%a, %d-%b-%Y %H:%M:%S'))

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
@@ -14,7 +14,7 @@ partitioned = ""
 if isPartitioned is not None and isPartitioned:
     partitioned = "Partitioned; "
 
-expires = datetime.utcnow() + timedelta(seconds=60*60*24*30)
+expires = datetime.now(timezone.utc) + timedelta(seconds=60*60*24*30)
 
 sys.stdout.write(
     'Set-Cookie: {name}={value}; expires={expires} GMT; Max-Age=2592000; SameSite=None; Secure; {partitioned}path=/\r\n'

--- a/LayoutTests/http/tests/resources/network-simulator.py
+++ b/LayoutTests/http/tests/resources/network-simulator.py
@@ -8,7 +8,7 @@ import re
 import sys
 import tempfile
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from portabilityLayer import get_state, set_state
 from urllib.parse import parse_qs
 
@@ -84,7 +84,7 @@ def generate_response(path, range_start=None, range_end=None):
             time.sleep(initial_delay / 1000)
 
         if os.path.isfile(path):
-            sys.stdout.write('Last-Modified: {} GMT\r\n'.format(datetime.utcfromtimestamp(os.stat(path).st_mtime).strftime('%a, %d %b %Y %H:%M:%S')))
+            sys.stdout.write('Last-Modified: {} GMT\r\n'.format(datetime.fromtimestamp(os.stat(path).st_mtime, timezone.utc).strftime('%a, %d %b %Y %H:%M:%S')))
 
             file_len = os.path.getsize(path)
             if range_start is not None or range_end is not None:

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save_report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save_report.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from report_file_path import report_filepath
 
 file = __file__.split(':/cygwin')[-1]
@@ -14,7 +14,7 @@ from resources.portabilityLayer import get_cookies
 
 def not_being_called():
     cookies = get_cookies()
-    expires = datetime.utcnow() - timedelta(seconds=60)
+    expires = datetime.now(timezone.utc) - timedelta(seconds=60)
     for cookie in cookies.keys():
         sys.stdout.write('Set-Cookie: {}=deleted; expires={} GMT; Max-Age=0; path=/\r\n'.format(cookie, expires.strftime('%a, %d-%b-%Y %H:%M:%S')))
 

--- a/LayoutTests/http/tests/storageAccess/resources/set-cookie.py
+++ b/LayoutTests/http/tests/storageAccess/resources/set-cookie.py
@@ -9,7 +9,7 @@ query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
 name = query.get('name', [''])[0]
 value = query.get('value', [''])[0]
 message = query.get('message', [''])[0]
-exp_time = datetime.utcnow() + timedelta(days=30)
+exp_time = datetime.now(timezone.utc) + timedelta(days=30)
 
 sys.stdout.write(
     'Set-Cookie: {}={}; expires={} GMT; Max-Age={}; SameSite=None; Secure; path=/\r\n'

--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py
@@ -3,12 +3,12 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 clear = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('clear', [None])[0]
-clear_exp_time = datetime.utcnow() - timedelta(seconds=1)
-exp_time = datetime.utcnow() + timedelta(hours=1)
+clear_exp_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+exp_time = datetime.now(timezone.utc) + timedelta(hours=1)
 
 if clear:
     sys.stdout.write(

--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies.py
@@ -2,13 +2,13 @@
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 clear = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('clear', [None])[0]
-clear_exp_time = datetime.utcnow() - timedelta(seconds=1)
-clear_exp_time_httponly = datetime.utcnow() - timedelta(seconds=1000)
-exp_time = datetime.utcnow() + timedelta(hours=1)
+clear_exp_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+clear_exp_time_httponly = datetime.now(timezone.utc) - timedelta(seconds=1000)
+exp_time = datetime.now(timezone.utc) + timedelta(hours=1)
 
 if clear:
     sys.stdout.write(


### PR DESCRIPTION
#### f32092ad8f903763043eedc8b8bab1fb972ef175
<pre>
[Python CGI] datetime.datetime.utcnow and datetime.utcfromtimestamp are deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=291303">https://bugs.webkit.org/show_bug.cgi?id=291303</a>

Reviewed by Sam Sneddon.

datetime.utcnow() and datetime.utcfromtimestamp(timestamp) are
deprecated.
&lt;<a href="https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow">https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow</a>&gt;
&lt;<a href="https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp">https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp</a>&gt;

Replaced them with datetime.now(timezone.utc) and
datetime.fromtimestamp(timestamp, timezone.utc).

* LayoutTests/http/tests/blink/sendbeacon/resources/save-beacon.py:
* LayoutTests/http/tests/cache/post-redirect-get.py:
* LayoutTests/http/tests/cache/post-with-cached-subresources.py:
* LayoutTests/http/tests/cache/resources/cacheable-iframe.py:
* LayoutTests/http/tests/cache/resources/iframe304.py:
* LayoutTests/http/tests/cache/resources/post-image-to-verify.py:
* LayoutTests/http/tests/cache/resources/reload-main-resource-iframe.py:
* LayoutTests/http/tests/cache/resources/stylesheet304-bad-content-type.py:
* LayoutTests/http/tests/cache/resources/x-frame-options.py:
* LayoutTests/http/tests/contentextensions/resources/save_ping.py:
(not_being_called):
(save_ping):
* LayoutTests/http/tests/cookies/multiple-redirect-and-set-cookie.py:
* LayoutTests/http/tests/cookies/resources/cookie-utility.py:
(delete_cookie):
* LayoutTests/http/tests/cookies/resources/cookie_utilities.py:
(reset_cookies_for_current_origin):
* LayoutTests/http/tests/cookies/resources/delete-cookie.py:
(delete_cookie):
* LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py:
* LayoutTests/http/tests/cookies/resources/set-cookie-on-redirect.py:
* LayoutTests/http/tests/cookies/resources/set-http-only-cookie.py:
* LayoutTests/http/tests/inspector/page/resources/set-cookie.py:
* LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py:
* LayoutTests/http/tests/media/resources/hls/generate-vod.py:
* LayoutTests/http/tests/media/resources/hls/sub-playlist-with-cookie.py:
* LayoutTests/http/tests/media/resources/hls/test-live.py:
* LayoutTests/http/tests/media/resources/serve_video.py:
(answering):
* LayoutTests/http/tests/misc/resources/prefetch-purpose.py:
* LayoutTests/http/tests/navigation/resources/save_ping.py:
(not_being_called):
* LayoutTests/http/tests/resourceLoadStatistics/resources/set-all-kinds-of-cookies.py:
* LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie-on-redirect.py:
* LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie.py:
* LayoutTests/http/tests/resources/network-simulator.py:
(generate_response):
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/save_report.py:
(not_being_called):
* LayoutTests/http/tests/storageAccess/resources/set-cookie.py:
* LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py:
* LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies.py:

Canonical link: <a href="https://commits.webkit.org/293480@main">https://commits.webkit.org/293480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe8d111da33dbff472b37b0004fe531d5536b8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98983 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75351 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32478 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106478 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83816 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19807 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16106 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26033 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->