### PR TITLE
Declarative Net Request redirect not working on clicked links

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -112,7 +112,7 @@ void ContentExtension::compileGlobalDisplayNoneStyleSheet()
 
 void ContentExtension::populateTopURLActionCacheIfNeeded(const URL& topURL) const
 {
-    if (m_cachedTopURL == topURL)
+    if (m_cachedTopURL == topURL || topURL.isEmpty())
         return;
 
     DFABytecodeInterpreter interpreter(m_compiledExtension->topURLFiltersBytecode());
@@ -129,7 +129,7 @@ void ContentExtension::populateTopURLActionCacheIfNeeded(const URL& topURL) cons
 
 void ContentExtension::populateFrameURLActionCacheIfNeeded(const URL& frameURL) const
 {
-    if (m_cachedFrameURL == frameURL)
+    if (m_cachedFrameURL == frameURL || frameURL.isEmpty())
         return;
 
     DFABytecodeInterpreter interpreter(m_compiledExtension->frameURLFiltersBytecode());

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -296,6 +296,14 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     auto sandboxFlags = frame->effectiveSandboxFlags();
     auto isPerformingHTTPFallback = frameLoader->isHTTPFallbackInProgress() ? IsPerformingHTTPFallback::Yes : IsPerformingHTTPFallback::No;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    if (RefPtr page = frame->page()) {
+        auto resourceType = frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument;
+        auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), resourceType, *frame->loader().documentLoader());
+        ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
+    }
+#endif
+
     if (isInitialEmptyDocumentLoad) {
         // We ignore the response from the client for initial empty document loads and proceed with the load synchronously.
         frameLoader->client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), clientRedirectSourceForHistory, navigationID, hitTestResult(action), hasOpener, isPerformingHTTPFallback, sandboxFlags, policyDecisionMode, [](PolicyAction) { });


### PR DESCRIPTION
#### 4aa69741aa3ffe42012e0c3fa70d12970647744f
<pre>
Declarative Net Request redirect not working on clicked links
<a href="https://bugs.webkit.org/show_bug.cgi?id=291325">https://bugs.webkit.org/show_bug.cgi?id=291325</a>
<a href="https://rdar.apple.com/142017438">rdar://142017438</a>

Reviewed by NOBODY (OOPS!).

The issue we were seeing here was that if an extension had a DNR redirect rule to redirect
navigations from site A to site B, when clicking on a link for site A, we would commit the navigation
to site A, fail that load, and set the provisional page for that load to `nil`. I believe setting
this page to `nil` is what cause the load to site B to be cancelled (commenting out that code
caused the redirect) to go through. Simply not setting the provisional page to nil if a redirect
would occur wouldn&apos;t work here because there&apos;s no way to determine that a redirect would occur in
`WebPageProxy::didFailProvisionalLoadForFrameShared`.

The fix here is to run URLs through the compiled byte code for DNR rules before deciding the policy
for the navigation. In doing this, we won&apos;t attempt to load site A, we will consult the DNR rules
first, and if a redirect should occur, we will update the request and decide the policy for site B.

Testing:
- Clicking on a link to site A redirects to site B
- Navigating to site A via a navigation bar redirects to site B
- Long pressing on a link for site A shows a preview for site B

* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::populateTopURLActionCacheIfNeeded const):
Don&apos;t populate the action cache if the topURL is empty.
(WebCore::ContentExtensions::ContentExtension::populateFrameURLActionCacheIfNeeded const):
Don&apos;t populate the action cache if the frameURL is empty.
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aa69741aa3ffe42012e0c3fa70d12970647744f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18677 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27118 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75388 "Found 17 new test failures: http/tests/contentextensions/block-child-document-resource-type.html http/tests/contentextensions/block-everything-unless-domain-iframe.html http/tests/contentextensions/block-everything-unless-domain.html http/tests/contentextensions/block-top-document-resource-type.html http/tests/contentextensions/css-display-none-after-ignore-previous-rules.html http/tests/contentextensions/css-display-none-overflows-rule-data-1.html http/tests/contentextensions/css-display-none-overflows-rule-data-2.html http/tests/contentextensions/css-display-none-overflows-rule-data-3.html http/tests/contentextensions/css-display-none-overflows-rule-data-4.html http/tests/contentextensions/css-display-none-overflows-rule-data-5.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32514 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14418 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14211 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48999 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84143 "Found 31 new API test failures: TestWebKitAPI.ResourceLoadStatistics.FlushObserverWhenWebPageIsClosedByJavaScript, TestWebKitAPI.IndexedDB.MigrateThirdPartyDataToGeneralStorageDirectory, TestWebKitAPI.InAppBrowserPrivacy.SetCookieForNonAppBoundDomainFails, TestWebKitAPI.WebpagePreferences.UpdateWebsitePoliciesInvalid, TestWebKitAPI.WKNavigationAction.UserInputState, TestWebKitAPI.ResourceLoadStatistics.NetworkProcessRestart, TestWebKitAPI.IndexedDB.IndexedDBThirdPartyDataRemoval, TestWebKitAPI.WKWebView.LocalStorageNoSizeOverflow, TestWebKitAPI.ResourceLoadStatistics.EnableResourceLoadStatisticsAfterNetworkProcessCreation, TestWebKitAPI.WebKit.ConfigurationHTTPSUpgrade ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26136 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19055 "Found 17 new test failures: http/tests/contentextensions/block-child-document-resource-type.html http/tests/contentextensions/block-top-document-resource-type.html http/tests/contentextensions/css-display-none-after-ignore-previous-rules.html http/tests/contentextensions/css-display-none-overflows-rule-data-1.html http/tests/contentextensions/css-display-none-overflows-rule-data-2.html http/tests/contentextensions/css-display-none-overflows-rule-data-3.html http/tests/contentextensions/css-display-none-overflows-rule-data-4.html http/tests/contentextensions/css-display-none-overflows-rule-data-5.html http/tests/contentextensions/css-display-none-overflows-rule-data-6.html http/tests/contentextensions/css-display-none-with-different-case-sensitivity-are-not-merged.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84351 "Found 17 new test failures: http/tests/contentextensions/block-child-document-resource-type.html http/tests/contentextensions/block-everything-unless-domain-iframe.html http/tests/contentextensions/block-everything-unless-domain.html http/tests/contentextensions/block-top-document-resource-type.html http/tests/contentextensions/css-display-none-after-ignore-previous-rules.html http/tests/contentextensions/css-display-none-overflows-rule-data-1.html http/tests/contentextensions/css-display-none-overflows-rule-data-2.html http/tests/contentextensions/css-display-none-overflows-rule-data-3.html http/tests/contentextensions/css-display-none-overflows-rule-data-4.html http/tests/contentextensions/css-display-none-overflows-rule-data-5.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26508 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83854 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28516 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/8918 "Failed to checkout and rebase branch from PR 43850") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31272 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->