### PR TITLE
[webkitpy] DeprecationWarning: datetime.utcnow() and datetime.datetime.utcfromtimestamp()

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -49,7 +49,7 @@ class Issue(object):
         def __repr__(self):
             return '({} @ {}) {}'.format(
                 self.user,
-                datetime.utcfromtimestamp(self.timestamp) if self.timestamp else '-',
+                datetime.fromtimestamp(self.timestamp, timezone.utc) if self.timestamp else '-',
                 self.content,
             )
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -38,8 +38,8 @@ class Bugzilla(Base, mocks.Requests):
 
     @classmethod
     def time_string(cls, timestamp):
-        from datetime import datetime, timedelta
-        return datetime.utcfromtimestamp(timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ')
+        from datetime import datetime, timedelta, timezone
+        return datetime.fromtimestamp(timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     @classmethod
     def transform_user(cls, user):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
@@ -54,8 +54,8 @@ class GitHub(Base, mocks.Requests):
 
     @classmethod
     def time_string(cls, timestamp):
-        from datetime import datetime, timedelta
-        return datetime.utcfromtimestamp(timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ')
+        from datetime import datetime, timedelta, timezone
+        return datetime.fromtimestamp(timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def __init__(self, hostname='github.example.com/WebKit/WebKit', users=None, issues=None, environment=None, projects=None, labels=None):
         hostname, repo = hostname.split('/', 1)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -95,7 +95,7 @@ class RadarModel(object):
                 yield property
 
         def add(self, item):
-            from datetime import datetime, timedelta
+            from datetime import datetime, timedelta, timezone
 
             username = self.model.client.authentication_strategy.username()
             if username:
@@ -105,7 +105,7 @@ class RadarModel(object):
 
             self._properties.append(Radar.DiagnosisEntry(
                 text=item.text,
-                addedAt=datetime.utcfromtimestamp(int(time.time())),
+                addedAt=datetime.fromtimestamp(int(time.time()), timezone.utc),
                 addedBy=by,
             ))
 
@@ -144,7 +144,7 @@ class RadarModel(object):
             self.name = name
 
     def __init__(self, client, issue, additional_fields=None):
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         additional_fields = additional_fields or []
 
@@ -153,8 +153,8 @@ class RadarModel(object):
         self.title = issue['title']
         self.id = issue['id']
         self.classification = issue.get('classification', 'Other Bug')
-        self.createdAt = datetime.utcfromtimestamp(issue['timestamp'] - timedelta(hours=7).seconds)
-        self.lastModifiedAt = datetime.utcfromtimestamp(issue['modified' if issue.get('modified') else 'timestamp'] - timedelta(hours=7).seconds)
+        self.createdAt = datetime.fromtimestamp(issue['timestamp'] - timedelta(hours=7).seconds, timezone.utc)
+        self.lastModifiedAt = datetime.fromtimestamp(issue['modified' if issue.get('modified') else 'timestamp'] - timedelta(hours=7).seconds, timezone.utc)
         self.assignee = self.Person(Radar.transform_user(issue['assignee']))
         self.description = self.CollectionProperty(self, self.DescriptionEntry(issue['description']))
         if issue.get('state'):
@@ -173,7 +173,7 @@ class RadarModel(object):
         self.diagnosis = self.CollectionProperty(self, *[
             Radar.DiagnosisEntry(
                 text=comment.content,
-                addedAt=datetime.utcfromtimestamp(comment.timestamp - timedelta(hours=7).seconds),
+                addedAt=datetime.fromtimestamp(comment.timestamp - timedelta(hours=7).seconds, timezone.utc),
                 addedBy=self.CommentAuthor(Radar.transform_user(comment.user)),
             ) for comment in issue.get('comments', [])
         ])

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -23,7 +23,7 @@
 import json
 import re
 
-from datetime import datetime
+from datetime import datetime, timezone
 from webkitbugspy import Tracker
 from webkitscmpy import Contributor
 from webkitcorepy import string_utils
@@ -266,7 +266,7 @@ class Commit(object):
         if self.author:
             result += '    by {}'.format(self.author)
             if self.timestamp:
-                result += ' @ {}'.format(datetime.utcfromtimestamp(self.timestamp))
+                result += ' @ {}'.format(datetime.fromtimestamp(self.timestamp, timezone.utc))
             result += '\n'
 
         if self.message and message:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -26,7 +26,7 @@ import os
 import re
 import time
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from webkitcorepy import OutputCapture, StringIO, decorators, mocks, string_utils
@@ -387,7 +387,7 @@ nothing to commit, working tree clean
                             hash=commit.hash,
                             author=commit.author.name,
                             email=commit.author.email,
-                            date=commit.timestamp if '--date=unix' in args else datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            date=commit.timestamp if '--date=unix' in args else datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000'),
                             log='\n'.join(
                                 [
                                     ('    ' + line) if line else '' for line in commit.message.splitlines()
@@ -650,7 +650,7 @@ nothing to commit, working tree clean
                             hash=commit.hash,
                             author=commit.author.name,
                             email=commit.author.email,
-                            date=datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            date=datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000'),
                             message=commit.message.rstrip(),
                             content='\n'.join(['+{}'.format(line) for line in commit.message.splitlines()]),
                         ) for commit in list(self.rev_list(args[2] if '..' in args[2] else '{}..HEAD'.format(args[2])))
@@ -696,7 +696,7 @@ nothing to commit, working tree clean
                             hash=self.find(args[2]).hash,
                             author=self.find(args[2]).author.name,
                             email=self.find(args[2]).author.email,
-                            date=self.find(args[2]).timestamp if '--date=unix' in args else datetime.utcfromtimestamp(self.find(args[2]).timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            date=self.find(args[2]).timestamp if '--date=unix' in args else datetime.fromtimestamp(self.find(args[2]).timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000'),
                             log='\n'.join(
                                 [
                                     ('    ' + line) if line else '' for line in self.find(args[2]).message.splitlines()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
@@ -23,7 +23,7 @@
 import json
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from webkitcorepy import mocks
@@ -41,7 +41,7 @@ class Svn(mocks.Subprocess):
         return 'r{revision} | {email} | {date}'.format(
             revision=commit.revision,
             email=email,
-            date=datetime.utcfromtimestamp(commit.timestamp).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
+            date=datetime.fromtimestamp(commit.timestamp, timezone.utc).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
         )
 
     def __init__(self, path='/.invalid-svn', datafile=None, remote=None, utc_offset=None):
@@ -211,7 +211,7 @@ class Svn(mocks.Subprocess):
                 branch=self.branch,
                 revision=commit.revision,
                 author=commit.author.email,
-                date=datetime.utcfromtimestamp(commit.timestamp).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
+                date=datetime.fromtimestamp(commit.timestamp, timezone.utc).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
             ),
         )
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -153,7 +153,7 @@ class GitHub(bmocks.GitHub):
         ], url=url)
 
     def _commits_response(self, url, ref):
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         base = self.commit(ref)
         if not base:
@@ -179,11 +179,11 @@ class GitHub(bmocks.GitHub):
                         'author': {
                             'name': commit.author.name,
                             'email': commit.author.email,
-                            'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                            'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                         }, 'committer': {
                             'name': commit.author.name,
                             'email': commit.author.email,
-                            'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                            'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                         }, 'message': commit.message + ('\ngit-svn-id: https://svn.example.org/repository/webkit/{}@{} 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'.format(
                             'trunk' if commit.branch == self.default_branch else commit.branch, commit.revision,
                         ) if commit.revision else ''),
@@ -199,7 +199,7 @@ class GitHub(bmocks.GitHub):
         return mocks.Response.fromJson(response, url=url)
 
     def _commit_response(self, url, ref):
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         path = None
         split = ref.split('/', 1)
@@ -230,11 +230,11 @@ class GitHub(bmocks.GitHub):
                 'author': {
                     'name': commit.author.name,
                     'email': commit.author.email,
-                    'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 }, 'committer': {
                     'name': commit.author.name,
                     'email': commit.author.email,
-                    'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 }, 'message': commit.message + ('\ngit-svn-id: https://svn.example.org/repository/webkit/{}@{} 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'.format(
                     'trunk' if commit.branch == self.default_branch else commit.branch, commit.revision,
                 ) if commit.revision else ''),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
@@ -119,7 +119,7 @@ class Svn(mocks.Requests):
 
     def request(self, method, url, data=None, **kwargs):
         import xmltodict
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         if not url.startswith('http://') and not url.startswith('https://'):
             return mocks.Response.create404(url)
@@ -246,7 +246,7 @@ class Svn(mocks.Requests):
                     '</D:multistatus>\n'.format(
                         stripped_url,
                         commit.revision,
-                        datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
+                        datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
                         commit.author.email,
                 ),
             )
@@ -278,7 +278,7 @@ class Svn(mocks.Requests):
                         '<S:date>{}</S:date>\n'
                         '{}{}</S:log-item>\n'.format(
                             commit.revision,
-                            datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
+                            datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
                             '' if data['S:log-report'].get('S:revpro') else '<D:comment>{}</D:comment>\n'
                             '<D:creator-displayname>{}</D:creator-displayname>\n'.format(
                                 commit.message,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -24,7 +24,7 @@ import json
 import re
 
 from .commit import Commit
-from datetime import datetime
+from datetime import datetime, timezone
 from webkitscmpy import Contributor
 from webkitcorepy import string_utils
 
@@ -57,7 +57,7 @@ class PullRequest(object):
         def __repr__(self):
             return '({} @ {}) {}'.format(
                 self.author,
-                datetime.utcfromtimestamp(self.timestamp) if self.timestamp else '-',
+                datetime.fromtimestamp(self.timestamp, timezone.utc) if self.timestamp else '-',
                 self.content,
             )
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -24,7 +24,7 @@ import json
 import logging
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from webkitbugspy import Tracker, bugzilla, radar
@@ -127,7 +127,7 @@ class TestCommit(unittest.TestCase):
     SVN revision: r123 on trunk
     identifier: 123 on trunk
     by Jonathan Bedard <jbedard@apple.com> @ {}
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, timezone.utc)),
         )
 
         self.assertEqual(
@@ -142,7 +142,7 @@ class TestCommit(unittest.TestCase):
     SVN revision: r124 on branch-a
     identifier: 1 on branch-a branched from 123
     by Jonathan Bedard <jbedard@apple.com> @ {}
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, timezone.utc)),
         )
 
         self.assertEqual(
@@ -159,7 +159,7 @@ class TestCommit(unittest.TestCase):
     by Jonathan Bedard <jbedard@apple.com> @ {}
 
 PRINTED
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, timezone.utc)),
         )
 
     def test_repr(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -23,7 +23,7 @@
 import os
 import shutil
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from webkitcorepy import LoggerCapture, OutputCapture, run, testing
@@ -518,7 +518,7 @@ CommitDate: {time_c}
                 [
                     'From bae5d1e90999d4f916a8a15810ccfa43f37a2fd6',
                     'From: Jonathan Bedard <jbedard@apple.com>',
-                    'Date: {} +0000'.format(datetime.utcfromtimestamp(1601668000 + time.timezone).strftime('%a %b %d %H:%M:%S %Y')),
+                    'Date: {} +0000'.format(datetime.fromtimestamp(1601668000 + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y')),
                     'Subject: [PATCH] 8th commit',
                     '---',
                     'diff --git a/ChangeLog b/ChangeLog',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py
@@ -24,7 +24,7 @@ import os
 import time
 import sys
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from webkitcorepy import OutputCapture, Terminal, testing
 from webkitcorepy.mocks import Time as MockTime
@@ -78,7 +78,7 @@ Date:   {}
 
     1st commit
 '''.format(*reversed([
-                datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000')
                 for commit in mocks.local.Git(self.path).commits['main']
             ])),
         )
@@ -127,7 +127,7 @@ Date:   {}
     1st commit
     git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc
 '''.format(*reversed([
-                    datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                    datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000')
                     for commit in mocks.local.Git(self.path).commits['main']
                 ])),
             )
@@ -176,7 +176,7 @@ Date:   {}
     1st commit
     git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc
 '''.format(*reversed([
-                    datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                    datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000')
                     for commit in mocks.local.Git(self.path).commits['main']
                 ])),
             )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
@@ -24,7 +24,7 @@ import os
 import time
 import sys
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from webkitcorepy import OutputCapture, Terminal, testing
 from webkitscmpy import program, mocks
@@ -66,7 +66,7 @@ index 2deba859a126..7b85f5cecd66 100644
 +        return;
     auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
     clipRect.moveBy(-offset);
-'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+'''.format(datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000')),
         )
 
     def test_git_svn(self):
@@ -99,7 +99,7 @@ index 2deba859a126..7b85f5cecd66 100644
 +        return;
     auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
     clipRect.moveBy(-offset);
-'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+'''.format(datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000')),
         )
 
     def test_svn(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
@@ -22,7 +22,7 @@
 
 import os
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from webkitcorepy import LoggerCapture, OutputCapture, testing
@@ -98,7 +98,7 @@ class TestLocalSvn(testing.PathTestCase):
                     u'Schedule': u'normal',
                     u'Last Changed Author': u'jbedard@apple.com',
                     u'Last Changed Rev': u'6',
-                    u'Last Changed Date': datetime.utcfromtimestamp(1601665100).strftime('%Y-%m-%d %H:%M:%S 0000 (%a, %d %b %Y)'),
+                    u'Last Changed Date': datetime.fromtimestamp(1601665100, timezone.utc).strftime('%Y-%m-%d %H:%M:%S 0000 (%a, %d %b %Y)'),
                 }, local.Svn(self.path).info(),
             )
 
@@ -323,7 +323,7 @@ class TestRemoteSvn(testing.TestCase):
         with mocks.remote.Svn():
             self.assertDictEqual({
                 'Last Changed Author': 'jbedard@apple.com',
-                'Last Changed Date': datetime.utcfromtimestamp(1601665100 - timedelta(hours=7).seconds).strftime('%Y-%m-%d %H:%M:%S'),
+                'Last Changed Date': datetime.fromtimestamp(1601665100 - timedelta(hours=7).seconds, timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
                 'Last Changed Rev': '6',
                 'Revision': 10,
             }, remote.Svn(self.remote).info())

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -277,7 +277,7 @@ class Git(SCM):
 
     def timestamp_of_native_revision(self, path, sha):
         unix_timestamp = self._run_git(['-C', self.find_checkout_root(path), 'log', '-1', sha, '--pretty=format:%ct']).rstrip()
-        commit_timestamp = datetime.datetime.utcfromtimestamp(float(unix_timestamp))
+        commit_timestamp = datetime.datetime.fromtimestamp(float(unix_timestamp), datetime.timezone.utc)
         return commit_timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def create_patch(self, git_commit=None, changed_files=None, git_index=False, commit_message=True, find_branch=False):

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
@@ -79,7 +79,7 @@ class PerfTestsRunner(object):
         self._webkit_base_dir_len = len(self._port.webkit_base())
         self._base_path = self._port.perf_tests_dir()
         self._timestamp = time.time()
-        self._utc_timestamp = datetime.datetime.utcnow()
+        self._utc_timestamp = datetime.datetime.now(datetime.timezone.utc)
 
     @staticmethod
     def _parse_args(args=None):


### PR DESCRIPTION
#### 4d1af55b74c93fa96864b0e827b4cadd2ada041b
<pre>
[webkitpy] DeprecationWarning: datetime.utcnow() and datetime.datetime.utcfromtimestamp()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291348">https://bugs.webkit.org/show_bug.cgi?id=291348</a>

Reviewed by Sam Sneddon.

datetime.utcnow() and datetime.utcfromtimestamp(timestamp) are
deprecated since Python 3.12.

This change doesn&apos;t touch resultsdbpy which have to be handled
separately with special care.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.Comment.__repr__):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla.time_string):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py:
(GitHub.time_string):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.CollectionProperty.add):
(RadarModel.__init__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit.pretty_print):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py:
(Svn.log_line):
(Svn._info):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub._commits_response):
(GitHub._commit_response):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py:
(Svn.request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.Comment.__repr__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py:
(TestLocalSvn.test_info):
(TestRemoteSvn.test_info):
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.timestamp_of_native_revision):
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py:
(PerfTestsRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/294023@main">https://commits.webkit.org/294023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed29a1649feaadd08216b14830d126e7ae171fa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105766 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/51217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/76629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/51217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/15801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/90893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/56984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/100103 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/15615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50593 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/85527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108120 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/20375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/85584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/100187 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87094 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/85124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29819 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/7547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/21735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27682 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->