### PR TITLE
Leverage the C++ spaceship operator further for WebAnimationTime

### DIFF
--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -208,6 +208,12 @@ std::partial_ordering operator<=>(const WebAnimationTime& a, const WebAnimationT
     return a.m_value <=> b.m_value;
 }
 
+std::partial_ordering operator<=>(const WebAnimationTime& a, Seconds b)
+{
+    ASSERT(a.m_type == WebAnimationTime::Type::Time);
+    return a.m_value <=> b.seconds();
+}
+
 WebAnimationTime WebAnimationTime::operator+(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
@@ -218,30 +224,6 @@ WebAnimationTime WebAnimationTime::operator-(const Seconds& other) const
 {
     ASSERT(m_type == Type::Time);
     return { m_type, m_value - other.seconds() };
-}
-
-bool WebAnimationTime::operator<(const Seconds& other) const
-{
-    ASSERT(m_type == Type::Time);
-    return m_value < other.seconds();
-}
-
-bool WebAnimationTime::operator<=(const Seconds& other) const
-{
-    ASSERT(m_type == Type::Time);
-    return m_value <= other.seconds();
-}
-
-bool WebAnimationTime::operator>(const Seconds& other) const
-{
-    ASSERT(m_type == Type::Time);
-    return m_value > other.seconds();
-}
-
-bool WebAnimationTime::operator>=(const Seconds& other) const
-{
-    ASSERT(m_type == Type::Time);
-    return m_value >= other.seconds();
 }
 
 bool WebAnimationTime::operator==(const Seconds& other) const

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -65,13 +65,10 @@ public:
 
     friend bool operator==(const WebAnimationTime&, const WebAnimationTime&) = default;
     friend std::partial_ordering operator<=>(const WebAnimationTime&, const WebAnimationTime&);
+    friend std::partial_ordering operator<=>(const WebAnimationTime&, Seconds);
 
     WebAnimationTime operator+(const Seconds&) const;
     WebAnimationTime operator-(const Seconds&) const;
-    bool operator<(const Seconds&) const;
-    bool operator<=(const Seconds&) const;
-    bool operator>(const Seconds&) const;
-    bool operator>=(const Seconds&) const;
     bool operator==(const Seconds&) const;
 
     WebAnimationTime operator*(double) const;


### PR DESCRIPTION
#### d8649de948730610f71a4e4615dc9a82efda5fd0
<pre>
Leverage the C++ spaceship operator further for WebAnimationTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=291323">https://bugs.webkit.org/show_bug.cgi?id=291323</a>

Reviewed by Darin Adler.

Leverage the C++ spaceship operator further for WebAnimationTime, in particular
when comparing to a Seconds type.

* Source/WebCore/animation/WebAnimationTime.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::WebAnimationTime::operator&lt; const): Deleted.
(WebCore::WebAnimationTime::operator&lt;= const): Deleted.
(WebCore::WebAnimationTime::operator&gt; const): Deleted.
(WebCore::WebAnimationTime::operator&gt;= const): Deleted.
* Source/WebCore/animation/WebAnimationTime.h:

Canonical link: <a href="https://commits.webkit.org/293481@main">https://commits.webkit.org/293481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c6e802f87b55d08c89716f25fc90ce72bb1555

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8901 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27104 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32504 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89426 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/55755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106512 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19040 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84342 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83845 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21267 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19851 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->