### PR TITLE
ClearKey session identifiers persist across MediaKeySystem instances

### DIFF
--- a/LayoutTests/http/tests/media/clearkey/clear-key-session-id-expected.txt
+++ b/LayoutTests/http/tests/media/clearkey/clear-key-session-id-expected.txt
@@ -1,0 +1,11 @@
+Test that ClearKey session identifiers do not persist across MediaKeySystem instances.
+-
+Create the first pair of sessions
+EXPECTED (session1.sessionId == '0') OK
+EXPECTED (session2.sessionId == '1') OK
+-
+Create the second pair of sessions
+EXPECTED (session1.sessionId == '0') OK
+EXPECTED (session2.sessionId == '1') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/clearkey/clear-key-session-id.html
+++ b/LayoutTests/http/tests/media/clearkey/clear-key-session-id.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>clear-key-session-id</title>
+    <script src=../../media-resources/video-test.js></script>
+    <script src="support.js"></script>
+    <script>
+
+    var session1;
+    var session2;
+
+    async function runTest() {
+        let createTwoSessions = async () => {
+            const config = [{ "initDataTypes":["webm"], "audioCapabilities":[{"contentType":"audio/mp4"}]}];
+            let mediaKeySystem = await navigator.requestMediaKeySystemAccess("org.w3.clearkey", config);
+            let mediaKeys = await mediaKeySystem.createMediaKeys();
+
+            const e = new Uint8Array([0]);
+
+            session1 = await mediaKeys.createSession();
+            let request = await session1.generateRequest("webm", e);
+
+            testExpected('session1.sessionId', '0');
+
+            session2 = await mediaKeys.createSession();
+            request = await session2.generateRequest("webm", e);
+
+            testExpected('session2.sessionId', '1');
+        };
+
+        consoleWrite('-');
+        consoleWrite('Create the first pair of sessions');
+        await createTwoSessions();
+
+        consoleWrite('-');
+        consoleWrite('Create the second pair of sessions');
+        await createTwoSessions();
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>Test that ClearKey session identifiers do not persist across MediaKeySystem instances.</div>
+</body>
+</html>

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -448,10 +448,7 @@ RefPtr<CDMInstanceSession> CDMInstanceClearKey::createSession()
 
 void CDMInstanceSessionClearKey::requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
-    static uint32_t s_sessionIdValue = 0;
-    ++s_sessionIdValue;
-
-    m_sessionID = String::number(s_sessionIdValue);
+    m_sessionID = String::number(parentInstance().getNextSessionIdValue());
 
     if (equalLettersIgnoringASCIICase(initDataType, "cenc"_s))
         initData = extractKeyidsFromCencInitData(initData.get());

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -96,6 +96,8 @@ public:
     CDMInstanceClearKey();
     virtual ~CDMInstanceClearKey();
 
+    uint32_t getNextSessionIdValue() { return m_nextSessionIdValue++; }
+
     // CDMInstance
     ImplementationType implementationType() const final { return ImplementationType::ClearKey; }
     void initializeWithConfiguration(const CDMKeySystemConfiguration&, AllowDistinctiveIdentifiers, AllowPersistentState, SuccessCallback&&) final;
@@ -103,6 +105,9 @@ public:
     void setStorageDirectory(const String&) final;
     const String& keySystem() const final;
     RefPtr<CDMInstanceSession> createSession() final;
+
+private:
+    uint32_t m_nextSessionIdValue { 0 };
 };
 
 class CDMInstanceSessionClearKey final : public CDMInstanceSessionProxy {


### PR DESCRIPTION
#### 2323626a34c2a10194368fe6e4fba21f5bf93d01
<pre>
ClearKey session identifiers persist across MediaKeySystem instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=286580">https://bugs.webkit.org/show_bug.cgi?id=286580</a>
<a href="https://rdar.apple.com/143525332">rdar://143525332</a>

Reviewed by Eric Carlson.

Store the next session identifier value in the CDMInstanceClearKey, rather than as
a static variable.

* LayoutTests/http/tests/media/clearkey/clear-key-session-id-expected.txt: Added.
* LayoutTests/http/tests/media/clearkey/clear-key-session-id.html: Added.
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMInstanceSessionClearKey::requestLicense):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:

Originally-landed-as: 283286.633@safari-7620-branch (0fdf187e80df). rdar://148112365
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2323626a34c2a10194368fe6e4fba21f5bf93d01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99269 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18916 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104398 "Hash 2323626a for PR 43873 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101309 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19205 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27350 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/104398 "Hash 2323626a for PR 43873 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32639 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102276 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/19205 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/104398 "Hash 2323626a for PR 43873 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/19205 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49228 "Hash 2323626a for PR 43873 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/19205 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106755 "Hash 2323626a for PR 43873 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26382 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/27350 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/106755 "Hash 2323626a for PR 43873 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26745 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/106755 "Hash 2323626a for PR 43873 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/9163 "Hash 2323626a for PR 43873 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/20107 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26322 "analyze-compile-webkit-results") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31513 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26143 "Hash 2323626a for PR 43873 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29456 "Hash 2323626a for PR 43873 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27710 "Hash 2323626a for PR 43873 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->