### PR TITLE
AX: With ENABLE(AX_THREAD_TEXT_APIS), navigating by line to br elements no longer results in any VoiceOver speech or VoiceOver cursor

### DIFF
--- a/LayoutTests/accessibility/mac/br-element-properties-expected.txt
+++ b/LayoutTests/accessibility/mac/br-element-properties-expected.txt
@@ -1,0 +1,15 @@
+This test ensures we compute the correct size and isEnabled state for br elements, especially in the context of text navigation.
+
+[x], height and width are valid, isEnabled is valid: true
+[newline], height and width are valid, isEnabled is valid: true
+[newline], height and width are valid, isEnabled is valid: true
+[newline], height and width are valid, isEnabled is valid: true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+x
+
+
+
+y

--- a/LayoutTests/accessibility/mac/br-element-properties.html
+++ b/LayoutTests/accessibility/mac/br-element-properties.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true ] -->
+<!-- Run singly due to the use of accessibilityController.setForceInitialFrameCaching(). -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="editable" contenteditable="true">x<br/><br/><br/><br/>y</div>
+
+<script>
+var output = "This test ensures we compute the correct size and isEnabled state for br elements, especially in the context of text navigation.\n\n";
+
+window.jsTestIsAsync = true;
+
+if (window.accessibilityController) {
+    // With ITM enabled, this forces us to follow the same codepath that ATs do, which is important to simulate the
+    // bug being tested. The behavior we're trying to test is that we don't serve an empty rect for br elements so that 
+    // VoiceOver can draw a cursor for them.
+    accessibilityController.setForceInitialFrameCaching(true);
+
+    var editable = accessibilityController.accessibleElementById("editable");
+    var startMarker = editable.startTextMarkerForTextMarkerRange(editable.textMarkerRangeForElement(editable));
+    var endMarker = editable.nextTextMarker(startMarker);
+    var markerRange, endElement;
+    setTimeout(async function() {
+        for (let i = 0; i < 4; i++) {
+            markerRange = editable.textMarkerRangeForMarkers(startMarker, endMarker);
+            endElement = editable.accessibilityElementForTextMarker(endMarker);
+
+            const string = editable.stringForTextMarkerRange(markerRange).replace("\n", "newline");
+            // If width or height is zero, VoiceOver won't be able to draw a cursor, e.g. by requesting the element's
+            // size or through NSAccessibilityBoundsForTextMarkerRangeAttribute. This scenario can be triggered by
+            // navigating up and down by lines through text with <br />s (e.g. the markup in this test).
+            //
+            // We need to await this because an accessibility paint may not have happened in order to cache the element
+            // frames.
+            await waitFor(() => endElement.height > 0 && endElement.width > 0);
+            // Furthermore, it's important that <br />s are considered to be enabled. Otherwise when you navigate by line
+            // to them, VoiceOver will speak "dimmed", which isn't right.
+            output += `[${string}], height and width are valid, isEnabled is valid: ${endElement.isEnabled === true}\n`;
+
+            startMarker = endMarker;
+            endMarker = editable.nextTextMarker(startMarker);
+        }
+
+        accessibilityController.setForceInitialFrameCaching(false);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/br-element-text-selection-expected.txt
+++ b/LayoutTests/accessibility/mac/br-element-text-selection-expected.txt
@@ -1,0 +1,23 @@
+This test ensures we can create valid text marker ranges from positions adjacent to br elements.
+
+PASS: webarea.stringForTextMarkerRange(range) === 'x'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'x'
+PASS: webarea.stringForTextMarkerRange(range) === '\n'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '\n'
+PASS: webarea.stringForTextMarkerRange(range) === '\n'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '\n'
+PASS: webarea.stringForTextMarkerRange(range) === 'y'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'y'
+PASS: webarea.stringForTextMarkerRange(range) === '\n'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '\n'
+PASS: webarea.stringForTextMarkerRange(range) === '\n'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === '\n'
+PASS: webarea.stringForTextMarkerRange(range) === 'x'
+PASS: webarea.attributedStringForTextMarkerRange(range).slice(-1) === 'x'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+x
+
+y

--- a/LayoutTests/accessibility/mac/br-element-text-selection.html
+++ b/LayoutTests/accessibility/mac/br-element-text-selection.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="editable" contenteditable="true">x<br/><br/>y</div>
+
+<script>
+var output = "This test ensures we can create valid text marker ranges from positions adjacent to br elements.\n\n";
+// The bug that inspired this fix was that for text selection changes adjacent to <br> elements, we would post an
+// AXSelectedTextChanged notification but fail to include a valid text marker range. This happened due to a bug in how
+// we create text marker ranges when |shouldCreateAXThreadCompatibleMarkers()| is true. This meant VoiceOver wasn't
+// announcing "newline" as you moved between <br>s.
+
+var range;
+var webarea;
+var editable = document.getElementById("editable");
+async function select(domNode, startIndex, endIndex, expectedCharacter, searchBackwards) {
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+
+    await waitFor(() => {
+        const selectedRange = webarea.selectedTextMarkerRange();
+        return !webarea.isTextMarkerRangeValid(selectedRange);
+    });
+
+    const domRange = document.createRange();
+    domRange.setStart(domNode, startIndex);
+    domRange.setEnd(domNode, endIndex);
+    selection.addRange(domRange);
+
+    let selectedRange;
+    await waitFor(() => {
+        selectedRange = webarea.selectedTextMarkerRange();
+        return webarea.isTextMarkerRangeValid(selectedRange);
+    });
+
+    let start, end;
+    if (searchBackwards) {
+        end = webarea.endTextMarkerForTextMarkerRange(selectedRange);
+        start = webarea.previousTextMarker(end);
+    } else {
+        start = webarea.startTextMarkerForTextMarkerRange(selectedRange);
+        end = webarea.nextTextMarker(start);
+    }
+
+    range = webarea.textMarkerRangeForMarkers(start, end);
+    output += expect("webarea.stringForTextMarkerRange(range)", `'${expectedCharacter}'`)
+    output += expect("webarea.attributedStringForTextMarkerRange(range).slice(-1)", `'${expectedCharacter}'`)
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    webarea = accessibilityController.rootElement.childAtIndex(0);
+    setTimeout(async function() {
+        // |x<br/><br/>y
+        await select(editable, 0, 0, "x");
+        // x|<br/><br/>y
+        await select(editable, 1, 1, "\\n");
+        // x<br/>|<br/>|y
+        await select(editable, 2, 2, "\\n");
+        // x<br/><br/>|y
+        await select(editable, 3, 3, "y");
+        // x<br/><br/>|y
+        await select(editable, 3, 3, "\\n", /* searchBackwards */ true);
+        // x<br/>|<br/>y
+        await select(editable, 2, 2, "\\n", /* searchBackwards */ true);
+        // x|<br/><br/>y
+        await select(editable, 1, 1, "x", /* searchBackwards */ true);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1237,6 +1237,8 @@ accessibility/mac/text-operation/text-operation-uppercase.html [ Skip ]
 
 # Skipping because AXTextMarkerRangeIsValid is not supported on WK1.
 accessibility/mac/attributed-string-with-image.html [ Skip ]
+accessibility/mac/br-element-properties.html [ Skip ]
+accessibility/mac/br-element-text-selection.html [ Skip ]
 accessibility/mac/dynamic-selection.html [ Skip ]
 accessibility/mac/replaced-element-text-selection.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3686,7 +3686,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
 
         };
 
-        if (isRendererReplacedElement(node->renderer()))
+        if (isRendererReplacedElement(node->renderer()) || is<RenderLineBreak>(node->renderer()))
             return createFromRendererAndOffset(*node->renderer(), domOffset);
 
         CheckedPtr<const RenderText> renderText = dynamicDowncast<RenderText>(node ? node->renderer() : nullptr);

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -95,11 +95,14 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject
     }
 
     RetainPtr<NSMutableAttributedString> result = start.isolatedObject()->createAttributedString(makeString(listMarkerText, start.runs()->substring(start.offset())), spellCheck);
-    auto appendToResult = [&result] (RetainPtr<NSMutableAttributedString> string) {
+    auto appendToResult = [&result] (RetainPtr<NSMutableAttributedString>&& string) {
+        if (!string)
+            return;
+
         if (result)
             [result appendAttributedString:string.autorelease()];
         else
-            result = string;
+            result = WTFMove(string);
     };
 
     auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -133,6 +133,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         String language = object.language();
         if (!language.isEmpty())
             setProperty(AXProperty::Language, WTFMove(language).isolatedCopy());
+        setProperty(AXProperty::IsEnabled, object.isEnabled());
     };
 
     // Allocate a capacity based on the minimum properties an object has (based on measurements from a real webpage).
@@ -160,7 +161,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
     setProperty(AXProperty::IsAttachment, object.isAttachment());
     setProperty(AXProperty::IsBusy, object.isBusy());
-    setProperty(AXProperty::IsEnabled, object.isEnabled());
     setProperty(AXProperty::IsExpanded, object.isExpanded());
 
     // FIXME: These three properties, plus AXProperty::IsRadioInput below, are basically

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -31,6 +31,7 @@
 #include "PaintInfo.h"
 #include "RenderBox.h"
 #include "RenderInline.h"
+#include "RenderLineBreak.h"
 #include "RenderStyleInlines.h"
 #include "TextBoxPainter.h"
 #include <wtf/Assertions.h>
@@ -74,8 +75,13 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
         return;
     }
 
-    if (box.isLineBreak())
+    if (box.isLineBreak()) {
+        if (m_paintInfo.phase == PaintPhase::Accessibility) {
+            auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(box.layoutBox().rendererForIntegration());
+            m_paintInfo.accessibilityRegionContext()->takeBounds(renderLineBreak, m_paintOffset);
+        }
         return;
+    }
 
     if (box.isInlineBox()) {
         if (!box.isVisible() || !hasDamage(box))

--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -31,6 +31,7 @@
 #include "RenderBox.h"
 #include "RenderBoxModelObject.h"
 #include "RenderInline.h"
+#include "RenderLineBreak.h"
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
 #include "RenderView.h"
@@ -77,6 +78,22 @@ void AccessibilityRegionContext::takeBounds(const RenderBox& renderBox, FloatRec
 {
     auto mappedPaintRect = enclosingIntRect(mapRect(paintRect));
     takeBoundsInternal(renderBox, WTFMove(mappedPaintRect));
+}
+
+void AccessibilityRegionContext::takeBounds(const RenderLineBreak* renderLineBreak, const LayoutPoint& paintOffset)
+{
+    if (!renderLineBreak)
+        return;
+    auto mappedPaintRect = renderLineBreak->linesBoundingBox();
+    mappedPaintRect.moveBy(roundedIntPoint(paintOffset));
+    // We want <br>s to have non-empty rects so that something is drawn when they are navigated to by-line by
+    // ATs like VoiceOver. Make them at least 2px so they roughly match the size of a cursor in either horizontal
+    // or vertical writing modes (matching CaretRectComputation::caretWidth).
+    if (!mappedPaintRect.width())
+        mappedPaintRect.setWidth(2);
+    if (!mappedPaintRect.height())
+        mappedPaintRect.setHeight(2);
+    takeBoundsInternal(*renderLineBreak, WTFMove(mappedPaintRect));
 }
 
 void AccessibilityRegionContext::takeBoundsInternal(const RenderBoxModelObject& renderObject, IntRect&& paintRect)

--- a/Source/WebCore/rendering/AccessibilityRegionContext.h
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.h
@@ -57,6 +57,7 @@ public:
     void takeBounds(const RenderInline&, LayoutRect&& /* paintRect */);
     void takeBounds(const RenderText&, FloatRect /* paintRect */);
     void takeBounds(const RenderView&, LayoutPoint&& /* paintOffset */);
+    void takeBounds(const RenderLineBreak*, const LayoutPoint& /* paintOffset */);
 
     // This group of methods serves only as a notification that the given object is
     // being painted. From there, we construct the geometry we need ourselves


### PR DESCRIPTION
#### 37aef476e4a0e82eb10684e0fe0121415d40a3c7
<pre>
AX: With ENABLE(AX_THREAD_TEXT_APIS), navigating by line to br elements no longer results in any VoiceOver speech or VoiceOver cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=291340">https://bugs.webkit.org/show_bug.cgi?id=291340</a>
<a href="https://rdar.apple.com/148945209">rdar://148945209</a>

Reviewed by Joshua Hoffman.

This commit fixes several bugs related to how we handle br elements, all regressing as a result of ENABLE(AX_THREAD_TEXT_APIS).

  - VoiceOver didn&apos;t speak anything when navigating to a br by line. This happened because creating a text marker via
    AXObjectCache::textMarkerDataForVisiblePosition early-exited for anything that wasn&apos;t a RenderText or replaced element.
    Fix this by handling br elements appropriately.

  - VoiceOver didn&apos;t draw a cursor for br elements when navigating to them by line. This was because we didn&apos;t cache
    a relative frame for them, which in turn happened because they are skipped by paint by default. Fix this by changing
    InlineContentPainter::paintDisplayBox to paint brs for PaintPhase::Accessibility, and add the appropriate handling
    in AccessibilityRegionContext.

  - VoiceOver read &quot;dimmed&quot; for br elements. This happened because we didn&apos;t cache AXProperty::IsEnabled for ignored
    objects. Thus when VoiceOver requested is-enabled, we returned the default value of false. Fix this by caching
    AXProperty::IsEnabled for all objects.

Also fix a crash in AXTextMarkerCocoa::toAttributedString where we tried to append a nil attributed string. This fix is
covered by new test, accessibility/mac/br-element-text-selection.html.

* LayoutTests/accessibility/mac/br-element-properties-expected.txt: Added.
* LayoutTests/accessibility/mac/br-element-properties.html: Added.
* LayoutTests/accessibility/mac/br-element-text-selection-expected.txt: Added.
* LayoutTests/accessibility/mac/br-element-text-selection.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations: Skip new tests.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBounds):
* Source/WebCore/rendering/AccessibilityRegionContext.h:

Canonical link: <a href="https://commits.webkit.org/293518@main">https://commits.webkit.org/293518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5738fa1d199ded093dd6b00ac7351188f25ecfbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32563 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102144 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7487 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49096 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26248 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84424 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83923 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21293 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19961 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->