### PR TITLE
Web Inspector: Debugger: add a way to step over `await` as though it was sync code

### DIFF
--- a/LayoutTests/inspector/debugger/resources/stepping-async.js
+++ b/LayoutTests/inspector/debugger/resources/stepping-async.js
@@ -1,0 +1,195 @@
+async function a() { return "a"; }
+async function b() { return "b"; }
+async function c() { return "c"; }
+
+async function testStatements() {
+    debugger;
+    let x = await 1;
+    let y = await 2;
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testFunctions() {
+    debugger;
+    let before = await 1;
+    await a();
+    let after = await 2;
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testEval() {
+    debugger;
+    let before = await 1;
+    await eval("1 + 1");
+    let after = await 2;
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testAnonymousFunction() {
+    await (async function() {
+        debugger;
+        let inner = await 1;
+    })();
+    let outer = await 2;
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testCommas() {
+    debugger;
+    let x = await 1,
+        y = await 2,
+        z = await 3;
+    await a(), await b(), await c();
+    await true && (await a(), await b(), await c()) && await true;
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testChainedExpressions() {
+    debugger;
+    await a() && await b() && await c();
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testDeclarations() {
+    debugger;
+    let x = await a(),
+        y = await b(),
+        z = await c();
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testInnerFunction() {
+    async function alpha() {
+        await beta();
+    }
+    async function beta() {
+        debugger;
+    }
+    await alpha();
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testFor() {
+    debugger;
+    for await (let item of [a(), b()]) {
+        c();
+    }
+    TestPage.dispatchEventToFrontend("done");
+}
+
+async function testRepeatedInvocation() {
+    async function wrap(state) {
+        if (state === 2)
+            debugger;
+        if (state === 1)
+            await a(); // should not pause on this line
+        await b();
+        if (state === 1)
+            await c(); // should not pause on this line
+        if (state === 2)
+            TestPage.dispatchEventToFrontend("done");
+    }
+
+    wrap(1);
+    wrap(2);
+}
+
+TestPage.registerInitializer(() => {
+    InspectorTest.SteppingAsync = {};
+
+    InspectorTest.SteppingAsync.run = function(name) {
+        let suite = InspectorTest.createAsyncSuite(name);
+
+        function addTestCase({name, expression}) {
+            suite.addTestCase({
+                name,
+                test(resolve, reject) {
+                    let done = false;
+                    let paused = false;
+
+                    let pausedListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, (event) => {
+                        InspectorTest.log(`PAUSED (${WI.debuggerManager.dataForTarget(WI.debuggerManager.activeCallFrame.target).pauseReason})`);
+                        paused = true;
+                    });
+
+                    let resumeListener = WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Resumed, (event) => {
+                        InspectorTest.log("RESUMED");
+                        paused = false;
+
+                        if (done) {
+                            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+                            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Resumed, resumeListener);
+                            resolve();
+                        }
+                    });
+
+                    InspectorTest.singleFireEventListener("done", (event) => {
+                        done = true;
+
+                        if (!paused) {
+                            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Paused, pausedListener);
+                            WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.Resumed, resumeListener);
+                            resolve();
+                        }
+                    });
+
+                    InspectorTest.evaluateInPage(expression).catch(reject);
+                },
+            });
+        }
+
+        addTestCase({
+            name: name + ".statements",
+            expression: "setTimeout(testStatements)",
+        });
+
+        addTestCase({
+            name: name + ".functions",
+            expression: "setTimeout(testFunctions)",
+        });
+
+        addTestCase({
+            name: name + ".eval",
+            expression: "setTimeout(testEval)",
+        });
+
+        addTestCase({
+            name: name + ".anonymousFunction",
+            expression: "setTimeout(testAnonymousFunction)",
+        });
+
+        addTestCase({
+            name: name + ".commas",
+            expression: "setTimeout(testCommas)",
+        });
+
+        addTestCase({
+            name: name + ".chainedExpressions",
+            expression: "setTimeout(testChainedExpressions)",
+        });
+
+        addTestCase({
+            name: name + ".declarations",
+            expression: "setTimeout(testDeclarations)",
+        });
+
+        addTestCase({
+            name: name + ".innerFunction",
+            expression: "setTimeout(testInnerFunction)",
+        });
+
+        addTestCase({
+            name: name + ".testFor",
+            expression: "setTimeout(testFor)",
+        });
+
+        addTestCase({
+            name: name + ".testRepeatedInvocation",
+            expression: "setTimeout(testRepeatedInvocation)",
+        });
+
+        loadLinesFromSourceCode(findScript(/\/inspector\/debugger\/resources\/stepping-async\.js$/)).then(() => {
+            suite.runTestCasesAndFinish();
+        });
+    };
+});

--- a/LayoutTests/inspector/debugger/stepping/stepInto-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepInto-await-expected.txt
@@ -1,0 +1,338 @@
+Checking pause locations when stepping with "stepInto".
+
+
+== Running test suite: Debugger.stepInto.await
+-- Running test case: Debugger.stepInto.await.statements
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:6:5
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+ ->   5        |debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:7:5
+      3
+      4    async function testStatements() {
+      5        debugger;
+ ->   6        |let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+      9    }
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.functions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:13:5
+      9    }
+     10
+     11    async function testFunctions() {
+ ->  12        |debugger;
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+
+PAUSE AT <anonymous>:14:5
+     10
+     11    async function testFunctions() {
+     12        debugger;
+ ->  13        |let before = await 1;
+     14        await a();
+     15        let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.eval
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:21:5
+     17    }
+     18
+     19    async function testEval() {
+ ->  20        |debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+
+PAUSE AT <anonymous>:22:5
+     18
+     19    async function testEval() {
+     20        debugger;
+ ->  21        |let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.anonymousFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:30:9
+     26
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+ ->  29            |debugger;
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+
+PAUSE AT <anonymous>:31:9
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+     29            debugger;
+ ->  30            |let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+     33        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.commas
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:38:5
+     34    }
+     35
+     36    async function testCommas() {
+ ->  37        |debugger;
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+
+PAUSE AT <anonymous>:39:5
+     35
+     36    async function testCommas() {
+     37        debugger;
+ ->  38        |let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.chainedExpressions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:48:5
+     44    }
+     45
+     46    async function testChainedExpressions() {
+ ->  47        |debugger;
+     48        await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+
+PAUSE AT <anonymous>:49:5
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        |await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+PAUSE AT a:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:22
+ ->   0    async function a() { |return "a"; }
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.declarations
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:54:5
+     50    }
+     51
+     52    async function testDeclarations() {
+ ->  53        |debugger;
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+
+PAUSE AT <anonymous>:55:5
+     51
+     52    async function testDeclarations() {
+     53        debugger;
+ ->  54        |let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT a:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:22
+ ->   0    async function a() { |return "a"; }
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.innerFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:66:9
+     62            await beta();
+     63        }
+     64        async function beta() {
+ ->  65            |debugger;
+     66        }
+     67        await alpha();
+     68        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.testFor
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:73:5
+     69    }
+     70
+     71    async function testFor() {
+ ->  72        |debugger;
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+
+PAUSE AT <anonymous>:74:28
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (let item of |[a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT a:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:22
+ ->   0    async function a() { |return "a"; }
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:1:35
+ ->   0    async function a() { return "a"; }|
+      1    async function b() { return "b"; }
+      2    async function c() { return "c"; }
+      3
+
+PAUSE AT <anonymous>:74:34
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (let item of [a(), |b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT b:2:35
+      0    async function a() { return "a"; }
+ ->   1    async function b() { return "b"; }|
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+PAUSE AT <anonymous>:2:22
+      0    async function a() { return "a"; }
+ ->   1    async function b() { |return "b"; }
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+PAUSE AT <anonymous>:2:35
+      0    async function a() { return "a"; }
+ ->   1    async function b() { return "b"; }|
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepInto.await.testRepeatedInvocation
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:83:13
+     79    async function testRepeatedInvocation() {
+     80        async function wrap(state) {
+     81            if (state === 2)
+ ->  82                |debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+
+PAUSE AT <anonymous>:84:13
+     80        async function wrap(state) {
+     81            if (state === 2)
+     82                debugger;
+ ->  83            if (|state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+     86            if (state === 1)
+
+PAUSE AT <anonymous>:86:9
+     82                debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+ ->  85            |await b();
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+
+PAUSE AT b:2:35
+      0    async function a() { return "a"; }
+ ->   1    async function b() { return "b"; }|
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+PAUSE AT <anonymous>:2:22
+      0    async function a() { return "a"; }
+ ->   1    async function b() { |return "b"; }
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+PAUSE AT <anonymous>:2:35
+      0    async function a() { return "a"; }
+ ->   1    async function b() { return "b"; }|
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+
+RESUMED
+

--- a/LayoutTests/inspector/debugger/stepping/stepInto-await.html
+++ b/LayoutTests/inspector/debugger/stepping/stepInto-await.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../resources/log-pause-location.js"></script>
+<script src="../resources/stepping-async.js"></script>
+<script>
+function test()
+{
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepInto();
+    });
+
+    InspectorTest.SteppingAsync.run("Debugger.stepInto.await");
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Checking pause locations when stepping with "stepInto".</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt
@@ -1,0 +1,608 @@
+Checking pause locations when stepping with "stepNext".
+
+
+== Running test suite: Debugger.stepNext.await
+-- Running test case: Debugger.stepNext.await.statements
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:6:5
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+ ->   5        |debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:7:5
+      3
+      4    async function testStatements() {
+      5        debugger;
+ ->   6        |let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+      9    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:8:5
+      4    async function testStatements() {
+      5        debugger;
+      6        let x = await 1;
+ ->   7        |let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+      9    }
+     10
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:9:5
+      5        debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+ ->   8        |TestPage.dispatchEventToFrontend("done");
+      9    }
+     10
+     11    async function testFunctions() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.functions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:13:5
+      9    }
+     10
+     11    async function testFunctions() {
+ ->  12        |debugger;
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+
+PAUSE AT <anonymous>:14:5
+     10
+     11    async function testFunctions() {
+     12        debugger;
+ ->  13        |let before = await 1;
+     14        await a();
+     15        let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:15:5
+     11    async function testFunctions() {
+     12        debugger;
+     13        let before = await 1;
+ ->  14        |await a();
+     15        let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+     17    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:16:5
+     12        debugger;
+     13        let before = await 1;
+     14        await a();
+ ->  15        |let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+     17    }
+     18
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:17:5
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+ ->  16        |TestPage.dispatchEventToFrontend("done");
+     17    }
+     18
+     19    async function testEval() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.eval
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:21:5
+     17    }
+     18
+     19    async function testEval() {
+ ->  20        |debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+
+PAUSE AT <anonymous>:22:5
+     18
+     19    async function testEval() {
+     20        debugger;
+ ->  21        |let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:23:5
+     19    async function testEval() {
+     20        debugger;
+     21        let before = await 1;
+ ->  22        |await eval("1 + 1");
+     23        let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+     25    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:24:5
+     20        debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+ ->  23        |let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+     25    }
+     26
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:25:5
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+ ->  24        |TestPage.dispatchEventToFrontend("done");
+     25    }
+     26
+     27    async function testAnonymousFunction() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.anonymousFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:30:9
+     26
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+ ->  29            |debugger;
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+
+PAUSE AT <anonymous>:31:9
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+     29            debugger;
+ ->  30            |let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+     33        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:33:5
+     29            debugger;
+     30            let inner = await 1;
+     31        })();
+ ->  32        |let outer = await 2;
+     33        TestPage.dispatchEventToFrontend("done");
+     34    }
+     35
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:34:5
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+ ->  33        |TestPage.dispatchEventToFrontend("done");
+     34    }
+     35
+     36    async function testCommas() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.commas
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:38:5
+     34    }
+     35
+     36    async function testCommas() {
+ ->  37        |debugger;
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+
+PAUSE AT <anonymous>:39:5
+     35
+     36    async function testCommas() {
+     37        debugger;
+ ->  38        |let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:40:9
+     36    async function testCommas() {
+     37        debugger;
+     38        let x = await 1,
+ ->  39            |y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:41:9
+     37        debugger;
+     38        let x = await 1,
+     39            y = await 2,
+ ->  40            |z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:5
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        |await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:16
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        await a(), |await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:27
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        await a(), await b(), |await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:5
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        |await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:20
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (|await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:31
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (await a(), |await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:42
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (await a(), await b(), |await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:44:5
+     40            z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+ ->  43        |TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+     46    async function testChainedExpressions() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.chainedExpressions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:48:5
+     44    }
+     45
+     46    async function testChainedExpressions() {
+ ->  47        |debugger;
+     48        await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+
+PAUSE AT <anonymous>:49:5
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        |await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:49:24
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        await a() && await |b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:49:37
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        await a() && await b() && await |c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:50:5
+     46    async function testChainedExpressions() {
+     47        debugger;
+     48        await a() && await b() && await c();
+ ->  49        |TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+     52    async function testDeclarations() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.declarations
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:54:5
+     50    }
+     51
+     52    async function testDeclarations() {
+ ->  53        |debugger;
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+
+PAUSE AT <anonymous>:55:5
+     51
+     52    async function testDeclarations() {
+     53        debugger;
+ ->  54        |let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:56:9
+     52    async function testDeclarations() {
+     53        debugger;
+     54        let x = await a(),
+ ->  55            |y = await b(),
+     56            z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+     58    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:57:9
+     53        debugger;
+     54        let x = await a(),
+     55            y = await b(),
+ ->  56            |z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+     58    }
+     59
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:58:5
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+ ->  57        |TestPage.dispatchEventToFrontend("done");
+     58    }
+     59
+     60    async function testInnerFunction() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.innerFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:66:9
+     62            await beta();
+     63        }
+     64        async function beta() {
+ ->  65            |debugger;
+     66        }
+     67        await alpha();
+     68        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.testFor
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:73:5
+     69    }
+     70
+     71    async function testFor() {
+ ->  72        |debugger;
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+
+PAUSE AT <anonymous>:74:28
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (let item of |[a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:74:34
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (let item of [a(), |b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:75:9
+     71    async function testFor() {
+     72        debugger;
+     73        for await (let item of [a(), b()]) {
+ ->  74            |c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+     77    }
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:75:9
+     71    async function testFor() {
+     72        debugger;
+     73        for await (let item of [a(), b()]) {
+ ->  74            |c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+     77    }
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:77:5
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+ ->  76        |TestPage.dispatchEventToFrontend("done");
+     77    }
+     78
+     79    async function testRepeatedInvocation() {
+
+RESUMED
+
+-- Running test case: Debugger.stepNext.await.testRepeatedInvocation
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:83:13
+     79    async function testRepeatedInvocation() {
+     80        async function wrap(state) {
+     81            if (state === 2)
+ ->  82                |debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+
+PAUSE AT <anonymous>:84:13
+     80        async function wrap(state) {
+     81            if (state === 2)
+     82                debugger;
+ ->  83            if (|state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+     86            if (state === 1)
+
+PAUSE AT <anonymous>:86:9
+     82                debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+ ->  85            |await b();
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:87:13
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+ ->  86            if (|state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+     89                TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:89:13
+     85            await b();
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+ ->  88            if (|state === 2)
+     89                TestPage.dispatchEventToFrontend("done");
+     90        }
+     91
+
+PAUSE AT <anonymous>:90:13
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+ ->  89                |TestPage.dispatchEventToFrontend("done");
+     90        }
+     91
+     92        wrap(1);
+
+RESUMED
+

--- a/LayoutTests/inspector/debugger/stepping/stepNext-await.html
+++ b/LayoutTests/inspector/debugger/stepping/stepNext-await.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../resources/log-pause-location.js"></script>
+<script src="../resources/stepping-async.js"></script>
+<script>
+function test()
+{
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepNext();
+    });
+
+    InspectorTest.SteppingAsync.run("Debugger.stepNext.await");
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Checking pause locations when stepping with "stepNext".</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/stepping/stepOut-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepOut-await-expected.txt
@@ -1,0 +1,134 @@
+Checking pause locations when stepping with "stepOut".
+
+
+== Running test suite: Debugger.stepOut.await
+-- Running test case: Debugger.stepOut.await.statements
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:6:5
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+ ->   5        |debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.functions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:13:5
+      9    }
+     10
+     11    async function testFunctions() {
+ ->  12        |debugger;
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.eval
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:21:5
+     17    }
+     18
+     19    async function testEval() {
+ ->  20        |debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.anonymousFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:30:9
+     26
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+ ->  29            |debugger;
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.commas
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:38:5
+     34    }
+     35
+     36    async function testCommas() {
+ ->  37        |debugger;
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.chainedExpressions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:48:5
+     44    }
+     45
+     46    async function testChainedExpressions() {
+ ->  47        |debugger;
+     48        await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.declarations
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:54:5
+     50    }
+     51
+     52    async function testDeclarations() {
+ ->  53        |debugger;
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.innerFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:66:9
+     62            await beta();
+     63        }
+     64        async function beta() {
+ ->  65            |debugger;
+     66        }
+     67        await alpha();
+     68        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.testFor
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:73:5
+     69    }
+     70
+     71    async function testFor() {
+ ->  72        |debugger;
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+
+RESUMED
+
+-- Running test case: Debugger.stepOut.await.testRepeatedInvocation
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:83:13
+     79    async function testRepeatedInvocation() {
+     80        async function wrap(state) {
+     81            if (state === 2)
+ ->  82                |debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+
+RESUMED
+

--- a/LayoutTests/inspector/debugger/stepping/stepOut-await.html
+++ b/LayoutTests/inspector/debugger/stepping/stepOut-await.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../resources/log-pause-location.js"></script>
+<script src="../resources/stepping-async.js"></script>
+<script>
+function test()
+{
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepOut();
+    });
+
+    InspectorTest.SteppingAsync.run("Debugger.stepOut.await");
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Checking pause locations when stepping with "stepOut".</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt
@@ -1,0 +1,599 @@
+Checking pause locations when stepping with "stepOver".
+
+
+== Running test suite: Debugger.stepOver.await
+-- Running test case: Debugger.stepOver.await.statements
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:6:5
+      2    async function c() { return "c"; }
+      3
+      4    async function testStatements() {
+ ->   5        |debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:7:5
+      3
+      4    async function testStatements() {
+      5        debugger;
+ ->   6        |let x = await 1;
+      7        let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+      9    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:8:5
+      4    async function testStatements() {
+      5        debugger;
+      6        let x = await 1;
+ ->   7        |let y = await 2;
+      8        TestPage.dispatchEventToFrontend("done");
+      9    }
+     10
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:9:5
+      5        debugger;
+      6        let x = await 1;
+      7        let y = await 2;
+ ->   8        |TestPage.dispatchEventToFrontend("done");
+      9    }
+     10
+     11    async function testFunctions() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.functions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:13:5
+      9    }
+     10
+     11    async function testFunctions() {
+ ->  12        |debugger;
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+
+PAUSE AT <anonymous>:14:5
+     10
+     11    async function testFunctions() {
+     12        debugger;
+ ->  13        |let before = await 1;
+     14        await a();
+     15        let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:15:5
+     11    async function testFunctions() {
+     12        debugger;
+     13        let before = await 1;
+ ->  14        |await a();
+     15        let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+     17    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:16:5
+     12        debugger;
+     13        let before = await 1;
+     14        await a();
+ ->  15        |let after = await 2;
+     16        TestPage.dispatchEventToFrontend("done");
+     17    }
+     18
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:17:5
+     13        let before = await 1;
+     14        await a();
+     15        let after = await 2;
+ ->  16        |TestPage.dispatchEventToFrontend("done");
+     17    }
+     18
+     19    async function testEval() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.eval
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:21:5
+     17    }
+     18
+     19    async function testEval() {
+ ->  20        |debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+
+PAUSE AT <anonymous>:22:5
+     18
+     19    async function testEval() {
+     20        debugger;
+ ->  21        |let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:23:5
+     19    async function testEval() {
+     20        debugger;
+     21        let before = await 1;
+ ->  22        |await eval("1 + 1");
+     23        let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+     25    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:24:5
+     20        debugger;
+     21        let before = await 1;
+     22        await eval("1 + 1");
+ ->  23        |let after = await 2;
+     24        TestPage.dispatchEventToFrontend("done");
+     25    }
+     26
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:25:5
+     21        let before = await 1;
+     22        await eval("1 + 1");
+     23        let after = await 2;
+ ->  24        |TestPage.dispatchEventToFrontend("done");
+     25    }
+     26
+     27    async function testAnonymousFunction() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.anonymousFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:30:9
+     26
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+ ->  29            |debugger;
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+
+PAUSE AT <anonymous>:31:9
+     27    async function testAnonymousFunction() {
+     28        await (async function() {
+     29            debugger;
+ ->  30            |let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+     33        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:33:5
+     29            debugger;
+     30            let inner = await 1;
+     31        })();
+ ->  32        |let outer = await 2;
+     33        TestPage.dispatchEventToFrontend("done");
+     34    }
+     35
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:34:5
+     30            let inner = await 1;
+     31        })();
+     32        let outer = await 2;
+ ->  33        |TestPage.dispatchEventToFrontend("done");
+     34    }
+     35
+     36    async function testCommas() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.commas
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:38:5
+     34    }
+     35
+     36    async function testCommas() {
+ ->  37        |debugger;
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+
+PAUSE AT <anonymous>:39:5
+     35
+     36    async function testCommas() {
+     37        debugger;
+ ->  38        |let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:40:9
+     36    async function testCommas() {
+     37        debugger;
+     38        let x = await 1,
+ ->  39            |y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:41:9
+     37        debugger;
+     38        let x = await 1,
+     39            y = await 2,
+ ->  40            |z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:5
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        |await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:16
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        await a(), |await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:42:27
+     38        let x = await 1,
+     39            y = await 2,
+     40            z = await 3;
+ ->  41        await a(), await b(), |await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:5
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        |await true && (await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:20
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (|await a(), await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:31
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (await a(), |await b(), await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:43:42
+     39            y = await 2,
+     40            z = await 3;
+     41        await a(), await b(), await c();
+ ->  42        await true && (await a(), await b(), |await c()) && await true;
+     43        TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:44:5
+     40            z = await 3;
+     41        await a(), await b(), await c();
+     42        await true && (await a(), await b(), await c()) && await true;
+ ->  43        |TestPage.dispatchEventToFrontend("done");
+     44    }
+     45
+     46    async function testChainedExpressions() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.chainedExpressions
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:48:5
+     44    }
+     45
+     46    async function testChainedExpressions() {
+ ->  47        |debugger;
+     48        await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+
+PAUSE AT <anonymous>:49:5
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        |await a() && await b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:49:24
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        await a() && await |b() && await c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:49:37
+     45
+     46    async function testChainedExpressions() {
+     47        debugger;
+ ->  48        await a() && await b() && await |c();
+     49        TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:50:5
+     46    async function testChainedExpressions() {
+     47        debugger;
+     48        await a() && await b() && await c();
+ ->  49        |TestPage.dispatchEventToFrontend("done");
+     50    }
+     51
+     52    async function testDeclarations() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.declarations
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:54:5
+     50    }
+     51
+     52    async function testDeclarations() {
+ ->  53        |debugger;
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+
+PAUSE AT <anonymous>:55:5
+     51
+     52    async function testDeclarations() {
+     53        debugger;
+ ->  54        |let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:56:9
+     52    async function testDeclarations() {
+     53        debugger;
+     54        let x = await a(),
+ ->  55            |y = await b(),
+     56            z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+     58    }
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:57:9
+     53        debugger;
+     54        let x = await a(),
+     55            y = await b(),
+ ->  56            |z = await c();
+     57        TestPage.dispatchEventToFrontend("done");
+     58    }
+     59
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:58:5
+     54        let x = await a(),
+     55            y = await b(),
+     56            z = await c();
+ ->  57        |TestPage.dispatchEventToFrontend("done");
+     58    }
+     59
+     60    async function testInnerFunction() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.innerFunction
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:66:9
+     62            await beta();
+     63        }
+     64        async function beta() {
+ ->  65            |debugger;
+     66        }
+     67        await alpha();
+     68        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.testFor
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:73:5
+     69    }
+     70
+     71    async function testFor() {
+ ->  72        |debugger;
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+
+PAUSE AT <anonymous>:74:28
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (let item of |[a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:75:9
+     71    async function testFor() {
+     72        debugger;
+     73        for await (let item of [a(), b()]) {
+ ->  74            |c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+     77    }
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:75:9
+     71    async function testFor() {
+     72        debugger;
+     73        for await (let item of [a(), b()]) {
+ ->  74            |c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+     77    }
+
+PAUSE AT <anonymous>:74:16
+     70
+     71    async function testFor() {
+     72        debugger;
+ ->  73        for await (|let item of [a(), b()]) {
+     74            c();
+     75        }
+     76        TestPage.dispatchEventToFrontend("done");
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:77:5
+     73        for await (let item of [a(), b()]) {
+     74            c();
+     75        }
+ ->  76        |TestPage.dispatchEventToFrontend("done");
+     77    }
+     78
+     79    async function testRepeatedInvocation() {
+
+RESUMED
+
+-- Running test case: Debugger.stepOver.await.testRepeatedInvocation
+PAUSED (debugger-statement)
+PAUSE AT <anonymous>:83:13
+     79    async function testRepeatedInvocation() {
+     80        async function wrap(state) {
+     81            if (state === 2)
+ ->  82                |debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+
+PAUSE AT <anonymous>:84:13
+     80        async function wrap(state) {
+     81            if (state === 2)
+     82                debugger;
+ ->  83            if (|state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+     86            if (state === 1)
+
+PAUSE AT <anonymous>:86:9
+     82                debugger;
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+ ->  85            |await b();
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+
+RESUMED
+PAUSED (other)
+PAUSE AT <anonymous>:87:13
+     83            if (state === 1)
+     84                await a(); // should not pause on this line
+     85            await b();
+ ->  86            if (|state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+     89                TestPage.dispatchEventToFrontend("done");
+
+PAUSE AT <anonymous>:89:13
+     85            await b();
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+ ->  88            if (|state === 2)
+     89                TestPage.dispatchEventToFrontend("done");
+     90        }
+     91
+
+PAUSE AT <anonymous>:90:13
+     86            if (state === 1)
+     87                await c(); // should not pause on this line
+     88            if (state === 2)
+ ->  89                |TestPage.dispatchEventToFrontend("done");
+     90        }
+     91
+     92        wrap(1);
+
+RESUMED
+

--- a/LayoutTests/inspector/debugger/stepping/stepOver-await.html
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-await.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../resources/log-pause-location.js"></script>
+<script src="../resources/stepping-async.js"></script>
+<script>
+function test()
+{
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepOver();
+    });
+
+    InspectorTest.SteppingAsync.run("Debugger.stepOver.await");
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Checking pause locations when stepping with "stepOver".</p>
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1133,7 +1133,7 @@ op :throw_static_error,
 op :debug,
     args: {
         debugHookType: DebugHookType,
-        hasBreakpoint: bool,
+        data: VirtualRegister,
     }
 
 op :end,

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
@@ -82,7 +82,6 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
 
     // No uses.
     case op_new_reg_exp:
-    case op_debug:
     case op_loop_hint:
     case op_jmp:
     case op_new_object:
@@ -110,6 +109,7 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
     USES(OpProfileType, targetVirtualRegister);
     USES(OpThrow, value)
     USES(OpThrowStaticError, message)
+    USES(OpDebug, data)
     USES(OpEnd, value)
     USES(OpRet, value)
     USES(OpJtrue, condition)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -174,6 +174,8 @@ static void dumpExpressionInfoDetails(size_t index, const JSInstructionStream& i
         case WillLeaveCallFrame: event = " WillLeaveCallFrame"; break;
         case WillExecuteStatement: event = " WillExecuteStatement"; break;
         case WillExecuteExpression: event = " WillExecuteExpression"; break;
+        case WillAwait: event = " WillAwait"; break;
+        case DidAwait: event = " DidAwait"; break;
         }
     }
     dataLogF("  [%zu] pc %u @ line %u col %u divot %u startOffset %u endOffset %u : %s%s\n", index, instructionOffset, lineColumn.line, lineColumn.column, divot, startOffset, endOffset, instruction->name(), event);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1023,10 +1023,9 @@ namespace JSC {
         RegisterID* emitLoadDerivedConstructorFromArrowFunctionLexicalEnvironment();
         RegisterID* emitLoadDerivedConstructor();
 
-        void emitDebugHook(DebugHookType, const JSTextPosition&);
-        void emitDebugHook(DebugHookType, unsigned line, unsigned charOffset, unsigned lineStart);
-        void emitDebugHook(StatementNode*);
-        void emitDebugHook(ExpressionNode*);
+        void emitDebugHook(DebugHookType, const JSTextPosition&, RegisterID* data = nullptr);
+        void emitDebugHook(StatementNode*, RegisterID* data = nullptr);
+        void emitDebugHook(ExpressionNode*, RegisterID* data = nullptr);
         void emitWillLeaveCallFrameDebugHook();
 
         RegisterID* emitLoad(RegisterID* dst, CompletionType type) { return emitLoad(dst, jsNumber(static_cast<int32_t>(type))); }
@@ -1059,8 +1058,7 @@ namespace JSC {
         void emitGeneratorStateLabel();
         void emitGeneratorStateChange(int32_t state);
         RegisterID* emitYield(RegisterID* argument);
-        RegisterID* emitAwait(RegisterID* dst, RegisterID* src);
-        RegisterID* emitAwait(RegisterID* srcDst) { return emitAwait(srcDst, srcDst); }
+        RegisterID* emitAwait(RegisterID* dst, RegisterID* src, const JSTextPosition&);
         RegisterID* emitDelegateYield(RegisterID* argument, ThrowableExpressionData*);
         RegisterID* generatorStateRegister() { return &m_parameters[static_cast<int32_t>(JSGenerator::Argument::State)]; }
         RegisterID* generatorValueRegister() { return &m_parameters[static_cast<int32_t>(JSGenerator::Argument::Value)]; }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1684,7 +1684,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
     return JSValue::decode(vmEntryToJavaScript(jitCode->addressForCall(), &vm, &protoCallFrame));
 }
 
-NEVER_INLINE void Interpreter::debug(CallFrame* callFrame, DebugHookType debugHookType)
+NEVER_INLINE void Interpreter::debug(CallFrame* callFrame, DebugHookType debugHookType, JSValue data)
 {
     VM& vm = this->vm();
     DeferTermination deferScope(vm);
@@ -1712,6 +1712,12 @@ NEVER_INLINE void Interpreter::debug(CallFrame* callFrame, DebugHookType debugHo
             break;
         case WillExecuteExpression:
             debugger->atExpression(callFrame);
+            break;
+        case WillAwait:
+            debugger->willAwait(callFrame, data);
+            break;
+        case DidAwait:
+            debugger->didAwait(callFrame, data);
             break;
         case WillExecuteProgram:
             debugger->willExecuteProgram(callFrame);
@@ -1753,6 +1759,12 @@ void printInternal(PrintStream& out, JSC::DebugHookType type)
         return;
     case JSC::WillExecuteExpression:
         out.print("WillExecuteExpression");
+        return;
+    case JSC::WillAwait:
+        out.print("WillAwait");
+        return;
+    case JSC::DidAwait:
+        out.print("DidAwait");
         return;
     }
 }

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -91,6 +91,8 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
         WillLeaveCallFrame,
         WillExecuteStatement,
         WillExecuteExpression,
+        WillAwait,
+        DidAwait,
     };
 
     enum StackFrameCodeType {
@@ -156,7 +158,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
 
         NEVER_INLINE CatchInfo unwind(VM&, CallFrame*&, Exception*);
         void notifyDebuggerOfExceptionToBeThrown(VM&, JSGlobalObject*, CallFrame*, Exception*);
-        NEVER_INLINE void debug(CallFrame*, DebugHookType);
+        NEVER_INLINE void debug(CallFrame*, DebugHookType, JSValue data);
         static String stackTraceAsString(VM&, const Vector<StackFrame>&);
 
         void getStackTrace(JSCell* owner, Vector<StackFrame>& results, size_t framesToSkip = 0, size_t maxStackSize = std::numeric_limits<size_t>::max(), JSCell* caller = nullptr, JSCell* ownerOfCallLinkInfo = nullptr, CallLinkInfo* = nullptr);

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1666,7 +1666,8 @@ void JIT::emit_op_debug(const JSInstruction* currentInstruction)
     loadPtr(addressFor(CallFrameSlot::codeBlock), regT0);
     load32(Address(regT0, CodeBlock::offsetOfDebuggerRequests()), regT0);
     Jump noDebuggerRequests = branchTest32(Zero, regT0);
-    callOperation(operationDebug, TrustedImmPtr(&vm()), static_cast<int>(bytecode.m_debugHookType));
+    emitGetVirtualRegister(bytecode.m_data, jsRegT32);
+    callOperation(operationDebug, TrustedImmPtr(&vm()), static_cast<int>(bytecode.m_debugHookType), jsRegT32);
     noDebuggerRequests.link(this);
 }
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2897,14 +2897,14 @@ JSC_DEFINE_JIT_OPERATION(operationHandleTraps, UnusedPtr, (JSGlobalObject* globa
     OPERATION_RETURN(scope, nullptr);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationDebug, void, (VM* vmPointer, int32_t debugHookType))
+JSC_DEFINE_JIT_OPERATION(operationDebug, void, (VM* vmPointer, int32_t debugHookType, EncodedJSValue encodedData))
 {
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    vm.interpreter.debug(callFrame, static_cast<DebugHookType>(debugHookType));
+    vm.interpreter.debug(callFrame, static_cast<DebugHookType>(debugHookType), JSValue::decode(encodedData));
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -367,7 +367,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewAsyncGenerator, JSCell*, (VM*, Structure*)
 JSC_DECLARE_JIT_OPERATION(operationNewRegExp, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationHandleTraps, UnusedPtr, (JSGlobalObject*));
 JSC_DECLARE_JIT_OPERATION(operationThrow, void, (JSGlobalObject*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationDebug, void, (VM*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationDebug, void, (VM*, int32_t debugHookType, EncodedJSValue encodedData));
 #if ENABLE(DFG_JIT)
 JSC_DECLARE_JIT_OPERATION(operationOptimize, UGPRPair, (VM*, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationTryOSREnterAtCatchAndValueProfile, UGPRPair, (VM*, uint32_t));

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2338,7 +2338,8 @@ LLINT_SLOW_PATH_DECL(slow_path_debug)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpDebug>();
-    vm.interpreter.debug(callFrame, bytecode.m_debugHookType);
+    auto data = getOperand(callFrame, bytecode.m_data);
+    vm.interpreter.debug(callFrame, bytecode.m_debugHookType, data);
     
     LLINT_END();
 }

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.h
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.h
@@ -53,7 +53,7 @@ public:
 
 private:
     void sourceParsed(JSC::JSGlobalObject*, JSC::SourceProvider*, int errorLine, const WTF::String& errorMsg) override;
-    void handlePause(JSC::JSGlobalObject*, JSC::Debugger::ReasonForPause) override;
+    void handlePause(JSC::JSGlobalObject*) override;
 
     bool m_callingDelegate;
 

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm
@@ -116,12 +116,12 @@ void WebScriptDebugger::sourceParsed(JSC::JSGlobalObject* lexicalGlobalObject, J
     m_callingDelegate = false;
 }
 
-void WebScriptDebugger::handlePause(JSC::JSGlobalObject* globalObject, Debugger::ReasonForPause reason)
+void WebScriptDebugger::handlePause(JSC::JSGlobalObject* globalObject)
 {
     if (m_callingDelegate)
         return;
 
-    if (reason != Debugger::PausedForException)
+    if (reasonForPause() != Debugger::PausedForException)
         return;
 
     m_callingDelegate = true;


### PR DESCRIPTION
#### 6eceba5825819069e719f9b9a560ca6c1a64b3e8
<pre>
Web Inspector: Debugger: add a way to step over `await` as though it was sync code
<a href="https://bugs.webkit.org/show_bug.cgi?id=291309">https://bugs.webkit.org/show_bug.cgi?id=291309</a>

Reviewed by Yusuke Suzuki.

When debugging async code with `await` it&apos;s often more desirable to follow what&apos;s written in code (i.e. as if the `await` didnt exist) instead of the literal execution flow, especially since it&apos;s possible for execution to stop after the `await` if it&apos;s the end of sync code.

For example, if the developer is trying to step through code similar to the following
```js
/* 1 */ async function wrap(callback, state) {
/* 2 */     console.log(state, &quot;before&quot;);
/* 3 */     await callback();
/* 4 */     console.log(state, &quot;after&quot;);
/* 5 */ }
/* 6 */
/* 7 */ wrap(foo, 1);
/* 8 */ debugger;
/* 9 */ wrap(foo, 2);
```
execution should never pause in the flow where `state === 1`, meaning that the debugger will &quot;skip&quot; (i.e. resume and then pause again) between &quot;2 before&quot; and &quot;1 after&quot;.

Without this, the developer has to manually create breakpoints after each `await` to ensure that execution pauses after, but even then there&apos;s no guarantee that will be in the right flow if the same function is invoked multiple times (i.e. one resolves before the other).

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp:
(JSC::computeUsesForBytecodeIndexImpl):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_debug):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::operationDebug):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::slow_path_debug):
Modify `OpDebug` to allow for additional data to be set alongside the `DebugHookType`.
Currently this is only used to pass along the `JSGenerator` instance as a way to link execution from before the `await` to after the `await`.
Drive-by: Remove the unused `hasBreakpoint` member variable.

* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::debug):
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::dumpExpressionInfoDetails):
* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::detach):
(JSC::Debugger::pauseIfNeeded):
(JSC::Debugger::handlePause):
(JSC::Debugger::willAwait): Added.
(JSC::Debugger::didAwait): Added.
(JSC::Debugger::resetAsyncPauseState): Added.
Introduce new `WillAwait` and `DidAwait` debug hooks for the `Debugger` to determine what `await` to pause on.
When performing a &quot;Step over&quot; or &quot;Step next&quot;, if an `await` is encountered then save the `JSGenerator` instance (which is the additional data set alongside the `DebugHookType`).
Once the `await` is done, if the `JSGenerator` matches what was saved then pause at the next opportunity.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitDebugHook):
(JSC::BytecodeGenerator::emitWillLeaveCallFrameDebugHook):
(JSC::BytecodeGenerator::emitAwait):
(JSC::BytecodeGenerator::emitIteratorGenericNext):
(JSC::BytecodeGenerator::emitIteratorGenericClose):
(JSC::BytecodeGenerator::emitDelegateYield):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ReturnNode::emitBytecode):
(JSC::emitProgramNodeBytecode):
(JSC::EvalNode::emitBytecode):
(JSC::FunctionNode::emitBytecode):
(JSC::AwaitExprNode::emitBytecode):
Drive-by: remove unnecessary overrides to make debug hook logic simpler.

* Source/WebKitLegacy/mac/WebView/WebScriptDebugger.h:
* Source/WebKitLegacy/mac/WebView/WebScriptDebugger.mm:
(WebScriptDebugger::handlePause):
Drive-by: no need to pass the `ReasonForPause` since it&apos;s already exposed via `Debugger::reasonForPause`.

* LayoutTests/inspector/debugger/resources/stepping-async.js: Added.
* LayoutTests/inspector/debugger/stepping/stepInto-await.html:
* LayoutTests/inspector/debugger/stepping/stepInto-await-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepNext-await.html:
* LayoutTests/inspector/debugger/stepping/stepNext-await-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepOut-await.html:
* LayoutTests/inspector/debugger/stepping/stepOut-await-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepOver-await.html:
* LayoutTests/inspector/debugger/stepping/stepOver-await-expected.txt:

Canonical link: <a href="https://commits.webkit.org/293628@main">https://commits.webkit.org/293628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba8d6354147665451801f1ef6580610e134397d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50035 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75683 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49395 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/92117 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106923 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/98053 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84642 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20291 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31689 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121669 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26308 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33982 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->