### PR TITLE
Simplify end-resolution in `SVGSMILElement::resolveInterval`

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -865,20 +865,15 @@ void SVGSMILElement::resolveInterval(bool first, SMILTime& beginResult, SMILTime
         SMILTime tempBegin = findInstanceTime(Begin, beginAfter, equalsMinimumOK);
         if (tempBegin.isUnresolved())
             break;
-        SMILTime tempEnd;
-        if (m_endTimes.isEmpty())
-            tempEnd = resolveActiveEnd(tempBegin, SMILTime::indefinite());
-        else {
-            tempEnd = findInstanceTime(End, tempBegin, true);
-            if ((first && tempBegin == tempEnd && tempEnd == lastIntervalTempEnd) || (!first && tempEnd == m_intervalEnd)) 
-                tempEnd = findInstanceTime(End, tempBegin, false);    
-            if (tempEnd.isUnresolved()) {
-                if (!m_endTimes.isEmpty() && !m_hasEndEventConditions)
-                    break;
-            }
-            tempEnd = resolveActiveEnd(tempBegin, tempEnd);
+        SMILTime tempEnd = findInstanceTime(End, tempBegin, true);
+        if (!m_endTimes.isEmpty()) {
+            if ((first && tempBegin == tempEnd && tempEnd == lastIntervalTempEnd) || (!first && tempEnd == m_intervalEnd))
+                tempEnd = findInstanceTime(End, tempBegin, false);
+            if (tempEnd.isUnresolved() && !m_hasEndEventConditions)
+                break;
         }
-        if (!first || (tempEnd > 0 || (!tempBegin.value() && !tempEnd.value()))) {
+        tempEnd = resolveActiveEnd(tempBegin, tempEnd);
+        if (!first || tempEnd > SMILTime() || (!tempBegin.value() && !tempEnd.value())) {
             beginResult = tempBegin;
             endResult = tempEnd;
             return;


### PR DESCRIPTION
#### 60dde2d1ee700d2d251120a375178f89cb63afe8
<pre>
Simplify end-resolution in `SVGSMILElement::resolveInterval`
<a href="https://bugs.webkit.org/show_bug.cgi?id=291349">https://bugs.webkit.org/show_bug.cgi?id=291349</a>

Reviewed by Nikolas Zimmermann.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/95179be9d1d66c639c98a6ba0c4214fe9e022730">https://chromium.googlesource.com/chromium/src.git/+/95179be9d1d66c639c98a6ba0c4214fe9e022730</a>

This patch do following things:

* findInstanceTime(End, ...) will return &quot;indefinite&quot; for an empty,
   so always call that.
* Sink the call to resolveActiveEnd(...) since it can be shared between
   the two cases.
* Drop the redundant &quot;!m_endTimes.isEmpty()&quot; check.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::resolveInterval const):

Canonical link: <a href="https://commits.webkit.org/293511@main">https://commits.webkit.org/293511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/445b452e8f0658f5ea764e2be105d7a4f1d035da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75442 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32561 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84402 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83916 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19953 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31362 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->