### PR TITLE
Address post-commit review feedback for 293455@main

### DIFF
--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -362,22 +362,11 @@ std::weak_ordering operator<=>(const MediaTime& a, const MediaTime& b)
     if (orFlags & MediaTime::Indefinite)
         return a.isIndefinite() ? std::weak_ordering::greater : std::weak_ordering::less;
 
-    if (andFlags & MediaTime::DoubleValue) {
-        if (a.m_timeValueAsDouble == b.m_timeValueAsDouble)
-            return std::weak_ordering::equivalent;
+    if (andFlags & MediaTime::DoubleValue)
+        return weakOrderingCast(a.m_timeValueAsDouble <=> b.m_timeValueAsDouble);
 
-        return a.m_timeValueAsDouble < b.m_timeValueAsDouble ? std::weak_ordering::less : std::weak_ordering::greater;
-    }
-
-    if (orFlags & MediaTime::DoubleValue) {
-        double aAsDouble = a.toDouble();
-        double bAsDouble = b.toDouble();
-        if (aAsDouble > bAsDouble)
-            return std::weak_ordering::greater;
-        if (aAsDouble < bAsDouble)
-            return std::weak_ordering::less;
-        return std::weak_ordering::equivalent;
-    }
+    if (orFlags & MediaTime::DoubleValue)
+        return weakOrderingCast(a.toDouble() <=> b.toDouble());
 
     if ((a.m_timeValue < 0) != (b.m_timeValue < 0))
         return a.m_timeValue < 0 ? std::weak_ordering::less : std::weak_ordering::greater;

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1560,10 +1560,12 @@ ALWAYS_INLINE std::optional<double> stringToDouble(std::span<const char> buffer,
     return result;
 }
 
-template<typename FloatingPointType>
-ALWAYS_INLINE std::weak_ordering compareFloatingPointWithWeakOrdering(FloatingPointType a, FloatingPointType b) requires (std::is_floating_point_v<FloatingPointType>)
+ALWAYS_INLINE std::weak_ordering weakOrderingCast(std::partial_ordering ordering)
 {
-    return (a < b) ? std::weak_ordering::less : ((a > b) ? std::weak_ordering::greater : std::weak_ordering::equivalent);
+    RELEASE_ASSERT(ordering != std::partial_ordering::unordered);
+    if (is_eq(ordering))
+        return std::weak_ordering::equivalent;
+    return is_lt(ordering) ? std::weak_ordering::less : std::weak_ordering::greater;
 }
 
 } // namespace WTF
@@ -1593,7 +1595,6 @@ using WTF::callStatelessLambda;
 using WTF::checkAndSet;
 using WTF::clampedMoveCursorWithinSpan;
 using WTF::compareSpans;
-using WTF::compareFloatingPointWithWeakOrdering;
 using WTF::constructFixedSizeArrayWithArguments;
 using WTF::consume;
 using WTF::consumeAndReinterpretCastTo;
@@ -1636,6 +1637,7 @@ using WTF::tryBinarySearch;
 using WTF::unsafeMakeSpan;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
+using WTF::weakOrderingCast;
 using WTF::zeroBytes;
 using WTF::zeroSpan;
 using WTF::Invocable;

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -133,7 +133,7 @@ std::weak_ordering IDBKey::compare(const IDBKey& other) const
     }
     case IndexedDB::KeyType::Date:
     case IndexedDB::KeyType::Number:
-        return compareFloatingPointWithWeakOrdering(std::get<double>(m_value), std::get<double>(other.m_value));
+        return weakOrderingCast(std::get<double>(m_value) <=> std::get<double>(other.m_value));
     case IndexedDB::KeyType::Invalid:
     case IndexedDB::KeyType::Min:
     case IndexedDB::KeyType::Max:

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -291,9 +291,9 @@ std::weak_ordering operator<=>(const IDBKeyData& a, const IDBKeyData& b)
         return comparison < 0 ? std::weak_ordering::less : std::weak_ordering::greater;
     }
     case IndexedDB::KeyType::Date:
-        return compareFloatingPointWithWeakOrdering(std::get<IDBKeyData::Date>(a.m_value).value, std::get<IDBKeyData::Date>(b.m_value).value);
+        return weakOrderingCast(std::get<IDBKeyData::Date>(a.m_value).value <=> std::get<IDBKeyData::Date>(b.m_value).value);
     case IndexedDB::KeyType::Number:
-        return compareFloatingPointWithWeakOrdering(std::get<double>(a.m_value), std::get<double>(b.m_value));
+        return weakOrderingCast(std::get<double>(a.m_value) <=> std::get<double>(b.m_value));
     case IndexedDB::KeyType::Max:
     case IndexedDB::KeyType::Min:
         return std::weak_ordering::equivalent;


### PR DESCRIPTION
#### 8480924d7d53a9a0331dbbc085de701a01509b59
<pre>
Address post-commit review feedback for 293455@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=291321">https://bugs.webkit.org/show_bug.cgi?id=291321</a>

Reviewed by Sam Weinig and Darin Adler.

Introduce a weakOrderingCast() function to cast from a partial_ordering to
a weak_ordering, while asserting that the partial_ordering is not unordered.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::weakOrderingCast):
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::compare const):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::operator&lt;=&gt;):

Canonical link: <a href="https://commits.webkit.org/293491@main">https://commits.webkit.org/293491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af44fcc80e0edb8125c581fec79f25cb7c9da0d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49019 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91741 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106545 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97681 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85660 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/83885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19884 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26109 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/31293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121296 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25932 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33911 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->