### PR TITLE
[CSS Tree Counting Functions] Invalidation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-expected.txt
@@ -2,5 +2,7 @@
 PASS basic sibling-index() test
 PASS basic sibling-count() test
 PASS sibling-index() in calc() with percentage
-PASS sibling-count on pseudo-element
+PASS sibling-count() on pseudo-element
+PASS sibling-index() on root
+PASS sibling-count() on root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt
@@ -2,5 +2,5 @@ Some element.
 Some other element.
 Some third element.
 
-FAIL Host children have sibling-index() and sibling-count() based on assignedNodes order assert_equals: expected "3" but got "1"
+FAIL Host children have sibling-index() and sibling-count() based on assignedNodes order assert_equals: expected "3" but got "4"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function.html
@@ -6,6 +6,10 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <style>
+    html {
+      z-index: calc(sibling-index() * 2);
+      widows: calc(sibling-count() * 2);
+    }
     #test {
       z-index: calc(sibling-index());
       counter-increment: foo calc(sibling-count());
@@ -46,7 +50,17 @@ test(() => {
   let style = getComputedStyle(document.getElementById('test'), '::before');
   assert_equals(style.zIndex, '4');
   assert_equals(style.widows, '10');
-}, 'sibling-count on pseudo-element');
+}, 'sibling-count() on pseudo-element');
+
+test(() => {
+  let style = getComputedStyle(document.documentElement);
+  assert_equals(style.zIndex, '2');
+}, 'sibling-index() on root');
+
+test(() => {
+  let style = getComputedStyle(document.documentElement);
+  assert_equals(style.widows, '2');
+}, 'sibling-count() on root');
   </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-invalidation-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Initially 6th sibling
-FAIL 5th sibling after removal assert_equals: expected 50 but got 60
+PASS 5th sibling after removal
 PASS Initially 6 siblings
-FAIL 5 siblings after removal assert_equals: expected 50 but got 60
+PASS 5 siblings after removal
 PASS Initially 6th slotted sibling
 FAIL 5th sibling after slot change assert_equals: expected 50 but got 60
 PASS Initially 6 slotted siblings

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL sibling-index() and sibling-count() evaluates to 0 from outer tree with ::part assert_equals: z-index should be 0 expected "0" but got "3"
+FAIL sibling-index() and sibling-count() evaluates to 0 from outer tree with ::part assert_equals: z-index should be 0 expected "0" but got "1"
 PASS sibling-index() and sibling-count() evaluate as normal from inner tree
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -220,6 +220,7 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.textDecorationLine = initialTextDecorationLine().toRaw();
     m_nonInheritedFlags.usesViewportUnits = false;
     m_nonInheritedFlags.usesContainerUnits = false;
+    m_nonInheritedFlags.useTreeCountingFunctions = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
     m_nonInheritedFlags.disallowsFastPathInheritance = false;
     m_nonInheritedFlags.hasContentNone = false;
@@ -399,6 +400,7 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     textDecorationLine = other.textDecorationLine;
     usesViewportUnits = other.usesViewportUnits;
     usesContainerUnits = other.usesContainerUnits;
+    useTreeCountingFunctions = other.useTreeCountingFunctions;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
     disallowsFastPathInheritance = other.disallowsFastPathInheritance;
     hasContentNone = other.hasContentNone;
@@ -1606,6 +1608,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // unicodeBidi
         // usesViewportUnits
         // usesContainerUnits
+        // useTreeCountingFunctions
         // hasExplicitlyInheritedProperties
         // disallowsFastPathInheritance
         // hasContentNone
@@ -4045,6 +4048,7 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
 
     LOG_IF_DIFFERENT(usesViewportUnits);
     LOG_IF_DIFFERENT(usesContainerUnits);
+    LOG_IF_DIFFERENT(useTreeCountingFunctions);
     LOG_IF_DIFFERENT(hasContentNone);
 
     LOG_IF_DIFFERENT_WITH_CAST(TextDecorationLine, textDecorationLine);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -394,6 +394,8 @@ public:
     bool usesViewportUnits() const { return m_nonInheritedFlags.usesViewportUnits; }
     void setUsesContainerUnits() { m_nonInheritedFlags.usesContainerUnits = true; }
     bool usesContainerUnits() const { return m_nonInheritedFlags.usesContainerUnits; }
+    void setUsesTreeCountingFunctions() { m_nonInheritedFlags.useTreeCountingFunctions = true; }
+    bool useTreeCountingFunctions() const { return m_nonInheritedFlags.useTreeCountingFunctions; }
     void setUsesAnchorFunctions();
     bool usesAnchorFunctions() const;
 
@@ -2374,6 +2376,7 @@ private:
 
         unsigned usesViewportUnits : 1;
         unsigned usesContainerUnits : 1;
+        unsigned useTreeCountingFunctions : 1;
         unsigned hasContentNone : 1;
         unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
         unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -284,6 +284,7 @@ public:
     unsigned scrollbarWidth : 2; // ScrollbarWidth
 
     unsigned usesAnchorFunctions : 1;
+    unsigned usesTreeCountingFunctions : 1;
 
 private:
     StyleRareNonInheritedData();

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -85,6 +85,8 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
         return false;
     if (style.usesContainerUnits())
         return false;
+    if (style.useTreeCountingFunctions())
+        return false;
     if (style.usesAnchorFunctions())
         return false;
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -329,11 +329,21 @@ double BuilderState::lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey& k
     return document().lookupCSSRandomBaseValue(key);
 }
 
-unsigned BuilderState::siblingCount() const
+// MARK: - Tree Counting Functions
+
+unsigned BuilderState::siblingCount()
 {
     // https://drafts.csswg.org/css-values-5/#funcdef-sibling-count
 
     ASSERT(element());
+
+    RefPtr parent = element()->parentElement();
+    if (!parent)
+        return 1;
+
+    m_style.setUsesTreeCountingFunctions();
+    parent->setChildrenAffectedByBackwardPositionalRules();
+    parent->setChildrenAffectedByForwardPositionalRules();
 
     unsigned count = 1;
     for (const auto* sibling = ElementTraversal::previousSibling(*element()); sibling; sibling = ElementTraversal::previousSibling(*sibling))
@@ -343,11 +353,19 @@ unsigned BuilderState::siblingCount() const
     return count;
 }
 
-unsigned BuilderState::siblingIndex() const
+unsigned BuilderState::siblingIndex()
 {
     // https://drafts.csswg.org/css-values-5/#funcdef-sibling-index
 
     ASSERT(element());
+
+    RefPtr parent = element()->parentElement();
+    if (!parent)
+        return 1;
+
+    m_style.setUsesTreeCountingFunctions();
+    parent->setChildrenAffectedByBackwardPositionalRules();
+    parent->setChildrenAffectedByForwardPositionalRules();
 
     unsigned count = 1;
     for (const auto* sibling = ElementTraversal::previousSibling(*element()); sibling; sibling = ElementTraversal::previousSibling(*sibling))

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -153,8 +153,8 @@ public:
     double lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey&, std::optional<CSS::Keyword::ElementShared>) const;
 
     // Accessors for sibling information used by the sibling-count() and sibling-index() CSS functions.
-    unsigned siblingCount() const;
-    unsigned siblingIndex() const;
+    unsigned siblingCount();
+    unsigned siblingIndex();
 
     AnchorPositionedStates* anchorPositionedStates() { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }
     const std::optional<BuilderPositionTryFallback>& positionTryFallback() const { return m_context.positionTryFallback; }


### PR DESCRIPTION
#### bc4b0a6362a439aac78cb889db08d6a1a862310b
<pre>
[CSS Tree Counting Functions] Invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=291329">https://bugs.webkit.org/show_bug.cgi?id=291329</a>
<a href="https://rdar.apple.com/149410107">rdar://149410107</a>

Reviewed by Ryosuke Niwa.

Ensures that that MatchedDeclarationsCache is disabled and sibling changes
invalidate the style when using CSS sibling tree counting functions().

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/tree-scoped-sibling-function-expected.txt:
    - Update tests and results.

* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
    - Adds flag to RenderStyle for when using tree counting functions
      and disable the MatchedDeclarationsCache when it is set.

* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleBuilderState.h:
    - Set the new RenderStyle flag for tree counting functions and set
      both ChildrenAffectedBy{Backward,Forward}PositionalRules flags
      on the parent element to ensure sibling changes invalidate the
      element&apos;s style. A more specific flag could be used in the future
      that only invalidates if the appropriate count/index changes, but
      that would require adding addition bits to m_styleBitfields which
      is already at capacity.

Canonical link: <a href="https://commits.webkit.org/294062@main">https://commits.webkit.org/294062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb1a9850c446a25036c29ed69d7ff1777bed3eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108077 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32890 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->