### PR TITLE
[libpas] Add PAS_PROFILE hook for new partial views

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -498,6 +498,7 @@ typedef enum {
 static PAS_ALWAYS_INLINE pas_allocation_result
 pas_local_allocator_set_up_primordial_bump(
     pas_local_allocator* allocator,
+    pas_allocation_mode allocation_mode,
     pas_segregated_partial_view* view,
     pas_segregated_shared_handle* handle,
     pas_segregated_page* page,
@@ -596,6 +597,8 @@ pas_local_allocator_set_up_primordial_bump(
         }
     }
 
+    PAS_PROFILE(POPULATE_PRIMORDIAL_PARTIAL_VIEW, page_config, page, view, bump_result, allocation_mode);
+
     switch (mode) {
     case pas_local_allocator_primordial_bump_return_first_allocation:
         return pas_allocation_result_create_success(page_boundary + begin_offset);
@@ -611,6 +614,7 @@ pas_local_allocator_set_up_primordial_bump(
 static PAS_ALWAYS_INLINE bool
 pas_local_allocator_start_allocating_in_primordial_partial_view(
     pas_local_allocator* allocator,
+    pas_allocation_mode allocation_mode,
     pas_segregated_partial_view* view,
     pas_segregated_size_directory* size_directory,
     pas_segregated_page_config page_config)
@@ -704,7 +708,7 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
         pas_zero_memory(allocator->bits, pas_segregated_page_config_num_alloc_bytes(page_config));
 
         pas_local_allocator_set_up_primordial_bump(
-            allocator, view, handle, page, &held_lock, bump_result,
+            allocator, allocation_mode, view, handle, page, &held_lock, bump_result,
             pas_local_allocator_primordial_bump_stash_whole_allocation,
             page_config);
 
@@ -894,6 +898,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
 
     result = pas_local_allocator_set_up_primordial_bump(
         allocator,
+        allocation_mode,
         partial_view,
         pas_unwrap_shared_handle(shared_view->shared_handle_or_page_boundary, page_config),
         page,
@@ -914,6 +919,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
 static PAS_ALWAYS_INLINE bool
 pas_local_allocator_refill_with_known_config(
     pas_local_allocator* allocator,
+    pas_allocation_mode allocation_mode,
     pas_allocator_counts* counts,
     pas_segregated_page_config page_config)
 {
@@ -1193,7 +1199,7 @@ pas_local_allocator_refill_with_known_config(
             pas_log("Going the primordial route.\n");
         
         return page_config.specialized_local_allocator_start_allocating_in_primordial_partial_view(
-            allocator, pas_segregated_view_get_partial(new_view), size_directory);
+            allocator, allocation_mode, pas_segregated_view_get_partial(new_view), size_directory);
     }
 
     new_page = pas_segregated_page_for_boundary(
@@ -1584,7 +1590,7 @@ pas_local_allocator_try_allocate_small_segregated_slow_impl(
            inlining this made it twice as expensive. It's just one of those things: if code size is ever
            an issue, then we should ponder turning this back into an outline call. */
         refill_result = pas_local_allocator_refill_with_known_config(
-            allocator, counts, config.small_segregated_config);
+            allocator, allocation_mode, counts, config.small_segregated_config);
 
         if (!refill_result)
             return pas_allocation_result_create_failure();
@@ -1726,7 +1732,7 @@ pas_local_allocator_try_allocate_slow_impl(pas_local_allocator* allocator,
 
         page_config = pas_segregated_page_config_kind_get_config(
             pas_local_allocator_config_kind_get_segregated_page_config_kind(allocator->config_kind));
-        page_config->specialized_local_allocator_refill(allocator, counts);
+        page_config->specialized_local_allocator_refill(allocator, allocation_mode, counts);
 
         PAS_TESTING_ASSERT(!pas_local_allocator_has_bitfit(allocator));
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
@@ -91,10 +91,11 @@ typedef pas_allocation_result
     pas_local_allocator* allocator, pas_allocation_mode allocation_mode);
 typedef bool
 (*pas_segregated_page_config_specialized_local_allocator_start_allocating_in_primordial_partial_view)(
-    pas_local_allocator* allocator, pas_segregated_partial_view* partial,
+    pas_local_allocator* allocator, pas_allocation_mode allocation_mode, pas_segregated_partial_view* partial,
     pas_segregated_size_directory* size_directory);
 typedef bool (*pas_segregated_page_config_specialized_local_allocator_refill)(
     pas_local_allocator* allocator,
+    pas_allocation_mode allocation_mode,
     pas_allocator_counts* counts);
 typedef void (*pas_segregated_page_config_specialized_local_allocator_return_memory_to_page)(
     pas_local_allocator* allocator,
@@ -206,10 +207,12 @@ PAS_API extern bool pas_medium_segregated_page_config_variant_is_enabled_overrid
         pas_local_allocator* allocator, pas_allocation_mode allocation_mode); \
     PAS_API bool lower_case_page_config_name ## _specialized_local_allocator_start_allocating_in_primordial_partial_view( \
         pas_local_allocator* allocator, \
+        pas_allocation_mode allocation_mode, \
         pas_segregated_partial_view* partial, \
         pas_segregated_size_directory* size_directory); \
     PAS_API bool lower_case_page_config_name ## _specialized_local_allocator_refill( \
         pas_local_allocator* allocator, \
+        pas_allocation_mode allocation_mode, \
         pas_allocator_counts* counts); \
     PAS_API void \
     lower_case_page_config_name ## _specialized_local_allocator_return_memory_to_page( \

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_inlines.h
@@ -43,18 +43,20 @@ PAS_BEGIN_EXTERN_C;
     \
     PAS_NEVER_INLINE bool lower_case_page_config_name ## _specialized_local_allocator_start_allocating_in_primordial_partial_view( \
         pas_local_allocator* allocator, \
+        pas_allocation_mode allocation_mode, \
         pas_segregated_partial_view* partial, \
         pas_segregated_size_directory* size_directory) \
     { \
         return pas_local_allocator_start_allocating_in_primordial_partial_view( \
-            allocator, partial, size_directory, (page_config_value)); \
+            allocator, allocation_mode, partial, size_directory, (page_config_value)); \
     } \
     \
     PAS_NEVER_INLINE bool lower_case_page_config_name ## _specialized_local_allocator_refill( \
         pas_local_allocator* allocator, \
+        pas_allocation_mode allocation_mode, \
         pas_allocator_counts* counts) \
     { \
-        return pas_local_allocator_refill_with_known_config(allocator, counts, (page_config_value)); \
+        return pas_local_allocator_refill_with_known_config(allocator, allocation_mode, counts, (page_config_value)); \
     } \
     \
     void lower_case_page_config_name ## _specialized_local_allocator_return_memory_to_page( \

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -100,8 +100,9 @@ PAS_BEGIN_EXTERN_C;
 #define __PAS_UNUSED_3(x, ...) PAS_UNUSED_PARAM(x), __PAS_UNUSED_2(__VA_ARGS__)
 #define __PAS_UNUSED_4(x, ...) PAS_UNUSED_PARAM(x), __PAS_UNUSED_3(__VA_ARGS__)
 #define __PAS_UNUSED_5(x, ...) PAS_UNUSED_PARAM(x), __PAS_UNUSED_4(__VA_ARGS__)
-#define __PAS_UNUSED_V_ARITY_IMPL(_1, _2, _3, _4, _5, N, ...) N
-#define __PAS_UNUSED_V_ARITY(...) __PAS_UNUSED_V_ARITY_IMPL(__VA_ARGS__, 5, 4, 3, 2, 1)
+#define __PAS_UNUSED_6(x, ...) PAS_UNUSED_PARAM(x), __PAS_UNUSED_5(__VA_ARGS__)
+#define __PAS_UNUSED_V_ARITY_IMPL(_1, _2, _3, _4, _5, _6, N, ...) N
+#define __PAS_UNUSED_V_ARITY(...) __PAS_UNUSED_V_ARITY_IMPL(__VA_ARGS__, 6, 5, 4, 3, 2, 1)
 #define __PAS_UNUSED_V_IMPL2(nargs) __PAS_UNUSED_ ## nargs
 #define __PAS_UNUSED_V_IMPL(nargs) __PAS_UNUSED_V_IMPL2(nargs)
 


### PR DESCRIPTION
#### 618680278807c4c6d7d6d771a51c90413543e493
<pre>
[libpas] Add PAS_PROFILE hook for new partial views
<a href="https://bugs.webkit.org/show_bug.cgi?id=291342">https://bugs.webkit.org/show_bug.cgi?id=291342</a>
<a href="https://rdar.apple.com/148945939">rdar://148945939</a>

Reviewed by Keith Miller.

This is a crucial thing to watch for performance optimization, so we
should have a PAS_PROFILE hook with which to do so.

* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_set_up_primordial_bump):
(pas_local_allocator_start_allocating_in_primordial_partial_view):
(pas_local_allocator_try_allocate_in_primordial_partial_view):
(pas_local_allocator_refill_with_known_config):
(pas_local_allocator_try_allocate_small_segregated_slow_impl):
(pas_local_allocator_try_allocate_slow_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/293686@main">https://commits.webkit.org/293686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59f5ace820bef1468203ce43d2e810d70a6e7422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49069 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91791 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106596 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97731 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84403 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/98670 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83917 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26162 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/121346 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25983 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33915 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->