### PR TITLE
[AutoTableLayout] Empty tables should include border and padding when computing intrinsic width.

### DIFF
--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-expected.txt
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-expected.txt
@@ -1,0 +1,2 @@
+PASS if no assert or crash.
+

--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-margin-collapse-expected.txt
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-margin-collapse-expected.txt
@@ -1,0 +1,2 @@
+PASS if no assert or crash.
+

--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-margin-collapse.html
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding-margin-collapse.html
@@ -1,0 +1,22 @@
+<style> 
+   .flex-box { 
+   display: flex;
+   flex-direction: row;
+   inline-size: 100px; }
+   table { 
+   inline-size: 100px; 
+   border: 5px solid green;
+   padding: 5px;
+   border-collapse: collapse;
+   }
+</style>
+<script>
+   if (window.testRunner) {
+    testRunner.dumpAsText();
+   }
+</script>
+<div class=flex-box>
+   <div>PASS if no assert or crash.</div>
+<table>
+</table>
+</div>

--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding.html
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border-and-padding.html
@@ -1,0 +1,21 @@
+<style> 
+   .flex-box { 
+   display: flex;
+   flex-direction: row;
+   inline-size: 100px; }
+   table { 
+   inline-size: 100px; 
+   border: 5px solid green;
+   padding: 5px;
+   } 
+</style>
+<script>
+   if (window.testRunner) {
+    testRunner.dumpAsText();
+   }
+</script>
+<div class=flex-box>
+   <div>PASS if no assert or crash.</div>
+<table>
+</table>
+</div>

--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border-expected.txt
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border-expected.txt
@@ -1,0 +1,2 @@
+PASS if no assert or crash.
+

--- a/LayoutTests/fast/flexbox/flex-empty-table-with-border.html
+++ b/LayoutTests/fast/flexbox/flex-empty-table-with-border.html
@@ -1,0 +1,19 @@
+<style> 
+   .flex-box { 
+   display: flex;
+   flex-direction: row;
+   inline-size: 100px; }
+   table { 
+   inline-size: 100px; 
+   border: 5px solid green;
+   } 
+</style>
+<script>
+   if (window.testRunner) {
+    testRunner.dumpAsText();
+   }
+</script>
+<div class=flex-box>
+   <div>PASS if no assert or crash.</div>
+   <table></table>
+</div>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -252,6 +252,13 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
             maxWidth = m_scaledWidthFromPercentColumns;
     }
 
+    if (intrinsics == TableIntrinsics::ForKeyword && m_layoutStruct.isEmpty()) {
+        ASSERT(!minWidth);
+        ASSERT(!maxWidth);
+        minWidth = m_table->bordersPaddingAndSpacingInRowDirection();
+        maxWidth = minWidth;
+    }
+
     maxWidth = std::max(maxWidth, LayoutUnit(spanMaxLogicalWidth));
 }
 


### PR DESCRIPTION
#### c0902fc4dd3abf5d2d5e008eb0b008aeae837953
<pre>
[AutoTableLayout] Empty tables should include border and padding when computing intrinsic width.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291341">https://bugs.webkit.org/show_bug.cgi?id=291341</a>
&lt;<a href="https://rdar.apple.com/141022147">rdar://141022147</a>&gt;

Reviewed by Alan Baradlay.

This PR fixes an issue where AutoTableLayout::computeIntrinsicLogicalWidths()
incorrectly ignores border padding values for empty tables. This later manifests
in RenderFlexibleBox()::computeMainAxisExtentForFlexItem() returning a negative value.
This causes us to fail an assert in RenderFlexibleBox::computeFlexItemMinMaxSizes()
that checks contentSize&gt;=0.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::computeIntrinsicLogicalWidths):

Canonical link: <a href="https://commits.webkit.org/293837@main">https://commits.webkit.org/293837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c0622c4d6d0e1bd09183e87307b36c6ec2ee5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105197 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/50650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/50650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8369 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/50019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/19905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84664 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21503 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7069 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32348 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26930 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->