### PR TITLE
[OTS] Batch async nodes deletion

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -950,6 +950,13 @@ public:
         shrink(size() - 1); 
     }
 
+    void removeLastElements(size_t n)
+    {
+        if (size() < n) [[unlikely]]
+            OverflowHandler::overflowed();
+        shrink(size() - n);
+    }
+
     void fill(const T&, size_t);
     void fill(const T& val) { fill(val, size()); }
 

--- a/Source/WebCore/dom/AsyncNodeDeletionQueue.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueue.h
@@ -38,14 +38,17 @@ public:
     ALWAYS_INLINE ~AsyncNodeDeletionQueue();
 
     ALWAYS_INLINE void addIfSubtreeSizeIsUnderLimit(NodeVector&&, unsigned subTreeSize);
-    ALWAYS_INLINE void deleteNodesNow();
+    ALWAYS_INLINE void deleteNodes(unsigned maxToDelete);
+    ALWAYS_INLINE void deleteAllNodes();
+    ALWAYS_INLINE unsigned nodeCount() const;
+
     ALWAYS_INLINE static ContainerNode::CanDelayNodeDeletion canNodeBeDeletedAsync(const Node&);
     ALWAYS_INLINE static bool isNodeLikelyLarge(const Node&);
 
 private:
-    Vector<Ref<Node>> m_queue;
-    unsigned m_nodeCount { 0 };
-    static constexpr unsigned s_maxSizeAsyncNodeDeletionQueue = 100000;
+    // We store at each queue item the _total_ number of nodes in the queue (for O(1) check).
+    Vector<std::pair<NodeVector, unsigned>> m_queue;
+    static constexpr unsigned s_maxSizeAsyncNodeDeletionQueue = 100'000;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -894,7 +894,7 @@ void Document::removedLastRef()
         m_documentElement = nullptr;
         m_focusNavigationStartingNode = nullptr;
         m_userActionElements.clear();
-        m_asyncNodeDeletionQueue.deleteNodesNow();
+        m_asyncNodeDeletionQueue.deleteAllNodes();
 #if ENABLE(FULLSCREEN_API)
         fullscreen().clear();
 #endif

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -95,7 +95,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     });
 
     for (auto& document : protectedDocuments) {
-        document->asyncNodeDeletionQueue().deleteNodesNow();
+        document->asyncNodeDeletionQueue().deleteAllNodes();
         if (CheckedPtr renderView = document->renderView()) {
             LayoutIntegration::LineLayout::releaseCaches(*renderView);
             Layout::TextBreakingPositionCache::singleton().clear();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5267,12 +5267,11 @@ void Page::willChangeLocationInCompletelyLoadedSubframe()
 
 void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
 {
+    deleteRemovedNodesAndDetachedRenderers();
     OptionSet<JSC::VM::SchedulerOptions> options;
     if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
         options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
     commonVM().performOpportunisticallyScheduledTasks(deadline, options);
-
-    deleteRemovedNodesAndDetachedRenderers();
 }
 
 void Page::deleteRemovedNodesAndDetachedRenderers()
@@ -5287,7 +5286,7 @@ void Page::deleteRemovedNodesAndDetachedRenderers()
         RefPtr document = frame.document();
         if (!document)
             return;
-        document->asyncNodeDeletionQueue().deleteNodesNow();
+        document->asyncNodeDeletionQueue().deleteNodes(100);
         RefPtr frameView = document->view();
         if (!frameView)
             return;

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -685,8 +685,12 @@ TEST(WTF_Vector, RemoveLast)
     EXPECT_EQ(10U, v.size());
     EXPECT_FALSE(v.removeLast(1));
     EXPECT_EQ(10U, v.size());
-    v.clear();
+    v.removeLastElements(3);
+    EXPECT_EQ(7U, v.size());
+    v.removeLastElements(7);
+    EXPECT_TRUE(v.isEmpty());
 
+    v.clear();
     v.fill(1, 10);
     EXPECT_EQ(10U, v.size());
     EXPECT_TRUE(v.removeLast(1));


### PR DESCRIPTION
#### 14b5c5be5c2aa3d1b969c16312d8963a353d9170
<pre>
[OTS] Batch async nodes deletion
<a href="https://bugs.webkit.org/show_bug.cgi?id=291347">https://bugs.webkit.org/show_bug.cgi?id=291347</a>

Reviewed by NOBODY (OOPS!).

To make the performance cost more predictable/constant,
we batch and limit the number of node deletion
per scheduled task (100).

Also, we do the deletion before the other tasks (Incremental Sweep)
instead of after because they can adapt their runtime duration with the deadline.

* Source/WTF/wtf/Vector.h:
(WTF::Vector::removeLastElements):
* Source/WebCore/dom/AsyncNodeDeletionQueue.h:
(): Deleted.
* Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h:
(WebCore::AsyncNodeDeletionQueue::nodeCount const):
(WebCore::AsyncNodeDeletionQueue::addIfSubtreeSizeIsUnderLimit):
(WebCore::AsyncNodeDeletionQueue::deleteNodes):
(WebCore::AsyncNodeDeletionQueue::deleteAllNodes):
(WebCore::AsyncNodeDeletionQueue::deleteNodesNow): Deleted.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::performOpportunisticallyScheduledTasks):
(WebCore::Page::deleteRemovedNodesAndDetachedRenderers):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, RemoveLast)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14b5c5be5c2aa3d1b969c16312d8963a353d9170

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66031 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a80ac50-593e-48f2-b32f-ebc121b13d15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87552 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42400 "Found 28 new test failures: fast/css/vertical-align-rem-on-root.html fast/dom/HTMLLabelElement/form/test1.html fast/events/event-listener-list-mutation.html fast/forms/fieldset-pseudo-valid-style.html fast/gradients/conic-stop-with-offset-zero-in-middle.html fast/html/HTMLOptionsCollection-set-property.html fast/shadow-dom/shadow-style-text-mutation.html imported/w3c/web-platform-tests/event-timing/event-click-counts.html js/arrowfunction-call.html js/char-at.html ... (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3d9b343-a25b-46b1-b135-97ce65b4b32b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67949 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21568 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64986 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107491 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124515 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113772 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96355 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/114664 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96142 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19199 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47609 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137973 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41587 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36860 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->