### PR TITLE
`DataListButtonElement` should override `isDisabledFormControl()` to report the shadow host's state

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed-expected.html
+++ b/LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<!-- This tests that a datalist button for an input which is disabled does not appear differently when pressed. -->
+<input list="list" id="input" name="input" disabled>
+<datalist id="list">
+</datalist>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed.html
+++ b/LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<!-- This tests that a datalist button for an input which is disabled does not appear differently when pressed. -->
+<input list="list" id="input" name="input" disabled>
+<datalist id="list">
+</datalist>
+<script>
+if (window.eventSender) {
+    var x = input.offsetLeft + input.offsetWidth - 2;
+    var y = input.offsetTop + 2;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -69,4 +69,10 @@ void DataListButtonElement::defaultEventHandler(Event& event)
         HTMLDivElement::defaultEventHandler(event);
 }
 
+bool DataListButtonElement::isDisabledFormControl() const
+{
+    RefPtr host = shadowHost();
+    return host && host->isDisabledFormControl();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -49,6 +49,7 @@ private:
     explicit DataListButtonElement(Document&, DataListButtonOwner&);
 
     void defaultEventHandler(Event&) override;
+    bool isDisabledFormControl() const override;
 
     DataListButtonOwner& m_owner;
 };

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -71,6 +71,12 @@ void SpinButtonElement::willDetachRenderers()
     releaseCapture();
 }
 
+bool SpinButtonElement::isDisabledFormControl() const
+{
+    RefPtr host = shadowHost();
+    return host && host->isDisabledFormControl();
+}
+
 void SpinButtonElement::defaultEventHandler(Event& event)
 {
     auto* mouseEvent = dynamicDowncast<MouseEvent>(event);

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -81,7 +81,7 @@ private:
 
     void willDetachRenderers() override;
     bool isSpinButtonElement() const override { return true; }
-    bool isDisabledFormControl() const override { return shadowHost() && protectedShadowHost()->isDisabledFormControl(); }
+    bool isDisabledFormControl() const override;
     bool matchesReadWritePseudoClass() const override;
     void defaultEventHandler(Event&) override;
     void willOpenPopup() override;


### PR DESCRIPTION
#### 99d26658d2465761e9b3ed9c3e467bbab8661419
<pre>
`DataListButtonElement` should override `isDisabledFormControl()` to report the shadow host&apos;s state
<a href="https://bugs.webkit.org/show_bug.cgi?id=291311">https://bugs.webkit.org/show_bug.cgi?id=291311</a>
<a href="https://rdar.apple.com/148877381">rdar://148877381</a>

Reviewed by Ryosuke Niwa.

Override `isDisabledFormControl()` for DataListButtonElements
to report the disabled state of the shadow host, if available.
Updated implementation of `isDisabledFormControl()` for
SpinButtonElements to match (behavior is the same).

Added LayoutTest to ensure that, when a disabled list button is
pressed, it appears the same as an unpressed disabled list button.

* LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed-expected.html: Added.
* LayoutTests/fast/forms/datalist/datalist-button-disabled-pressed.html: Added.
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
(WebCore::DataListButtonElement::isDisabledFormControl const):
* Source/WebCore/html/shadow/DataListButtonElement.h:
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::isDisabledFormControl const):
* Source/WebCore/html/shadow/SpinButtonElement.h:

Canonical link: <a href="https://commits.webkit.org/293504@main">https://commits.webkit.org/293504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ad7ea9d343cc03d40aeacb2628932132d22f2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85652 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83869 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19878 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31287 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->