### PR TITLE
RenderTheme web control painting should always use FloatRects snapped to device pixels

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -865,7 +865,6 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     if (UNLIKELY(!canPaint(paintInfo, box.settings(), appearance)))
         return false;
 
-    IntRect integralSnappedRect = snappedIntRect(rect);
     float deviceScaleFactor = box.document().deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
 
@@ -875,28 +874,28 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::Radio:
         return paintRadio(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::ColorWell:
-        return paintColorWell(box, paintInfo, integralSnappedRect);
+        return paintColorWell(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::ColorWellSwatch:
-        return paintColorWellSwatch(box, paintInfo, integralSnappedRect);
+        return paintColorWellSwatch(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::PushButton:
     case StyleAppearance::SquareButton:
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
-        return paintButton(box, paintInfo, integralSnappedRect);
+        return paintButton(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Menulist:
         return paintMenuList(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::MenulistButton:
-        return paintMenuListButton(box, paintInfo, integralSnappedRect);
+        return paintMenuListButton(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Meter:
-        return paintMeter(box, paintInfo, integralSnappedRect);
+        return paintMeter(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::ProgressBar:
-        return paintProgressBar(box, paintInfo, integralSnappedRect);
+        return paintProgressBar(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SliderHorizontal:
     case StyleAppearance::SliderVertical:
-        return paintSliderTrack(box, paintInfo, integralSnappedRect);
+        return paintSliderTrack(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
-        return paintSliderThumb(box, paintInfo, integralSnappedRect);
+        return paintSliderThumb(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::TextField:
     case StyleAppearance::TextArea:
     case StyleAppearance::Listbox:
@@ -906,13 +905,13 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::SearchField:
         return paintSearchField(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SearchFieldCancelButton:
-        return paintSearchFieldCancelButton(box, paintInfo, integralSnappedRect);
+        return paintSearchFieldCancelButton(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SearchFieldDecoration:
-        return paintSearchFieldDecorationPart(box, paintInfo, integralSnappedRect);
+        return paintSearchFieldDecorationPart(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SearchFieldResultsDecoration:
-        return paintSearchFieldResultsDecorationPart(box, paintInfo, integralSnappedRect);
+        return paintSearchFieldResultsDecorationPart(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::SearchFieldResultsButton:
-        return paintSearchFieldResultsButton(box, paintInfo, integralSnappedRect);
+        return paintSearchFieldResultsButton(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Switch:
         return true;
     case StyleAppearance::SwitchThumb:
@@ -921,14 +920,14 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
         return paintSwitchTrack(box, paintInfo, devicePixelSnappedRect);
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
-        return paintImageControlsButton(box, paintInfo, integralSnappedRect);
+        return paintImageControlsButton(box, paintInfo, snappedIntRect(rect));
 #endif
     case StyleAppearance::ListButton:
         return paintListButton(box, paintInfo, devicePixelSnappedRect);
 #if ENABLE(ATTACHMENT_ELEMENT)
     case StyleAppearance::Attachment:
     case StyleAppearance::BorderlessAttachment:
-        return paintAttachment(box, paintInfo, integralSnappedRect);
+        return paintAttachment(box, paintInfo, snappedIntRect(rect));
 #endif
     default:
         break;
@@ -991,10 +990,6 @@ void RenderTheme::paintDecorations(const RenderBox& box, const PaintInfo& paintI
     if (paintInfo.context().paintingDisabled())
         return;
 
-    // FIXME: Investigate whether all controls can use a device-pixel-snapped rect
-    // rather than an integral-snapped rect.
-
-    IntRect integralSnappedRect = snappedIntRect(rect);
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.document().deviceScaleFactor());
 
     // Call the appropriate paint method based off the appearance value.
@@ -1012,11 +1007,11 @@ void RenderTheme::paintDecorations(const RenderBox& box, const PaintInfo& paintI
         paintColorWellDecorations(box, paintInfo, devicePixelSnappedRect);
         break;
     case StyleAppearance::Menulist:
-        paintMenuListDecorations(box, paintInfo, integralSnappedRect);
+        paintMenuListDecorations(box, paintInfo, devicePixelSnappedRect);
         break;
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SearchField:
-        paintSearchFieldDecorations(box, paintInfo, integralSnappedRect);
+        paintSearchFieldDecorations(box, paintInfo, devicePixelSnappedRect);
         break;
     case StyleAppearance::Meter:
     case StyleAppearance::ProgressBar:

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -220,7 +220,7 @@ public:
     virtual String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const;
 
     enum class FileUploadDecorations : bool { SingleFile, MultipleFiles };
-    virtual void paintFileUploadIconDecorations(const RenderObject& /*inputRenderer*/, const RenderObject& /*buttonRenderer*/, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) { }
+    virtual void paintFileUploadIconDecorations(const RenderObject& /*inputRenderer*/, const RenderObject& /*buttonRenderer*/, const PaintInfo&, const FloatRect&, Icon*, FileUploadDecorations) { }
     
 #if ENABLE(SERVICE_CONTROLS)
     virtual IntSize imageControlsButtonSize() const { return IntSize(); }
@@ -284,16 +284,16 @@ protected:
     virtual bool paintRadio(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustButtonStyle(RenderStyle&, const Element*) const;
-    virtual bool paintButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustColorWellStyle(RenderStyle&, const Element*) const;
-    virtual bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintColorWell(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
     virtual void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) { }
 
     virtual void adjustColorWellSwatchStyle(RenderStyle&, const Element*) const { }
     virtual void adjustColorWellSwatchOverlayStyle(RenderStyle&, const Element*) const { }
     virtual void adjustColorWellSwatchWrapperStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const;
     virtual bool paintInnerSpinButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
@@ -308,14 +308,14 @@ protected:
 
     virtual void adjustMenuListStyle(RenderStyle&, const Element*) const;
     virtual bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
-    virtual void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
+    virtual void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) { }
 
     virtual void adjustMenuListButtonStyle(RenderStyle&, const Element*) const { }
     virtual void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
-    virtual bool paintMenuListButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintMenuListButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustMeterStyle(RenderStyle&, const Element*) const;
-    virtual bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintMeter(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
 #if ENABLE(APPLE_PAY)
     virtual void adjustApplePayButtonStyle(RenderStyle&, const Element*) const { }
@@ -336,29 +336,29 @@ protected:
 #endif
 
     virtual void adjustProgressBarStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintProgressBar(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSliderTrackStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSliderTrack(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSliderThumbStyle(RenderStyle&, const Element*) const;
-    virtual bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSliderThumb(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSearchFieldStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchField(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
-    virtual void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) { }
+    virtual void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
 
     virtual void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const FloatRect&) { return true; }
 
     virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const { }
-    virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
+    virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const FloatRect&) { return true; }
 
     void adjustSwitchStyleDisplay(RenderStyle&) const;
     virtual void adjustSwitchStyle(RenderStyle&, const Element*) const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -58,16 +58,16 @@ protected:
     bool paintRadio(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustButtonStyle(RenderStyle&, const Element*) const override;
-    bool paintButton(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintButton(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustColorWellStyle(RenderStyle&, const Element*) const override;
-    bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintColorWell(const RenderObject&, const PaintInfo&, const FloatRect&) override;
     void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustColorWellSwatchStyle(RenderStyle&, const Element*) const override;
     void adjustColorWellSwatchOverlayStyle(RenderStyle&, const Element*) const override;
     void adjustColorWellSwatchWrapperStyle(RenderStyle&, const Element*) const override;
-    bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintColorWellSwatch(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const override;
     bool paintInnerSpinButton(const RenderObject&, const PaintInfo&, const FloatRect&) override;
@@ -82,43 +82,43 @@ protected:
 
     void adjustMenuListStyle(RenderStyle&, const Element*) const override;
     bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) override;
-    void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustMenuListButtonStyle(RenderStyle&, const Element*) const override;
     void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
-    bool paintMenuListButton(const RenderObject&, const PaintInfo&, const IntRect&) final;
+    bool paintMenuListButton(const RenderObject&, const PaintInfo&, const FloatRect&) final;
 
     void adjustMeterStyle(RenderStyle&, const Element*) const override;
-    bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintMeter(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustListButtonStyle(RenderStyle&, const Element*) const override;
     bool paintListButton(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustProgressBarStyle(RenderStyle&, const Element*) const override;
-    bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintProgressBar(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const override;
-    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
     void adjustSliderThumbStyle(RenderStyle&, const Element*) const override;
-    bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintSliderThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSearchFieldStyle(RenderStyle&, const Element*) const override;
     bool paintSearchField(const RenderObject&, const PaintInfo&, const FloatRect&) override;
-    void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) override;
+    void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const override;
-    bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const IntRect&) override;
+    bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const override;
-    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const override;
-    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) override;
+    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const override;
-    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) override;
+    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSwitchStyle(RenderStyle&, const Element*) const override;
     bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
@@ -138,7 +138,7 @@ private:
 
     bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const final;
 
-    void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) override;
+    void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const FloatRect&, Icon*, FileUploadDecorations) override;
 
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -160,7 +160,7 @@ Color RenderThemeCocoa::pictureFrameColor(const RenderObject& buttonRenderer)
     return systemColor(CSSValueAppleSystemControlBackground, buttonRenderer.styleColorOptions());
 }
 
-void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderObject&, const RenderObject& buttonRenderer, const PaintInfo& paintInfo, const IntRect& rect, Icon* icon, FileUploadDecorations fileUploadDecorations)
+void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderObject&, const RenderObject& buttonRenderer, const PaintInfo& paintInfo, const FloatRect& rect, Icon* icon, FileUploadDecorations fileUploadDecorations)
 {
     GraphicsContextStateSaver stateSaver(paintInfo.context());
 
@@ -409,7 +409,7 @@ void RenderThemeCocoa::adjustButtonStyle(RenderStyle& style, const Element* elem
     RenderTheme::adjustButtonStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintButton(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintButton(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintButtonForVectorBasedControls(box, paintInfo, rect))
@@ -459,7 +459,7 @@ void RenderThemeCocoa::adjustColorWellSwatchWrapperStyle(RenderStyle& style, con
     RenderTheme::adjustColorWellSwatchWrapperStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintColorWellSwatch(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintColorWellSwatch(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintColorWellSwatchForVectorBasedControls(box, paintInfo, rect))
@@ -469,7 +469,7 @@ bool RenderThemeCocoa::paintColorWellSwatch(const RenderObject& box, const Paint
     return RenderTheme::paintColorWellSwatch(box, paintInfo, rect);
 }
 
-bool RenderThemeCocoa::paintColorWell(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintColorWell(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintColorWellForVectorBasedControls(box, paintInfo, rect))
@@ -589,7 +589,7 @@ bool RenderThemeCocoa::paintMenuList(const RenderObject& box, const PaintInfo& p
     return RenderTheme::paintMenuList(box, paintInfo, rect);
 }
 
-void RenderThemeCocoa::paintMenuListDecorations(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+void RenderThemeCocoa::paintMenuListDecorations(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintMenuListDecorationsForVectorBasedControls(box, paintInfo, rect))
@@ -619,7 +619,7 @@ void RenderThemeCocoa::paintMenuListButtonDecorations(const RenderBox& box, cons
     RenderTheme::paintMenuListButtonDecorations(box, paintInfo, rect);
 }
 
-bool RenderThemeCocoa::paintMenuListButton(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintMenuListButton(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintMenuListButtonForVectorBasedControls(box, paintInfo, rect))
@@ -639,7 +639,7 @@ void RenderThemeCocoa::adjustMeterStyle(RenderStyle& style, const Element* eleme
     RenderTheme::adjustMeterStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintMeter(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintMeter(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintMeterForVectorBasedControls(box, paintInfo, rect))
@@ -679,7 +679,7 @@ void RenderThemeCocoa::adjustProgressBarStyle(RenderStyle& style, const Element*
     RenderTheme::adjustProgressBarStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintProgressBar(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintProgressBar(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintProgressBarForVectorBasedControls(box, paintInfo, rect))
@@ -699,7 +699,7 @@ void RenderThemeCocoa::adjustSliderTrackStyle(RenderStyle& style, const Element*
     RenderTheme::adjustSliderTrackStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSliderTrackForVectorBasedControls(box, paintInfo, rect))
@@ -729,7 +729,7 @@ void RenderThemeCocoa::adjustSliderThumbStyle(RenderStyle& style, const Element*
     RenderTheme::adjustSliderThumbStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSliderThumb(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSliderThumb(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSliderThumbForVectorBasedControls(box, paintInfo, rect))
@@ -759,7 +759,7 @@ bool RenderThemeCocoa::paintSearchField(const RenderObject& box, const PaintInfo
     return RenderTheme::paintSearchField(box, paintInfo, rect);
 }
 
-void RenderThemeCocoa::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+void RenderThemeCocoa::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSearchFieldDecorationsForVectorBasedControls(box, paintInfo, rect))
@@ -779,7 +779,7 @@ void RenderThemeCocoa::adjustSearchFieldCancelButtonStyle(RenderStyle& style, co
     RenderTheme::adjustSearchFieldCancelButtonStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSearchFieldCancelButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSearchFieldCancelButton(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSearchFieldCancelButtonForVectorBasedControls(box, paintInfo, rect))
@@ -799,7 +799,7 @@ void RenderThemeCocoa::adjustSearchFieldDecorationPartStyle(RenderStyle& style, 
     RenderTheme::adjustSearchFieldDecorationPartStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSearchFieldDecorationPartForVectorBasedControls(box, paintInfo, rect))
@@ -819,7 +819,7 @@ void RenderThemeCocoa::adjustSearchFieldResultsDecorationPartStyle(RenderStyle& 
     RenderTheme::adjustSearchFieldResultsDecorationPartStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSearchFieldResultsDecorationPartForVectorBasedControls(box, paintInfo, rect))
@@ -839,7 +839,7 @@ void RenderThemeCocoa::adjustSearchFieldResultsButtonStyle(RenderStyle& style, c
     RenderTheme::adjustSearchFieldResultsButtonStyle(style, element);
 }
 
-bool RenderThemeCocoa::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeCocoa::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
     if (paintSearchFieldResultsButtonForVectorBasedControls(box, paintInfo, rect))

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -97,7 +97,7 @@ private:
     void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const override;
-    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
 
@@ -107,13 +107,13 @@ private:
     bool hasSwitchHapticFeedback(SwitchTrigger) const final { return true; }
 #endif
 
-    bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    bool paintProgressBar(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
     IntSize sliderTickSize() const override;
     int sliderTickOffsetFromTrackCenter() const override;
 
     void adjustSearchFieldStyle(RenderStyle&, const Element*) const override;
-    void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) override;
+    void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
 
     Color checkboxRadioBorderColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
     Color checkboxRadioBackgroundColor(const RenderStyle&, OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
@@ -126,7 +126,7 @@ private:
     void paintCheckboxRadioInnerShadow(const PaintInfo&, const FloatRoundedRect&, OptionSet<ControlStyle::State>);
 
     bool supportsMeter(StyleAppearance) const final;
-    bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) final;
+    bool paintMeter(const RenderObject&, const PaintInfo&, const FloatRect&) final;
 
     bool paintListButton(const RenderObject&, const PaintInfo&, const FloatRect&) final;
 
@@ -135,13 +135,13 @@ private:
     void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) final;
 
     void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) final;
+    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const FloatRect&) final;
 
     void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) final;
+    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const FloatRect&) final;
 
     void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) final;
+    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const FloatRect&) final;
 
     bool supportsFocusRing(const RenderObject&, const RenderStyle&) const final;
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -616,7 +616,7 @@ void RenderThemeIOS::adjustSliderTrackStyle(RenderStyle& style, const Element* e
 
 constexpr auto nativeControlBorderInlineSize = 1.0f;
 
-bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
     if (box.settings().macStyleControlsOnCatalyst())
@@ -722,7 +722,7 @@ void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element* el
 constexpr auto reducedMotionProgressAnimationMinOpacity = 0.3f;
 constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
 
-bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
     if (renderer.settings().macStyleControlsOnCatalyst())
@@ -853,7 +853,7 @@ void RenderThemeIOS::adjustSearchFieldStyle(RenderStyle& style, const Element* e
     adjustRoundBorderRadius(style, *box);
 }
 
-void RenderThemeIOS::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+void RenderThemeIOS::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
     if (paintSearchFieldDecorationsForCatalyst(box, paintInfo, rect))
@@ -1651,7 +1651,7 @@ bool RenderThemeIOS::supportsMeter(StyleAppearance appearance) const
     return appearance == StyleAppearance::Meter;
 }
 
-bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
     if (renderer.settings().macStyleControlsOnCatalyst())
@@ -1882,7 +1882,7 @@ void RenderThemeIOS::adjustSearchFieldDecorationPartStyle(RenderStyle& style, co
     style.setMarginEnd({ searchFieldDecorationMargin, LengthType::Fixed });
 }
 
-bool RenderThemeIOS::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
     if (box.settings().macStyleControlsOnCatalyst())
@@ -1931,7 +1931,7 @@ void RenderThemeIOS::adjustSearchFieldResultsDecorationPartStyle(RenderStyle& st
     adjustSearchFieldDecorationPartStyle(style, element);
 }
 
-bool RenderThemeIOS::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     return paintSearchFieldDecorationPart(box, paintInfo, rect);
 }
@@ -1941,7 +1941,7 @@ void RenderThemeIOS::adjustSearchFieldResultsButtonStyle(RenderStyle& style, con
     adjustSearchFieldDecorationPartStyle(style, element);
 }
 
-bool RenderThemeIOS::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+bool RenderThemeIOS::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     return paintSearchFieldDecorationPart(box, paintInfo, rect);
 }


### PR DESCRIPTION
#### e9ae55b490477df786ef2c74d95db0740a1f5126
<pre>
RenderTheme web control painting should always use FloatRects snapped to device pixels
<a href="https://bugs.webkit.org/show_bug.cgi?id=291344">https://bugs.webkit.org/show_bug.cgi?id=291344</a>
<a href="https://rdar.apple.com/146913126">rdar://146913126</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

RenderTheme&apos;s paint methods for web facing controls now all take a FloatRect
parameter rather than an IntRect. When each of these methods are called in
`RenderTheme::paint`, pass a rect which has been snapped to the device pixels
rather than sometimes passing a snapped integral rect.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::paintDecorations):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::paintFileUploadIconDecorations):
(WebCore::RenderTheme::paintButton):
(WebCore::RenderTheme::paintColorWell):
(WebCore::RenderTheme::paintColorWellSwatch):
(WebCore::RenderTheme::paintMenuListDecorations):
(WebCore::RenderTheme::paintMenuListButton):
(WebCore::RenderTheme::paintMeter):
(WebCore::RenderTheme::paintProgressBar):
(WebCore::RenderTheme::paintSliderTrack):
(WebCore::RenderTheme::paintSliderThumb):
(WebCore::RenderTheme::paintSearchFieldDecorations):
(WebCore::RenderTheme::paintSearchFieldCancelButton):
(WebCore::RenderTheme::paintSearchFieldDecorationPart):
(WebCore::RenderTheme::paintSearchFieldResultsDecorationPart):
(WebCore::RenderTheme::paintSearchFieldResultsButton):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintFileUploadIconDecorations):
(WebCore::RenderThemeCocoa::paintButton):
(WebCore::RenderThemeCocoa::paintColorWellSwatch):
(WebCore::RenderThemeCocoa::paintColorWell):
(WebCore::RenderThemeCocoa::paintMenuListDecorations):
(WebCore::RenderThemeCocoa::paintMenuListButton):
(WebCore::RenderThemeCocoa::paintMeter):
(WebCore::RenderThemeCocoa::paintProgressBar):
(WebCore::RenderThemeCocoa::paintSliderTrack):
(WebCore::RenderThemeCocoa::paintSliderThumb):
(WebCore::RenderThemeCocoa::paintSearchFieldDecorations):
(WebCore::RenderThemeCocoa::paintSearchFieldCancelButton):
(WebCore::RenderThemeCocoa::paintSearchFieldDecorationPart):
(WebCore::RenderThemeCocoa::paintSearchFieldResultsDecorationPart):
(WebCore::RenderThemeCocoa::paintSearchFieldResultsButton):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::paintProgressBar):
(WebCore::RenderThemeIOS::paintSearchFieldDecorations):
(WebCore::RenderThemeIOS::paintMeter):
(WebCore::RenderThemeIOS::paintSearchFieldDecorationPart):
(WebCore::RenderThemeIOS::paintSearchFieldResultsDecorationPart):
(WebCore::RenderThemeIOS::paintSearchFieldResultsButton):

Canonical link: <a href="https://commits.webkit.org/293541@main">https://commits.webkit.org/293541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c4592ad3d612f13aa636a0bdbd4ccfbd7417fc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75437 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102128 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14476 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106607 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83910 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21307 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19945 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31354 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->