### PR TITLE
Script imports in Web Extension content script are not isolated from service workers.

### DIFF
--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -58,12 +58,12 @@ CachedModuleScriptLoader::~CachedModuleScriptLoader()
     }
 }
 
-bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL)
+bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::optional<ServiceWorkersMode> serviceWorkersMode)
 {
     ASSERT(m_promise);
     ASSERT(!m_cachedScript);
     String integrity = m_parameters ? m_parameters->integrity() : String { };
-    m_cachedScript = scriptFetcher().requestModuleScript(document, sourceURL, WTFMove(integrity));
+    m_cachedScript = scriptFetcher().requestModuleScript(document, sourceURL, WTFMove(integrity), serviceWorkersMode);
     if (!m_cachedScript)
         return false;
     m_sourceURL = WTFMove(sourceURL);

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~CachedModuleScriptLoader();
 
-    bool load(Document&, URL&& sourceURL);
+    bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>);
 
     CachedScript* cachedScript() { return m_cachedScript.get(); }
     CachedScriptFetcher& scriptFetcher() { return static_cast<CachedScriptFetcher&>(ModuleScriptLoader::scriptFetcher()); }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -42,12 +42,12 @@ Ref<CachedScriptFetcher> CachedScriptFetcher::create(const AtomString& charset)
     return adoptRef(*new CachedScriptFetcher(charset));
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, String&& integrity) const
+CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
-    return requestScriptWithCache(document, sourceURL, String { }, WTFMove(integrity), { });
+    return requestScriptWithCache(document, sourceURL, String { }, WTFMove(integrity), { }, serviceWorkersMode);
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority) const
+CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
     if (!document.settings().isScriptEnabled())
         return nullptr;
@@ -57,6 +57,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = hasKnownNonce ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+    options.serviceWorkersMode = serviceWorkersMode.value_or(ServiceWorkersMode::All);
     options.integrity = WTFMove(integrity);
     options.referrerPolicy = m_referrerPolicy;
     options.fetchPriority = m_fetchPriority;

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -29,6 +29,7 @@
 #include "ReferrerPolicy.h"
 #include "RequestPriority.h"
 #include "ResourceLoadPriority.h"
+#include "ResourceLoaderOptions.h"
 #include <JavaScriptCore/ScriptFetcher.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ class Document;
 
 class CachedScriptFetcher : public JSC::ScriptFetcher {
 public:
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity) const;
+    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity, std::optional<ServiceWorkersMode>) const;
 
     static Ref<CachedScriptFetcher> create(const AtomString& charset);
 
@@ -59,7 +60,7 @@ protected:
     {
     }
 
-    CachedResourceHandle<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>) const;
+    CachedResourceHandle<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
 
 private:
     String m_nonce;

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -149,7 +149,7 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     };
 
     m_weakDocument = document;
-    CachedResourceHandle cachedScript = requestScriptWithCache(document, sourceURL, crossOriginMode(), String { integrity() }, priority());
+    CachedResourceHandle cachedScript = requestScriptWithCache(document, sourceURL, crossOriginMode(), String { integrity() }, priority(), { });
     m_cachedScript = cachedScript;
     if (!cachedScript)
         return false;

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 
 const ASCIILiteral ScriptElementCachedScriptFetcher::defaultCrossOriginModeForModule { "anonymous"_s };
 
-CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, String&& integrity) const
+CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
     // If the fetcher is not module script, credential mode is always "same-origin" ("anonymous").
     // This code is for dynamic module import (`import` operator).
 
-    return requestScriptWithCache(document, sourceURL, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTFMove(integrity), { });
+    return requestScriptWithCache(document, sourceURL, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTFMove(integrity), { }, serviceWorkersMode);
 }
 
 }

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CachedScriptFetcher.h"
+#include "ResourceLoaderOptions.h"
 #include "ScriptType.h"
 
 namespace WebCore {
@@ -34,7 +35,7 @@ class ScriptElementCachedScriptFetcher : public CachedScriptFetcher {
 public:
     static const ASCIILiteral defaultCrossOriginModeForModule;
 
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity) const;
+    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity, std::optional<ServiceWorkersMode>) const;
 
     virtual ScriptType scriptType() const = 0;
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }


### PR DESCRIPTION
#### 1d68c6b3b5216b0cfa5678fd1e8e0edc17ace7e2
<pre>
Script imports in Web Extension content script are not isolated from service workers.
<a href="https://webkit.org/b/287305">https://webkit.org/b/287305</a>
<a href="https://rdar.apple.com/144104878">rdar://144104878</a>

Reviewed by Chris Dumez.

When importing a script in an extension isolated world, we should load it so that
it does not use the page&apos;s service worker to prevent interference.

* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
(WebCore::CachedModuleScriptLoader::load): Pass serviceWorkersMode.
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestModuleScript const): Pass serviceWorkersMode.
(WebCore::CachedScriptFetcher::requestScriptWithCache const): Use serviceWorkersMode or
default to ServiceWorkersMode::All.
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::fetch): Pass ServiceWorkersMode based on the current world.
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::load): Pass { } for serviceWorkersMode.
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp:
(WebCore::ScriptElementCachedScriptFetcher::requestModuleScript const): Pass serviceWorkersMode.
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, ContentScriptImport)): Added.

Originally-landed-as: 289651.71@safari-7621-branch (e0100f67af2d). <a href="https://rdar.apple.com/148059318">rdar://148059318</a>
Canonical link: <a href="https://commits.webkit.org/293506@main">https://commits.webkit.org/293506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/086c66d5345c73ccc45759f70cfed49a52a160c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75424 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32544 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7453 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19097 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84380 "Found 6 new test failures: http/wpt/webcodecs/videoFrame-negative-timestamp.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-document.html imported/w3c/web-platform-tests/selection/Document-open.html imported/w3c/web-platform-tests/streams/readable-streams/async-iterator.any.html imported/w3c/web-platform-tests/web-locks/workers.tentative.https.html imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p0 (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19916 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16120 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31325 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->