### PR TITLE
Support generating trivial serializers

### DIFF
--- a/Source/WTF/wtf/ArgumentCoder.h
+++ b/Source/WTF/wtf/ArgumentCoder.h
@@ -56,7 +56,8 @@ struct ArgumentCoder<bool> {
 };
 
 template<typename T>
-struct ArgumentCoder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> {
+struct TrivialArgumentCoder {
+    static constexpr bool isTrivial = true;
     template<typename Encoder>
     static void encode(Encoder& encoder, T value)
     {
@@ -68,6 +69,10 @@ struct ArgumentCoder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> {
     {
         return decoder.template decodeObject<T>();
     }
+};
+
+template<typename T>
+struct ArgumentCoder<T, typename std::enable_if_t<std::is_arithmetic_v<T>>> : TrivialArgumentCoder<T> {
 };
 
 template<typename T>

--- a/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
@@ -21,26 +21,26 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 header: <WebCore/PathSegmentData.h>
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathMoveTo {
+[CustomHeader, Trivial] struct WebCore::PathMoveTo {
     WebCore::FloatPoint point;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathLineTo {
+[CustomHeader, Trivial] struct WebCore::PathLineTo {
     WebCore::FloatPoint point;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathQuadCurveTo {
+[CustomHeader, Trivial] struct WebCore::PathQuadCurveTo {
     WebCore::FloatPoint controlPoint;
     WebCore::FloatPoint endPoint;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathBezierCurveTo {
+[CustomHeader, Trivial] struct WebCore::PathBezierCurveTo {
     WebCore::FloatPoint controlPoint1;
     WebCore::FloatPoint controlPoint2;
     WebCore::FloatPoint endPoint;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathArcTo {
+[CustomHeader, Trivial] struct WebCore::PathArcTo {
     WebCore::FloatPoint controlPoint1;
     WebCore::FloatPoint controlPoint2;
     float radius;
@@ -68,11 +68,11 @@ header: <WebCore/PathSegmentData.h>
     WebCore::RotationDirection direction;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathEllipseInRect {
+[CustomHeader, Trivial] struct WebCore::PathEllipseInRect {
     WebCore::FloatRect rect;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathRect {
+[CustomHeader, Trivial] struct WebCore::PathRect {
     WebCore::FloatRect rect;
 };
 
@@ -86,7 +86,7 @@ header: <WebCore/PathSegmentData.h>
     WebCore::PathRoundedRect::Strategy strategy;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathContinuousRoundedRect {
+[CustomHeader, Trivial] struct WebCore::PathContinuousRoundedRect {
     WebCore::FloatRect rect;
     float cornerWidth;
     float cornerHeight;
@@ -96,20 +96,20 @@ header: <WebCore/PathSegmentData.h>
     std::span<const float, 4> span();
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataQuadCurve {
+[CustomHeader, Trivial] struct WebCore::PathDataQuadCurve {
     WebCore::FloatPoint start;
     WebCore::FloatPoint controlPoint;
     WebCore::FloatPoint endPoint;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataBezierCurve {
+[CustomHeader, Trivial] struct WebCore::PathDataBezierCurve {
     WebCore::FloatPoint start;
     WebCore::FloatPoint controlPoint1;
     WebCore::FloatPoint controlPoint2;
     WebCore::FloatPoint endPoint;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataArc {
+[CustomHeader, Trivial] struct WebCore::PathDataArc {
     WebCore::FloatPoint start;
     WebCore::FloatPoint controlPoint1;
     WebCore::FloatPoint controlPoint2;
@@ -117,7 +117,7 @@ header: <WebCore/PathSegmentData.h>
 };
 
 header: <WebCore/PathSegment.h>
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathCloseSubpath {
+[CustomHeader, Trivial] struct WebCore::PathCloseSubpath {
 };
 
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::PathSegment {

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -45,6 +45,9 @@ import sys
 # CustomEncoder - Only generate the decoder, not the encoder.
 # WebKitSecureCodingClass - For webkit_secure_coding declarations that need a custom way of establishing the Obj-C class to instantiate (e.g. softlinked frameworks)
 # Wrapper - use a wrapper class to get members and to construct for an external type
+# Trivial - value is a trivially copyable value without IPC validation for all of the members. Members are
+#           to be listed in order to validate the assumptions. Trivial serializers are always available for
+#           all encoder types.
 #
 # Supported member attributes:
 #
@@ -97,6 +100,7 @@ class SerializedType(object):
         self.populate_from_empty_constructor = False
         self.nested = False
         self.rvalue = False
+        self.trivial = False
         self.webkit_platform = False
         self.members_are_subclasses = False
         self.custom_encoder = False
@@ -145,6 +149,8 @@ class SerializedType(object):
                         self.support_wkkeyedcoder = True
                     elif attribute == 'DebugDecodingFailure':
                         self.debug_decoding_failure = True
+                    elif attribute == 'Trivial':
+                        self.trivial = True
         self.templates = templates
         if other_metadata:
             if other_metadata == 'subclasses':
@@ -494,12 +500,11 @@ _license_header = """/*
 """
 
 
-def one_argument_coder_declaration_cf(type):
+def one_argument_coder_declaration_cf(type, name_with_template):
     result = []
     result.append('')
     if type.condition is not None:
         result.append(f'#if {type.condition}')
-    name_with_template = type.namespace_and_name()
     result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
     for encoder in type.encoders:
         result.append(f'    static void encode({encoder}&, {name_with_template});')
@@ -517,16 +522,29 @@ def one_argument_coder_declaration_cf(type):
     return result
 
 
+def one_argument_coder_declaration_trivial(type, name_with_template):
+    result = []
+    if type.condition is not None:
+        result.append(f'#if {type.condition}')
+    result.append(f'template<> struct ArgumentCoder<{name_with_template}> : TrivialArgumentCoder<{name_with_template}> {{')
+    result.append(f'}};')
+    if type.condition is not None:
+        result.append('#endif')
+    return result
+
+
 def one_argument_coder_declaration(type, template_argument):
+    name_with_template = type.namespace_and_name()
+    if template_argument is not None:
+        name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
     if type.cf_type is not None:
-        return one_argument_coder_declaration_cf(type)
+        return one_argument_coder_declaration_cf(type, name_with_template)
+    if type.trivial:
+        return one_argument_coder_declaration_trivial(type, name_with_template)
     result = []
     result.append('')
     if type.condition is not None:
         result.append(f'#if {type.condition}')
-    name_with_template = type.namespace_and_name()
-    if template_argument is not None:
-        name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
     result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
     for encoder in type.encoders:
         if type.rvalue:
@@ -715,6 +733,36 @@ def resolve_inheritance(serialized_types):
         result.append(serialized_type)
     return result
 
+
+def check_type_members_trivial(type, name_with_template):
+    result = []
+    for member in type.members:
+        if member.condition is not None:
+            result.append(f'#if {member.condition}')
+        result.append(f'static_assert(std::is_trivially_copyable<{name_with_template}>());')
+        if '()' in member.name:
+            result.append(f'static_assert(std::is_same_v<std::remove_cvref_t<decltype(std::declval<{name_with_template}&>().{member.name})>, {member.type}>);')
+        else:
+            result.append(f'static_assert(std::is_same_v<decltype({name_with_template}::{member.name}), {member.type}>);')
+        result.append(f'static_assert(ArgumentCoder<{member.type}>::isTrivial);')
+        if member.condition is not None:
+            result.append('#endif')
+    result.append(f'namespace {{')
+    result.append(f'struct ShouldBeSameSizeAs{type.name_as_identifier()} {{')
+    for member in type.members:
+        if member.condition is not None:
+            result.append(f'#if {member.condition}')
+        result.append(f'    {member.type} {sanitize_string_for_variable_name(member.name)};')
+        if member.condition is not None:
+            result.append('#endif')
+    for member in type.dictionary_members:
+        result.append(f'        {member.dictionary_type()} {member.type};')
+    result.append('};')
+    result.append(f'static_assert(sizeof(ShouldBeSameSizeAs{type.name_as_identifier()}) == sizeof({type.namespace_and_name()}));')
+    result.append(f'static_assert(alignof(ShouldBeSameSizeAs{type.name_as_identifier()}) == alignof({type.namespace_and_name()}));')
+    result.append(f'}}')
+
+    return result
 
 def check_type_members(type, checking_parent_class):
     result = []
@@ -989,11 +1037,19 @@ def construct_type(type, specialization, indentation):
     return result
 
 
-def generate_one_impl(type, template_argument):
+def generate_one_impl_trivial(type, name_with_template):
     result = []
+    result = result + check_type_members_trivial(type, name_with_template)
+    return result
+
+
+def generate_one_impl(type, template_argument):
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
         name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
+    if type.trivial:
+        return generate_one_impl_trivial(type, name_with_template)
+    result = []
     if type.condition is not None:
         result.append(f'#if {type.condition}')
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -60,10 +60,12 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/FloatPoint.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
 #include <WebCore/MoveOnlyDerivedClass.h>
+#include <WebCore/PathSegmentData.h>
 #if USE(APPKIT)
 #include <WebCore/ScrollbarTrackCornerSystemImageMac.h>
 #endif
@@ -1524,6 +1526,34 @@ std::optional<WebCore::RectEdges<bool>> ArgumentCoder<WebCore::RectEdges<bool>>:
     };
 }
 
+static_assert(std::is_trivially_copyable<WebCore::FloatPoint>());
+static_assert(std::is_same_v<std::remove_cvref_t<decltype(std::declval<WebCore::FloatPoint&>().x())>, float>);
+static_assert(ArgumentCoder<float>::isTrivial);
+static_assert(std::is_trivially_copyable<WebCore::FloatPoint>());
+static_assert(std::is_same_v<std::remove_cvref_t<decltype(std::declval<WebCore::FloatPoint&>().y())>, float>);
+static_assert(ArgumentCoder<float>::isTrivial);
+namespace {
+struct ShouldBeSameSizeAsFloatPoint {
+    float x;
+    float y;
+};
+static_assert(sizeof(ShouldBeSameSizeAsFloatPoint) == sizeof(WebCore::FloatPoint));
+static_assert(alignof(ShouldBeSameSizeAsFloatPoint) == alignof(WebCore::FloatPoint));
+}
+static_assert(std::is_trivially_copyable<PathDataLine>());
+static_assert(std::is_same_v<decltype(PathDataLine::start), WebCore::FloatPoint>);
+static_assert(ArgumentCoder<WebCore::FloatPoint>::isTrivial);
+static_assert(std::is_trivially_copyable<PathDataLine>());
+static_assert(std::is_same_v<decltype(PathDataLine::end), WebCore::FloatPoint>);
+static_assert(ArgumentCoder<WebCore::FloatPoint>::isTrivial);
+namespace {
+struct ShouldBeSameSizeAsPathDataLine {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint end;
+};
+static_assert(sizeof(ShouldBeSameSizeAsPathDataLine) == sizeof(PathDataLine));
+static_assert(alignof(ShouldBeSameSizeAsPathDataLine) == alignof(PathDataLine));
+}
 } // namespace IPC
 
 namespace WTF {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -92,6 +92,7 @@ class ScrollingStateFrameHostingNodeWithStuffAfterTuple;
 class AppKitControlSystemImage;
 #endif
 template<typename> class RectEdges;
+class FloatPoint;
 struct Amazing;
 }
 
@@ -123,6 +124,7 @@ struct RequestEncodedWithBodyRValue;
 #if USE(SKIA)
 class SkFooBar;
 #endif
+struct PathDataLine;
 
 #if USE(CFBAR)
 typedef struct __CFBar * CFBarRef;
@@ -419,6 +421,10 @@ template<> struct ArgumentCoder<WebCore::AppKitControlSystemImage> {
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
     static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::FloatPoint> : TrivialArgumentCoder<WebCore::FloatPoint> {
+};
+template<> struct ArgumentCoder<PathDataLine> : TrivialArgumentCoder<PathDataLine> {
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -26,8 +26,6 @@
 #include "GeneratedWebKitSecureCoding.h"
 
 #include "ArgumentCodersCocoa.h"
-#include <wtf/cocoa/TypeCastsCocoa.h>
-
 #if USE(AVFOUNDATION)
 #include <pal/cocoa/AVFoundationSoftLink.h>
 #endif
@@ -132,11 +130,11 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(
 CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_AVOutputContextSerializationKeyContextID = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"]);
+    m_AVOutputContextSerializationKeyContextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
     if (![m_AVOutputContextSerializationKeyContextID isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextID = nullptr;
 
-    m_AVOutputContextSerializationKeyContextType = checked_objc_cast<NSString>([dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"]);
+    m_AVOutputContextSerializationKeyContextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
     if (![m_AVOutputContextSerializationKeyContextType isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextType = nullptr;
 
@@ -179,7 +177,7 @@ CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(
 CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_StringKey = checked_objc_cast<NSString>([dictionary objectForKey:@"StringKey"]);
+    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
     if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 
@@ -287,7 +285,7 @@ CoreIPCDDScannerResult::CoreIPCDDScannerResult(
 CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
-    m_StringKey = checked_object_cast<NSString>([dictionary objectForKey:@"StringKey"]);
+    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
     if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
 

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -61,10 +61,12 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/FloatPoint.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
 #include <WebCore/MoveOnlyDerivedClass.h>
+#include <WebCore/PathSegmentData.h>
 #if USE(APPKIT)
 #include <WebCore/ScrollbarTrackCornerSystemImageMac.h>
 #endif
@@ -554,6 +556,26 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "bool"_s,
                 "left()"_s
+            },
+        } },
+        { "WebCore::FloatPoint"_s, {
+            {
+                "float"_s,
+                "x()"_s
+            },
+            {
+                "float"_s,
+                "y()"_s
+            },
+        } },
+        { "PathDataLine"_s, {
+            {
+                "WebCore::FloatPoint"_s,
+                "start"_s
+            },
+            {
+                "WebCore::FloatPoint"_s,
+                "end"_s
             },
         } },
 #if USE(PASSKIT)

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -363,3 +363,14 @@ using WebCore::ConditionalVariant = std::variant<
 >;
 
 using WebCore::NonConditionalVariant = std::variant<int, double>
+
+[Trivial] class WebCore::FloatPoint {
+    float x()
+    float y()
+};
+
+header: <WebCore/PathSegmentData.h>
+[CustomHeader, Trivial] struct PathDataLine {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint end;
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -489,18 +489,18 @@ struct WebCore::CharacterRange {
     std::span<const double, 6> span();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatPoint {
+[Trivial] class WebCore::FloatPoint {
     float x()
     float y()
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatPoint3D {
+[Trivial] class WebCore::FloatPoint3D {
     float x()
     float y()
     float z()
 }
 
-class WebCore::FloatQuad {
+[Trivial] class WebCore::FloatQuad {
     WebCore::FloatPoint p1();
     WebCore::FloatPoint p2();
     WebCore::FloatPoint p3();
@@ -722,22 +722,22 @@ enum class WebCore::IndexedDB::RequestType : uint8_t {
 
 #if USE(CG)
 headers: <CoreGraphics/CGGeometry.h> <CoreGraphics/CGAffineTransform.h>
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] struct CGSize {
+[WebKitPlatform, Trivial] struct CGSize {
     CGFloat width
     CGFloat height
 };
 
-[WebKitPlatform] struct CGPoint {
+[WebKitPlatform, Trivial] struct CGPoint {
     CGFloat x
     CGFloat y
 };
 
-[WebKitPlatform] struct CGRect {
+[WebKitPlatform, Trivial] struct CGRect {
     CGPoint origin
     CGSize size
 };
 
-struct CGAffineTransform {
+[Trivial] struct CGAffineTransform {
   CGFloat a
   CGFloat b
   CGFloat c
@@ -747,7 +747,7 @@ struct CGAffineTransform {
 };
 #endif
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatRect {
+[Trivial] class WebCore::FloatRect {
     WebCore::FloatPoint location()
     WebCore::FloatSize size()
 }
@@ -972,17 +972,17 @@ header: <WebCore/RenderStyleConstants.h>
     [Validator='WebCore::IntRect { *location, *size }.isValid()'] WebCore::IntSize size();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::IntPoint {
+[Trivial] class WebCore::IntPoint {
     int x();
     int y();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::IntSize {
+[Trivial] class WebCore::IntSize {
     int width();
     int height();
 }
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::FloatSize {
+[Trivial] class WebCore::FloatSize {
     float width();
     float height();
 }
@@ -5303,7 +5303,7 @@ header: <WebCore/ImageTypes.h>
     WebCore::PlatformDynamicRangeLimit dynamicRangeLimit();
 };
 
-[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::FloatSegment {
+[Trivial] struct WebCore::FloatSegment {
     float begin;
     float end;
 };


### PR DESCRIPTION
#### 03e15f5be89e97a8ed3be15a7a9a2e22ee750d9e
<pre>
Support generating trivial serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=291317">https://bugs.webkit.org/show_bug.cgi?id=291317</a>
<a href="https://rdar.apple.com/148894511">rdar://148894511</a>

Reviewed by NOBODY (OOPS!).

Before, only arithmetic types (floats, ints, ..) were serialized as
trivial: encode with a memcpy and decode by a copy from
reinterpret_casted pointer.

Support marking serialized type as trivially serializable with
&quot;Trivial&quot; attribute. The type has to be trivially copyable, not require
validation and have all its members have trivial serializer.

Useful for trivally copyable compound types that are inconvenient or
impossible to be implemented as std::array of the constituent types.

Example: FloatRect is a pair &lt;FloatPoint, FloatSize&gt; e.g. an tuple
&lt;&lt;float, float&gt;, &lt;float, float&gt;&gt;. It is also a trivially copyable
object, so it is ok to vivify it by a copy from or to memory with
memcpy or equivalent.

* Source/WTF/wtf/ArgumentCoder.h:
* Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(one_argument_coder_declaration_cf):
(one_argument_coder_declaration_trivial):
(one_argument_coder_declaration):
(check_type_members_trivial):
(generate_one_impl_trivial):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre>