### PR TITLE
WTF::UUID's `operator NSUUID *()` is leak-prone

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -66,7 +66,7 @@ public:
     WTF_EXPORT_PRIVATE static UUID createVersion5(UUID, std::span<const uint8_t>);
 
 #ifdef __OBJC__
-    WTF_EXPORT_PRIVATE operator NSUUID *() const;
+    WTF_EXPORT_PRIVATE RetainPtr<NSUUID> createNSUUID() const;
     WTF_EXPORT_PRIVATE static std::optional<UUID> fromNSUUID(NSUUID *);
 #endif
 

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -31,9 +31,9 @@
 
 namespace WTF {
 
-UUID::operator NSUUID *() const
+RetainPtr<NSUUID> UUID::createNSUUID() const
 {
-    return [[NSUUID alloc] initWithUUIDString:toString()];
+    return adoptNS([[NSUUID alloc] initWithUUIDString:toString().createNSString().get()]);
 }
 
 std::optional<UUID> UUID::fromNSUUID(NSUUID *nsUUID)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1563,7 +1563,7 @@ void NetworkSessionCocoa::notifyAdAttributionKitOfSessionTermination()
     if (m_donatedEphemeralImpressionSessionID) {
         // FIXME: Remove this respondsToSelector check in 2026 or so.
         if ([ASDInstallWebAttributionService.sharedInstance respondsToSelector:@selector(removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:completionHandler:)])
-            [ASDInstallWebAttributionService.sharedInstance removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:*m_donatedEphemeralImpressionSessionID completionHandler:^(NSError *) { }];
+            [ASDInstallWebAttributionService.sharedInstance removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:m_donatedEphemeralImpressionSessionID->createNSUUID().get() completionHandler:^(NSError *) { }];
     }
 #endif
 }
@@ -2257,7 +2257,7 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
 
         // FIXME: Remove this respondsToSelector check in 2026 or so.
         if ([config respondsToSelector:@selector(privateBrowsingSessionId)])
-            config.get().privateBrowsingSessionId = *m_donatedEphemeralImpressionSessionID;
+            config.get().privateBrowsingSessionId = m_donatedEphemeralImpressionSessionID->createNSUUID().get();
     }
 #endif // HAVE(AD_ATTRIBUTION_KIT_PRIVATE_BROWSING)
 #if HAVE(ASD_INSTALL_WEB_ATTRIBUTION_SERVICE)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -104,7 +104,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSUUID *)_documentIdentifier
 {
-    return _frameInfo->documentID()->object();
+    return _frameInfo->documentID()->object().createNSUUID().autorelease();
 }
 
 - (pid_t)_processIdentifier

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -160,7 +160,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 - (NSUUID *)identifier
 {
     if (auto identifier = self._protectedWebExtensionControllerConfiguration->identifier())
-        return identifier.value();
+        return identifier.value().createNSUUID().autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -645,7 +645,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     WebKit::WebsiteDataStore::fetchAllDataStoreIdentifiers([completionHandlerCopy](auto&& identifiers) {
         auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
         for (auto identifier : identifiers)
-            [result addObject:(NSUUID *)identifier];
+            [result addObject:identifier.createNSUUID().get()];
 
         completionHandlerCopy(result.autorelease());
     });
@@ -1355,7 +1355,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     if (!identifier)
         return nil;
 
-    return *identifier;
+    return identifier->createNSUUID().autorelease();
 }
 
 - (NSString *)_webPushPartition

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -219,7 +219,7 @@ static NSString *dataKey = @"data";
 
 - (NSUUID *)uuid
 {
-    return (NSUUID *)_coreData.notificationID;
+    return (NSUUID *)_coreData.notificationID.createNSUUID().autorelease();
 }
 
 - (NSDictionary *)userInfo

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -106,7 +106,7 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
 - (NSUUID *)documentID
 {
     if (auto documentID = _info->documentID())
-        return documentID.value();
+        return documentID.value().createNSUUID().autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -853,7 +853,7 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     if (!currentIdentifier)
         return nullptr;
 
-    return *currentIdentifier;
+    return currentIdentifier->createNSUUID().autorelease();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -282,12 +282,12 @@ WindowKind PageClientImplCocoa::windowKind()
 #if ENABLE(WRITING_TOOLS)
 void PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    [m_webView _proofreadingSessionShowDetailsForSuggestionWithUUID:replacementID relativeToRect:selectionBoundsInRootView];
+    [m_webView _proofreadingSessionShowDetailsForSuggestionWithUUID:replacementID.createNSUUID().get() relativeToRect:selectionBoundsInRootView];
 }
 
 void PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    [m_webView _proofreadingSessionUpdateState:state forSuggestionWithUUID:replacementID];
+    [m_webView _proofreadingSessionUpdateState:state forSuggestionWithUUID:replacementID.createNSUUID().get()];
 }
 
 static NSString *writingToolsActiveKey = @"writingToolsActive";
@@ -314,12 +314,12 @@ bool PageClientImplCocoa::writingToolsTextReplacementsFinished()
 
 void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& data)
 {
-    [m_webView _addTextAnimationForAnimationID:uuid withData:data];
+    [m_webView _addTextAnimationForAnimationID:uuid.createNSUUID().get() withData:data];
 }
 
 void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
 {
-    [m_webView _removeTextAnimationForAnimationID:uuid];
+    [m_webView _removeTextAnimationForAnimationID:uuid.createNSUUID().get()];
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4811,7 +4811,7 @@ void WebViewImpl::addTextAnimationForAnimationID(WTF::UUID uuid, const WebCore::
     if (!m_textAnimationTypeManager)
         m_textAnimationTypeManager = adoptNS([[WKTextAnimationManager alloc] initWithWebViewImpl:*this]);
 
-    [m_textAnimationTypeManager addTextAnimationForAnimationID:uuid withData:data];
+    [m_textAnimationTypeManager addTextAnimationForAnimationID:uuid.createNSUUID().get() withData:data];
 }
 
 void WebViewImpl::removeTextAnimationForAnimationID(WTF::UUID uuid)
@@ -4819,7 +4819,7 @@ void WebViewImpl::removeTextAnimationForAnimationID(WTF::UUID uuid)
     if (!m_page->preferences().textAnimationsEnabled())
         return;
 
-    [m_textAnimationTypeManager removeTextAnimationForAnimationID:uuid];
+    [m_textAnimationTypeManager removeTextAnimationForAnimationID:uuid.createNSUUID().get()];
 }
 
 void WebViewImpl::hideTextAnimationView()

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/UUIDCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/UUIDCocoa.mm
@@ -31,17 +31,17 @@
 TEST(WTF, NSUUIDConversionForDeletedValue)
 {
     WTF::UUID deletedUUID { WTF::UUID::deletedValue };
-    NSUUID *deletedNSUUID = deletedUUID;
-    EXPECT_STREQ("00000000-0000-0000-0000-000000000001", [[deletedUUID UUIDString] UTF8String]);
-    auto uuid = WTF::UUID::fromNSUUID(deletedNSUUID);
+    RetainPtr deletedNSUUID = deletedUUID.createNSUUID();
+    EXPECT_STREQ("00000000-0000-0000-0000-000000000001", [[deletedNSUUID UUIDString] UTF8String]);
+    auto uuid = WTF::UUID::fromNSUUID(deletedNSUUID.get());
     EXPECT_FALSE(uuid);
 }
 
 TEST(WTF, NSUUIDConversionForEmptyValue)
 {
     WTF::UUID emptyUUID { WTF::UUID::emptyValue };
-    NSUUID *emptyNSUUID = emptyUUID;
+    RetainPtr emptyNSUUID = emptyUUID.createNSUUID();
     EXPECT_STREQ("00000000-0000-0000-0000-000000000000", [[emptyNSUUID UUIDString] UTF8String]);
-    auto uuid = WTF::UUID::fromNSUUID(emptyNSUUID);
+    auto uuid = WTF::UUID::fromNSUUID(emptyNSUUID.get());
     EXPECT_FALSE(uuid);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -921,7 +921,7 @@ public:
 
         RetainPtr<_WKWebsiteDataStoreConfiguration> dataStoreConfiguration;
         if (dataStoreIdentifier)
-            dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:*dataStoreIdentifier]);
+            dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:dataStoreIdentifier->createNSUUID().get()]);
         else
             dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
         [dataStoreConfiguration setWebPushPartitionString:pushPartition];


### PR DESCRIPTION
#### e3f4bc0b561fa968e18dcf600564d102fdb0bc9c
<pre>
WTF::UUID&apos;s `operator NSUUID *()` is leak-prone
<a href="https://bugs.webkit.org/show_bug.cgi?id=291324">https://bugs.webkit.org/show_bug.cgi?id=291324</a>

Reviewed by Ryosuke Niwa.

This implicit type conversion operator returned a NSUUID that had +1 refcount, which
is very unexpected and prone to leaking. Drop this operator and introduce a createNSUUID()
function instead which returns a NSUUID.

The operator had several call sites, one of them using ARC so no leak. The other call sites
were leaking memory however.

* Source/WTF/wtf/UUID.h:
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
(WTF::UUID::createNSUUID const):
(WTF::UUID::operator NSUUID * const): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration identifier]):

Canonical link: <a href="https://commits.webkit.org/293482@main">https://commits.webkit.org/293482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a1f7d6d5600fd0d07861bfb5239e0d2aff4cb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/32516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48995 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91716 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/84146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106521 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97656 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19050 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/84352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31267 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25913 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33909 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->